### PR TITLE
Origin/claude/fix cross dll omp

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # rxode2 5.1.3
 
+- Added `setRxThreadId()` so a package that drives rxode2's per-subject
+  solve from its OWN OpenMP team (e.g. nlmixr2est's FOCEi inner loop)
+  can supply the real thread id.  On Windows each package statically
+  links its own libgomp, so rxode2's `omp_get_thread_num()` returns 0
+  for every foreign worker thread, which collapsed all of rxode2's
+  per-thread solve buffers onto one slot and corrupted the heap at more
+  than one core.  When the id is set (>= 0) rxode2 uses it for per-thread
+  buffer indexing instead of `omp_get_thread_num()`.
+
 - Added Jacobian handling of adaptive dosing events (retaining them
   when calculating Jacobian).  Should be able to be applied in forward
   sensitivity analysis as well.

--- a/inst/include/rxode2ptr.h
+++ b/inst/include/rxode2ptr.h
@@ -219,6 +219,9 @@ extern "C" {
   typedef int (*getRxNsim_t)(rx_solve *rx);
   extern getRxNsim_t getRxNsim;
 
+  typedef void (*setRxThreadId_t)(int id);
+  extern setRxThreadId_t setRxThreadId;
+
   static inline SEXP iniRxodePtrs0(SEXP p) {
     if (_rxode2_rxRmvnSEXP_ == NULL) {
       _rxode2_rxRmvnSEXP_ = (_rxode2_rxRmvnSEXP_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 0));
@@ -286,6 +289,7 @@ extern "C" {
       rxInt = (rxInt_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 62));
       rxReal = (rxReal_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 63));
       getRxNsim = (getRxNsim_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 64));
+      setRxThreadId = (setRxThreadId_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 65));
     }
     return R_NilValue;
   }
@@ -356,6 +360,7 @@ extern "C" {
   rxInt_t rxInt = NULL;                                 \
   rxReal_t rxReal = NULL;                               \
   getRxNsim_t getRxNsim = NULL;                         \
+  setRxThreadId_t setRxThreadId = NULL;                 \
   SEXP iniRxodePtrs(SEXP ptr) {                         \
     return iniRxodePtrs0(ptr);                          \
   }                                                     \

--- a/src/init.c
+++ b/src/init.c
@@ -384,6 +384,9 @@ SEXP _rxode2_atolRtolFactor_(SEXP);
 void allocExtraDosingC(void);
 void atolRtolFactorC_(double factor);
 
+// Cross-DLL OpenMP thread-id override (defined in rxData.cpp); see comment there.
+void setRxThreadId(int id);
+
 SEXP _rxode2_rxode2Ptr(void) {
   int pro = 0;  // Counter for the number of PROTECT calls
   // Create an external pointer for _lotriLstToMat
@@ -647,9 +650,6 @@ SEXP _rxode2_mlogit_f(SEXP x, SEXP p);
 SEXP _rxode2_mlogit_j(SEXP x);
 SEXP _rxode2_rxMemoryComponents_(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
 SEXP _rxode2_rxSolveSetCurObj_(SEXP);
-
-// Cross-DLL OpenMP thread-id override (defined in rxData.cpp); see comment there.
-void setRxThreadId(int id);
 
 void R_init_rxode2(DllInfo *info){
   allocExtraDosingC();

--- a/src/init.c
+++ b/src/init.c
@@ -645,6 +645,9 @@ SEXP _rxode2_mlogit_j(SEXP x);
 SEXP _rxode2_rxMemoryComponents_(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
 SEXP _rxode2_rxSolveSetCurObj_(SEXP);
 
+// Cross-DLL OpenMP thread-id override (defined in rxData.cpp); see comment there.
+void setRxThreadId(int id);
+
 void R_init_rxode2(DllInfo *info){
   allocExtraDosingC();
   R_CallMethodDef callMethods[]  = {
@@ -828,6 +831,7 @@ void R_init_rxode2(DllInfo *info){
   // C callable to assign environments.
   R_RegisterCCallable("rxode2", "linCmtA", (DL_FUNC) &linCmtA);
   R_RegisterCCallable("rxode2", "linCmtB", (DL_FUNC) &linCmtB);
+  R_RegisterCCallable("rxode2", "setRxThreadId", (DL_FUNC) &setRxThreadId);
   R_RegisterCCallable("rxode2", "_rxode2_rxRmvnSEXP",
                       (DL_FUNC) &_rxode2_rxRmvnSEXP);
   R_RegisterCCallable("rxode2", "_rxode2_evalUdf", (DL_FUNC) &_rxode2_evalUdf);

--- a/src/init.c
+++ b/src/init.c
@@ -463,8 +463,9 @@ SEXP _rxode2_rxode2Ptr(void) {
   SEXP rxode2rxInt = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxInt, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2rxReal = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxReal, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2getRxNsim = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&getRxNsim, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2setRxThreadId = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setRxThreadId, R_NilValue, R_NilValue)); pro++;
 
-#define nVec 65
+#define nVec 66
   SEXP ret = PROTECT(Rf_allocVector(VECSXP, nVec)); pro++;
   SET_VECTOR_ELT(ret, 0, rxode2rxRmvnSEXP);
   SET_VECTOR_ELT(ret, 1, rxode2rxParProgress);
@@ -531,6 +532,7 @@ SEXP _rxode2_rxode2Ptr(void) {
   SET_VECTOR_ELT(ret, 62, rxode2rxInt);
   SET_VECTOR_ELT(ret, 63, rxode2rxReal);
   SET_VECTOR_ELT(ret, 64, rxode2getRxNsim);
+  SET_VECTOR_ELT(ret, 65, rxode2setRxThreadId);
 
 
   SEXP retN = PROTECT(Rf_allocVector(STRSXP, nVec)); pro++;
@@ -599,6 +601,7 @@ SEXP _rxode2_rxode2Ptr(void) {
   SET_STRING_ELT(retN, 62, Rf_mkChar("rxode2rxInt"));
   SET_STRING_ELT(retN, 63, Rf_mkChar("rxode2rxReal"));
   SET_STRING_ELT(retN, 64, Rf_mkChar("rxode2getRxNsim"));
+  SET_STRING_ELT(retN, 65, Rf_mkChar("rxode2setRxThreadId"));
 
 #undef nVec
 
@@ -831,7 +834,6 @@ void R_init_rxode2(DllInfo *info){
   // C callable to assign environments.
   R_RegisterCCallable("rxode2", "linCmtA", (DL_FUNC) &linCmtA);
   R_RegisterCCallable("rxode2", "linCmtB", (DL_FUNC) &linCmtB);
-  R_RegisterCCallable("rxode2", "setRxThreadId", (DL_FUNC) &setRxThreadId);
   R_RegisterCCallable("rxode2", "_rxode2_rxRmvnSEXP",
                       (DL_FUNC) &_rxode2_rxRmvnSEXP);
   R_RegisterCCallable("rxode2", "_rxode2_evalUdf", (DL_FUNC) &_rxode2_evalUdf);

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -272,7 +272,11 @@ extern "C" double linCmtA(rx_solve *rx, int id,
   rx_solving_options_ind *ind = &(rx->subjects[id]);
   rx_solving_options *op = rx->op;
   // get the linear solved system object.
-  linA_t lca = __linCmtA[omp_get_thread_num()];
+  // rx_get_thread() honors the cross-DLL thread-id override (see rxData.cpp /
+  // setRxThreadId): under an external OpenMP team rxode2's omp_get_thread_num()
+  // would return 0 for every worker, collapsing this per-thread linCmt scratch
+  // onto slot 0.  __linCmtB (line ~489) already uses rx_get_thread().
+  linA_t lca = __linCmtA[rx_get_thread((int)__linCmtA.size())];
   int idx = ind->idx;
   // Create the solved system object
   if (!lc.isSame(ncmt, oral0, trans, rx->ndiff)) {

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -1513,26 +1513,47 @@ extern "C" {
 
 } // extern "C"
 
+// --- Cross-DLL OpenMP thread-id override (Windows static-libgomp fix) --------
+// When rxode2's per-individual solve is driven from an EXTERNAL OpenMP team
+// (e.g. nlmixr2est's FOCEi innerOpt), rxode2's own statically-linked libgomp
+// returns omp_get_thread_num()==0 for every foreign thread, collapsing all
+// per-thread buffers (LSODA ctx pool, glhs, gon, tol arrays, ...) onto slot 0
+// -> concurrent writes / lsoda_free -> heap corruption (Windows segment heap;
+// benign on Linux's single shared libgomp).  The external driver supplies the
+// correct per-thread id via setRxThreadId(); when set (>=0) rxode2 uses it
+// instead of omp_get_thread_num().  thread_local is compiler TLS (per-OS-
+// thread), so the same OS thread that sets the id also runs the solve.  Inside
+// rxode2's own par_solve the override stays -1 and omp_get_thread_num()
+// (correct within rxode2's own team) is used.
+static thread_local int _rxThreadIdOverride = -1;
+extern "C" void setRxThreadId(int id) { _rxThreadIdOverride = id; }
+extern "C" int getRxThreadId(void) { return _rxThreadIdOverride; }
+static inline int _rxTid(void) {
+  int t = _rxThreadIdOverride;
+  if (t < 0) t = omp_get_thread_num();
+  return (t < 0) ? 0 : t;
+}
+
 static inline double *getLinCmtSaveThread() {
   rx_solve* rx = getRxSolve_();
   rx_solving_options* op = rx->op;
-  return _globals.gLinSave + (op->numLinSens+op->numLin)*omp_get_thread_num();
+  return _globals.gLinSave + (op->numLinSens+op->numLin)*_rxTid();
 }
 
 static inline double *getLinCmtDummyThread() {
   rx_solve* rx = getRxSolve_();
   rx_solving_options* op = rx->op;
-  return _globals.gLinDummy + (op->neq)*omp_get_thread_num();
+  return _globals.gLinDummy + (op->neq)*_rxTid();
 }
 
 static inline double *getAlagFamilyPointerFromThreadId(double *ptr) {
   rx_solve* rx = getRxSolve_();
   rx_solving_options* op = rx->op;
-  return ptr + (op->neq + op->extraCmt)*omp_get_thread_num();
+  return ptr + (op->neq + op->extraCmt)*_rxTid();
 }
 
 static inline double *getInfusionRateThread() {
-  return _globals.gInfusionRate[omp_get_thread_num()];
+  return _globals.gInfusionRate[_rxTid()];
 }
 
 static inline double *getTlastSThread() {
@@ -1560,30 +1581,30 @@ extern "C" void _setIndPointersByThread(rx_solving_options_ind *ind) {
     ind->linCmtSave = getLinCmtSaveThread();
     ind->linCmtDummy = getLinCmtDummyThread();
 
-    ind->ignoredDoses = _globals.ignoredDoses[omp_get_thread_num()];
-    ind->ignoredDosesN = &(_globals.nIgnoredDoses[omp_get_thread_num()]);
+    ind->ignoredDoses = _globals.ignoredDoses[_rxTid()];
+    ind->ignoredDosesN = &(_globals.nIgnoredDoses[_rxTid()]);
     ind->ignoredDosesN[0] = 0; // reset
-    ind->ignoredDosesAllocN = &(_globals.nAllocIgnoredDoses[omp_get_thread_num()]);
+    ind->ignoredDosesAllocN = &(_globals.nAllocIgnoredDoses[_rxTid()]);
 
-    ind->pendingDoses = _globals.pendingDoses[omp_get_thread_num()];
-    ind->pendingDosesN = &(_globals.nPendingDoses[omp_get_thread_num()]);
+    ind->pendingDoses = _globals.pendingDoses[_rxTid()];
+    ind->pendingDosesN = &(_globals.nPendingDoses[_rxTid()]);
     ind->pendingDosesN[0] = 0; // reset
-    ind->pendingDosesAllocN = &(_globals.nAllocPendingDoses[omp_get_thread_num()]);
+    ind->pendingDosesAllocN = &(_globals.nAllocPendingDoses[_rxTid()]);
 
-    ind->extraDoseN = &(_globals.extraDoseN[omp_get_thread_num()]);
+    ind->extraDoseN = &(_globals.extraDoseN[_rxTid()]);
     ind->extraDoseN[0] = 0; //reset
-    ind->extraDoseAllocN = &(_globals.extraDoseAllocN[omp_get_thread_num()]);
-    ind->extraDoseTimeIdx = _globals.extraDoseTimeIdx[omp_get_thread_num()];
-    ind->extraDoseTime = _globals.extraDoseTime[omp_get_thread_num()];
-    ind->extraDoseEvid = _globals.extraDoseEvid[omp_get_thread_num()];
-    ind->extraDoseDose = _globals.extraDoseDose[omp_get_thread_num()];
+    ind->extraDoseAllocN = &(_globals.extraDoseAllocN[_rxTid()]);
+    ind->extraDoseTimeIdx = _globals.extraDoseTimeIdx[_rxTid()];
+    ind->extraDoseTime = _globals.extraDoseTime[_rxTid()];
+    ind->extraDoseEvid = _globals.extraDoseEvid[_rxTid()];
+    ind->extraDoseDose = _globals.extraDoseDose[_rxTid()];
     ind->idxExtra = 0;
     ind->extraSorted = 0;
 
-    ind->on = _globals.gon + ncmt*omp_get_thread_num();
-    ind->solveSave = _globals.gSolveSave + op->neq*omp_get_thread_num();
-    ind->solveLast = _globals.gSolveLast + op->neq*omp_get_thread_num();
-    ind->solveLast2 = _globals.gSolveLast2 + op->neq*omp_get_thread_num();
+    ind->on = _globals.gon + ncmt*_rxTid();
+    ind->solveSave = _globals.gSolveSave + op->neq*_rxTid();
+    ind->solveLast = _globals.gSolveLast + op->neq*_rxTid();
+    ind->solveLast2 = _globals.gSolveLast2 + op->neq*_rxTid();
   } else {
     ind->InfusionRate = NULL;
     ind->tlastS = NULL;
@@ -1596,23 +1617,23 @@ extern "C" void _setIndPointersByThread(rx_solving_options_ind *ind) {
     ind->linCmtSave = NULL;
   }
   if (rx->nMtime > 0) {
-    ind->mtime0 = _globals.gmtime0 + rx->nMtime * omp_get_thread_num();
+    ind->mtime0 = _globals.gmtime0 + rx->nMtime * _rxTid();
   } else {
     ind->mtime0 = NULL;
   }
   if (!ind->indOwnAlloc) {
-    ind->timeThread = _globals.timeThread + rx->maxAllTimes*omp_get_thread_num();
+    ind->timeThread = _globals.timeThread + rx->maxAllTimes*_rxTid();
   }
-  ind->llikSave = _globals.gLlikSave + op->nLlik*rxLlikSaveSize*omp_get_thread_num();
-  ind->lhs = _globals.glhs+op->nlhs*omp_get_thread_num();
+  ind->llikSave = _globals.gLlikSave + op->nLlik*rxLlikSaveSize*_rxTid();
+  ind->lhs = _globals.glhs+op->nlhs*_rxTid();
   // Point the individual's tolerance arrays at the current thread's
   // slice.  iniSubject() will then multiply them by ind->tolFactor to
   // apply any sticky loosening.  No conditional needed here: tolFactor
   // is always valid (set to 1.0 by setupRxInd() on first allocation).
-  ind->atol2  = _globals.gatol2Thread  + op->neq * omp_get_thread_num();
-  ind->rtol2  = _globals.grtol2Thread  + op->neq * omp_get_thread_num();
-  ind->ssAtol = _globals.gssAtolThread + op->neq * omp_get_thread_num();
-  ind->ssRtol = _globals.gssRtolThread + op->neq * omp_get_thread_num();
+  ind->atol2  = _globals.gatol2Thread  + op->neq * _rxTid();
+  ind->rtol2  = _globals.grtol2Thread  + op->neq * _rxTid();
+  ind->ssAtol = _globals.gssAtolThread + op->neq * _rxTid();
+  ind->ssRtol = _globals.gssRtolThread + op->neq * _rxTid();
 }
 
 extern "C" void setZeroMatrix(int which) {
@@ -1652,7 +1673,7 @@ extern "C" void atolRtolFactorC_(double factor) {
 
   // Modify only the current thread's tolerance arrays -- fully thread-safe,
   // no critical section needed because each thread has its own slice.
-  int _threadId = omp_get_thread_num();
+  int _threadId = _rxTid();
   double *_atol2  = _globals.gatol2Thread  + op->neq * _threadId;
   double *_rtol2  = _globals.grtol2Thread  + op->neq * _threadId;
   double *_ssAtol = _globals.gssAtolThread + op->neq * _threadId;
@@ -6905,12 +6926,12 @@ void rxAssignPtr(SEXP object = R_NilValue){
 }
 
 extern "C" void updateExtraDoseGlobals(rx_solving_options_ind* ind) {
-  _globals.ignoredDoses[omp_get_thread_num()] = ind->ignoredDoses;
-  _globals.pendingDoses[omp_get_thread_num()] = ind->pendingDoses;
-  _globals.extraDoseTimeIdx[omp_get_thread_num()] = ind->extraDoseTimeIdx;
-  _globals.extraDoseTime[omp_get_thread_num()] = ind->extraDoseTime;
-  _globals.extraDoseEvid[omp_get_thread_num()] = ind->extraDoseEvid;
-  _globals.extraDoseDose[omp_get_thread_num()] = ind->extraDoseDose;
+  _globals.ignoredDoses[_rxTid()] = ind->ignoredDoses;
+  _globals.pendingDoses[_rxTid()] = ind->pendingDoses;
+  _globals.extraDoseTimeIdx[_rxTid()] = ind->extraDoseTimeIdx;
+  _globals.extraDoseTime[_rxTid()] = ind->extraDoseTime;
+  _globals.extraDoseEvid[_rxTid()] = ind->extraDoseEvid;
+  _globals.extraDoseDose[_rxTid()] = ind->extraDoseDose;
 }
 
 extern "C" void rxAssignPtrC(SEXP obj){

--- a/src/rxomp.h
+++ b/src/rxomp.h
@@ -5,8 +5,22 @@
 #include <pthread.h>
 #include <omp.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+// Cross-DLL OpenMP thread-id override (defined in rxData.cpp).  Returns the
+// id supplied by an external OpenMP driver (e.g. nlmixr2est FOCEi) or -1 when
+// unset.  See the long comment in rxData.cpp.  Needed because rxode2's static
+// libgomp reports omp_get_thread_num()==0 for threads created by another DLL's
+// libgomp, which would collapse all per-thread buffers onto slot 0.
+int getRxThreadId(void);
+#ifdef __cplusplus
+}
+#endif
+
 static inline int rx_get_thread(int mx) {
-  int tn = omp_get_thread_num();
+  int tn = getRxThreadId();
+  if (tn < 0) tn = omp_get_thread_num();
   if (tn < 0) return 0;
   if (tn < mx) return tn;
   // Clamp to last valid index rather than collapsing to 0,


### PR DESCRIPTION
Not sure why I couldn't push to #1072 

This are the fixes for that branch.

@billdenney  the nlmixr2est branch needs to call the `setRxThreadId()` directly without the prefix.  In some contexts this ( `rxode2::setRxThreadId()`) has corrupted the solves in Linux at least. 