### PR TITLE
Switch to arma_cerr_stream<T>

### DIFF
--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -326,7 +326,7 @@ extern "C" int indLin(int cSub, rx_solving_options *op, double tp, double *yp_, 
   // double phiTol=op->indLinPhiTol;
   // double phiAnorm = op->indLinPhiAnorm;
   std::ostream nullstream(0);
-  arma::set_cerr_stream(nullstream);
+  arma::arma_cerr_stream<char>(&nullstream);
   
   int locf=(op->is_locf!=2);
   double tcov = tf;


### PR DESCRIPTION
Armadillo updates its coding convention over time. We have been fairly hard at work to have RcppArmadillo-using packages switch from a now-deprecated older way of instantiatig variables to a newer one (see [issue #391](https://github.com/RcppCore/RcppArmadillo/issues/391) for details; this PR is part of the related [issue #402](https://github.com/RcppCore/RcppArmadillo/issues/402)).

When compiling packages using RcppArmadillo with the deprecation-warning-suppressor we still use, some new warnings come up. One concerns a deprecated way of setting an output or error stream as your package does in one spot in one file. Changing this is fairly straightforward, and affects only that one file.

The package compiles with the change as it did before; I could not test it as it didn't want to load in the quick check I made.  I trust that this is minor as the PR change is.

It would be much appreciated if you could apply this pull request and update the package at CRAN within the next few months. Let me know if you have any questions.