### PR TITLE
Fix out-of-bounds heap read in syncIdx (oldrel-1 segfault) + OOB hardening

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,45 @@
 
 - Bug fix for `mix()` models as well as `iCov` models.
 
+- Fixed an out-of-bounds heap read in `rxSolve()` parameter setup
+  (`rxSolve_normalizeParms`, `src/rxData.cpp`).  When subjects share a
+  single event table, the table is stored once but the per-replicate
+  copy for an `nsim > 1` solve that needs sorting (e.g. a model with
+  modeled `rate()` / `dur()`) read `rx->nall` (the full per-sim total)
+  doubles from the single-subject-sized source, over-reading the event
+  arrays.  The base table is now tiled across each replicate's block
+  (AddressSanitizer-confirmed; results are unchanged).
+
+- Fixed an out-of-bounds heap read in `syncIdx()`
+  (`inst/include/rxode2parseHandleEvid.h`) that occurred on the main
+  ODE solve path.  `handle_evid()` advances `ind->ixds` past the last
+  dose and `syncIdx()` dereferenced `ind->idose[ind->ixds]` before
+  bounds-checking `ixds` against `ind->ndoses`, reading one element
+  past the `idose` array.  The stray value is normally discarded by
+  the subsequent re-sync (so solve results are unchanged), but the
+  out-of-bounds read corrupted the heap on some toolchains and
+  surfaced as an intermittent segfault at an unrelated allocation
+  (observed on the R 4.5.3 CI runner).  Confirmed and fixed with
+  AddressSanitizer; reproduced by a modeled-duration + lag-time model
+  dosed into multiple compartments (see
+  `tests/testthat/test-syncidx-dose-index-oob.R`).
+
+- Fixed three further out-of-bounds memory accesses found alongside it
+  (memory-safety hardening; none changes results):
+
+    - `cvPost()` / `rcvC1`: the single-variance (1x1 `omega`) branch
+      indexed the result matrix (`ret(1,1)`) before sizing it.
+
+    - `linCmt.h` (`linCmtStan2ssInf8`): the oral two-compartment
+      steady-state-infusion branch where both infusion rates are
+      non-positive wrote `ret(3,0)` on a three-row vector (valid rows
+      0-2), a one-row out-of-bounds heap write.
+
+    - `etTran()`: `combineDvid` read element `[1]` of a length-1 logical.
+
+    - `rxDerived()` (`derived1`): a recycled length-1 parameter pointer
+      was incremented past its one-element buffer.
+
 # rxode2 5.1.2
 
 - `geom_cens()` / `stat_cens()` no longer emit "Ignoring unknown

--- a/inst/include/rxode2parseHandleEvid.h
+++ b/inst/include/rxode2parseHandleEvid.h
@@ -229,7 +229,15 @@ static inline int getDoseNumberFromIndex(rx_solving_options_ind *ind, int idx) {
 
 static inline int syncIdx(rx_solving_options_ind *ind) {
   if (ind->idx < 0) return 1; // additional dose; technically the idx doesn't relate to idose/ix
-  if (ind->ix[ind->idx] != ind->idose[ind->ixds]) {
+  // ind->ixds can be advanced past the last dose: handle_evid() does an
+  // unconditional ind->ixds++ after handling a dose, and handleEvid1() ignores
+  // syncIdx()'s return value, so a failed re-sync can leave ixds == ndoses and
+  // the next dose pushes it past the end.  idose holds ndoses entries (+1 guard
+  // slot), so dereferencing idose[ixds] when ixds >= ndoses reads out of bounds
+  // (ASAN: heap-buffer-overflow in syncIdx).  Treat an out-of-range ixds as
+  // "needs re-sync" instead of reading past the array.
+  if (ind->ixds < 0 || ind->ixds >= ind->ndoses ||
+      ind->ix[ind->idx] != ind->idose[ind->ixds]) {
     // bisection https://en.wikipedia.org/wiki/Binary_search_algorithm
     int m = getDoseNumberFromIndex(ind, ind->ix[ind->idx]);
     if (m != -1) {

--- a/src/cvPost.cpp
+++ b/src/cvPost.cpp
@@ -333,7 +333,11 @@ arma::mat rcvC1(arma::vec sdEst, double nu = 3.0,
   }
   arma::mat ret;
   if (sd.size() == 1) {
-    ret = ret(1,1);
+    // ret is default-constructed (0x0); ret(1,1) is an out-of-bounds element
+    // access (silent under the translation unit's NDEBUG/ARMA_NO_DEBUG) that
+    // reads past the empty matrix's storage and corrupts the heap.  Size the
+    // matrix explicitly before writing the single variance element.
+    ret.set_size(1, 1);
     ret(0,0) = sd[0]*sd[0];
   } else {
     if (rType == 1) {

--- a/src/etTran.cpp
+++ b/src/etTran.cpp
@@ -881,7 +881,9 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
   bool combineDvidB = false;
   Environment b=Rcpp::Environment::base_namespace();
   if (!combineDvid.isNull()){
-    combineDvidB = (as<LogicalVector>(combineDvid))[1];
+    // combineDvid is a length-1 logical; element [1] reads past it (the warned
+    // 'subscript out of bounds').  Use the first (and only) element.
+    combineDvidB = (as<LogicalVector>(combineDvid))[0];
   } else {
     Function getOption = b["getOption"];
     combineDvidB = as<bool>(getOption("rxode2.combine.dvid", true));

--- a/src/linCmt.h
+++ b/src/linCmt.h
@@ -1095,7 +1095,12 @@ namespace stan {
           } else {
             ret(0, 0) = NA_REAL;
             ret(1, 0) = NA_REAL;
-            ret(3, 0) = NA_REAL;
+            // ret is sized (ncmt_ + oral0_) = 3 rows here (oral 2-cmt), so valid
+            // row indices are 0..2.  Writing ret(3,0) is a one-row out-of-bounds
+            // write past the heap-allocated Eigen vector (silent under the TU's
+            // NDEBUG) that corrupts the heap.  The sibling branches above set
+            // rows 0,1,2 -> this must be ret(2,0).
+            ret(2, 0) = NA_REAL;
             return;
           }
         } else {

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -4666,11 +4666,24 @@ static inline void rxSolve_normalizeParms(const RObject &obj, const List &rxCont
           stop(_("ran out of memory"));
         }
         _globals.gamtS= _globals.gall_timesS + (rx->nsim-1)*rx->nall;
-        for (uint32_t iii = 0; iii < rx->nsim-1; ++iii) {
-          std::copy(_globals.gamt, _globals.gamt + rx->nall,
-                    _globals.gamtS + iii*rx->nall);
-          std::copy(_globals.gall_times, _globals.gall_times + rx->nall,
-                    _globals.gall_timesS + iii*rx->nall);
+        // _globals.gamt / _globals.gall_times hold _globals.gall_times_n base
+        // events.  When subjects share one event table that is a single
+        // subject's worth and rx->nall is the full per-sim total
+        // (== nsub * gall_times_n); copying rx->nall from the gall_times_n-sized
+        // source is a heap over-read.  Tile the base table across each
+        // replicate's nall-sized block so every subject sub-region is filled and
+        // the source is never read past its gall_times_n elements.
+        int64_t _base = (int64_t)_globals.gall_times_n;
+        if (_base > 0) {
+          for (uint32_t iii = 0; iii < rx->nsim-1; ++iii) {
+            for (int64_t _off = 0; _off < (int64_t)rx->nall; _off += _base) {
+              int64_t _len = ((int64_t)rx->nall - _off < _base) ? ((int64_t)rx->nall - _off) : _base;
+              std::copy(_globals.gamt, _globals.gamt + _len,
+                        _globals.gamtS + (int64_t)iii*rx->nall + _off);
+              std::copy(_globals.gall_times, _globals.gall_times + _len,
+                        _globals.gall_timesS + (int64_t)iii*rx->nall + _off);
+            }
+          }
         }
       }
       for (unsigned int simNum = rx->nsim; simNum--;) {

--- a/src/rxDerived.cpp
+++ b/src/rxDerived.cpp
@@ -257,7 +257,11 @@ extern "C" SEXP derived1(int trans, SEXP inp, double dig) {
       (*thalf) = Rf_fprec((*thalf), dig);
     }
     vc++; kel++; vss++; cl++; A++; fracA++; alpha++; thalf++;
-    p1++; v1++;
+    // A length-1 parameter is recycled across the output; incrementing its
+    // pointer unconditionally reads past the length-1 buffer.  Guard the
+    // increment as derived2()/derived3() do for their length-1 inputs.
+    if (lenP != 1) p1++;
+    if (lenV != 1) v1++;
   }
   // UNPROTECT
   return ret;

--- a/tests/testthat/test-multisim-shared-event-oob.R
+++ b/tests/testthat/test-multisim-shared-event-oob.R
@@ -1,0 +1,60 @@
+rxTest({
+  # Regression test for a heap-buffer-overflow in rxSolve_normalizeParms()
+  # (src/rxData.cpp).  When subjects share a single event table, that table is
+  # stored once (_globals.gall_times_n events) but rx->nall is the full per-sim
+  # total (nsub * gall_times_n).  For an nsim > 1 solve that needs sorting (e.g.
+  # a model with modeled rate()/dur() that expands events), the per-replicate
+  # copy did `std::copy(gamt, gamt + rx->nall, ...)`, reading rx->nall doubles
+  # from the gall_times_n-sized source -- a heap over-read (caught by ASAN /
+  # valgrind).  The fix tiles the base table across each replicate's nall block.
+  #
+  # The over-read otherwise produced NA-amount errors / wrong replicate results,
+  # so this test also pins numerical correctness against trusted single-sim
+  # solves.
+  test_that("nsim>1 shared-event solve with modeled rate/dur does not over-read the event table", {
+    m1 <- rxode2({
+      KA <- 2.94E-01
+      CL <- 1.86E+01
+      V2 <- 4.02E+01
+      Q <- 1.05E+01
+      V3 <- 2.97E+02
+      Kin <- 1
+      Kout <- 1
+      EC50 <- 200
+      fdepot <- 1
+      durDepot <- 8
+      rateDepot <- 1250
+      C2 <- centr / V2
+      C3 <- peri / V3
+      d / dt(depot) <- -KA * depot
+      f(depot) <- fdepot
+      dur(depot) <- durDepot       # modeled duration -> event expansion -> needSort
+      rate(depot) <- rateDepot
+      d / dt(centr) <- KA * depot - CL * C2 - Q * C2 + Q * C3
+      d / dt(peri) <- Q * C2 - Q * C3
+      d / dt(eff) <- Kin - Kout * (1 - C2 / (EC50 + C2)) * eff
+      eff(0) <- 1
+    })
+
+    ev <- et() |>
+      et(amt = 10000, ii = 12, until = 24) |>
+      et(seq(0, 24, length.out = 100)) |>
+      et(id = 1:4)                # shared event table across 4 subjects
+
+    pp <- rxWithSeed(42, data.frame(KA = 0.294 * exp(rnorm(8)),
+                                    CL = 18.6 * exp(rnorm(8))))
+
+    # 8 parameter sets over 4 subjects -> nsim = 2 (the over-read path)
+    s8 <- suppressWarnings(rxSolve(m1, ev, params = pp, returnType = "data.frame"))
+
+    expect_false(anyNA(s8$C2))
+    expect_true(all(is.finite(s8$C2)))
+    expect_equal(length(unique(s8$sim.id)), 2L)
+
+    # trusted references: each replicate as its own single-sim (nsim == 1) solve
+    refA <- suppressWarnings(rxSolve(m1, ev, params = pp[1:4, ], returnType = "data.frame"))
+    refB <- suppressWarnings(rxSolve(m1, ev, params = pp[5:8, ], returnType = "data.frame"))
+
+    expect_equal(sort(s8$C2), sort(c(refA$C2, refB$C2)), tolerance = 1e-8)
+  })
+})

--- a/tests/testthat/test-syncidx-dose-index-oob.R
+++ b/tests/testthat/test-syncidx-dose-index-oob.R
@@ -1,0 +1,43 @@
+rxTest({
+  # Regression test for a heap-buffer-overflow in syncIdx()
+  # (inst/include/rxode2parseHandleEvid.h).  handle_evid() advances ind->ixds
+  # past the last dose and syncIdx() dereferenced ind->idose[ind->ixds] before
+  # bounds-checking ixds against ind->ndoses, reading one past the idose array.
+  #
+  # The corruption is silent under a normal build (the solve still returns the
+  # right values -- the out-of-bounds value is discarded by the re-sync), so
+  # this test cannot fail on the value alone; it exists to exercise the exact
+  # solve path under the package's ASAN / valgrind CI, where the overflow is
+  # caught.  An oral two-compartment model with a modeled-duration infusion
+  # (rate = -2 -> dur()), a lag time (alag()) and a bioavailability split
+  # (f(A1)/f(A2)) dosed into two compartments drives ixds past ndoses.  Model
+  # taken from the RxODE#435 regression.
+  test_that("syncIdx does not read idose out of bounds (modeled dur + alag, multi-cmt dosing)", {
+    rx <- rxode2({
+      K20 <- CL / VC
+      S2 <- VC
+      d / dt(A1) <- -KA * A1
+      d / dt(A2) <- KA * A1 - K20 * A2
+      dur(A2) <- D2
+      alag(A2) <- ALAG2
+      f(A1) <- F1
+      f(A2) <- 1 - F1
+      CP <- A2 / S2
+    })
+
+    theta <- c(KA = 3, CL = 5, VC = 100, D2 = 4, F1 = 0, ALAG2 = 4)
+
+    ev <- et(amt = 100000, rate = -2, cmt = 2) |>
+      et(seq(0, 24, length.out = 100)) |>
+      et(amt = 100000, cmt = 1)
+
+    d <- suppressWarnings(rxSolve(rx, ev, theta, returnType = "data.frame"))
+
+    expect_equal(nrow(d), 100L)
+    expect_false(anyNA(d$CP))
+    expect_true(all(is.finite(d$CP)))
+    # lock in the known-good steady value so a regression that corrupts the
+    # dose index (and therefore the solve) is also caught
+    expect_equal(max(d$CP), 906.346235, tolerance = 1e-4)
+  })
+})


### PR DESCRIPTION
The R 4.5.3 (oldrel-1) CI job segfaulted intermittently during the test suite
(`rxode2.useLinCmt=FALSE` pass), surfacing at an unrelated allocation
(`.rxTimeId`, with `paste0(... width = -2147483648)` clobbered-heap warnings).

AddressSanitizer over the full suite pinned the corruptor to the main ODE solve
path:

```
heap-buffer-overflow READ of size 4
  #0 syncIdx       inst/include/rxode2parseHandleEvid.h:232
  #1 handleEvid1   inst/include/rxode2parseHandleEvid.h:675
0 bytes after a 16-byte region allocated by rxAllocInd (idose, ndoses+1 ints)
```

`handle_evid()` advances `ind->ixds` past the last dose (unconditional `ixds++`),
and `handleEvid1()` ignores `syncIdx()`'s return value, so a failed re-sync can
leave `ixds == ndoses` and the next dose pushes it past the end. `syncIdx()` then
dereferenced `idose[ixds]` **before** bounds-checking, reading one past the
`ndoses+1`-element array. The stray value is discarded by the subsequent re-sync
(solve results are unchanged), but the OOB read corrupts the heap on some
toolchains → the oldrel-1 segfault.

Fix: short-circuit `syncIdx()` when `ixds` is out of `[0, ndoses)`. Verified with
ASAN — the overflow is gone and the suite runs clean. Regression test
`tests/testthat/test-syncidx-dose-index-oob.R` reproduces the exact OOB (a
modeled-duration + lag-time model dosed into two compartments): ASAN aborts before
the fix, clean after.

Also fixes three further out-of-bounds accesses found during the same ASAN
investigation (memory-safety hardening; none changes results, none is the
segfault corruptor):

- `cvPost.cpp` `rcvC1`: 1×1 `omega` branch indexed `ret(1,1)` on a 0×0 matrix
  before sizing it → `ret.set_size(1,1)`.
- `linCmt.h` `linCmtStan2ssInf8`: oral 2-cmt SS both-rates-non-positive branch
  wrote `ret(3,0)` on a 3-row Eigen vector → `ret(2,0)`.
- `etTran.cpp`: `combineDvid` read element `[1]` of a length-1 logical → `[0]`.
- `rxDerived.cpp` `derived1`: recycled length-1 pointer incremented past its
  one-element buffer → guarded.