### PR TITLE
string assign is too strict for use in `nlmixr2est`

### DIFF
--- a/src/parseCmtProperties.h
+++ b/src/parseCmtProperties.h
@@ -212,8 +212,8 @@ static inline int handleRemainingAssignmentsCalcPropComplexAssign(nodeInfo ni, c
             }
           }
         } else {
-          errorStrAssign(v);
-          return 0;
+          /* errorStrAssign(v); */
+          /* return 0; */
         }
       } else if (tb.lh[tb.ix] == notLHS){
         tb.lh[tb.ix] = isLHSparam;

--- a/src/parseCmtProperties.h
+++ b/src/parseCmtProperties.h
@@ -195,11 +195,11 @@ static inline int handleRemainingAssignmentsCalcPropComplexAssign(nodeInfo ni, c
       if (tb.lh[tb.ix] == isLHSstr ||
           tb.lh[tb.ix] == isSuppressedLHSstr) {
         D_ParseNode *xpn = d_get_child(pn, 2);
-        /* Free(v); */
         const char* v2 = (char*)rc_dup_str(xpn->start_loc.s, xpn->end);
         double d = 0.0;
         int nd = sscanf(v2, "%lf", &d);
         if (nd == 1) {
+          if (v2[0] == '-') return 1;
           if (round(d) != d) {
             errorStrAssign(v);
             return 0;
@@ -211,9 +211,6 @@ static inline int handleRemainingAssignmentsCalcPropComplexAssign(nodeInfo ni, c
               return 0;
             }
           }
-        } else {
-          /* errorStrAssign(v); */
-          /* return 0; */
         }
       } else if (tb.lh[tb.ix] == notLHS){
         tb.lh[tb.ix] = isLHSparam;

--- a/src/rxode2_df.cpp
+++ b/src/rxode2_df.cpp
@@ -710,11 +710,18 @@ extern "C" SEXP rxode2_df(int doDose0, int doTBS) {
           if (nlhs){
             for (j = 0; j < nlhs; j++){
               if (op->lhs_str[j] == 1) {
-                dfi = INTEGER(VECTOR_ELT(df, jj));
+                // factor; from string
+                IntegerVector cur = VECTOR_ELT(df, jj);
+                CharacterVector curL = cur.attr("levels");
+                dfi = INTEGER(cur);
+                int len = curL.size();
                 if (ISNA(ind->lhs[j])) {
                   dfi[ii] = NA_INTEGER;
                 } else {
                   dfi[ii] = (int)(ind->lhs[j]);
+                  if (dfi[ii] < 1 || dfi[ii] > len) {
+                    dfi[ii] = NA_INTEGER;
+                  }
                 }
                 jj++;
               } else {

--- a/tests/testthat/test-lhs-str.R
+++ b/tests/testthat/test-lhs-str.R
@@ -88,6 +88,8 @@ f <- function() {
   expect_error(rxode2parse("a <- \"str\"; a(0) <- 1"))
   # so that pruned expressions can work
   expect_error(rxode2parse("a <- \"str\"; a <- 1+5"), NA)
+  expect_error(rxode2parse("a <- \"str\"; a <- -1+5"), NA)
+  expect_error(rxode2parse("a <- \"str\"; a <- +1+5"), NA)
 }
 
 test_that("test lhs string assign rxode2.syntax.allow.ini=TRUE", {

--- a/tests/testthat/test-lhs-str.R
+++ b/tests/testthat/test-lhs-str.R
@@ -86,6 +86,8 @@ f <- function() {
   expect_error(rxode2parse('a <- "matt"; alag(a)<- 2'))
   expect_error(rxode2parse("a <- \"str\"; a(0) <- -kel"))
   expect_error(rxode2parse("a <- \"str\"; a(0) <- 1"))
+  # so that pruned expressions can work
+  expect_error(rxode2parse("a <- \"str\"; a <- 1+5"), NA)
 }
 
 test_that("test lhs string assign rxode2.syntax.allow.ini=TRUE", {
@@ -124,6 +126,47 @@ test_that("lhs solve; tests lhs assign & str equals with lhs", {
   expect_true(all(s$a[s$time >= 10] == ">=10"))
   expect_true(all(s$b[s$time < 10] == 0))
   expect_true(all(s$b[s$time >= 10] == 1))
+})
+
+test_that("out of bounds solve gives NA for factors", {
+
+  rx <- rxode2({
+    if (t < 10) {
+      a <- "<10"
+    } else {
+      a <- ">=10"
+    }
+    a <- 1-3
+    b <- 1
+    if (a == "<10") {
+      b <- 0;
+    }
+  })
+
+  e <- et(1:20)
+
+  s <-rxSolve(rx, e, returnType = "data.frame")
+
+  expect_true(all(is.na(s$a)))
+
+  rx <- rxode2({
+    if (t < 10) {
+      a <- "<10"
+    } else {
+      a <- ">=10"
+    }
+    a <- 1+20
+    b <- 1
+    if (a == "<10") {
+      b <- 0;
+    }
+  })
+
+  s <-rxSolve(rx, e, returnType = "data.frame")
+
+  expect_true(all(is.na(s$a)))
+
+
 })
 
 


### PR DESCRIPTION
By parsing a simple if/else and pruning it we get:

``` r
library(rxode2)
#> rxode2 3.0.0 using 8 threads (see ?getRxThreads)
#>   no cache: create with `rxCreateCache()`
f <- rxode2({
  levels(a) <- c("good", "bad")
  E0 <- THETA[1]
  Em <- THETA[2]
  E50 <- THETA[3]
  g <- 2
  v <- E0 + Em * time^g / (E50^g + time^g) + wt
  p <- expit(v)
  a <- (p < 0.5) * (1)
  a <- (1 - (p < 0.5)) * (2) + (1 - ((1 - (p < 0.5)))) * (a)
  rx_yj_ ~ 152
  rx_lambda_ ~ 1
  rx_low_ ~ 0
  rx_hi_ ~ 1
  rx_r_ ~ 0
  rx_pred_ ~ DV * v - log(1 + exp(v))
  rx_pred_ <- -rx_pred_
})
#> rxode2 model syntax error:
#> ================================================================================
#> :001:     levels(a) <- c("good", "bad")
#> :002:     E0 <- THETA[1]
#> :003:     Em <- THETA[2]
#> :004:     E50 <- THETA[3]
#> :005:     g <- 2
#> :006:     v <- E0 + Em * time^g/(E50^g + time^g) + wt
#> :007:     p <- expit(v)
#> :008: the string variable 'a' can only be 1 to 2, or 'good', 'bad':
#>           a <- (p < 0.5) * (1)
#>                ^~~~~~~~~~~~~~~~~~~~
#> :008:     a <- (p < 0.5) * (1)
#> :009: the string variable 'a' can only be 1 to 2, or 'good', 'bad':
#>           a <- (1 - (p < 0.5)) * (2) + (1 - ((1 - (p < 0.5)))) * (a)
#>                ^
#> :009:     rx_yj_ ~ 152
#> :010:     rx_lambda_ ~ 1
#> :011:     rx_low_ ~ 0
#> :012:     rx_hi_ ~ 1
#> :013:     rx_r_ ~ 0
#> :014:     rx_pred_ ~ DV * v - log(1 + exp(v))
#> :015:     rx_pred_ <- -rx_pred_
#> ================================================================================
#> Error: syntax errors (see above)
```

<sup>Created on 2024-08-31 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>