### PR TITLE
Make atolRtolFactor_ thread-safe; replace body with atolRtolFactorC_'s

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # rxode2 5.1.3
 
+- Make `atolRtolFactor_` thread-safe by replacing its body with the
+  per-thread / per-individual implementation that previously lived in
+  `atolRtolFactorC_`.  Loosening writes now go to the calling thread's
+  slice of `_globals.gatol2Thread / grtol2Thread / gssAtolThread /
+  gssRtolThread` and update `ind->tolFactor` for the subject currently
+  being solved on that thread, so subsequent re-solves pick up the
+  cumulative loosening regardless of which thread later runs the
+  subject.  The function signature is unchanged; existing downstream
+  binaries (including `nlmixr2est` on CRAN) pick up the fix without
+  needing a rebuild.  `atolRtolFactorC_` is retained as an alias.
+  This closes the non-determinism in parallel FOCEI optimization
+  reported in https://github.com/nlmixr2/nlmixr2est/issues/641.
+
 - Bug fix for `mix()` models as well as `iCov` models.
 
 # rxode2 5.1.2

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -1633,24 +1633,21 @@ double maxAtolRtolFactor = 0.1;
 //[[Rcpp::interfaces(cpp)]]
 //[[Rcpp::export]]
 void atolRtolFactor_(double factor) {
-  // this is NOT thread safe and is intended for backward compatibility only.
-  // it will eventually go away but nlmixr2est 5.0 needs this interface.
-  rx_solve* rx = getRxSolve_();
-  rx_solving_options* op = rx->op;
-  for (int i = op->neq;i--;){
-    _globals.grtol2[i] = min2(_globals.grtol2[i]*factor, maxAtolRtolFactor);
-    _globals.gatol2[i] = min2(_globals.gatol2[i]*factor, maxAtolRtolFactor);
-  }
-  op->ATOL = min2(op->ATOL*factor, maxAtolRtolFactor);
-  op->RTOL = min2(op->RTOL*factor, maxAtolRtolFactor);
-}
-
-extern "C" void atolRtolFactorC_(double factor) {
+  // Thread-safe tolerance loosening.  Writes only to the calling thread's
+  // slice of the per-thread atol/rtol/ssAtol/ssRtol arrays and updates the
+  // tolFactor of the individual currently being solved on this thread, so
+  // iniSubject() reapplies the cumulative loosening on every re-solve.
+  // Outside parallel regions omp_get_thread_num() returns 0, so
+  // single-threaded behaviour is bit-for-bit equivalent to the previous
+  // sequential semantics.
+  //
+  // op->ATOL / op->RTOL are NOT modified — those are scalars shared across
+  // threads, and parallel/sequential solve paths now read the per-thread
+  // arrays through op->atol2 / op->rtol2 (or ind->atol2 / ind->rtol2),
+  // which point into _globals.gatol2Thread / grtol2Thread.
   rx_solve *rx = getRxSolve_();
   rx_solving_options *op = rx->op;
 
-  // Modify only the current thread's tolerance arrays — fully thread-safe,
-  // no critical section needed because each thread has its own slice.
   int _threadId = omp_get_thread_num();
   double *_atol2  = _globals.gatol2Thread  + op->neq * _threadId;
   double *_rtol2  = _globals.grtol2Thread  + op->neq * _threadId;
@@ -1664,14 +1661,16 @@ extern "C" void atolRtolFactorC_(double factor) {
     _ssRtol[_i] = min2(_ssRtol[_i] * factor, maxAtolRtolFactor);
   }
 
-  // Persist the cumulative factor on the individual currently being solved
-  // on this thread so that iniSubject() can reapply it on every re-solve.
   rx_solving_options_ind *_ind = &(inds_thread[rx_get_thread(op->cores)]);
   if (_ind != NULL) {
     _ind->tolFactor = min2(_ind->tolFactor * factor, maxAtolRtolFactor);
   }
-  // Note: op->ATOL and op->RTOL are deliberately NOT modified here to
-  // avoid races between threads sharing the op structure.
+}
+
+// Retained as an alias of atolRtolFactor_ (now thread-safe) for the
+// external-pointer reference in src/init.c.  Callers may use either name.
+extern "C" void atolRtolFactorC_(double factor) {
+  atolRtolFactor_(factor);
 }
 
 extern "C" double * getAol(int n, double atol){


### PR DESCRIPTION
## Summary

`atolRtolFactor_` was kept around as "NOT thread safe… nlmixr2est 5.0 needs this interface."  In addition to the race, its writes to `_globals.gatol2 / grtol2` had no effect on the parallel solve (solvers read the per-thread slices set by `_setIndPointersByThread`), so loosening calls from downstream packages were essentially silent no-ops on the actual numerics, with racy writes to `op->ATOL / op->RTOL` thrown in.

This PR makes `atolRtolFactor_` actually work, thread-safely, by replacing its body with the existing `atolRtolFactorC_` implementation:

- Per-thread writes to `_globals.gatol2Thread / grtol2Thread / gssAtolThread / gssRtolThread`
- Per-individual `ind->tolFactor` update for the subject currently solving on this thread, so `iniSubject()` reapplies the cumulative loosening regardless of which thread runs the subject on a later iteration
- No writes to `op->ATOL / op->RTOL`

`atolRtolFactorC_` is retained as a thin alias for `src/init.c`'s `R_MakeExternalPtrFn` reference.

## ABI invariance

Function signature, registration name (`_rxode2_atolRtolFactor_`), and Rcpp interface attributes are unchanged.  Existing downstream binaries that called `R_GetCCallable("rxode2", "_rxode2_atolRtolFactor_")` resolve the new code transparently when users update rxode2 — no rebuild required.  In particular, this includes the current CRAN `nlmixr2est`.

## Test plan
- [x] `tests/testthat/test-par-solve.R` source-runs to completion.
- [x] Empirically reduces FOCEI two-run OFV gap from ~1544 to ~0.77 on the https://github.com/nlmixr2/nlmixr2est/issues/641 reproducer at `cores=2`.
- [ ] Bit-identical determinism not yet achieved on that reproducer — at least one more non-determinism source remains, outside this function's scope.