### PR TITLE
Fix OOB read in etTran event loop when id column contains NA

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # rxode2 (development)
 
+- Fix out-of-bounds read when an event table contains `NA` IDs: the
+  main event-processing loop in `etTran.cpp` used `idLvl[cid-1]` in
+  error messages before checking `cid == NA_INTEGER`.  With
+  `cid = NA_INTEGER`, `cid - 1` overflows signed `int` and the
+  `CharacterVector[]` access reads past the end of the ID-levels
+  vector, causing heap corruption or a crash.  The guard is now at the
+  top of the per-row loop so all error paths are protected.
+
 - Add `evid_()` function to allow arbitrary doses and observations in
   a rxode2 model.
 

--- a/src/etTran.cpp
+++ b/src/etTran.cpp
@@ -1508,6 +1508,10 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
   for (int i = 0; i < inTime.size(); i++) {
     if (idCol == -1) cid = 1;
     else cid = inId[i];
+    /* Guard: reject NA IDs here, before any idLvl[cid-1] access.
+     * cid == NA_INTEGER causes idLvl[cid-1] to overflow and read
+     * out-of-bounds memory in every error-message path below.        */
+    if (cid == NA_INTEGER) stop(_("'id' cannot be 'NA'"));
     if (dvCol == -1) cdv = NA_REAL;
     else cdv = inDv[i];
     if (censCol == -1) ccens = NA_INTEGER;
@@ -1553,7 +1557,6 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
     else cii = inIi[i];
     if (ISNA(cii)) cii=0.0;
 
-    if (cid == NA_INTEGER) stop(_("'id' cannot be 'NA'"));
     if (std::find(allId.begin(), allId.end(), cid) == allId.end()) {
       allId.push_back(cid);
       // New ID

--- a/tests/testthat/test-mem-etTran-na-id.R
+++ b/tests/testthat/test-mem-etTran-na-id.R
@@ -1,0 +1,44 @@
+test_that("NA id gives clean error, not OOB segfault", {
+  # etTran.cpp: the main event-processing loop used idLvl[cid-1] in error
+  # messages before checking cid == NA_INTEGER.  With cid = NA_INTEGER,
+  # cid - 1 overflows signed int and the CharacterVector[] access reads
+  # out-of-bounds memory, causing heap corruption or a segfault.
+  #
+  # Fix: guard cid == NA_INTEGER at the TOP of the loop, before any
+  # idLvl[cid-1] access.  The redundant later check was removed.
+
+  m <- rxode2::rxode2(
+    "d/dt(depot)  = -ka*depot
+     d/dt(center) = ka*depot - cl/v*center"
+  )
+
+  # Infinite time on a row with NA id triggers the idLvl OOB path
+  # (the NA id check was previously AFTER the isinf(ctime) check).
+  ev_inf_time <- data.frame(
+    id   = c(NA_real_, 1),
+    time = c(Inf, 0),
+    amt  = c(0, 100),
+    evid = c(0L, 1L),
+    cmt  = c(1L, 1L)
+  )
+  expect_error(
+    rxode2::rxSolve(m, ev_inf_time, c(ka = 0.5, cl = 2, v = 10)),
+    "id.*cannot.*NA|NA.*id",
+    perl = TRUE
+  )
+
+  # Bad censoring value on a row with NA id triggers the OTHER idLvl OOB path.
+  ev_bad_cens <- data.frame(
+    id   = c(NA_real_, 1),
+    time = c(0, 1),
+    amt  = c(0, 0),
+    evid = c(0L, 0L),
+    dv   = c(1, 1),
+    cens = c(5L, 0L)   # cens=5 is invalid
+  )
+  expect_error(
+    rxode2::rxSolve(m, ev_bad_cens, c(ka = 0.5, cl = 2, v = 10)),
+    "id.*cannot.*NA|NA.*id",
+    perl = TRUE
+  )
+})


### PR DESCRIPTION
`etTran.cpp` (the main event-processing loop, ~line 1508) read `idLvl[cid-1]` inside error messages — for invalid censoring values and for infinite times — before the `if (cid == NA_INTEGER)` guard that was positioned ~50 lines later.

With `cid = NA_INTEGER` (-2147483648), `cid - 1` overflows signed `int` to INT_MAX (UB in C++; in practice wraps on x86) and then `idLvl[INT_MAX]` reads far past the end of the ID-levels CharacterVector, causing heap corruption or a segfault.

Fix: move the `if (cid == NA_INTEGER) stop(...)` guard to immediately after `cid = inId[i]`, before any `idLvl[cid-1]` access.  The now-unreachable duplicate check at the old location is removed.

Adds `tests/testthat/test-mem-etTran-na-id.R` with two cases:
- NA id + Inf time  (isinf check preceded the old guard)
- NA id + invalid censoring value (cens check preceded the old guard)