### PR TITLE
Correct default option for append in documentation (no code changes)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -110,7 +110,7 @@ NeedsCompilation: yes
 VignetteBuilder: knitr
 License: GPL (>= 3) 
 URL: https://nlmixr2.github.io/rxode2/, https://github.com/nlmixr2/rxode2/
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2
 Biarch: true
 LinkingTo: 
     rxode2parse (>= 2.0.12),

--- a/R/ui.R
+++ b/R/ui.R
@@ -209,8 +209,8 @@ ini.default <- function(x, ...) {
 #' @param append This is a boolean to determine if the lines are
 #'   appended in piping.  The possible values for this is:
 #'
-#'  - `TRUE` which is when the lines are appended to the model instead of replaced (default)
-#'  - `FALSE` when the lines are replaced in the model
+#'  - `TRUE` which is when the lines are appended to the model instead of replaced
+#'  - `FALSE` when the lines are replaced in the model (default)
 #'  - `NA` is when the lines are pre-pended to the model instead of replaced
 #'
 #' @param auto This boolean tells if piping automatically selects the
@@ -345,11 +345,11 @@ print.rxUi <-function(x, ...) {
 }
 #' Compress/Decompress `rxode2` ui
 #'
-#' 
+#'
 #' @param ui rxode2 ui object
 #' @return A compressed or decompressed rxui object
 #' @author Matthew L. Fidler
-#' @export 
+#' @export
 #' @examples
 #'   one.cmt <- function() {
 #'    ini({
@@ -376,7 +376,7 @@ print.rxUi <-function(x, ...) {
 #' f <- rxode2(one.cmt)
 #' print(class(f))
 #' print(is.environment(f))
-#' 
+#'
 #' f  <- rxUiDecompress(f)
 #' print(class(f))
 #' print(is.environment(f))

--- a/man/dot-modelHandleModelLines.Rd
+++ b/man/dot-modelHandleModelLines.Rd
@@ -23,8 +23,8 @@
 \item{append}{This is a boolean to determine if the lines are
 appended in piping.  The possible values for this is:
 \itemize{
-\item \code{TRUE} which is when the lines are appended to the model instead of replaced (default)
-\item \code{FALSE} when the lines are replaced in the model
+\item \code{TRUE} which is when the lines are appended to the model instead of replaced
+\item \code{FALSE} when the lines are replaced in the model (default)
 \item \code{NA} is when the lines are pre-pended to the model instead of replaced
 }}
 

--- a/man/model.Rd
+++ b/man/model.Rd
@@ -35,8 +35,8 @@ model(
 \item{append}{This is a boolean to determine if the lines are
 appended in piping.  The possible values for this is:
 \itemize{
-\item \code{TRUE} which is when the lines are appended to the model instead of replaced (default)
-\item \code{FALSE} when the lines are replaced in the model
+\item \code{TRUE} which is when the lines are appended to the model instead of replaced
+\item \code{FALSE} when the lines are replaced in the model (default)
 \item \code{NA} is when the lines are pre-pended to the model instead of replaced
 }}
 


### PR DESCRIPTION
The default value for append is FALSE.  This corrects the documentation to reflect that.  (Another option would be to remove the "(default)" text since it's already in the function call above.)