### PR TITLE
Remove Python references

### DIFF
--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -174,7 +174,7 @@
 #'
 #' `pairwise` uses the pairwise sum (fast, default)
 #'
-#' `fsum` uses Python's fsum function (most accurate)
+#' `fsum` uses the PreciseSum package's fsum function (most accurate)
 #'
 #' `kahan` uses Kahan correction
 #'

--- a/man-roxygen/rmdhunks/stiff.Rmdh
+++ b/man-roxygen/rmdhunks/stiff.Rmdh
@@ -51,14 +51,8 @@ print(s2)
 ```
 
 While this is easy enough to do, it is a bit tedious.  If you have
-rxode2 setup appropriately, that is you have:
-
-- **Python** installed in your system
-- **sympy** installed in your system
-- **SnakeCharmR** installed in R
-
-You can use the computer algebra system sympy to calculate the
-Jacobian automatically.
+rxode2 setup appropriately, you can use the computer algebra system
+sympy to calculate the Jacobian automatically.
 
 This is done by the rxode2 option `calcJac` option:
 

--- a/man/rxPkg.Rd
+++ b/man/rxPkg.Rd
@@ -37,7 +37,7 @@ example \code{rx_129f8f97fb94a87ca49ca8dafe691e1e_i386.dll}}
 
 \item{fields}{A named list of fields to add to \code{DESCRIPTION}, potentially
 overriding default values. See \code{\link[usethis:use_description]{use_description()}} for how you can set
-personalized defaults using package options.}
+personalized defaults using package options}
 }
 \value{
 this function returns nothing and is used for its side effects

--- a/man/rxSolve.Rd
+++ b/man/rxSolve.Rd
@@ -643,7 +643,7 @@ rxode2 code blocks.
 
 \code{pairwise} uses the pairwise sum (fast, default)
 
-\code{fsum} uses Python's fsum function (most accurate)
+\code{fsum} uses the PreciseSum package's fsum function (most accurate)
 
 \code{kahan} uses Kahan correction
 

--- a/tests/testthat/test-000sum.R
+++ b/tests/testthat/test-000sum.R
@@ -1,6 +1,6 @@
 rxode2Test(
   {
-    context("Test PythonFsum")
+    context("Test PreciseSums::fsum")
     test_that("Fsum", {
       et <- eventTable() %>%
         add.sampling(0)


### PR DESCRIPTION
As suggested above, this removes references to Python in the documentation.