### PR TITLE
Warn for empty arguments to rxRename (and anything using `.quoteCallInfoLines()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rxode2 (development version)
 
+## New feaures
+
+- Empty arguments to `rxRename()` give a warning (#688)
+
 # rxode2 2.1.3
 
 ## Bug fixes

--- a/R/piping.R
+++ b/R/piping.R
@@ -284,7 +284,11 @@
       }
     }
     .quoted <- eval(call("quote", callInfo[[i]]))
-    if (length(.quoted) == 1) {
+    if (missing(.quoted)) {
+      # Capture empty arguments (rxode2#688)
+      warning("empty argument ignored")
+      return(NULL)
+    } else if (length(.quoted) == 1) {
       .bracket[i] <- TRUE
       assign(".bracket", .bracket, envir=.env)
     } else if (identical(.quoted[[1]], quote(`{`)) ||

--- a/tests/testthat/test-piping-ini.R
+++ b/tests/testthat/test-piping-ini.R
@@ -826,3 +826,23 @@ if (!.Call(`_rxode2_isIntel`)) {
 
   })
 }
+
+test_that("empty arguments to rxRename() give a warning (#688)", {
+  mod1 <- function() {
+    ini({
+      Kin=1
+    })
+    model({
+      eff <- Kin
+    })
+  }
+
+  expect_warning(
+    rxRename(mod1, ),
+    "empty argument ignored"
+  )
+  expect_warning(
+    rxRename(mod1, foo = eff, ),
+    "empty argument ignored"
+  )
+})


### PR DESCRIPTION
Fix #688