### PR TITLE
Clarify and standardize all file-related test skips

### DIFF
--- a/tests/testthat/test-cbind-study-individual.R
+++ b/tests/testthat/test-cbind-study-individual.R
@@ -36,10 +36,10 @@ if (FALSE) {
 }
 
 test_that("cbind study and individual", {
-  qs <- test_path("data-cbind-study-individual.qs")
-  skip_if_not(file.exists(qs))
+  fileCbindStudyIndividual <- test_path("data-cbind-study-individual.qs")
+  skip_if_not(file.exists(fileCbindStudyIndividual))
   
-  l <- qs::qload(qs)
+  l <- qs::qload(fileCbindStudyIndividual)
   
   tmat <- l$tmat
   ev1 <- l$ev1

--- a/tests/testthat/test-cmt-order.R
+++ b/tests/testthat/test-cmt-order.R
@@ -1,6 +1,6 @@
-filePath <- test_path("warfarin.qs")
-skip_if_not(file.exists(filePath))
-warfarin <- qs::qread(filePath)
+fileWarfarin <- test_path("warfarin.qs")
+skip_if_not(file.exists(fileWarfarin))
+warfarin <- qs::qread(fileWarfarin)
 
 test_that("cmt() syntax makes sense", {
   mod <- rxode2({

--- a/tests/testthat/test-etTrans.R
+++ b/tests/testthat/test-etTrans.R
@@ -192,24 +192,17 @@ d/dt(blood)     = a*intestine - b*blood
     d/dt(Rest_of_Body) = QRB * (Arterial_Blood/VAB - Rest_of_Body/KbRB/VRB)")
   
   
-  et1 <- test_path("etTrans1.qs")
-  
-  if (file.exists(et1)) {
-    
+  test_that("strange rate doesn't affect model", {
+    et1 <- test_path("etTrans1.qs")
+    skip_if_not(file.exists(et1))
     dat <- qs::qread(et1)
-    
-    test_that("strange rate doesn't affect model", {
-      expect_false(any(etTrans(dat, mod)$AMT < 0, na.rm = TRUE))
-    })
-    
-  }
+    expect_false(any(etTrans(dat, mod)$AMT < 0, na.rm = TRUE))
+  })
   
-  t <- test_path("theoSd.qs")
-  
-  if (file.exists(t)) {
-    theoSd <- qs::qread(t)
-    
-    
+  test_that("Missing evid gives the same results", {
+    fileTheo <- test_path("theoSd.qs")
+    skip_if_not(file.exists(fileTheo))
+    theoSd <- qs::qread(fileTheo)
     d <- theoSd[, names(theoSd) != "EVID"]
     
     mod <- rxode2({
@@ -222,17 +215,13 @@ d/dt(blood)     = a*intestine - b*blood
     t1 <- etTrans(theoSd, mod)
     t2 <- etTrans(d, mod)
     
-    test_that("Missing evid gives the same results", {
-      expect_equal(t1$ID, t2$ID)
-      expect_equal(t1$TIME, t2$TIME)
-      expect_equal(t1$EVID, t2$EVID)
-      expect_equal(t1$AMT, t2$AMT)
-      expect_equal(t1$II, t2$II)
-      expect_equal(t1$DV, t2$DV)
-    })
-    
-  }
-  
+    expect_equal(t1$ID, t2$ID)
+    expect_equal(t1$TIME, t2$TIME)
+    expect_equal(t1$EVID, t2$EVID)
+    expect_equal(t1$AMT, t2$AMT)
+    expect_equal(t1$II, t2$II)
+    expect_equal(t1$DV, t2$DV)
+  })
   
   ## Test non-standard inputs
   tmp <- as.data.frame(et() %>% et(amt = 3, time = 0.24, evid = 4))
@@ -644,10 +633,9 @@ d/dt(blood)     = a*intestine - b*blood
     expect_equal(levels(tmp$ID), lvls)
   })
   
-  qs <- test_path("warfarin.qs")
-  
-  if (file.exists(qs)) {
-    
+  test_that("warfarin model", {
+    qs <- test_path("warfarin.qs")
+    skip_if_not(file.exists(qs))
     warfarin <- qs::qread(qs)
     
     mod <- rxode2({
@@ -710,5 +698,5 @@ d/dt(blood)     = a*intestine - b*blood
     
     expect_equal(as.double((t$sex == "male") * 1), t$sm)
     expect_equal(as.double((t$sex == "female") * 1), t$sf)
-  }
+  })
 }

--- a/tests/testthat/test-idFactor.R
+++ b/tests/testthat/test-idFactor.R
@@ -1,5 +1,5 @@
 test_that("simple solving with ID(s) in the dataset", {
-  skip_if(!file.exists(test_path("theoSd.qs")))
+  skip_if_not(file.exists(test_path("theoSd.qs")))
   theoSd <- qs::qread(test_path("theoSd.qs"))
   d <- theoSd[, names(theoSd) != "EVID"]
   d <- d[d$ID != 10, ]
@@ -35,7 +35,7 @@ test_that("simple solving with ID(s) in the dataset", {
 })
 
 test_that("Test giving IDs to data-frames", {
-  skip_if(!file.exists(test_path("theoSd.qs")))
+  skip_if_not(file.exists(test_path("theoSd.qs")))
   d <- qs::qread(test_path("theoSd.qs"))
   d$ID <- paste(d$ID)
   
@@ -80,7 +80,7 @@ test_that("Test giving IDs to data-frames", {
   
   ## Now add an id to the dataset
   
-  skip_if(!file.exists(test_path("theoSd.qs")))
+  skip_if_not(file.exists(test_path("theoSd.qs")))
   d <- qs::qread(test_path("theoSd.qs"))
   d$ID <- paste(d$ID)
   
@@ -102,7 +102,7 @@ test_that("Test giving IDs to data-frames", {
   expect_equal(levels(tmp2$id), levels(tmp2$params$id))
   
   ## Now try letters
-  skip_if(!file.exists(test_path("theoSd.qs")))
+  skip_if_not(file.exists(test_path("theoSd.qs")))
   d <- qs::qread(test_path("theoSd.qs"))
   d$ID <- letters[d$ID]
   
@@ -150,7 +150,7 @@ test_that("Test giving IDs to data-frames", {
 })
 
 test_that("test iCov ID", {
-  skip_if(!file.exists(test_path("theoSd.qs")))
+  skip_if_not(file.exists(test_path("theoSd.qs")))
   d <- qs::qread(test_path("theoSd.qs"))
   d$ID <- paste(d$ID)
   
@@ -197,7 +197,7 @@ test_that("test iCov ID", {
   
   ## Now add an id to the dataset
   
-  skip_if(!file.exists(test_path("theoSd.qs")))
+  skip_if_not(file.exists(test_path("theoSd.qs")))
   d <- qs::qread(test_path("theoSd.qs"))
   d$ID <- paste(d$ID)
   d <- d[, names(d) != "WT"]
@@ -217,7 +217,7 @@ test_that("test iCov ID", {
   expect_equal(tmp2$cwt, tmp2$wt)
   
   ## Now try letters
-  skip_if(!file.exists(test_path("theoSd.qs")))
+  skip_if_not(file.exists(test_path("theoSd.qs")))
   d <- qs::qread(test_path("theoSd.qs"))
   
   d <- d[, names(d) != "WT"]
@@ -255,7 +255,7 @@ test_that("test iCov ID", {
 })
 
 test_that("id is retained as an integer", {
-  skip_if(!file.exists(test_path("theoSd.qs")))
+  skip_if_not(file.exists(test_path("theoSd.qs")))
   theoSd <- qs::qread(test_path("theoSd.qs"))
   
   d <- theoSd[, names(theoSd) != "EVID"]

--- a/tests/testthat/test-mdv.R
+++ b/tests/testthat/test-mdv.R
@@ -1,5 +1,5 @@
 test_that("mdv means EVID=2 when amt=0", {
-  skip_if(!file.exists(test_path("theoSd.qs")))
+  skip_if_not(file.exists(test_path("theoSd.qs")))
   theoSd <- qs::qread(test_path("theoSd.qs"))
   
   d <- theoSd[, names(theoSd) != "EVID"]

--- a/tests/testthat/test-par-solve.R
+++ b/tests/testthat/test-par-solve.R
@@ -238,7 +238,7 @@ for (meth in c("dop853", "liblsoda", "lsoda")) {
 
 test_that("Can solve the system.", {
   ## Now Try multi-subject data.
-  skip_if(!file.exists(test_path("test-data-setup.qs")))
+  skip_if_not(file.exists(test_path("test-data-setup.qs")))
   dat <- qs::qread(test_path("test-data-setup.qs"))
   
   pk7a <-

--- a/tests/testthat/test-rxIs.R
+++ b/tests/testthat/test-rxIs.R
@@ -1,5 +1,5 @@
 test_that("rxIs tests", {
-  skip_if(!file.exists(test_path("test-data-setup.qs")))
+  skip_if_not(file.exists(test_path("test-data-setup.qs")))
   dat <- qs::qread(test_path("test-data-setup.qs"))
   dat <- tibble::as_tibble(dat)
   expect_true(rxIs(dat, "data.frame"))

--- a/tests/testthat/test-rxode-issue-430.R
+++ b/tests/testthat/test-rxode-issue-430.R
@@ -1,5 +1,5 @@
 test_that("rxode2 threading doesn't disturb some solves; Issue RxODE#430", {
-  skip_if(!file.exists("test-issue-430.qs"))
+  skip_if_not(file.exists("test-issue-430.qs"))
   
   model <- rxode2({
     KA <- THETA_KA * exp(ETA_KA)


### PR DESCRIPTION
Some tests were skipped using `if (file.exists(...))` making the skip silent.  This switches to using `skip_if_not(file.exists(...))` throughout to make file skips clearer.  It also tries to give the file variables unique names so that a skipped test is immediately findable.