### PR TITLE
Don't show warnings for directory creation

### DIFF
--- a/R/genShinyApp.template.R
+++ b/R/genShinyApp.template.R
@@ -90,7 +90,7 @@ genShinyApp.template <-
       )
     }
     if (!file.exists(appDir)) {
-      dir.create(appDir, recursive = TRUE)
+      dir.create(appDir, recursive = TRUE, showWarnings = FALSE)
     }
     # if(.Platform$OS.type=="windows") appDir <- gsub("\\\\", "/", utils::shortPathName(.normalizePath(appDir)))  # safe pathname
 

--- a/R/modlib.R
+++ b/R/modlib.R
@@ -187,7 +187,7 @@ rxUse <- function(obj, overwrite = TRUE, compress = "bzip2",
       }
     }
     if (!dir.exists(devtools::package_file("src"))) {
-      dir.create(devtools::package_file("src"), recursive = TRUE)
+      dir.create(devtools::package_file("src"), recursive = TRUE, showWarnings = FALSE)
     }
     .pkg <- basename(usethis::proj_get())
     .rx <- loadNamespace("rxode2")

--- a/R/rxode-options.R
+++ b/R/rxode-options.R
@@ -66,7 +66,7 @@
   } else {
     assignInMyNamespace(".hasUnits", FALSE)
   }
-  backports::import(pkgname) 
+  backports::import(pkgname)
   ## Setup rxode2.prefer.tbl
   .Call(`_rxode2_setRstudio`, Sys.getenv("RSTUDIO") == "1")
   rxSyncOptions("permissive")
@@ -116,11 +116,11 @@
 
 .mkCache <- function(.tmp) {
   if (!file.exists(.tmp)) {
-    dir.create(.tmp, recursive = TRUE)
+    dir.create(.tmp, recursive = TRUE, showWarnings = FALSE)
   } else if (!file.exists(file.path(.tmp, paste0(rxode2.md5, ".md5")))) {
     if (!.cacheIsTemp) packageStartupMessage("detected new version of rxode2, cleaning cache")
     unlink(.tmp, recursive = TRUE, force = TRUE)
-    dir.create(.tmp, recursive = TRUE)
+    dir.create(.tmp, recursive = TRUE, showWarnings = FALSE)
     writeLines("rxode2", file.path(.tmp, paste0(rxode2.md5, ".md5")))
   }
 }

--- a/R/rxode2.R
+++ b/R/rxode2.R
@@ -440,7 +440,7 @@ rxode2 <- # nolint
     }
 
     if (!file.exists(wd)) {
-      dir.create(wd, recursive = TRUE)
+      dir.create(wd, recursive = TRUE, showWarnings = FALSE)
     }
 
     .env$modName <- modName
@@ -460,7 +460,7 @@ rxode2 <- # nolint
       with(.(.env), {
         .rx <- base::loadNamespace("rxode2")
         if (!file.exists(wd)) {
-          dir.create(wd, recursive = TRUE)
+          dir.create(wd, recursive = TRUE, showWarnings = FALSE)
         }
         on.exit({
           .rx$.clearME()
@@ -1321,7 +1321,7 @@ rxCompile <- function(model, dir, prefix, force = FALSE, modName = NULL,
     .include <- .normalizePath(file.path(.cache, "include"))
     if (!dir.exists(.include)) {
       .malert("creating rxode2 include directory")
-      dir.create(.include, recursive = TRUE)
+      dir.create(.include, recursive = TRUE, showWarnings = FALSE)
       .sysInclude <- system.file("include", package = "rxode2")
       .files <- list.files(.parseInclude)
       lapply(.files, function(file) {
@@ -1344,7 +1344,7 @@ rxCompile <- function(model, dir, prefix, force = FALSE, modName = NULL,
       .malert("precompiling headers")
       .args <- paste0(
         .cc, " -I", gsub("[\\]", "/", .normalizePath(R.home("include"))), " ",
-        " -I\"", .normalizePath(.parseInclude), "\" ", 
+        " -I\"", .normalizePath(.parseInclude), "\" ",
         .cflags, " ", .shlibCflags, " ", .cpicflags, " -I", gsub("[\\]", "/", .normalizePath(.include)), " ",
         paste(gsub("[\\]", "/", .normalizePath(.include)), "rxode2_model_shared.h", sep = "/"),
         ""
@@ -1392,7 +1392,7 @@ rxCompile.rxModelVars <- function(model, # Model
   }
   .dir <- suppressMessages(.normalizePath(.dir, mustWork = FALSE))
   if (!file.exists(.dir)) {
-    dir.create(.dir, recursive = TRUE)
+    dir.create(.dir, recursive = TRUE, showWarnings = FALSE)
     writeLines("rxode2", file.path(.dir, paste0(rxode2.md5, ".md5")))
   }
 

--- a/src/install.libs.R
+++ b/src/install.libs.R
@@ -1,17 +1,18 @@
 ## Similar to default behavior according to R extension manual
 files <- Sys.glob(paste0("*", SHLIB_EXT))
 dest <- file.path(R_PACKAGE_DIR, paste0('libs', R_ARCH))
-dir.create(dest, recursive = TRUE, showWarnings = FALSE)
+dir.create(dest, recursive = TRUE, showWarnings = FALSE, showWarnings = FALSE)
 file.copy(files, dest, overwrite = TRUE)
 ## for (f in files)
 ##     file.copy(f,file.path(dest,paste0("lib",f)),overwrite = TRUE)
-if(file.exists("symbols.rds"))
+if(file.exists("symbols.rds")) {
     file.copy("symbols.rds", dest, overwrite = TRUE)
+}
 
 ## Add headers
 incl <- file.path(R_PACKAGE_DIR, "include")
 headers <- c(Sys.glob("*.h"), Sys.glob("*.h.gch"))
-if (any(file.exists(headers))){
-    dir.create(incl,recursive=TRUE,showWarnings = FALSE)
-    file.copy(headers,incl,overwrite=TRUE)
+if (any(file.exists(headers))) {
+    dir.create(incl, recursive = TRUE, showWarnings = FALSE)
+    file.copy(headers, incl, overwrite = TRUE)
 }

--- a/src/install.libs.R
+++ b/src/install.libs.R
@@ -1,7 +1,7 @@
 ## Similar to default behavior according to R extension manual
 files <- Sys.glob(paste0("*", SHLIB_EXT))
 dest <- file.path(R_PACKAGE_DIR, paste0('libs', R_ARCH))
-dir.create(dest, recursive = TRUE, showWarnings = FALSE, showWarnings = FALSE)
+dir.create(dest, recursive = TRUE, showWarnings = FALSE)
 file.copy(files, dest, overwrite = TRUE)
 ## for (f in files)
 ##     file.copy(f,file.path(dest,paste0("lib",f)),overwrite = TRUE)

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -1,26 +1,26 @@
 rxTest({
   withr::with_tempdir({
     test.dir <- tempfile("Rx_base-")
-    dir.create(test.dir)
+    dir.create(test.dir, showWarnings = FALSE)
     ode <- "d/dt(y) = r * y * (1.0 - y/K);"
     fn <- file.path(test.dir, "exam3.1.txt")
     writeLines(ode, fn)
-    
+
     m1 <- rxode2(model = ode, modName = "m1")
-    
+
     test_that("ODE inside a string", {
       expect_s3_class(m1, "rxode2")
     })
-    
+
     m2 <- rxode2(filename = fn, modName = "f1")
     test_that("ODE inside a text file", {
       expect_s3_class(m2, "rxode2")
     })
-    
+
     test_that("arguments model= and filename= are mutually exclusive.", {
       expect_error(rxode2(model = ode, filename = fn), "must specify exactly one of 'model' or 'filename'")
     })
-    
+
     unlink(test.dir, recursive = TRUE)
   })
 })


### PR DESCRIPTION
I saw an unnecessary warning for directory creation, so I removed all dir.create() warnings.  I think that this just makes it quieter without changing functionality.