### PR TITLE
Skip tests if the units library is not installed

### DIFF
--- a/tests/testthat/test-alag.R
+++ b/tests/testthat/test-alag.R
@@ -19,6 +19,7 @@ rxTest({
 
   ms <- c("liblsoda", "lsoda", "dop853")
   for (m in ms) {
+    skip_if_not_installed("units")
     obs <- units::set_units(seq(0, 10, by = 1 / 24), "days")
 
     et <- eventTable(time.units = "days")


### PR DESCRIPTION
I was running the tests on a different system than normal, and this was an error because the units library was not installed.