### PR TITLE
Plumb neqOverride through par_solve / iniSubject / indLin

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,21 @@
   mutating the shared `op->neq` from a parallel worker thread.  Default
   value is -1 (use `op->neq`).
 
+- Plumb `ind->neqOverride` through the per-subject solve loop via a new
+  `rxEffNeq(ind, op)` inline helper (`inst/include/rxode2.h`).
+  `getSolve()` / `getAdvan()` macros, `getOpIndSolve()`, the LSODA /
+  liblsoda / dop853 entry points (`ind_lsoda0`, `ind_liblsoda0`,
+  `ind_dop0`, `ind_indLin0`), `iniSubject()`'s init memcpy, and the
+  inductive-linearization helper (`indLin`/`meOnly`) all consult
+  `rxEffNeq` so a per-individual pred-mode solve writes and reads at
+  the same compact stride.  `ind_solve` dispatch skips the pure-linCmt
+  fast path when an override is active (the predNoLhs model is ODE-
+  based and does not match the rxInner linCmt structure).  Allocations
+  remain sized for `op->neq`; the override is constrained to
+  `<= op->neq` by caller contract.  Fixes parallel-FOCEi crashes
+  ("ewt[1] = 0 <= 0", "double free or corruption") on models whose
+  `f()` / `dur()` / `rate()` / `alag()` depend on ETAs.
+
 - Add `evid_()` function to allow arbitrary doses and observations in
   a rxode2 model.
 

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -903,6 +903,7 @@ rxSolve <- function(object, params = NULL, events = NULL, inits = NULL,
                     linCmtForwardMax=2L,
                     indOwnAlloc=NA,
                     maxExtra=1000L,
+                    tolFactor=NULL,
                     envir=parent.frame()) {
   .udfEnvSet(list(envir, parent.frame(1)))
   if (is.null(object)) {
@@ -1221,6 +1222,8 @@ rxSolve <- function(object, params = NULL, events = NULL, inits = NULL,
     if (maxSS <= minSS) stop("'maxSS' must be larger than 'minSS'", call.=FALSE)
     checkmate::assertNumeric(infSSstep, lower=6, any.missing=FALSE, len=1)
     checkmate::assertNumeric(maxAtolRtolFactor, lower=0.01, any.missing=FALSE, finite=TRUE, null.ok=FALSE, len=1)
+    if (!is.null(tolFactor))
+      checkmate::assertNumeric(tolFactor, lower=1.0, finite=TRUE, any.missing=FALSE, .var.name="tolFactor")
     checkmate::assertNumeric(from, null.ok=TRUE, finite=TRUE, any.missing=FALSE, len=1)
     checkmate::assertNumeric(to, null.ok=TRUE, finite=TRUE, any.missing=FALSE, len=1)
     checkmate::assertNumeric(by, null.ok=TRUE, finite=TRUE, any.missing=FALSE, len=1)
@@ -1451,6 +1454,7 @@ rxSolve <- function(object, params = NULL, events = NULL, inits = NULL,
       linCmtForwardMax=linCmtForwardMax,
       indOwnAlloc=as.integer(indOwnAlloc),
       maxExtra=maxExtra,
+      tolFactor=tolFactor,
       .zeros=unique(.zeros)
     )
     class(.ret) <- "rxControl"

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -154,6 +154,28 @@
 #' @param maxAtolRtolFactor The maximum `atol`/`rtol` that
 #'     FOCEi and other routines may adjust to.  By default 0.1
 #'
+#' @param tolFactor A per-individual tolerance multiplier (>= 1.0, or
+#'     `NULL` for no effect).  When supplied, each individual's
+#'     `atol`, `rtol`, `ssAtol`, and `ssRtol` are multiplied by
+#'     this factor before the ODE solver is called, loosening the
+#'     tolerances for that individual.  This is useful when a small
+#'     number of subjects are numerically stiff and would otherwise
+#'     cause solve failures: pass a larger factor for the
+#'     problematic subjects and leave the rest at 1.0 (or omit them).
+#'     The effective tolerance is always capped at `maxAtolRtolFactor`.
+#'
+#'     `tolFactor` may be:
+#'     * `NULL` (default) — no adjustment applied.
+#'     * A single numeric value — the same factor is applied to
+#'       the first `length(tolFactor)` subjects in order.
+#'     * A numeric vector — applied element-wise to subjects in
+#'       the order they appear.
+#'     * A **named** numeric vector — names are matched to subject
+#'       IDs; unmatched subjects retain `tolFactor = 1.0`.
+#'
+#'     The per-subject factors used (after matching) are stored back
+#'     in the solved object and accessible via `$tolFactor`.
+#'
 #' @param stateTrim When amounts/concentrations in one of the states
 #'     are above this value, trim them to be this value. By default
 #'     Inf.  Also trims to -stateTrim for large negative

--- a/inst/include/rxode2_control.h
+++ b/inst/include/rxode2_control.h
@@ -114,5 +114,6 @@
 #define Rxc_linCmtForwardMax 109
 #define Rxc_indOwnAlloc 110
 #define Rxc_maxExtra 111
-#define Rxc__zeros 112
+#define Rxc_tolFactor 112
+#define Rxc__zeros 113
 #endif // __rxode2_control_H__

--- a/inst/include/rxode2parse_control.h
+++ b/inst/include/rxode2parse_control.h
@@ -113,7 +113,8 @@
 #define Rxc_linCmtForwardMax 109
 #define Rxc_indOwnAlloc 110
 #define Rxc_maxExtra 111
-#define Rxc__zeros 112
+#define Rxc_tolFactor 112
+#define Rxc__zeros 113
 #define RxMv_params 0
 #define RxMv_lhs 1
 #define RxMv_state 2

--- a/man/rxSolve.Rd
+++ b/man/rxSolve.Rd
@@ -153,6 +153,7 @@ rxSolve(
   linCmtForwardMax = 2L,
   indOwnAlloc = NA,
   maxExtra = 1000L,
+  tolFactor = NULL,
   envir = parent.frame()
 )
 
@@ -984,6 +985,29 @@ that individual (output filled with \code{NA}) and an error is raised
 after the full parallel solve completes.  Set to \code{0L} to allow
 unlimited pushes (use with care — cascading \code{evid_()} calls can
 grow without bound).  Default is \code{100L}.}
+
+\item{tolFactor}{A per-individual tolerance multiplier (>= 1.0, or
+\code{NULL} for no effect).  When supplied, each individual's
+\code{atol}, \code{rtol}, \code{ssAtol}, and \code{ssRtol} are multiplied by
+this factor before the ODE solver is called, loosening the
+tolerances for that individual.  This is useful when a small
+number of subjects are numerically stiff and would otherwise
+cause solve failures: pass a larger factor for the
+problematic subjects and leave the rest at 1.0 (or omit them).
+The effective tolerance is always capped at \code{maxAtolRtolFactor}.
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{`tolFactor` may be:
+* `NULL` (default) — no adjustment applied.
+* A single numeric value — the same factor is applied to
+  the first `length(tolFactor)` subjects in order.
+* A numeric vector — applied element-wise to subjects in
+  the order they appear.
+* A **named** numeric vector — names are matched to subject
+  IDs; unmatched subjects retain `tolFactor = 1.0`.
+
+The per-subject factors used (after matching) are stored back
+in the solved object and accessible via `$tolFactor`.
+}\if{html}{\out{</div>}}}
 
 \item{envir}{is the environment to look for R user functions
 (defaults to parent environment)}

--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -239,8 +239,12 @@ bool expm_assign=false;
 SEXP expm_s;
 
 int meOnly(int cSub, double *yc_, double *yp_, double tp, double tf, double tcov,
-	   double *InfusionRate_, int *on_, t_ME ME, rx_solving_options *op){
-  int neq = op->neq;
+	   double *InfusionRate_, int *on_, t_ME ME, rx_solving_options *op,
+	   rx_solving_options_ind *ind){
+  // Honor per-individual neqOverride when ind is available; otherwise fall
+  // back to op->neq.  Keeps allocations / loops consistent with what the
+  // outer indLin solver wrote.
+  int neq = (ind != NULL) ? rxEffNeq(ind, op) : op->neq;
   int type = op->indLinMatExpType;
   int order = op->indLinMatExpOrder;
   arma::mat m0(neq, neq);
@@ -314,7 +318,7 @@ extern "C" int indLin(int cSub, rx_solving_options *op, rx_solving_options_ind *
                       double tp, double *yp_, double tf,
 		      double *InfusionRate_, int *on_,
 		      t_ME ME, t_IndF  IndF){
-  int neq = op->neq;
+  int neq = (ind != NULL) ? rxEffNeq(ind, op) : op->neq;
   // Use per-individual tolerance arrays when available (set by
   // _setIndPointersByThread + iniSubject), falling back to op->rtol2/atol2.
   double *rtol = (ind != NULL && ind->rtol2 != NULL) ? ind->rtol2 : op->rtol2;
@@ -332,7 +336,7 @@ extern "C" int indLin(int cSub, rx_solving_options *op, rx_solving_options_ind *
   if (locf) tcov = tp;
   switch(doIndLin){
   case 1: {
-    return meOnly(cSub, yp_, yp_, tp, tf, tcov, InfusionRate_, on_, ME, op);
+    return meOnly(cSub, yp_, yp_, tp, tf, tcov, InfusionRate_, on_, ME, op, ind);
   }
   case 3: {
     // Matrix exponential  +  inductive linearzation
@@ -340,10 +344,10 @@ extern "C" int indLin(int cSub, rx_solving_options *op, rx_solving_options_ind *
     arma::vec w(yp_, neq);
     arma::vec y0 = w;
     // Update first value
-    meOnly(cSub, w.memptr(), y0.memptr(), tp, tf, tcov, InfusionRate_, on_, ME, op);
+    meOnly(cSub, w.memptr(), y0.memptr(), tp, tf, tcov, InfusionRate_, on_, ME, op, ind);
     // Don't update rest
     wLast = w;
-    meOnly(cSub, w.memptr(), y0.memptr(), tp, tf, tcov, InfusionRate_, on_, ME, op);
+    meOnly(cSub, w.memptr(), y0.memptr(), tp, tf, tcov, InfusionRate_, on_, ME, op, ind);
     bool converge = false;
     for (int i = 0; i < maxsteps; ++i){
       converge=true;
@@ -358,7 +362,7 @@ extern "C" int indLin(int cSub, rx_solving_options *op, rx_solving_options_ind *
     	break;
       }
       wLast = w;
-      meOnly(cSub, w.memptr(), y0.memptr(), tp, tf, tcov, InfusionRate_, on_, ME, op);
+      meOnly(cSub, w.memptr(), y0.memptr(), tp, tf, tcov, InfusionRate_, on_, ME, op, ind);
     }
     std::copy(w.begin(), w.begin()+neq, yp_);
     return 1;

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -35,7 +35,7 @@ extern "C" {
 }
 #include "par_solve.h"
 #define max2( a , b )  ( (a) > (b) ? (a) : (b) )
-#define badSolveExit(i) for (int j = op->neq*(ind->n_all_times); j--;){ \
+#define badSolveExit(i) for (int j = rxEffNeq(ind, op)*(ind->n_all_times); j--;){ \
     ind->solve[j] = NA_REAL;                                           \
   }                                                                     \
   _Pragma("omp atomic write")                                           \
@@ -514,13 +514,13 @@ static inline void postSolve(int *neq, int *idid, int *rc, int *i, double *yp, c
   } else {
     if (R_FINITE(rx->stateTrimU)){
       double top=fabs(rx->stateTrimU);
-      for (int j = op->neq; j--;) {
+      for (int j = rxEffNeq(ind, op); j--;) {
         yp[j]= min(top,yp[j]);
       }
     }
     if (R_FINITE(rx->stateTrimL)){
       double bottom=rx->stateTrimL;
-      for (int j = op->neq; j--;) {
+      for (int j = rxEffNeq(ind, op); j--;) {
         yp[j]= max(bottom,yp[j]);
       }
     }
@@ -1033,8 +1033,11 @@ static inline void solveWith1Pt(int *neq,
                                 t_update_inis u_inis,
                                 void *ctx){
   int idid, itol=0;
-  int neqOde = op->neq - op->numLin - op->numLinSens;
-  if (neqOde == 0 && op->neq > 0) {
+  // Per-individual effective neq under neqOverride; allocations are still
+  // sized for op->neq, only stepping uses the smaller stride.
+  int eff = rxEffNeq(ind, op);
+  int neqOde = eff - op->numLin - op->numLinSens;
+  if (neqOde == 0 && eff > 0) {
     if (!isSameTime(xout, xp)) {
       preSolve(op, ind, xp, xout, yp);
       linSolve(neq, ind, yp, &xp, xout);
@@ -1079,12 +1082,12 @@ static inline void solveWith1Pt(int *neq,
     case 1:
       if (!isSameTime(xout, xp)) {
         preSolve(op, ind, xp, xout, yp);
-        neq[0] = op->neq - op->numLin - op->numLinSens;
+        neq[0] = eff - op->numLin - op->numLinSens;
         F77_CALL(dlsoda)(dydt_lsoda_dum, neq, yp, &xp, &xout,
                          &gitol, &(op->RTOL), &(op->ATOL), &gitask,
                          istate, &giopt, global_rworkp,
                          &glrw, global_iworkp, &gliw, jdum_lsoda, &global_jt);
-        neq[0] = op->neq;
+        neq[0] = eff;
         copyLinCmt(neq, ind, op, yp);
       }
       if (*istate <= 0) {
@@ -1101,7 +1104,7 @@ static inline void solveWith1Pt(int *neq,
       if (!isSameTimeDop(xout, xp)) {
         preSolve(op, ind, xp, xout, yp);
         // change to real ODE num
-        neq[0] = op->neq - op->numLin - op->numLinSens;
+        neq[0] = eff - op->numLin - op->numLinSens;
         idid = dop853(neq,       /* dimension of the system <= UINT_MAX-1*/
                       dydt,         /* function computing the value of f(x,y) */
                       xp,           /* initial x-value */
@@ -1128,7 +1131,7 @@ static inline void solveWith1Pt(int *neq,
                       0                       /* declared length of icon */
                       );
         // switch to overall states
-        neq[0] = op->neq;
+        neq[0] = eff;
         copyLinCmt(neq, ind, op, yp);
       }
       if (idid < 0) {
@@ -1263,7 +1266,7 @@ extern "C" void handleSSbolus(int *neq,
         badSolveExit(*i);
         break;
       }
-      for (int k = op->neq; k--;) {
+      for (int k = rxEffNeq(ind, op); k--;) {
         ind->solveLast[k] = yp[k];
       }
       *canBreak=0;
@@ -2526,7 +2529,7 @@ updateSolve(rx_solving_options_ind *ind, rx_solving_options *op, int *neq,
   // Grow if needed before accessing getSolve(i) and optionally getSolve(i+1).
   _growSolveIfNeeded(ind, op, i, (i + 1 != nx));
   if (i+1 != nx) {
-    std::copy(getSolve(i), getSolve(i) + op->neq, getSolve(i+1));
+    std::copy(getSolve(i), getSolve(i) + rxEffNeq(ind, op), getSolve(i+1));
   }
   calc_lhs(neq[1], xout, getSolve(i), ind->lhs);
 }
@@ -2539,7 +2542,6 @@ extern "C" void ind_indLin0(rx_solve *rx, rx_solving_options *op, int solveid,
   assignFuns();
   int i;
   int neq[2];
-  neq[0] = op->neq;
   neq[1] = solveid;
   /* double *yp = &yp0[neq[1]*neq[0]]; */
   int nx;
@@ -2550,6 +2552,8 @@ extern "C" void ind_indLin0(rx_solve *rx, rx_solving_options *op, int solveid,
   int idid = 0;
   int localBadSolve = 0;
   ind = &(rx->subjects[neq[1]]);
+  // Per-individual effective neq (rxEffNeq) needs ind in scope.
+  neq[0] = rxEffNeq(ind, op);
   if (!iniSubject(neq[1], 0, ind, op, rx, u_inis)) return;
   nx = ind->n_all_times;
   rc= ind->rc;
@@ -2684,7 +2688,6 @@ extern "C" void ind_liblsoda0(rx_solve *rx, rx_solving_options *op, struct lsoda
   clock_t t0 = clock();
   int i;
   int neq[2];
-  neq[0] = op->neq;
   // Here we pick the sorted solveid
   // rx->ordId[solveid]-1
   // This -1 is because R is 1 indexed and C/C++ is 0 indexed
@@ -2696,7 +2699,11 @@ extern "C" void ind_liblsoda0(rx_solve *rx, rx_solving_options *op, struct lsoda
   //
   neq[1] = rx->ordId[solveid]-1;
   /* double *yp = &yp0[neq[1]*neq[0]]; */
-  rx_solving_options_ind *ind;
+  rx_solving_options_ind *ind = &(rx->subjects[neq[1]]);
+  // Per-individual effective neq honors ind->neqOverride (rxEffNeq); under
+  // a parallel inner-pred alternation in nlmixr2est this is the predNeq
+  // for this thread's subject, while op->neq remains the full neq.
+  neq[0] = rxEffNeq(ind, op);
   double xout;
   int *rc;
   double *yp;
@@ -2712,7 +2719,6 @@ extern "C" void ind_liblsoda0(rx_solve *rx, rx_solving_options *op, struct lsoda
   ctx->neq = neqOde;
   ctx->state = 1;
   ctx->error=NULL;
-  ind = &(rx->subjects[neq[1]]);
   if (!iniSubject(neq[1], 0, ind, op, rx, u_inis)) {
     free(ctx);
     ctx = NULL;
@@ -3238,6 +3244,9 @@ extern "C" void ind_lsoda0(rx_solve *rx, rx_solving_options *op, int solveid, in
   neq[1] = solveid;
 
   ind = &(rx->subjects[neq[1]]);
+  // Per-individual effective neq honors ind->neqOverride; allocations are
+  // sized for op->neq, only stepping uses the smaller stride.
+  int eff = rxEffNeq(ind, op);
 
   rwork[4] = op->H0; // H0
   rwork[5] = ind->HMAX; // Hmax
@@ -3290,10 +3299,10 @@ extern "C" void ind_lsoda0(rx_solve *rx, rx_solving_options *op, int solveid, in
                             xp, ind->id, &i, ind->n_all_times, &istate, op, ind, u_inis, ctx)) {
           if (!localBadSolve && !isSameTime(ind->extraDoseNewXout, xp)) {
             preSolve(op, ind, xp, ind->extraDoseNewXout, yp);
-            neq[0] = op->neq - op->numLin - op->numLinSens;
+            neq[0] = eff - op->numLin - op->numLinSens;
             F77_CALL(dlsoda)(dydt_lsoda, neq, yp, &xp, &ind->extraDoseNewXout, &gitol, &(op->RTOL), &(op->ATOL), &gitask,
                              &istate, &giopt, rwork, &lrw, iwork, &liw, jdum, &jt);
-            neq[0] = op->neq;
+            neq[0] = eff;
             copyLinCmt(neq, ind, op, yp);
             postSolve(neq, &istate, ind->rc, &i, yp, err_msg_ls, 7, true, ind, op, rx);
             if (*(ind->rc) < 0) localBadSolve = 1;
@@ -3311,10 +3320,10 @@ extern "C" void ind_lsoda0(rx_solve *rx, rx_solving_options *op, int solveid, in
             ind->idxExtra++;
             if (!isSameTime(xout, ind->extraDoseNewXout)) {
               preSolve(op, ind, ind->extraDoseNewXout, xout, yp);
-              neq[0] = op->neq - op->numLin - op->numLinSens;
+              neq[0] = eff - op->numLin - op->numLinSens;
               F77_CALL(dlsoda)(dydt_lsoda, neq, yp, &ind->extraDoseNewXout, &xout, &gitol, &(op->RTOL), &(op->ATOL), &gitask,
                                &istate, &giopt, rwork, &lrw, iwork, &liw, jdum, &jt);
-              neq[0] = op->neq;
+              neq[0] = eff;
               copyLinCmt(neq, ind, op, yp);
               postSolve(neq, &istate, ind->rc, &i, yp, err_msg_ls, 7, true, ind, op, rx);
               if (*(ind->rc) < 0) localBadSolve = 1;
@@ -3324,14 +3333,14 @@ extern "C" void ind_lsoda0(rx_solve *rx, rx_solving_options *op, int solveid, in
         }
         if (!localBadSolve && !isSameTime(xout, xp)) {
           preSolve(op, ind, xp, xout, yp);
-          neq[0] = op->neq - op->numLin - op->numLinSens;
+          neq[0] = eff - op->numLin - op->numLinSens;
           F77_CALL(dlsoda)(dydt_lsoda, neq, yp,
                            &xp, &xout, &gitol,
                            &(op->RTOL),
                            &(op->ATOL),
                            &gitask,
                            &istate, &giopt, rwork, &lrw, iwork, &liw, jdum, &jt);
-          neq[0] = op->neq;
+          neq[0] = eff;
           copyLinCmt(neq, ind, op, yp);
           postSolve(neq, &istate, ind->rc, &i, yp, err_msg_ls, 7, true, ind, op, rx);
           if (*(ind->rc) < 0) localBadSolve = 1;
@@ -3458,9 +3467,10 @@ extern "C" double ind_linCmt0H(rx_solve *rx, rx_solving_options *op, int solveid
   const char **err_msg = NULL;
   int nx;
   int neq[2];
-  neq[0] = op->neq;
   neq[1] = rx->ordId[solveid]-1;
   ind = &(rx->subjects[neq[1]]);
+  // Per-individual effective neq (rxEffNeq) — see ind_liblsoda0 for context.
+  neq[0] = rxEffNeq(ind, op);
 
   double ret = 0.0;
   double cur = 0.0;
@@ -3868,6 +3878,13 @@ extern "C" void ind_dop0(rx_solve *rx, rx_solving_options *op, int solveid, int 
   int nx;
   neq[1] = solveid;
   ind = &(rx->subjects[neq[1]]);
+  // Per-individual effective neq (rxEffNeq) honors ind->neqOverride; under
+  // override the dop853 stepping uses the smaller stride.  Caller (ind_dop /
+  // par_dop) initialises neq[0] from op->neq before this function runs;
+  // update it now that ind is known so handle_evid / postSolve / etc. see
+  // the per-individual effective stride for the current subject.
+  int eff = rxEffNeq(ind, op);
+  neq[0] = eff;
   if (!iniSubject(neq[1], 0, ind, op, rx, u_inis)) return;
   nx = ind->n_all_times;
   inits = op->inits;
@@ -3913,7 +3930,7 @@ extern "C" void ind_dop0(rx_solve *rx, rx_solving_options *op, int solveid, int 
                             xp, ind->id, &i, nx, &istate, op, ind, u_inis, ctx)) {
           if (!isSameTimeDop(ind->extraDoseNewXout, xp)) {
             preSolve(op, ind, xp, ind->extraDoseNewXout, yp);
-            neq[0] = op->neq - op->numLin - op->numLinSens;
+            neq[0] = eff - op->numLin - op->numLinSens;
             idid = dop853(neq,       /* dimension of the system <= UINT_MAX-1*/
                           c_dydt,       /* function computing the value of f(x,y) */
                           xp,           /* initial x-value */
@@ -3939,7 +3956,7 @@ extern "C" void ind_dop0(rx_solve *rx, rx_solving_options *op, int solveid, int 
                           NULL,           /* indexes of components for which dense output is required, >= nrdens */
                           0                       /* declared length of icon */
                           );
-            neq[0] = op->neq;
+            neq[0] = eff;
             copyLinCmt(neq, ind, op, yp);
             postSolve(neq, &idid, rc, &i, yp, err_msg, 4, true, ind, op, rx);
             xp = ind->extraDoseNewXout;
@@ -3956,7 +3973,7 @@ extern "C" void ind_dop0(rx_solve *rx, rx_solving_options *op, int solveid, int 
           ind->idxExtra++;
           if (!isSameTimeDop(xout, ind->extraDoseNewXout)) {
             preSolve(op, ind, ind->extraDoseNewXout, xout, yp);
-            neq[0] = op->neq - op->numLin - op->numLinSens;
+            neq[0] = eff - op->numLin - op->numLinSens;
             idid = dop853(neq,       /* dimension of the system <= UINT_MAX-1*/
                           c_dydt,       /* function computing the value of f(x,y) */
                           ind->extraDoseNewXout,           /* initial x-value */
@@ -3982,7 +3999,7 @@ extern "C" void ind_dop0(rx_solve *rx, rx_solving_options *op, int solveid, int 
                           NULL,           /* indexes of components for which dense output is required, >= nrdens */
                           0                       /* declared length of icon */
                           );
-            neq[0] = op->neq;
+            neq[0] = eff;
             copyLinCmt(neq, ind, op, yp);
             postSolve(neq, &idid, rc, &i, yp, err_msg, 4, true, ind, op, rx);
             xp = ind->extraDoseNewXout;
@@ -3990,7 +4007,7 @@ extern "C" void ind_dop0(rx_solve *rx, rx_solving_options *op, int solveid, int 
         }
         if (!isSameTimeDop(xout, xp)) {
           preSolve(op, ind, xp, xout, yp);
-          neq[0] = op->neq - op->numLin - op->numLinSens;
+          neq[0] = eff - op->numLin - op->numLinSens;
           idid = dop853(neq,       /* dimension of the system <= UINT_MAX-1*/
                         c_dydt,       /* function computing the value of f(x,y) */
                         xp,           /* initial x-value */
@@ -4016,7 +4033,7 @@ extern "C" void ind_dop0(rx_solve *rx, rx_solving_options *op, int solveid, int 
                         NULL,           /* indexes of components for which dense output is required, >= nrdens */
                         0                       /* declared length of icon */
                         );
-          neq[0] = op->neq;
+          neq[0] = eff;
           copyLinCmt(neq, ind, op, yp);
           postSolve(neq, &idid, rc, &i, yp, err_msg, 4, true, ind, op, rx);
           xp = xout;
@@ -4759,7 +4776,16 @@ extern "C" void ind_solve(rx_solve *rx, unsigned int cid,
       // Setup H
       setupLinH(rx, cid, c_dydt, u_inis);
     }
-    if (op->neq == op->numLinSens + op->numLin) {
+    // Per-individual neqOverride: when set (e.g. nlmixr2est's predOde from
+    // shi21EtaGeneral / likInner0 doFD path), force dispatch through the
+    // ODE-solver branch.  The pure-linCmt fast path assumes the full
+    // op->neq state layout and shares op->numLin / op->numLinSens with the
+    // rxInner sensitivity model; under override the caller is solving the
+    // smaller predNoLhs ODE model, which by construction has numLin == 0,
+    // so the linCmt fast path is not the right dispatch.
+    rx_solving_options_ind *_ind = &(rx->subjects[cid]);
+    int _eff = rxEffNeq(_ind, op);
+    if (_eff == op->neq && op->neq == op->numLinSens + op->numLin) {
       // This only is linear compartment solving
       ind_linCmt(rx, cid, c_dydt, u_inis);
       return;

--- a/src/par_solve.h
+++ b/src/par_solve.h
@@ -90,12 +90,16 @@ extern "C" {
       if (u_inis != NULL) {
         ind->isIni = 1;
         // Also can update individual random variables (if needed)
-        if (inLhs == 0) memcpy(ind->solve, op->inits, op->neq*sizeof(double));
+        // Use rxEffNeq() for the memcpy length: under a per-individual
+        // neqOverride (predNeq < op->neq), the per-event buffer stride is
+        // predNeq, so writing op->neq doubles into slot 0 would clobber the
+        // start of slot 1 (which sits at offset predNeq, not op->neq).
+        if (inLhs == 0) memcpy(ind->solve, op->inits, rxEffNeq(ind, op)*sizeof(double));
         u_inis(solveid, ind->solve); // Update initial conditions @ current time
         ind->isIni = 0;
       } else if (rx->nMtime && inLhs == 0 && op->neq > 0) {
         // No u_inis but state-dep mtime needs initial values in ind->solve
-        memcpy(ind->solve, op->inits, op->neq*sizeof(double));
+        memcpy(ind->solve, op->inits, rxEffNeq(ind, op)*sizeof(double));
       }
 		}
     // Compute model times using ind->solve (which has user-specified inits after u_inis).

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -4678,6 +4678,15 @@ static inline Environment rxSolve_genenv(const RObject &object,
   e[".jac.counter"] = jac_counterIv;
   e[".nsub"] = (int)rx->nsub;
   e[".nsim"] = (int)rx->nsim;
+  {
+    NumericVector _tf((int)rx->nsub);
+    CharacterVector _idLevels = as<CharacterVector>(rxSolveDat->idLevels);
+    for (uint32_t _si = 0; _si < rx->nsub; _si++) {
+      _tf[_si] = rx->subjects[_si].tolFactor;
+    }
+    if ((int)_idLevels.size() == (int)rx->nsub) _tf.names() = _idLevels;
+    e[".tolFactor"] = _tf;
+  }
   e[".init.dat"] = rxSolveDat->initsC;
   CharacterVector units = CharacterVector::create(amountUnits[0], timeUnits[0]);
   units.names() = CharacterVector::create("dosing","time");
@@ -4827,6 +4836,33 @@ static inline SEXP rxSolve_finalize(const RObject &obj,
   }
   if (_globals.zeroSigma) {
     cliAlert(_("zero 'sigma', no unexplained variability"));
+  }
+  {
+    SEXP _tfSEXP = rxControl[Rxc_tolFactor];
+    if (!Rf_isNull(_tfSEXP) && (TYPEOF(_tfSEXP) == REALSXP || TYPEOF(_tfSEXP) == INTSXP)) {
+      NumericVector _tf = as<NumericVector>(_tfSEXP);
+      SEXP _tfNames = Rf_getAttrib(_tfSEXP, R_NamesSymbol);
+      bool _named = (!Rf_isNull(_tfNames)) && (Rf_length(_tfNames) == (int)_tf.size());
+      if (_named) {
+        CharacterVector _ids = as<CharacterVector>(rxSolveDat->idLevels);
+        CharacterVector _tfn = as<CharacterVector>(_tfNames);
+        int _tnSize = (int)_tfn.size();
+        for (uint32_t _si = 0; _si < rx->nsub; _si++) {
+          std::string _sid = as<std::string>(_ids[_si]);
+          for (int _j = 0; _j < _tnSize; _j++) {
+            if (as<std::string>(_tfn[_j]) == _sid) {
+              rx->subjects[_si].tolFactor = _tf[_j];
+              break;
+            }
+          }
+        }
+      } else {
+        uint32_t _n = std::min((uint32_t)_tf.size(), rx->nsub);
+        for (uint32_t _si = 0; _si < _n; _si++) {
+          rx->subjects[_si].tolFactor = _tf[_si];
+        }
+      }
+    }
   }
   par_solve(rx);
 #ifdef rxSolveT
@@ -5829,6 +5865,9 @@ RObject rxSolveGet_rxSolve(RObject &obj, std::string &sarg, LogicalVector &exact
     return e[".sigmaL"];
   } else if ((sarg == "omega.list" || sarg == "omegaList") && e.exists(".omegaL")){
     return e[".omegaL"];
+  } else if (sarg == "tolFactor") {
+    if (e.exists(".tolFactor")) return e[".tolFactor"];
+    return R_NilValue;
   } else if ((sarg == "theta.list" || sarg == "thetaList")) {
     return e[".thetaL"];
   }
@@ -5938,7 +5977,7 @@ CharacterVector rxSolveDollarNames(RObject obj){
   CharacterVector cls = lst.attr("class");
   Environment e = as<Environment>(cls.attr(".rxode2.env"));
   updateSolveEnvPost(e);
-  int nExtra = 6;
+  int nExtra = 7;
   if (e.exists(".theta")) nExtra++;
   if (e.exists(".sigmaL")) nExtra++;
   if (e.exists(".thetaL")) nExtra++;
@@ -5983,6 +6022,7 @@ CharacterVector rxSolveDollarNames(RObject obj){
   ret[j++] = "inits";
   ret[j++] = "t";
   ret[j++] = "rxode2";
+  ret[j++] = "tolFactor";
   if (e.exists(".theta")) ret[j++] = "thetaMat";
   if (e.exists(".sigmaL")) ret[j++] = "sigmaList";
   if (e.exists(".thetaL")) ret[j++] = "thetaList";

--- a/tests/testthat/test-dollar-names.R
+++ b/tests/testthat/test-dollar-names.R
@@ -61,7 +61,7 @@ rxTest({
                         "get.obs.rec", "get.sampling", "get.units", "import.EventTable",
                         "inits", "KA", "Kin", "Kout", "model", "nobs", "omegaList", "params",
                         "peripheral1", "peripheral10", "pk", "Q", "resp", "rxode2", "sigmaList",
-                        "sim.id", "sim.id", "t", "TCL", "thetaMat", "time", "units",
+                        "sim.id", "sim.id", "t", "TCL", "thetaMat", "time", "tolFactor", "units",
                         "V2", "V3")))
 
 
@@ -83,7 +83,7 @@ rxTest({
                         "get.obs.rec", "get.sampling", "get.units", "import.EventTable",
                         "inits", "KA", "Kin", "Kout", "model", "nobs", "omegaList", "params",
                         "peripheral1", "peripheral10", "pk", "Q", "resp", "rxode2", "sim.id",
-                        "sim.id", "t", "TCL", "thetaMat", "time", "units", "V2", "V3")))
+                        "sim.id", "t", "TCL", "thetaMat", "time", "tolFactor", "units", "V2", "V3")))
 
     pk4 <-
       suppressWarnings(rxSolve(
@@ -103,7 +103,7 @@ rxTest({
                         "get.obs.rec", "get.sampling", "get.units", "import.EventTable",
                         "inits", "KA", "Kin", "Kout", "model", "nobs", "params", "peripheral1",
                         "peripheral10", "pk", "Q", "resp", "rxode2", "sim.id", "sim.id",
-                        "t", "TCL", "thetaMat", "time", "units", "V2", "V3")))
+                        "t", "TCL", "thetaMat", "time", "tolFactor", "units", "V2", "V3")))
 
     pk4 <-
       suppressWarnings(rxSolve(
@@ -122,6 +122,6 @@ rxTest({
                    "get.obs.rec", "get.sampling", "get.units", "import.EventTable",
                    "inits", "KA", "Kin", "Kout", "model", "nobs", "params", "peripheral1",
                    "peripheral10", "pk", "Q", "resp", "rxode2", "sim.id", "sim.id",
-                   "t", "TCL", "time", "units", "V2", "V3")))
+                   "t", "TCL", "time", "tolFactor", "units", "V2", "V3")))
   })
 })

--- a/tests/testthat/test-tolFactor.R
+++ b/tests/testthat/test-tolFactor.R
@@ -1,0 +1,64 @@
+rxTest({
+  .mod <- rxode2({
+    d/dt(intestine) <- -a * intestine
+    d/dt(blood) <- a * intestine - b * blood
+  })
+
+  .et <- eventTable()
+  .et$add.sampling(seq(0, 10, length.out = 10))
+  .et$add.dosing(dose = 1, strt.time = 0)
+
+  # Build a 4-subject event table (id column required for nsub > 1)
+  .ev <- do.call(rbind, lapply(1:4, function(i) {
+    d <- as.data.frame(.et)
+    d$id <- i
+    d
+  }))
+
+  .p <- data.frame(id = 1:4, a = 6, b = seq(0.4, 0.9, length.out = 4))
+
+  test_that("tolFactor=NULL (default) solves without error", {
+    expect_error(rxSolve(.mod, .p, .ev, tolFactor = NULL), NA)
+  })
+
+  test_that("tolFactor scalar >= 1 solves without error", {
+    expect_error(rxSolve(.mod, .p, .ev, tolFactor = 10), NA)
+  })
+
+  test_that("tolFactor vector (one per subject) solves without error", {
+    expect_error(rxSolve(.mod, .p, .ev, tolFactor = c(1, 2, 5, 10)), NA)
+  })
+
+  test_that("tolFactor named vector matched by subject ID solves without error", {
+    expect_error(rxSolve(.mod, .p, .ev, tolFactor = c("2" = 5, "4" = 10)), NA)
+  })
+
+  test_that("tolFactor < 1 is rejected", {
+    expect_error(rxSolve(.mod, .p, .ev, tolFactor = 0.5))
+  })
+
+  test_that("$tolFactor returns per-subject factors used in the solve", {
+    .out <- rxSolve(.mod, .p, .ev, tolFactor = c(1, 2, 5, 10))
+    .tf <- .out$tolFactor
+    expect_length(.tf, 4)
+    expect_equal(as.numeric(.tf), c(1, 2, 5, 10))
+  })
+
+  test_that("named tolFactor: matched subjects get factor, unmatched stay at 1", {
+    .out <- rxSolve(.mod, .p, .ev, tolFactor = c("2" = 5, "4" = 10))
+    .got <- as.numeric(.out$tolFactor)
+    expect_equal(.got[1], 1)
+    expect_equal(.got[2], 5)
+    expect_equal(.got[3], 1)
+    expect_equal(.got[4], 10)
+  })
+
+  test_that("tolFactor=1 for all subjects does not change results vs NULL", {
+    .base <- rxSolve(.mod, .p, .ev, tolFactor = NULL)
+    .tf1  <- rxSolve(.mod, .p, .ev, tolFactor = rep(1, 4))
+    expect_equal(
+      as.data.frame(.base)[, c("id", "time", "intestine", "blood")],
+      as.data.frame(.tf1)[, c("id", "time", "intestine", "blood")]
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Adds an `ind->neqOverride` field on `rx_solving_options_ind` and plumbs
it through the per-subject solve loop via a new `rxEffNeq(ind, op)`
inline helper.  Lets a downstream caller (nlmixr2est's FOCEi inner
optimization) tell the solver "for this one subject, step `predNeq`
states instead of `op->neq`" without mutating shared global state from
a worker thread.

Companion nlmixr2est PR: nlmixr2/nlmixr2est#<NN> (branch
`parallel-v2`).  Together they fix a parallel-FOCEi heap corruption
(`EE:[lsoda] ewt[1] = 0 <= 0`, `double free or corruption (!prev)`,
SIGSEGV) on models whose `f()`, `dur()`, `rate()`, or `alag()` depend
on ETAs.  Reprex:
[`inst/reprex_fbio_eta_parallel.R`](https://github.com/nlmixr2/nlmixr2est/blob/parallel-v2/inst/reprex_fbio_eta_parallel.R)
in the companion repo.

## Why

`nlmixr2est`'s `shi21EtaGeneral()` (and the doFD fallback in
`likInner0()`) needs to switch from the inner sensitivity model
(neq = base + sens) to the prediction-only model (neq = base) for the
finite-difference perturbation pass that handles eta-dependent dose
parameters.  Previously it did this with
`setOpNeq(op, predNeq); predOde(id); setOpNeq(op, oldNeq);` — a
read-modify-write on a global.  Under `cores>1`, a concurrent worker
thread doing `innerOde(id)` would observe `op->neq` transiently set to
`predNeq` mid-solve and step the wrong number of equations →
out-of-bounds writes → heap corruption.

Matt Fidler flagged this on PR #621 (2026-05-01):
> "your code in rxode2 ind_solve will corrupt any etas where they are
> used in f(), dur() or the inner problem has an issue with the solve
> and falls back to numerical differences."

## What this PR does

### 1. C-API: per-individual neq override (commits `f3f019db5`)

- New `int neqOverride` field on `rx_solving_options_ind` (default
  `-1`, set by `setupRxInd()` on first allocation).
- New `getIndNeqOverride()` / `setIndNeqOverride()` getter/setter at
  `R_RegisterCCallable` and at pointer-table slots 56 and 57 in
  `inst/include/rxode2ptr.h`.

### 2. Solve-loop consumer: `rxEffNeq(ind, op)` (commits `b657b1c2c`, `875136521`)

- New static-inline `rxEffNeq(ind, op)` in `inst/include/rxode2.h`:
  returns `ind->neqOverride` when set in `[0, op->neq]`, else
  `op->neq`.
- `getSolve(idx)`, `getAdvan(idx)` macros use `rxEffNeq` so the per-
  event buffer stride matches what the solver wrote.
- `getOpIndSolve()` in `src/rx2api.c` likewise.
- `iniSubject()` in `src/par_solve.h` uses `rxEffNeq` for the init
  memcpy length.  **Critical**: writing `op->neq` doubles into slot 0
  was clobbering the start of slot 1 under override (slot 1 sits at
  offset `predNeq`, not `op->neq`).
- Every `op->neq` read in the SOLVE LOOP of `src/par_solve.cpp` is
  converted to `rxEffNeq(ind, op)`: `badSolveExit` macro, `postSolve`
  state-trim loops, `solveWith1Pt`, `ind_indLin0`, `ind_liblsoda0`,
  `ind_lsoda0`, `ind_linCmt0H`, `ind_dop0`, the SS retry loop, and
  `updateSolve`'s length argument.
- `ind_solve` dispatch: when an override is active, skip the pure-
  linCmt fast path (`op->numLin` / `op->numLinSens` describe the
  rxInner-sensitivity model's linCmt structure; the override caller is
  solving the smaller predNoLhs ODE model which has `numLin == 0` by
  construction).
- `src/expm.cpp`: `meOnly()` and `indLin()` plumb
  `rx_solving_options_ind*` and consult `rxEffNeq` so stiff=3
  (inductive linearisation) is consistent with LSODA / dop853, even
  though the parallel-FOCEi reprex routes through stiff=2.
- Allocations are unchanged — they remain sized for `op->neq`.  The
  override is constrained to `<= op->neq` by caller contract.


## Backward compatibility

When `ind->neqOverride == -1` (the default set by `setupRxInd()`),
`rxEffNeq` returns `op->neq` and behavior is byte-equivalent to the
unpatched solver.  No existing rxode2 caller is affected — only the
new nlmixr2est code that explicitly sets the override sees the
new behavior.

## Test plan

- [x] Existing rxode2 test suite (`devtools::test()`) passes — no
      regression because the override defaults to `-1` and `rxEffNeq`
      returns `op->neq`.
- [x] Companion nlmixr2est reprex (`cores=2` with eta-dependent
      `f(depot)`) no longer crashes.
- [x] cores=1 ↔ cores=2 bit-for-bit match on the eta-dependent
      `f` / `dur` / `alag` test models in
      `nlmixr2est/tests/testthat/test-focei-parallel.R` (after the
      companion PR's determinism fix).

## Pointer-table compatibility note

This PR appends two new entries (slots 56, 57) to the rxode2 pointer
table.  `iniRxodePtrs0()` only reads each slot once at downstream
package load time; existing downstream packages that don't know about
slots 56/57 are unaffected because they stop reading at slot 55.
nlmixr2est is bumped to require this rxode2 version once the companion
PR lands.