### PR TITLE
Fix partial argument matching

### DIFF
--- a/R/et.R
+++ b/R/et.R
@@ -261,7 +261,7 @@ et.default <- function(x, ..., time, amt, evid, cmt, ii, addl,
   }
   if (!missing(by)) {
     force(by)
-    checkmate::assertNumeric(by, finite = TRUE, max.len = 1, any.missing = FALSE, min = 0)
+    checkmate::assertNumeric(by, finite = TRUE, max.len = 1, any.missing = FALSE, min.len = 0)
     if (!missing(length.out)) {
       stop("cannot supply both 'by' and 'length.out'", call. = FALSE)
     }

--- a/R/piping.R
+++ b/R/piping.R
@@ -111,7 +111,7 @@
 #'
 #' @export
 .quoteCallInfoLines <- function(callInfo, envir=parent.frame()) {
-  .bracket <- rep(FALSE, length=length(callInfo))
+  .bracket <- rep(FALSE, length.out=length(callInfo))
   .env <- environment()
   .ret <- lapply(seq_along(callInfo), function(i) {
     .name <- names(callInfo)[i]


### PR DESCRIPTION
I always run with `options(warnPartialMatchArgs=TRUE)` which results in warnings when function argument names are only partially-matched.  So, when doing some testing, I found these two partial argument matches.