### PR TITLE
Allow append to work with parameter promotion

### DIFF
--- a/R/piping-ini.R
+++ b/R/piping-ini.R
@@ -433,9 +433,6 @@
          call. = FALSE)
   }
 
-  # (Maybe) update parameter order
-  .iniHandleAppend(expr = expr, rxui = rxui, envir = envir, append = append)
-
   # Convert fix(name) or unfix(name) to name <- fix or name <- unfix
   if (.matchesLangTemplate(expr, str2lang("fix(.name)"))) {
     expr <- as.call(list(quote(`<-`), expr[[2]], quote(`fix`)))
@@ -473,6 +470,10 @@
     # that is not a character string.
     stop("invalid expr for ini() modification", call.=FALSE)
   }
+
+  # (Maybe) update parameter order; this must be at the end so that the
+  # parameter exists in case it is promoted from a covariate
+  .iniHandleAppend(expr = expr, rxui = rxui, envir = envir, append = append)
 }
 
 # TODO: while nlmixr2est is changed

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -82,3 +82,4 @@ below to see their documentation.
   \item{rxode2random}{\code{\link[rxode2random:dot-cbindOme]{.cbindOme}}, \code{\link[rxode2random:dot-expandPars]{.expandPars}}, \code{\link[rxode2random:dot-vecDf]{.vecDf}}, \code{\link[rxode2random]{cvPost}}, \code{\link[rxode2random]{invWR1d}}, \code{\link[rxode2random]{phi}}, \code{\link[rxode2random]{rinvchisq}}, \code{\link[rxode2random]{rLKJ1}}, \code{\link[rxode2random]{rxGetSeed}}, \code{\link[rxode2random]{rxGetSeed}}, \code{\link[rxode2random]{rxRmvn}}, \code{\link[rxode2random]{rxSeedEng}}, \code{\link[rxode2random]{rxSetSeed}}, \code{\link[rxode2random]{rxSetSeed}}, \code{\link[rxode2random]{rxSetSeed}}, \code{\link[rxode2random:rxWithSeed]{rxWithPreserveSeed}}, \code{\link[rxode2random]{rxWithSeed}}, \code{\link[rxode2random]{rxWithSeed}}}
 }}
 
+\value{ Inherited from parent routine }

--- a/tests/testthat/test-piping-ini.R
+++ b/tests/testthat/test-piping-ini.R
@@ -508,3 +508,40 @@ test_that("Piping outside the boundaries", {
     expect_equal(f2$iniDf[f2$iniDf$name == "x3","upper"], Inf)
   })
 })
+
+test_that("append allows promoting from covariate (#472)", {
+  mod <- function() {
+    ini({
+      lka <- 0.45
+      lcl <- 1
+      lvc  <- 3.45
+      propSd <- 0.5
+    })
+    model({
+      ka <- exp(lka)
+      cl <- exp(lcl)
+      vc  <- exp(lvc)
+
+      kel <- cl / vc
+
+      d/dt(depot) <- -ka*depot
+      d/dt(central) <- ka*depot-kel*central
+
+      cp <- central / vc
+      cp ~ prop(propSd)
+    })
+  }
+  suppressMessages(
+    newmod <-
+      mod %>%
+      model(
+        ka <- exp(lka + ka_dose*DOSE),
+        auto = FALSE
+      ) %>%
+      ini(
+        ka_dose <- 1,
+        append = "lka"
+      )
+  )
+  expect_equal(newmod$iniDf$name, c("lka", "ka_dose", "lcl", "lvc", "propSd"))
+})


### PR DESCRIPTION
Fix #472

The order of the `.iniHandleLine()` function needed the append code to be at the end of line handling.