### PR TITLE
ini(diag()) doesn't work (though ini(diag) does)

### DIFF
--- a/R/piping.R
+++ b/R/piping.R
@@ -374,7 +374,8 @@
       warning("empty argument ignored")
       return(NULL)
     } else if (length(.quoted) == 1) {
-      if (identical(.quoted, quote(`diag`))) {
+      if (identical(.quoted, quote(`diag`)) ||
+            (is.call(.quoted) && identical(.quoted[[1]], quote(`diag`)))) {
         .quoted <- str2lang("~diag()")
       } else {
         .bracket[i] <- TRUE

--- a/tests/testthat/test-piping-ini.R
+++ b/tests/testthat/test-piping-ini.R
@@ -1035,4 +1035,13 @@ test_that("ini(diag) and ini(-cov()) tests", {
                  lvc ~ 3.45
                }))
 
+  tmp <- mod %>% ini(diag())
+
+  expect_equal(tmp$omega,
+               lotri({
+                 lka ~ 0.45
+                 lcl ~ 1
+                 lvc ~ 3.45
+               }))
+
 })


### PR DESCRIPTION
``` r
  library(rxode2)
#> rxode2 3.0.0 using 8 threads (see ?getRxThreads)
#>   no cache: create with `rxCreateCache()`
  mod <- function() {
    ini({
      lka ~ 0.45
      lcl ~ c(0.01, 1)
      lvc ~ c(-0.01, 0.01, 3.45)
    })
    model({
      ka <- exp(lka)
      cl <- exp(lcl)
      vc  <- exp(lvc)
      kel <- cl / vc
      d/dt(depot) <- -ka*depot
      d/dt(central) <- ka*depot-kel*central
      cp <- central / vc
    })
  }


  mod %>% ini(diag)
#> ℹ remove covariance `(lka,lcl)`
#> ℹ remove covariance `(lka,lvc)`
#> ℹ remove covariance `(lcl,lvc)`
#>  ── rxode2-based free-form 2-cmt ODE model ──────────────────────────────────────
#>  ── Initalization: ──
#>
#> Omega ($omega):
#>      lka lcl  lvc
#> lka 0.45   0 0.00
#> lcl 0.00   1 0.00
#> lvc 0.00   0 3.45
#>
#> States ($state or $stateDf):
#>   Compartment Number Compartment Name
#> 1                  1            depot
#> 2                  2          central
#>  ── Model (Normalized Syntax): ──
#> function() {
#>     ini({
#>         lka ~ 0.45
#>         lcl ~ 1
#>         lvc ~ 3.45
#>     })
#>     model({
#>         ka <- exp(lka)
#>         cl <- exp(lcl)
#>         vc <- exp(lvc)
#>         kel <- cl/vc
#>         d/dt(depot) <- -ka * depot
#>         d/dt(central) <- ka * depot - kel * central
#>         cp <- central/vc
#>     })
#> }


  mod %>% ini(diag())
#> Error: vectors and list need to be named numeric expression
```

<sup>Created on 2024-09-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>