### PR TITLE
Catch too little memory available, and skip the test

### DIFF
--- a/tests/testthat/test-npde-mac.R
+++ b/tests/testthat/test-npde-mac.R
@@ -1,5 +1,9 @@
 test_that("npde simulation works on mac nlmixr #460", {
-  skip_if(!file.exists(test_path("si.qs")))
+  # This test requires a lot of RAM (approximately 22GiB), so skip it if there
+  # is not enough RAM available.  This skip only works on Windows because
+  # `memory.limit()` returns Inf (with a warning) on other platforms.
+  skip_if_not(suppressWarnings(memory.limit()) > 22*1024, message="Not enough memory to run test")
+  skip_if_not(file.exists(test_path("si.qs")))
   si <- qs::qread(test_path("si.qs"))
   si$object <- rxode2(si$object)
   withr::with_seed(


### PR DESCRIPTION
The npde test fails when there is not a lot of memory available (about 22GiB in my tests).  So, skip it if there is not that much available.  The test for "not that much available" only works on Windows, and doing the test for Linux or Mac would get complicated (https://stackoverflow.com/questions/36079906/alternative-to-rs-memory-size-in-linux).