### PR TITLE
Per-individual neqOverride C-API + plumb through getSolve/getAdvan

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # rxode2 (development)
 
+- Add `getIndNeqOverride()` / `setIndNeqOverride()` C-API at pointer
+  table slots 56 and 57 (and as `R_RegisterCCallable` entries).  This
+  allows downstream packages (e.g. nlmixr2est) to mark a per-individual
+  effective neq for parallel-FOCEi pred/inner alternation without
+  mutating the shared `op->neq` from a parallel worker thread.  Default
+  value is -1 (use `op->neq`).
+
 - Add `evid_()` function to allow arbitrary doses and observations in
   a rxode2 model.
 

--- a/inst/include/rxode2.h
+++ b/inst/include/rxode2.h
@@ -27,8 +27,22 @@
 #include <stdint.h>    // for uint64_t rather than unsigned long long
 
 #ifndef __RXODE2PTR_H__  // directly refer to abi need to be excluded
-#define getSolve(idx) ind->solve + (op->neq)*(idx)
-#define getAdvan(idx) ind->solve + op->linOffset + op->neq*(idx)
+// Effective neq for the SOLVE LOOP and per-event SOLVE BUFFER stride.
+// Returns ind->neqOverride when set in [0, op->neq], else op->neq.
+// Allocations remain sized for op->neq; the override is always <= op->neq
+// (caller's contract).  Used by getSolve()/getAdvan() so that a per-
+// individual pred-mode solve writes and reads at the same compact stride
+// without mutating shared op->neq from a parallel worker thread.
+// NOTE: getAdvan() + neqOverride is unsupported when op->numLin > 0
+// (op->linOffset is computed from the full neq layout).  In nlmixr2est's
+// FOCEi flow the predNoLhs model has numLin == 0, so this is fine.
+static inline int rxEffNeq(const rx_solving_options_ind *ind,
+                           const rx_solving_options *op) {
+  int o = ind->neqOverride;
+  return (o >= 0 && o <= op->neq) ? o : op->neq;
+}
+#define getSolve(idx) ind->solve + (rxEffNeq(ind, op))*(idx)
+#define getAdvan(idx) ind->solve + op->linOffset + (rxEffNeq(ind, op))*(idx)
 #endif
 
 #ifdef _isrxode2_

--- a/inst/include/rxode2parseStruct.h
+++ b/inst/include/rxode2parseStruct.h
@@ -250,6 +250,14 @@ typedef struct {
   // or setIndTolFactor() persists across re-solves for stiff individuals.
   double tolFactor;
 
+  // Per-individual neq override; -1 means use op->neq (default).  Set
+  // via setIndNeqOverride()/getIndNeqOverride() so that downstream
+  // packages (e.g. nlmixr2est's predOde / shi21EtaGeneral) can solve
+  // with a different neq for a single individual without mutating the
+  // shared op->neq from a parallel worker thread.  Cleared by
+  // restoring -1.
+  int neqOverride;
+
   // When 1, this individual owns its dose/ii/all_times/solve arrays
   // (independently malloc'd, not pointers into the global buffer)
   int indOwnAlloc;

--- a/inst/include/rxode2ptr.h
+++ b/inst/include/rxode2ptr.h
@@ -190,6 +190,14 @@ extern "C" {
   typedef void (*setIndTolFactor_t)(rx_solving_options_ind *ind, double tolFactor);
   extern setIndTolFactor_t setIndTolFactor;
 
+  // Get the per-individual neq override (-1 = use op->neq)
+  typedef int (*getIndNeqOverride_t)(rx_solving_options_ind *ind);
+  extern getIndNeqOverride_t getIndNeqOverride;
+
+  // Set the per-individual neq override (pass -1 to clear)
+  typedef void (*setIndNeqOverride_t)(rx_solving_options_ind *ind, int neq);
+  extern setIndNeqOverride_t setIndNeqOverride;
+
   static inline SEXP iniRxodePtrs0(SEXP p) {
     if (_rxode2_rxRmvnSEXP_ == NULL) {
       _rxode2_rxRmvnSEXP_ = (_rxode2_rxRmvnSEXP_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 0));
@@ -248,6 +256,8 @@ extern "C" {
       setRxMixnum = (setRxMixnum_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 53));
       getIndTolFactor = (getIndTolFactor_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 54));
       setIndTolFactor = (setIndTolFactor_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 55));
+      getIndNeqOverride = (getIndNeqOverride_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 56));
+      setIndNeqOverride = (setIndNeqOverride_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 57));
     }
     return R_NilValue;
   }
@@ -309,6 +319,8 @@ extern "C" {
   setRxMixnum_t setRxMixnum = NULL;                     \
   getIndTolFactor_t getIndTolFactor = NULL;             \
   setIndTolFactor_t setIndTolFactor = NULL;             \
+  getIndNeqOverride_t getIndNeqOverride = NULL;         \
+  setIndNeqOverride_t setIndNeqOverride = NULL;         \
   SEXP iniRxodePtrs(SEXP ptr) {                         \
     return iniRxodePtrs0(ptr);                          \
   }                                                     \

--- a/src/init.c
+++ b/src/init.c
@@ -441,8 +441,10 @@ SEXP _rxode2_rxode2Ptr(void) {
   SEXP rxode2setRxMixnum = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setRxMixnum, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2getIndTolFactor = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&getIndTolFactor, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2setIndTolFactor = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setIndTolFactor, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2getIndNeqOverride = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&getIndNeqOverride, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2setIndNeqOverride = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setIndNeqOverride, R_NilValue, R_NilValue)); pro++;
 
-#define nVec 56
+#define nVec 58
   SEXP ret = PROTECT(Rf_allocVector(VECSXP, nVec)); pro++;
   SET_VECTOR_ELT(ret, 0, rxode2rxRmvnSEXP);
   SET_VECTOR_ELT(ret, 1, rxode2rxParProgress);
@@ -500,6 +502,8 @@ SEXP _rxode2_rxode2Ptr(void) {
   SET_VECTOR_ELT(ret, 53, rxode2setRxMixnum);
   SET_VECTOR_ELT(ret, 54, rxode2getIndTolFactor);
   SET_VECTOR_ELT(ret, 55, rxode2setIndTolFactor);
+  SET_VECTOR_ELT(ret, 56, rxode2getIndNeqOverride);
+  SET_VECTOR_ELT(ret, 57, rxode2setIndNeqOverride);
 
   SEXP retN = PROTECT(Rf_allocVector(STRSXP, nVec)); pro++;
   SET_STRING_ELT(retN, 0, Rf_mkChar("rxode2rxRmvnSEXP"));
@@ -558,6 +562,8 @@ SEXP _rxode2_rxode2Ptr(void) {
   SET_STRING_ELT(retN, 53, Rf_mkChar("rxode2setRxMixnum"));
   SET_STRING_ELT(retN, 54, Rf_mkChar("rxode2getIndTolFactor"));
   SET_STRING_ELT(retN, 55, Rf_mkChar("rxode2setIndTolFactor"));
+  SET_STRING_ELT(retN, 56, Rf_mkChar("rxode2getIndNeqOverride"));
+  SET_STRING_ELT(retN, 57, Rf_mkChar("rxode2setIndNeqOverride"));
 
 #undef nVec
 
@@ -896,6 +902,8 @@ void R_init_rxode2(DllInfo *info){
   R_RegisterCCallable("rxode2", "simeta", (DL_FUNC) &simeta);
   R_RegisterCCallable("rxode2", "getIndTolFactor", (DL_FUNC) &getIndTolFactor);
   R_RegisterCCallable("rxode2", "setIndTolFactor", (DL_FUNC) &setIndTolFactor);
+  R_RegisterCCallable("rxode2", "getIndNeqOverride", (DL_FUNC) &getIndNeqOverride);
+  R_RegisterCCallable("rxode2", "setIndNeqOverride", (DL_FUNC) &setIndNeqOverride);
   // log likelihoods used in calculations
   static const R_CMethodDef cMethods[] = {
     {"rxode2_sum",               (DL_FUNC) &rxode2_sum, 2, rxode2_Sum_t},

--- a/src/rx2api.c
+++ b/src/rx2api.c
@@ -98,6 +98,14 @@ void setIndTolFactor(rx_solving_options_ind *ind, double tolFactor) {
   ind->tolFactor = tolFactor;
 }
 
+int getIndNeqOverride(rx_solving_options_ind *ind) {
+  return ind->neqOverride;
+}
+
+void setIndNeqOverride(rx_solving_options_ind *ind, int neq) {
+  ind->neqOverride = neq;
+}
+
 int getIndEvid(rx_solving_options_ind* ind, int kk) {
   if (kk < 0 || kk >= ind->n_all_times) {
     Rf_error("[getIndEvid]: kk (%d) should be between [0, %d)", kk, ind->n_all_times);

--- a/src/rx2api.c
+++ b/src/rx2api.c
@@ -248,5 +248,5 @@ double * getOpIndSolve(rx_solving_options* op, rx_solving_options_ind* ind, int 
   if (idx  < 0 || idx >= ind->n_all_times) {
     Rf_error("[getOpIndSolve]: the individual should be between [0, %d); neq: %d", ind->n_all_times, op->neq);
   }
-  return ind->solve + (op->neq)*(idx);
+  return ind->solve + (rxEffNeq(ind, op))*(idx);
 }

--- a/src/rx2api.h
+++ b/src/rx2api.h
@@ -147,6 +147,17 @@ extern "C" {
   // requested tolerance so the factor persists across re-solves.
   void setIndTolFactor(rx_solving_options_ind *ind, double tolFactor);
 
+  // Get the per-individual neq override.  Returns -1 when no override
+  // is in effect (caller should fall back to op->neq).  Use to solve
+  // a single individual with a different effective neq without
+  // mutating the shared op->neq from a parallel worker thread.
+  int getIndNeqOverride(rx_solving_options_ind *ind);
+
+  // Set the per-individual neq override.  Pass -1 to clear the
+  // override.  Caller is responsible for restoring the prior value
+  // (RAII guard in nlmixr2est).
+  void setIndNeqOverride(rx_solving_options_ind *ind, int neq);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -3693,6 +3693,10 @@ extern "C" void setupRxInd(rx_solving_options_ind* ind, int first) {
     // on subsequent calls (first == 0) so that stiff individuals retain
     // their loosened tolerances across re-solves.
     ind->tolFactor = 1.0;
+    // neqOverride = -1 means "use op->neq".  Reset on first allocation
+    // only; downstream callers (e.g. nlmixr2est) set/restore this
+    // per-call and we do not want to clobber an in-flight override.
+    ind->neqOverride = -1;
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `setIndNeqOverride()` / `getIndNeqOverride()` C-API at pointer
  table slots 56/57 (and as `R_RegisterCCallable` entries) plus a
  `neqOverride` field on `rx_solving_options_ind` (default `-1`).
- Adds `rxEffNeq(ind, op)` static-inline helper in `inst/include/rxode2.h`
  that returns `ind->neqOverride` when set in `[0, op->neq]`, else `op->neq`.
- Routes `getSolve()`, `getAdvan()`, and `getOpIndSolve()` through the
  helper so a per-individual pred-mode solve writes/reads at the compact
  stride without mutating the shared `op->neq` from a parallel worker
  thread.

## Why

Closes the half-fixed gap behind nlmixr2est PR #621 (parallel FOCEi):
`shi21EtaGeneral` mutates `op->neq` to switch from inner-mode to
pred-mode, which races with concurrent inner solves on other threads
and produces heap corruption in `lsoda_free` for models whose `f()`,
`dur()`, `rate()`, or `lag()` depend on ETAs (Matt Fidler's 2026-05-01
review comment on PR #621).

This PR exposes the metadata; nlmixr2est consumes it via its companion
PR (parallel-v2). Allocations remain sized for `op->neq`; the override
is constrained to `<= op->neq` by caller contract.

## Test plan

- [ ] Existing rxode2 tests (`devtools::test()`) pass — additive change.
- [ ] nlmixr2est `tests/testthat/test-focei-parallel.R` passes with
      cores=2 baseline / mceta=0 / mceta=2.
- [ ] `inst/reprex_fbio_eta_parallel.R` in nlmixr2est (the f(depot)+ETA
      reprex) survives cores=2 once nlmixr2est PR #621 lands on top.