### PR TITLE
With backward compatibility tests subscript of range warning

### DIFF
--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -4896,7 +4896,12 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
       rxSolveDat->mv = rxModelVars(object);
       rxSolveFreeObj = object;
     }
-  } else if (rxSolveDat->mv.size() == 0) {
+  }
+  if (rxSolveDat->mv.size() == 0) {
+    // sometimes the model variables have not been assigned, but this
+    // needs to be assigned to set the user defined functions
+    // this is shown indirectly in the backward compatible testing
+    // where the subscript wasn't defined;  See #750
     rxSolveDat->mv = rxModelVars(object);
   }
   _rxode2_udfEnvSet(rxSolveDat->mv[RxMv_udf]);

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -4896,8 +4896,9 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
       rxSolveDat->mv = rxModelVars(object);
       rxSolveFreeObj = object;
     }
+  } else if (rxSolveDat->mv.size() == 0) {
+    rxSolveDat->mv = rxModelVars(object);
   }
-
   _rxode2_udfEnvSet(rxSolveDat->mv[RxMv_udf]);
   LogicalVector recompileUdf = _rxode2_assignUdf(rxSolveDat->mv[RxMv_udf]);
 

--- a/tests/testthat/test-backward.R
+++ b/tests/testthat/test-backward.R
@@ -173,7 +173,7 @@ expect_error(rxode2("cp<-cent/vc;d/dt(gutcp)<--ka*gutcp;d/dt(cent)<-(ka*gutcp)-q
       expect_equal(as.numeric(tmp$time[2]), 0.5)
       expect_equal(as.numeric(x$time[2]), 1)
       ## $ access updates object.
-      x$add.sampling(0.5)
+      expect_warning(x$add.sampling(0.5), NA) # from issue #750
       expect_equal(as.numeric(x$time[2]), 0.5)
     })
     x <- solve(mod1, theta, ev, inits)


### PR DESCRIPTION
Not sure when introduced, but with the backward compatibility testing
now gives the following warning:

``` r
Warning (test-backward.R:176:7): Add sampling makes sense
subscript out of bounds (index 20 >= vector size 0)
Backtrace:
    ▆
 1. └─x$add.sampling(0.5) at test-backward.R:176:7
 2.   ├─rxode2::rxSolve(.args.object, events = .et, updateObject = TRUE)
 3.   └─rxode2:::rxSolve.default(.args.object, events = .et, updateObject = TRUE) at rxode2/R/rxsolve.R:1135:3
 4.     └─base::lapply(.ws, function(x) warning(x, call. = FALSE)) at rxode2/R/rxsolve.R:1799:3
 5.       └─rxode2 (local) FUN(X[[i]], ...)

Warning (test-backward.R:185:7): Add dosing makes sense
subscript out of bounds (index 20 >= vector size 0)
Backtrace:
    ▆
 1. └─x$add.dosing(0.5) at test-backward.R:185:7
 2.   ├─rxode2::rxSolve(.args.object, events = .newEt, updateObject = TRUE)
 3.   └─rxode2:::rxSolve.default(.args.object, events = .newEt, updateObject = TRUE) at rxode2/R/rxsolve.R:1135:3
 4.     └─base::lapply(.ws, function(x) warning(x, call. = FALSE)) at rxode2/R/rxsolve.R:1799:3
 5.       └─rxode2 (local) FUN(X[[i]], ...)

Warning (test-backward.R:191:5): (code run outside of `test_that()`)
subscript out of bounds (index 20 >= vector size 0)
Backtrace:
    ▆
 1. ├─rxode2::rxTest(...) at test-backward.R:1:1
 2. │ └─base::force(type) at rxode2/R/rxValidate.R:22:5
 3. ├─base::`$<-`(`*tmp*`, t, value = `<dbl>`) at test-backward.R:191:5
 4. ├─rxode2:::`$<-.rxSolve`(`*tmp*`, t, value = `<dbl>`) at test-backward.R:191:5
 5. └─rxode2 (local) `<fn>`(`<dbl>`)
 6.   ├─rxode2::rxSolve(.args.object, events = .newEt, updateObject = TRUE)
 7.   └─rxode2:::rxSolve.default(.args.object, events = .newEt, updateObject = TRUE) at rxode2/R/rxsolve.R:1135:3
 8.     └─base::lapply(.ws, function(x) warning(x, call. = FALSE)) at rxode2/R/rxsolve.R:1799:3
 9.       └─rxode2 (local) FUN(X[[i]], ...)
```