### PR TITLE
parameters can be promoted from covariate to parameter with bounds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rxode2 (development version)
 
+## New feaures
+
+- Empty arguments to `rxRename()` give a warning (#688)
+
 # rxode2 2.1.3
 
 ## Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 ## New feaures
 
 - Empty arguments to `rxRename()` give a warning (#688)
+- Promoting from covariates to parameters with model piping (via `ini()`) now
+  allows setting bounds (#692)
 
 # rxode2 2.1.3
 

--- a/R/piping-model.R
+++ b/R/piping-model.R
@@ -935,6 +935,11 @@ rxSetCovariateNamesForPiping <- function(covariates=NULL) {
     } else if (toEta) {
       checkmate::assertNumeric(value, len=1, any.missing=TRUE)
     } else {
+      if (length(value) %in% c(2, 3)) {
+        # This is for promotion to parameter, only.  Additional bound setting
+        # happens elsewhere.
+        value <- value[2]
+      }
       checkmate::assertNumeric(value, len=1, any.missing=FALSE)
     }
   } else {

--- a/R/piping.R
+++ b/R/piping.R
@@ -284,7 +284,11 @@
       }
     }
     .quoted <- eval(call("quote", callInfo[[i]]))
-    if (length(.quoted) == 1) {
+    if (missing(.quoted)) {
+      # Capture empty arguments (rxode2#688)
+      warning("empty argument ignored")
+      return(NULL)
+    } else if (length(.quoted) == 1) {
       .bracket[i] <- TRUE
       assign(".bracket", .bracket, envir=.env)
     } else if (identical(.quoted[[1]], quote(`{`)) ||

--- a/tests/testthat/test-piping-ini.R
+++ b/tests/testthat/test-piping-ini.R
@@ -826,3 +826,23 @@ if (!.Call(`_rxode2_isIntel`)) {
 
   })
 }
+
+test_that("empty arguments to rxRename() give a warning (#688)", {
+  mod1 <- function() {
+    ini({
+      Kin=1
+    })
+    model({
+      eff <- Kin
+    })
+  }
+
+  expect_warning(
+    rxRename(mod1, ),
+    "empty argument ignored"
+  )
+  expect_warning(
+    rxRename(mod1, foo = eff, ),
+    "empty argument ignored"
+  )
+})

--- a/tests/testthat/test-piping-ini.R
+++ b/tests/testthat/test-piping-ini.R
@@ -846,3 +846,32 @@ test_that("empty arguments to rxRename() give a warning (#688)", {
     "empty argument ignored"
   )
 })
+
+test_that("parameters can be promoted from covariate to parameter with bounds (#692)", {
+  mod1 <- function() {
+    model({
+      eff <- Kin
+    })
+  }
+
+  expect_message(
+    mod1 %>% ini(Kin = 2),
+    "promote `Kin` to population parameter with initial estimate 2"
+  )
+  expect_message(
+    expect_message(
+      mod1 %>% ini(Kin = c(1, 2)),
+      "promote `Kin` to population parameter with initial estimate 2"
+    ),
+    regexp = "change initial estimate (2) and lower bound (1) of `Kin`",
+    fixed = TRUE
+  )
+  expect_message(
+    expect_message(
+      mod1 %>% ini(Kin = c(1, 2, 3)),
+      "promote `Kin` to population parameter with initial estimate 2"
+    ),
+    regexp = "change initial estimate (2) and upper/lower bound (1 to 3) of `Kin`",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
This is on top of #693 because changes were made to the same files.

fix #692 