### PR TITLE
Warning when declaring/using inappropriate interpolation (change to locf)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,9 @@
   forward, `nocb` which is the next observation carried backward, as
   well as `NA` which puts a `NA` in all imputed data rows. See #756.
 
+   - Note: when interpolation is linear/midpoint for
+     factors/characters it changes to locf with a warning (#759)
+
 - Now you can specify the interpolation method per covariate in the model:
 
   - `linear(var1, var2)` says both `var1` and `var2` would use linear

--- a/src/approx.c
+++ b/src/approx.c
@@ -254,7 +254,11 @@ void _update_par_ptr(double t, unsigned int id, rx_solve *rx, int idxIn) {
         idx = j;
       } else if (isSameTimeOp(v, getTime(ind->ix[i], ind))) {
         idx = i;
-      } else if (op->is_locf == 2) {
+      } else if (op->instant_backward == 0) {
+        // use instant_backward to change the idx too; it does not
+        // change based on covariate
+        // backward=0=locf
+        // backward=1=nocb
         // nocb
         idx = j;
       }  else {

--- a/tests/testthat/test-interp.R
+++ b/tests/testthat/test-interp.R
@@ -238,3 +238,157 @@ test_that("interp $simulationModel", {
 
 
 })
+
+
+test_that("time varying character/factors should not be interpolated by linear solving", {
+
+  f <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- log(c(0, 2.7, 100))
+      tv <- 3.45
+      eta.ka ~ 0.6
+      eta.cl ~ 0.3
+      eta.v ~ 0.1
+      tviov.cl <- c(0, 0.1)
+      iov.cl1 ~ fix(1)
+      iov.cl2 ~ fix(1)
+      add.sd <- 0.7
+    })
+    model({
+      iov.cl <- sqrt(tviov.cl) * ((OCC=="first") * iov.cl1 +
+                                    (OCC=="second") * iov.cl2)
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv + eta.v)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+
+  et <- et(amt=100) %>%
+    et(0:24) %>%
+    as.data.frame()
+
+  et$OCC  <- "first"
+  et$OCC[et$time > 12] <- "second"
+
+  f <- suppressWarnings(f()$simulationIniModel)
+  expect_warning(rxSolve(f, et, covsInterpolation="linear"))
+  expect_warning(rxSolve(f, et, covsInterpolation="nocb"), NA)
+  expect_warning(rxSolve(f, et, covsInterpolation="locf"), NA)
+  expect_warning(rxSolve(f, et, covsInterpolation="midpoint"))
+
+  f <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- log(c(0, 2.7, 100))
+      tv <- 3.45
+      eta.ka ~ 0.6
+      eta.cl ~ 0.3
+      eta.v ~ 0.1
+      tviov.cl <- c(0, 0.1)
+      iov.cl1 ~ fix(1)
+      iov.cl2 ~ fix(1)
+      add.sd <- 0.7
+    })
+    model({
+      midpoint(OCC)
+      iov.cl <- sqrt(tviov.cl) * ((OCC=="first") * iov.cl1 +
+                                    (OCC=="second") * iov.cl2)
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv + eta.v)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  f <- suppressWarnings(f()$simulationIniModel)
+
+  expect_warning(rxSolve(f, et))
+
+  f <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- log(c(0, 2.7, 100))
+      tv <- 3.45
+      eta.ka ~ 0.6
+      eta.cl ~ 0.3
+      eta.v ~ 0.1
+      tviov.cl <- c(0, 0.1)
+      iov.cl1 ~ fix(1)
+      iov.cl2 ~ fix(1)
+      add.sd <- 0.7
+    })
+    model({
+      linear(OCC)
+      iov.cl <- sqrt(tviov.cl) * ((OCC=="first") * iov.cl1 +
+                                    (OCC=="second") * iov.cl2)
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv + eta.v)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  f <- suppressWarnings(f()$simulationIniModel)
+
+  expect_warning(rxSolve(f, et))
+
+  f <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- log(c(0, 2.7, 100))
+      tv <- 3.45
+      eta.ka ~ 0.6
+      eta.cl ~ 0.3
+      eta.v ~ 0.1
+      tviov.cl <- c(0, 0.1)
+      iov.cl1 ~ fix(1)
+      iov.cl2 ~ fix(1)
+      add.sd <- 0.7
+    })
+    model({
+      nocb(OCC)
+      iov.cl <- sqrt(tviov.cl) * ((OCC=="first") * iov.cl1 +
+                                    (OCC=="second") * iov.cl2)
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv + eta.v)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  f <- suppressWarnings(f()$simulationIniModel)
+
+  expect_warning(rxSolve(f, et), NA)
+
+  f <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- log(c(0, 2.7, 100))
+      tv <- 3.45
+      eta.ka ~ 0.6
+      eta.cl ~ 0.3
+      eta.v ~ 0.1
+      tviov.cl <- c(0, 0.1)
+      iov.cl1 ~ fix(1)
+      iov.cl2 ~ fix(1)
+      add.sd <- 0.7
+    })
+    model({
+      locf(OCC)
+      iov.cl <- sqrt(tviov.cl) * ((OCC=="first") * iov.cl1 +
+                                    (OCC=="second") * iov.cl2)
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv + eta.v)
+      linCmt() ~ add(add.sd)
+    })
+  }
+
+  f <- suppressWarnings(f()$simulationIniModel)
+
+  expect_warning(rxSolve(f, et), NA)
+
+})


### PR DESCRIPTION
For characters and integer/factors, `linear()` and `midpoint()` do not
make sense.  These should warn and change to locf

