### PR TITLE
Fix tad()/tlast(<state>) returning NA when a cmt() observable shifts compartment indices (nlmixr2est#685)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,14 @@
   dosing helpers (e.g. `bolus(50, cmt = "depot")`) so it produces the
   correct compartment reference.
 
+- Fixed `tad(<state>)` / `tlast(<state>)` (and the rest of the per-state
+  dose-timing family) returning `NA` or the wrong value in `linCmt()`
+  models that also declare an extra `cmt()` compartment for an algebraic
+  observable (e.g. an nlmixr2 ui model with `Cc ~ prop(propSd)`).  The
+  injected observable compartment used to sort before the linear
+  compartments (which are added last) and shifted the slot indices the
+  generated code used for the per-state lookups (nlmixr2est#685).
+
 - Added a forward automatic derivative linear compartment model, which
   beats the reverse mode automatic derivatives for linear compartment
   models

--- a/src/genModelVars.h
+++ b/src/genModelVars.h
@@ -317,9 +317,22 @@ static inline SEXP sortStateVectors(SEXP ordS) {
       // This is a compartment only defined by CMT() and is used for
       // dvid ordering, no properties should be defined.
       ord[i] = -cur;
+      // Extra states (idu == 0) are algebraic observables that also appear
+      // in a cmt() statement; they are not real ODE/dosing compartments and
+      // etTran() numbers them after the real states (state ++ extraState).
+      // Push them to the end of this ordering too so the generated
+      // __DDT__/_DEPOT_/_CENTRAL_ slot indices stay aligned with the runtime
+      // compartment numbering.  Otherwise an observable whose cmt() is seen
+      // before the real compartments are numbered sorts ahead of them and
+      // shifts every tad()/tlast(<state>) lookup.  This happens whenever the
+      // cmt() precedes the d/dt() block, and always in linCmt() models, where
+      // the linear compartments (depot, central, ...) are added last in
+      // calcLinCmt().
+      if (tb.idu[i] == 0) ord[i] += tb.de.n;
       if (sortStateVectorsErrHandle(prop, i)) continue;
     } else {
       ord[i] = cur;
+      if (tb.idu[i] == 0) ord[i] += tb.de.n;
     }
   }
   if (sbt.o != 0) {

--- a/tests/testthat/test-tad.R
+++ b/tests/testthat/test-tad.R
@@ -456,6 +456,121 @@ rxTest({
     expect_equal(s$dose, s$dosec)
   })
 
+  test_that("tad(<state>)/tlast(<state>) survive an injected cmt() observable (nlmixr2est#685)", {
+    # An algebraic observable in a residual-error tilde makes rxUi inject a
+    # cmt() compartment for the observable *after* the linCmt() compartments.
+    # That extra compartment must not shift the slot indices that
+    # tad(<state>)/tlast(<state>) resolve to.  In a linCmt() model the
+    # depot/central compartments are added last (calcLinCmt()), so an earlier
+    # cmt() observable used to sort before them and shifted every per-state
+    # lookup -- tad(depot) returned NA and tad(central) returned the current
+    # time instead of NA.
+    et <-
+      et(amt = 100, time = c(0, 24, 48), cmt = "depot") |>
+      et(time = c(72, 96, 120), cmt = "central")
+
+    pars <- c(lka = log(1), lkel = log(0.1), lvc = log(10))
+
+    # mirrors the structure of an rxUi simulation model: tad()/tlast() before
+    # linCmt(), with cmt(Cc) injected for the algebraic observable
+    withCmt <- rxode2({
+      ka  <- exp(lka)
+      kel <- exp(lkel)
+      vc  <- exp(lvc)
+      tdDepot   <- tad(depot)
+      tdCentral <- tad(central)
+      tlDepot   <- tlast(depot)
+      tdAny     <- tad()
+      Cc <- linCmt()
+      cmt(Cc)
+    })
+
+    withoutCmt <- rxode2({
+      ka  <- exp(lka)
+      kel <- exp(lkel)
+      vc  <- exp(lvc)
+      tdDepot   <- tad(depot)
+      tdCentral <- tad(central)
+      tlDepot   <- tlast(depot)
+      tdAny     <- tad()
+      Cc <- linCmt()
+    })
+
+    # the injected cmt() observable does not change the ODE-state ordering
+    expect_equal(rxState(withCmt), c("depot", "central"))
+    expect_equal(rxState(withCmt), rxState(withoutCmt))
+    expect_equal(withCmt$stateExtra, "Cc")
+
+    s1 <- rxSolve(withCmt, pars, et)
+    s2 <- rxSolve(withoutCmt, pars, et)
+
+    # the cmt() observable must not perturb the per-state lookups
+    expect_equal(s1$tdDepot, s2$tdDepot)
+    expect_equal(s1$tdCentral, s2$tdCentral)
+    expect_equal(s1$tlDepot, s2$tlDepot)
+
+    # only depot was dosed (at 0, 24, 48); observations are at 72, 96, 120
+    obs <- s1[s1$time %in% c(72, 96, 120), ]
+    expect_equal(obs$tdDepot, c(24, 48, 72))     # time since last depot dose
+    expect_equal(obs$tdAny, c(24, 48, 72))       # tad(depot) == tad() here
+    expect_equal(obs$tlDepot, c(48, 48, 48))     # last depot dose time
+    expect_true(all(is.na(obs$tdCentral)))       # central was never dosed
+  })
+
+  test_that("tad(<state>) survives a cmt() observable declared before d/dt (nlmixr2est#685)", {
+    # The same slot-shift bug can be triggered in a pure-ODE model when the
+    # algebraic-observable cmt() compartment is declared *before* the d/dt
+    # block.  The d/dt states only get their compartment index when the d/dt
+    # line is parsed, so an earlier cmt() observable used to sort before them.
+    # (When the cmt() observable comes after the d/dt block, as the nlmixr2 ui
+    # appends it, the ODE states are already numbered and there is no shift.)
+    et <-
+      et(amt = 100, time = c(0, 24, 48), cmt = "depot") |>
+      et(time = c(72, 96, 120), cmt = "central")
+
+    pars <- c(lka = log(1), lkel = log(0.1), lvc = log(10))
+
+    cmtBefore <- rxode2({
+      tdDepot   <- tad(depot)
+      tdCentral <- tad(central)
+      ka  <- exp(lka)
+      kel <- exp(lkel)
+      vc  <- exp(lvc)
+      Cc <- central / vc
+      cmt(Cc)                  # declared before the d/dt block
+      d/dt(depot)   <- -ka * depot
+      d/dt(central) <-  ka * depot - kel * central
+    })
+
+    cmtAfter <- rxode2({
+      tdDepot   <- tad(depot)
+      tdCentral <- tad(central)
+      ka  <- exp(lka)
+      kel <- exp(lkel)
+      vc  <- exp(lvc)
+      d/dt(depot)   <- -ka * depot
+      d/dt(central) <-  ka * depot - kel * central
+      Cc <- central / vc
+      cmt(Cc)
+    })
+
+    # the observable does not change the ODE-state ordering, regardless of
+    # where cmt() is declared relative to the d/dt block
+    expect_equal(rxState(cmtBefore), c("depot", "central"))
+    expect_equal(rxState(cmtBefore), rxState(cmtAfter))
+    expect_equal(cmtBefore$stateExtra, "Cc")
+
+    s1 <- rxSolve(cmtBefore, pars, et)
+    s2 <- rxSolve(cmtAfter, pars, et)
+
+    expect_equal(s1$tdDepot, s2$tdDepot)
+    expect_equal(s1$tdCentral, s2$tdCentral)
+
+    obs <- s1[s1$time %in% c(72, 96, 120), ]
+    expect_equal(obs$tdDepot, c(24, 48, 72))   # depot dose history is tracked
+    expect_true(all(is.na(obs$tdCentral)))     # central was never dosed
+  })
+
   # context("tad family of functions with linCmt()/ode mix")
 
   test_that("ode mixed", {


### PR DESCRIPTION
## Summary

Fixes nlmixr2/nlmixr2est#685. The argumented dose-timing functions
`tad(<state>)` / `tlast(<state>)` (and the rest of the per-state family:
`tafd`, `tfirst`, `dose`, `podo`) returned `NA` or the wrong value when a model
declares an extra `cmt()` compartment for an algebraic observable.

Minimal reproducer (nlmixr2 ui model with an algebraic observable in a
residual-error tilde):

```r
f <- function() {
  ini({ lka <- log(1); lkel <- log(0.1); lvc <- log(10); propSd <- 0.1 })
  model({
    td_depot   <- tad(depot)
    td_central <- tad(central)
    ka <- exp(lka); kel <- exp(lkel); vc <- exp(lvc)
    d/dt(depot)   <- -ka * depot
    d/dt(central) <-  ka * depot - kel * central
    Cc <- central / vc
    Cc ~ prop(propSd)            # injects cmt(Cc) for the observable
  })
}
```

Doses go to `depot` only. Before this PR `tad(depot)` returned `NA` and
`tad(central)` returned the current time; after, `tad(depot)` tracks the depot
dose history and `tad(central)` is `NA` (central is never dosed).

## Root cause

An algebraic-observable `cmt()` compartment is an "extra" state (`idu == 0`);
`etTran()` numbers these *after* the real states (`state ++ extraState`). But in
`sortStateVectors()` the observable was sorted **ahead** of the real
compartments whenever those compartments were numbered after the `cmt()` was
seen. The generated `__DDT__` / `_DEPOT_` / `_CENTRAL_` slot indices then no
longer matched the runtime compartment numbering used for dosing, so
`tad(depot)` read `central`'s slot (→ `NA`) and `tad(central)` read a phantom
slot (→ current time).

This happens in two situations:

* **Pure ODE** — only when the `cmt()` observable is declared *before* the
  `d/dt()` block (the ODE states aren't numbered yet).
* **`linCmt()` models** — *always*, because the linear compartments (`depot`,
  `central`, …) are added last in `calcLinCmt()`.

The second case is why the issue's `d/dt()` reproducer was affected even though
the nlmixr2 ui appends `cmt()` *after* the model body: the 5.1.3 automatic
ODE→`linCmt()` conversion defers the depot/central indices to `calcLinCmt()`.

## Fix

In `sortStateVectors()`, push `idu == 0` extra compartments to the end of the
compartment ordering, matching how `etTran()` already numbers them. Pure-ODE
models with `cmt()` after the `d/dt()` block are unchanged (the states are
already numbered, so the observable already sorted last).

## Testing

* New regression tests in `test-tad.R` for both the `linCmt()` and the pure-ODE
  (`cmt`-before-`d/dt`) variants, asserting the observable does not change
  `rxState()` and that the per-state lookups match the no-observable model.
* Verified before/after on the baseline: the pure-ODE `cmt`-before-`d/dt`
  variant returns `td_depot=NA, td_central=72,96,120` without the fix and
  `td_depot=24,48,72, td_central=NA` with it.
* Full `rxode2` test suite: **29581 passed, 0 failed** across 237 files.

Fixes nlmixr2/nlmixr2est#685