### PR TITLE
Handle more input types (character and formula) for ini() piping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,10 @@
 - Parameter order may be modified via the `append` argument to `ini()` when
   piping a model.  For example, `ini(param = 1, append = 0)` or
   `ini(param = label("text"), append = "param2")` (#352).
+  
+- Internal handling of `ini()` piping handles more input types including
+  character strings and formula, and it gives a clear error if no change is made
+  (#439)
 
 # rxode2 2.0.11
 

--- a/tests/testthat/test-piping-ini.R
+++ b/tests/testthat/test-piping-ini.R
@@ -289,3 +289,44 @@ test_that(".iniHandleAppend", {
     regexp = "only theta parameters can be moved"
   )
 })
+
+test_that(".iniHandleLineCleanup", {
+  expect_equal(
+    .iniHandleLineCleanup(str2lang("A")),
+    str2lang("A")
+  )
+  expect_equal(
+    .iniHandleLineCleanup(str2lang("A <- B")),
+    str2lang("A <- B")
+  )
+  expect_equal(
+    .iniHandleLineCleanup("A <- B"),
+    str2lang("A <- B")
+  )
+  expect_equal(
+    .iniHandleLineCleanup("A = B"),
+    str2lang("A <- B")
+  )
+  # formula are converted to language objects
+  expect_equal(
+    .iniHandleLineCleanup(a~b),
+    str2lang("a~b")
+  )
+
+  # Multi-line parsing does not work (str2lang fails)
+  expect_error(
+    .iniHandleLineCleanup("A <- B; C <- D"),
+    regexp = "cannot convert to a usable expression: 'A <- B; C <- D'; Error",
+    fixed = TRUE
+  )
+  # vectorized input does not work
+  expect_error(
+    .iniHandleLineCleanup(c("A <- B", "C <- D"))
+  )
+  # Unsupported inputs do not work
+  expect_error(
+    .iniHandleLineCleanup(factor("A")),
+    regexp = "invalid expr for ini() modification",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
Fix #439

This will handle character and formula inputs for `ini()` piping.