### PR TITLE
Declare censoring aesthetics in stat_cens, tighten pair validation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rxode2
-Version: 5.1.1
+Version: 5.1.2
 Title: Facilities for Simulating from ODE-Based Models
 Authors@R: c(
    person("Matthew L.","Fidler", role = c("aut", "cre"), email = "matthew.fidler@gmail.com", comment=c(ORCID="0000-0001-8538-6691")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # rxode2 5.1.1
 
+- `geom_cens()` / `stat_cens()` no longer emit "Ignoring unknown
+  aesthetics" warnings when censoring aesthetics are mapped.
+  Documentation corrected to describe the two supported lowercase
+  forms: `lower`/`upper` (both required) or `cens` (with optional
+  `limit`). The two forms cannot be mixed, `lower` and `upper` are
+  now required together, and `limit` without `cens` is rejected
+  rather than silently ignored.
+
 - Various low level fixes to allow `nlmixr2est` to have parallelized
   focei.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# rxode2 5.1.1
+# rxode2 5.1.2
 
 - `geom_cens()` / `stat_cens()` no longer emit "Ignoring unknown
   aesthetics" warnings when censoring aesthetics are mapped.
@@ -7,6 +7,8 @@
   `limit`). The two forms cannot be mixed, `lower` and `upper` are
   now required together, and `limit` without `cens` is rejected
   rather than silently ignored.
+
+# rxode2 5.1.1
 
 - Various low level fixes to allow `nlmixr2est` to have parallelized
   focei.

--- a/R/geom-cens.R
+++ b/R/geom-cens.R
@@ -83,7 +83,7 @@
   if (is.null(params$width)) {
     params$width <- 0.01
   }
-  return(params)
+  params
 }
 
 GeomPolygonCens <- ggplot2::ggproto("GeomPolygonCens", ggplot2::GeomPolygon,

--- a/R/geom-cens.R
+++ b/R/geom-cens.R
@@ -23,17 +23,38 @@
 }
 
 .setupGroupCensBox <- function(data, params) {
+  .nm <- names(data)
+  .hasCens <- "cens" %in% .nm
+  .hasLimit <- "limit" %in% .nm
+  .hasLower <- "lower" %in% .nm
+  .hasUpper <- "upper" %in% .nm
+  .censSet <- .hasCens || .hasLimit
+  .lowerSet <- .hasLower || .hasUpper
+  if (.censSet && .lowerSet) {
+    stop("stat_cens cannot mix the (cens, limit) and (lower, upper) aesthetic pairs; supply only one pair",
+      call. = FALSE
+    )
+  }
+  if (!.censSet && !.lowerSet) {
+    stop("stat_cens requires either the (lower, upper) or (cens, limit) aesthetic pair",
+      call. = FALSE
+    )
+  }
+  if (.hasLimit && !.hasCens) {
+    stop("stat_cens requires `cens` when the `limit` aesthetic is supplied",
+      call. = FALSE
+    )
+  }
+  if (.lowerSet && !(.hasLower && .hasUpper)) {
+    stop("stat_cens requires both `lower` and `upper` aesthetics when using the (lower, upper) pair",
+      call. = FALSE
+    )
+  }
   .dat <- data
-  if (any(names(data) == "cens")) {
-    if (any(names(data) == "lower")) {
-      stop("stat_cens cannot have lower aesthetic with cens aesthetic", call. = FALSE)
-    }
-    if (any(names(data) == "upper")) {
-      stop("stat_cens cannot have lower aesthetic with cens aesthetic", call. = FALSE)
-    }
+  if (.hasCens) {
     .dat$lower <- ifelse(.dat$cens == 0, NA_real_, -Inf)
     .dat$upper <- ifelse(.dat$cens == 0, NA_real_, Inf)
-    if (any(names(data) == "limit")) {
+    if (.hasLimit) {
       .dat$upper <- ifelse(.dat$cens == 1, .dat$y, ifelse(is.na(.dat$limit), .dat$upper, .dat$limit))
       .dat$lower <- ifelse(.dat$cens == -1, .dat$y, ifelse(is.na(.dat$limit), .dat$lower, .dat$limit))
     } else {
@@ -42,25 +63,18 @@
     }
     data <- .dat
   }
-  if (any(names(data) == "lower")) {
-    if (!any(names(data) == "upper")) {
-      stop("stat_cens requires the following aesthetics: upper, lower or cens (and optionally limit)",
-        call. = FALSE
-      )
-    }
-    .dat <- data[!is.na(data$lower), , drop = FALSE]
-    if (length(.dat[, 1]) > 0) {
-      .r <- c(data$y, data$upper[is.finite(data$upper)], data$lower[is.finite(data$lower)])
-      .r <- range(.r, na.rm = TRUE)
-      .rw <- .r[2] - .r[1]
-      .dat$..ni <- .r[1] - 0.01 * .rw
-      .dat$..pi <- .r[2] + 0.01 * .rw
-      .dat$..delta <- .rw
-      .r <- range(data$x, na.rm = TRUE)
-      .dat$..width <- (.r[2] - .r[1]) * params$width
-      .dat$lower <- ifelse(is.finite(.dat$lower), .dat$lower, .dat$..ni)
-      .dat$upper <- ifelse(is.finite(.dat$upper), .dat$upper, .dat$..pi)
-    }
+  .dat <- data[!is.na(data$lower), , drop = FALSE]
+  if (length(.dat[, 1]) > 0) {
+    .r <- c(data$y, data$upper[is.finite(data$upper)], data$lower[is.finite(data$lower)])
+    .r <- range(.r, na.rm = TRUE)
+    .rw <- .r[2] - .r[1]
+    .dat$..ni <- .r[1] - 0.01 * .rw
+    .dat$..pi <- .r[2] + 0.01 * .rw
+    .dat$..delta <- .rw
+    .r <- range(data$x, na.rm = TRUE)
+    .dat$..width <- (.r[2] - .r[1]) * params$width
+    .dat$lower <- ifelse(is.finite(.dat$lower), .dat$lower, .dat$..ni)
+    .dat$upper <- ifelse(is.finite(.dat$upper), .dat$upper, .dat$..pi)
   }
   .dat
 }
@@ -92,7 +106,8 @@ StatCens <- ggplot2::ggproto("StatCens", ggplot2::Stat,
   compute_group = function(data, scales, width) {
     .createCensBox(data)
   },
-  required_aes = c("x", "y")
+  required_aes = c("x", "y"),
+  optional_aes = c("cens", "limit", "lower", "upper")
 )
 
 #' Censoring geom/stat
@@ -101,10 +116,18 @@ StatCens <- ggplot2::ggproto("StatCens", ggplot2::Stat,
 #'
 #' Requires the following aesthetics:
 #'
-#'  - `x` Represents the independent variable, often the time scale
+#'  - `x` represents the independent variable, often the time scale
 #'  - `y` represents the dependent variable
-#'  - `CENS` for the censoring information; (`-1` right censored, `0` no censoring or `1` left censoring)
-#'  - `LIMIT` which represents the corresponding limit ()
+#'
+#' Plus exactly one of these aesthetic forms (the two forms cannot be mixed):
+#'
+#'  - `lower` and `upper` give the lower and upper bounds of the censoring
+#'    interval directly. Both must be supplied. Use `-Inf`/`Inf` for an
+#'    unbounded side; use `NA` on both for observed (non-censored) rows.
+#'  - `cens` (with optional `limit`) gives the censoring indicator
+#'    (`-1` right censored, `0` not censored, `1` left censored) and, when
+#'    `limit` is also supplied, the associated limit value. Internally
+#'    converted to `lower`/`upper`.
 #'
 #' Will add boxes representing the areas of the fit that were censored.
 #'

--- a/man/stat_cens.Rd
+++ b/man/stat_cens.Rd
@@ -112,10 +112,19 @@ This is a censoring geom that shows the left or right censoring specified in the
 \details{
 Requires the following aesthetics:
 \itemize{
-\item \code{x} Represents the independent variable, often the time scale
+\item \code{x} represents the independent variable, often the time scale
 \item \code{y} represents the dependent variable
-\item \code{CENS} for the censoring information; (\code{-1} right censored, \code{0} no censoring or \code{1} left censoring)
-\item \code{LIMIT} which represents the corresponding limit ()
+}
+
+Plus exactly one of these aesthetic forms (the two forms cannot be mixed):
+\itemize{
+\item \code{lower} and \code{upper} give the lower and upper bounds of the censoring
+interval directly. Both must be supplied. Use \code{-Inf}/\code{Inf} for an
+unbounded side; use \code{NA} on both for observed (non-censored) rows.
+\item \code{cens} (with optional \code{limit}) gives the censoring indicator
+(\code{-1} right censored, \code{0} not censored, \code{1} left censored) and, when
+\code{limit} is also supplied, the associated limit value. Internally
+converted to \code{lower}/\code{upper}.
 }
 
 Will add boxes representing the areas of the fit that were censored.

--- a/tests/testthat/test-geom-cens.R
+++ b/tests/testthat/test-geom-cens.R
@@ -1,0 +1,103 @@
+rxTest({
+
+  test_that(".setupGroupCensBox accepts lower/upper pair and produces polygon-ready data", {
+    d <- data.frame(
+      x = c(1, 2, 3),
+      y = c(1, 2, 3),
+      lower = c(NA_real_, -Inf, 2),
+      upper = c(NA_real_, 0.5, Inf)
+    )
+    out <- .setupGroupCensBox(d, list(width = 0.01))
+    expect_true(all(c("..ni", "..pi", "..width") %in% names(out)))
+    # NA-lower rows are dropped (observed rows) — two censored rows remain
+    expect_equal(nrow(out), 2L)
+  })
+
+  test_that(".setupGroupCensBox cens/limit pair produces same lower/upper as direct form", {
+    d_cl <- data.frame(
+      x = c(1, 2, 3),
+      y = c(1, 2, 3),
+      cens = c(0, 1, -1),
+      limit = c(NA_real_, 0.5, 5)
+    )
+    d_lu <- data.frame(
+      x = c(1, 2, 3),
+      y = c(1, 2, 3),
+      lower = c(NA_real_, 0.5, 3),
+      upper = c(NA_real_, 2,   5)
+    )
+    out_cl <- .setupGroupCensBox(d_cl, list(width = 0.01))
+    out_lu <- .setupGroupCensBox(d_lu, list(width = 0.01))
+    expect_equal(out_cl$lower, out_lu$lower)
+    expect_equal(out_cl$upper, out_lu$upper)
+  })
+
+  test_that(".setupGroupCensBox rejects mixing the two aesthetic pairs", {
+    d <- data.frame(x = 1, y = 1, cens = 1, limit = 0, lower = -Inf, upper = 0)
+    expect_error(
+      .setupGroupCensBox(d, list(width = 0.01)),
+      regexp = "cannot mix"
+    )
+  })
+
+  test_that(".setupGroupCensBox accepts cens alone (limit optional)", {
+    d <- data.frame(x = 1:3, y = c(1, 2, 3), cens = c(0, 1, -1))
+    out <- .setupGroupCensBox(d, list(width = 0.01))
+    # cens == 0 row is dropped (lower == NA); the other two remain
+    expect_equal(nrow(out), 2L)
+  })
+
+  test_that(".setupGroupCensBox rejects limit without cens", {
+    d_limit_only <- data.frame(x = 1:2, y = 1:2, limit = c(NA_real_, 0.5))
+    expect_error(
+      .setupGroupCensBox(d_limit_only, list(width = 0.01)),
+      regexp = "requires `cens` when the `limit`"
+    )
+  })
+
+  test_that(".setupGroupCensBox rejects partial lower/upper pair", {
+    d_lower_only <- data.frame(x = 1:2, y = 1:2, lower = c(NA_real_, -Inf))
+    expect_error(
+      .setupGroupCensBox(d_lower_only, list(width = 0.01)),
+      regexp = "both `lower` and `upper`"
+    )
+    d_upper_only <- data.frame(x = 1:2, y = 1:2, upper = c(NA_real_, 0.5))
+    expect_error(
+      .setupGroupCensBox(d_upper_only, list(width = 0.01)),
+      regexp = "both `lower` and `upper`"
+    )
+  })
+
+  test_that(".setupGroupCensBox rejects when neither pair is given", {
+    d <- data.frame(x = 1:2, y = 1:2)
+    expect_error(
+      .setupGroupCensBox(d, list(width = 0.01)),
+      regexp = "either the \\(lower, upper\\) or \\(cens, limit\\)"
+    )
+  })
+
+  test_that("geom_cens does not warn about unknown aesthetics", {
+    d <- data.frame(
+      x = 1:5,
+      y = c(1, 2, 1, 2, 3),
+      lower = c(NA_real_, -Inf, NA_real_, 3, NA_real_),
+      upper = c(NA_real_, 0.5,  NA_real_, Inf, NA_real_)
+    )
+    p <- ggplot2::ggplot(d, ggplot2::aes(x = x, y = y)) +
+      ggplot2::geom_point() +
+      geom_cens(ggplot2::aes(lower = lower, upper = upper))
+    expect_no_warning(suppressMessages(ggplot2::ggplot_build(p)))
+
+    d2 <- data.frame(
+      x = 1:5,
+      y = c(1, 2, 1, 2, 3),
+      cens = c(0, 1, 0, -1, 0),
+      limit = c(NA_real_, 0.5, NA_real_, 3, NA_real_)
+    )
+    p2 <- ggplot2::ggplot(d2, ggplot2::aes(x = x, y = y)) +
+      ggplot2::geom_point() +
+      geom_cens(ggplot2::aes(cens = cens, limit = limit))
+    expect_no_warning(suppressMessages(ggplot2::ggplot_build(p2)))
+  })
+
+})


### PR DESCRIPTION
Add `optional_aes = c("cens", "limit", "lower", "upper")` to `StatCens` so ggplot2 stops emitting "Ignoring unknown aesthetics" warnings when callers map the censoring aesthetics. The internal `.setupGroupCensBox()` already reads these column names; they were just never declared on the ggproto.

Tighten pair validation in `.setupGroupCensBox()`:

  - reject mixing the (cens, limit) and (lower, upper) forms (previously only the cens+lower combination errored, and with a misleading "lower aesthetic" message even for the upper check)
  - require both `lower` and `upper` together (previously `upper` alone was silently accepted and produced empty output)
  - reject `limit` without `cens` (previously silently ignored)
  - require one of the two pair forms (previously empty data passed through)

`cens` alone (with implicit -Inf/Inf bounds) remains accepted.

Fix the roxygen docs to describe the actual lowercase aesthetic forms. The previous text claimed `CENS`/`LIMIT` (uppercase), which the implementation has never accepted.

Fixes nlmixr2/nlmixr2plot#31