### PR TITLE
rxode2 cmt/linear and other interp interaction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -86,6 +86,10 @@
 - Fix when keeping data has `NA` values that it will not crash R; Also
   fixed some incorrect `NA` interpolations. See #756
 
+- When using `cmt()` sometimes the next statement would be corrupted
+  in the normalized syntax (like for instance `locf`); This bug was
+  fixed (#763)
+
 ## Big change
 
 - At the request of CRAN, combine `rxode2parse`, `rxode2random`, and

--- a/src/parseCmtProperties.h
+++ b/src/parseCmtProperties.h
@@ -71,11 +71,11 @@ static inline int handleCmtPropertyRate(nodeInfo ni, char *name, char *v) {
 }
 
 static inline int handleCmtPropertyCmtOrder(nodeInfo ni, char *name, char *v) {
-  if (nodeHas(cmt_statement)){
-    sb.o=0;sbDt.o=0; sbt.o=0;
-    sAppend(&sbt, "cmt(%s)", v);
-    sAppend(&sbNrm, "%s;\n", sbt.s);
-    addLine(&sbNrmL, "%s;\n", sbt.s);
+  if (nodeHas(cmt_statement)) {
+    sb.o=0; sbDt.o=0; sbt.o=0;
+    //sAppend(&sbt, "cmt(%s)", v);
+    sAppend(&sbNrm, "cmt(%s);\n", v);
+    addLine(&sbNrmL, "cmt(%s);\n", v);
     return 1;
   }
   return 0;

--- a/src/tran.h
+++ b/src/tran.h
@@ -274,7 +274,6 @@ extern sbuf sbOut;
 extern sbuf _gbuf, _mv;
 
 #define SBPTR sb.s+sb.o
-#define SBTPTR sbt.s+sbt.o
 #define NV tb.ss.n
 
 extern char *gBuf;

--- a/tests/testthat/test-parsing.R
+++ b/tests/testthat/test-parsing.R
@@ -1351,4 +1351,9 @@ mu = 1+bad ## nonstiff; 10 moderately stiff; 1000 stiff
     }
   })
 
+  test_that("cmt/locf interaction", {
+    expect_equal(rxNorm(rxModelVars("cmt(a);\nlocf(b);d/dt(a)=b*kel")),
+                 "cmt(a);\nlocf(b);\nd/dt(a)=b*kel;\n")
+  })
+
 })


### PR DESCRIPTION
``` r
message(rxode2::rxNorm(rxode2::rxModelVars("cmt(a);\nlocf(b);d/dt(a)=b*kel")))
#> cmt(a);
#> locfcmt(a)(b);
#> d/dt(a)=b*kel;
```

<sup>Created on 2024-08-10 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

`locfcmt(a)(b)` is not valid syntax and it should be `locf(b)`