### PR TITLE
make lotri calls work when the package isn't loaded

### DIFF
--- a/R/piping-ini.R
+++ b/R/piping-ini.R
@@ -333,13 +333,13 @@
     .rhs <- expr[[2]]
     if (length(.rhs) > 1) {
       if (identical(.rhs[[1]], quote(`+`))) {
-        .iniHandleLotriMatrix(eval(as.call(list(quote(`lotri`), as.call(list(quote(`{`), expr)))),
+        .iniHandleLotriMatrix(eval(as.call(list(quote(`lotri::lotri`), as.call(list(quote(`{`), expr)))),
                                    envir=envir),
                               rxui)
         return(invisible())
       }
     }
-    expr[[3]] <- eval(as.call(list(quote(`lotri`), as.call(list(quote(`{`), expr)))),
+    expr[[3]] <- eval(as.call(list(quote(`lotri::lotri`), as.call(list(quote(`{`), expr)))),
                       envir=envir)[1, 1]
     .iniHandleFixOrUnfixEqual(expr=expr, rxui=rxui, envir=envir, maxLen=1L)
   }

--- a/R/ui.R
+++ b/R/ui.R
@@ -185,7 +185,7 @@
 #' @export
 ini <- function(x, ..., envir = parent.frame()) {
   if (is(substitute(x), "{")) {
-    .ini <- eval(bquote(lotri(.(substitute(x)))), envir=envir)
+    .ini <- eval(bquote(lotri::lotri(.(substitute(x)))), envir=envir)
     assignInMyNamespace(".lastIni", .ini)
     assignInMyNamespace(".lastIniQ", bquote(.(substitute(x))))
     return(invisible(.ini))


### PR DESCRIPTION
This should fix #277

Generally, it calls directly to lotri in the lotri package which will work even when it is not loaded.