### PR TITLE
Fix Windows 8.3 short-path mismatch in odeToLin DLL test

### DIFF
--- a/tests/testthat/test-odeToLin.R
+++ b/tests/testthat/test-odeToLin.R
@@ -324,7 +324,14 @@ rxTest({
     .mLin <- suppressMessages(odeToLin(.m))
 
     .getDll <- function(r) {
-      get("dll", envir = attr(attr(r, "class"), ".rxode2.env"), inherits = FALSE)
+      # normalizePath() canonicalizes the path so that the comparison is robust
+      # to Windows 8.3 short-name mangling: the .rxd cache directory name is too
+      # long for an 8.3 path, so one solve can report it in long form
+      # (rx_..._x64_.rxd) while another reports the shortened form
+      # (RX_...~1.RXD).  Both point to the same DLL; normalizing makes them equal.
+      normalizePath(
+        get("dll", envir = attr(attr(r, "class"), ".rxode2.env"), inherits = FALSE),
+        winslash = "/", mustWork = FALSE)
     }
 
     # useLinCmt=TRUE must use the same DLL as explicit odeToLin conversion


### PR DESCRIPTION
test-odeToLin.R compares the compiled DLL path of a `useLinCmt = TRUE` solve against an explicit `odeToLin()` solve to confirm they share the same DLL.  On Windows the rxode2 cache directory name (`rx_<md5>_x64_.rxd`) is longer than the 8.3 limit, so one solve reports the path with the long directory name while the other reports the mangled 8.3 short form (`RX_<...>~1.RXD`).  The two strings differ even though both point to the same file, so `expect_equal()` failed on windows-latest only:

  actual   ...\RX_EDB~1.RXD/rx_...x64.dll
  expected ...\rx_..._x64_.rxd/rx_...x64.dll

Normalize the stored path with `normalizePath(..., winslash = "/", mustWork = FALSE)` in the test's `.getDll()` helper so the comparison is robust to 8.3 short-name mangling and separator differences.  This is a test-only change; no package code is affected.