### PR TITLE
Fix steady-state convergence test, lsoda EVID-off slot, and keep-column NA-interp OOB

### DIFF
--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -2465,10 +2465,10 @@ extern "C" void solveSSinf(int *neq,
         }
       }
       for (int k = neq[0]; k--;) {
-        ind->solveLast[k] = yp[k];
         if (op->ssRtol[k]*fabs(yp[k]) + op->ssAtol[k] <= fabs(yp[k]-ind->solveLast[k])){
           *canBreak=0;
         }
+        ind->solveLast[k] = yp[k];
       }
     }
     // yp is last solve or y0
@@ -2603,10 +2603,10 @@ extern "C" void solveSSinfLargeDur(int *neq,
         }
       }
       for (int k = neq[0]; k--;) {
-        ind->solveLast[k] = yp[k];
         if (op->ssRtol[k]*fabs(yp[k]) + op->ssAtol[k] <= fabs(yp[k]-ind->solveLast[k])){
           *canBreak=0;
         }
+        ind->solveLast[k] = yp[k];
       }
     }
     // yp is last solve or y0
@@ -4491,7 +4491,7 @@ extern "C" void ind_lsoda0(rx_solve *rx, rx_solving_options *op, int solveid, in
         handleSS(neq, ind->BadDose, ind->InfusionRate, ind->dose, yp, xout,
                  xp, ind->id, &i, ind->n_all_times, &istate, op, ind, u_inis, ctx);
         if (ind->wh0 == EVID0_OFF){
-          ind->solve[ind->cmt] = op->inits[ind->cmt];
+          yp[ind->cmt] = op->inits[ind->cmt];
         }
         if (rx->istateReset) istate = 1;
         xp = xout;

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -2896,11 +2896,15 @@ extern "C" double get_fkeep(int col, int id, rx_solving_options_ind *ind,int fid
         while (i >= fid && (R_IsNA(vals[i]) || R_IsNaN(vals[i]))) {
           i--;
         }
-        // if it can't be found find the next non-NA value
-        if (R_IsNA(vals[i]) || R_IsNaN(vals[i])) {
+        // if it can't be found (i < fid) find the next non-NA value;
+        // guard the index so we never dereference vals[fid-1] / past the id block
+        if (i < fid) {
           i = id;
-          while (i < fid  + ind->n_all_times && (R_IsNA(vals[i]) || R_IsNaN(vals[i]))) {
+          while (i < fid + ind->n_all_times && (R_IsNA(vals[i]) || R_IsNaN(vals[i]))) {
             i++;
+          }
+          if (i >= fid + ind->n_all_times) {
+            return val; // entire id block is NA
           }
         }
         return vals[i];
@@ -2910,11 +2914,14 @@ extern "C" double get_fkeep(int col, int id, rx_solving_options_ind *ind,int fid
         while (i < fid + ind->n_all_times && (R_IsNA(vals[i]) || R_IsNaN(vals[i]))) {
           i++;
         }
-        // if it can't be found find the previous non-NA value
-        if (R_IsNA(vals[i]) || R_IsNaN(vals[i])) {
+        // if it can't be found find the previous non-NA value; guard the index
+        if (i >= fid + ind->n_all_times) {
           i = id;
           while (i >= fid && (R_IsNA(vals[i]) || R_IsNaN(vals[i]))) {
             i--;
+          }
+          if (i < fid) {
+            return val; // entire id block is NA
           }
         }
         return vals[i];

--- a/tests/testthat/test-keep.R
+++ b/tests/testthat/test-keep.R
@@ -236,4 +236,30 @@ rxTest({
 
     })
   }
+
+  test_that("keep column with leading/trailing NA for the first subject (no OOB)", {
+    ## Before the fix, get_fkeep's LOCF/NOCB scan could exit at i = fid-1 (reads
+    ## vals[-1] for the first subject) or i = fid + n_all_times (past the id
+    ## block) and dereference that out-of-bounds element.  Here the first
+    ## subject's leading/trailing keep values are NA, forcing the scan off the
+    ## end of the id block.
+    mod <- rxode2({
+      d/dt(center) <- -kel * center
+      cp <- center / v
+    })
+    d <- data.frame(ID = 1L, TIME = 0:3, AMT = c(100, 0, 0, 0),
+                    EVID = c(1L, 0L, 0L, 0L), WT = c(NA, NA, 70, 72))
+    s <- rxSolve(mod, d, params = c(kel = 0.2, v = 10),
+                 keep = "WT", keepInterpolation = "locf")
+    ## leading NA at the first observation forward-fills to the first available
+    ## value (70), not garbage read from vals[-1]
+    expect_equal(s$WT, c(70, 70, 72))
+
+    d2 <- data.frame(ID = 1L, TIME = 0:3, AMT = c(100, 0, 0, 0),
+                     EVID = c(1L, 0L, 0L, 0L), WT = c(70, 72, NA, NA))
+    s2 <- rxSolve(mod, d2, params = c(kel = 0.2, v = 10),
+                  keep = "WT", keepInterpolation = "nocb")
+    ## trailing NA falls back to the last available value (72)
+    expect_equal(s2$WT, c(72, 72, 72))
+  })
 })


### PR DESCRIPTION
Three solver/data fixes (independent of fix-rxode2-misc-memory-logic):

* `solveSSinf`/`solveSSinfLargeDur` (E5): the infusion-phase convergence loop stored `ind->solveLast[k]=yp[k]` before comparing `|yp[k]-solveLast[k]|`, so the difference was identically 0 and that phase never counted toward non-convergence. Compare before storing (as the off-phase block already does).
* `ind_lsoda0` EVID-off (E4): reset `ind->solve[cmt]` (compartment of solve slot 0) instead of `yp[cmt]` (the current event slot); every other solver family resets `yp[cmt]`. For any non-first event this zeroed the wrong row.
* `get_fkeep` (F3): LOCF/NOCB keep-column interpolation could exit the scan at `i=fid-1` (→ `vals[-1]` for the first subject) or `i=fid+n_all_times` (past the id block) and then dereference `vals[i]`. Guard the index and return NA when the whole id block is NA.
Regression-tested: SS-infusion converges with no NaN; leading/trailing-NA keep columns fill correctly under locf/nocb; basic solve unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)