### PR TITLE
Fix updateRate/updateDur "inline used but never defined" warning

### DIFF
--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -54,6 +54,7 @@ extern "C" void ensureAutoJacBuf(int nCores, int neq);
 
 #include "cbindThetaOmega.h"
 #include "../inst/include/rxode2parseHandleEvid.h"
+#include "../inst/include/rxode2parseGetTime.h" // defines updateRate/updateDur forward-declared in handleEvid.h
 #include "rxThreadData.h"
 
 #include "threadSafeConstants.h"

--- a/src/utilc.cpp
+++ b/src/utilc.cpp
@@ -1075,6 +1075,7 @@ extern "C" SEXP _rxode2_phi(SEXP q) {
 }
 
 #include "../inst/include/rxode2parseHandleEvid.h"
+#include "../inst/include/rxode2parseGetTime.h" // defines updateRate/updateDur forward-declared in handleEvid.h
 
 extern "C" SEXP _rxode2_getWh(SEXP in) {
   rxProtect rx_protect;


### PR DESCRIPTION
## What

`rxData.cpp` and `utilc.cpp` included `rxode2parseHandleEvid.h` (for `cbindThetaOmega` / `getWh`) without `rxode2parseGetTime.h`, producing on every build:

```
rxode2parseHandleEvid.h:477: warning: inline function 'updateRate' used but never defined
rxode2parseHandleEvid.h:478: warning: inline function 'updateDur'  used but never defined
```

## Why

`handleEvid.h` forward-declares the `static inline` functions `updateRate()`/`updateDur()`; they're defined in `getTime.h`, which the header comment says is "included after this header." The two TUs above don't call `handle_evid()` today, so it's discarded and there's no link error — but the reference is real, and any future `handle_evid()` call in those files would fail to link. This follows the header's own documented convention (include `getTime.h` after `handleEvid.h`), matching `approx.cpp`/`par_solve.cpp`/`handle_evid.cpp`.

## Verification

Full clean rebuild on Ubuntu: 4 → 0 warnings. No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)