### PR TITLE
Expose threefry RNG engine entry points via the function-pointer table

### DIFF
--- a/inst/include/rxode2ptr.h
+++ b/inst/include/rxode2ptr.h
@@ -27,6 +27,18 @@ extern "C" {
   typedef void (*rxGetSolveAtolRtol_t)(double *atol, double *rtol);
   extern rxGetSolveAtolRtol_t rxGetSolveAtolRtol;
 
+  // threefry RNG engine entry points (src/rxthreefry.cpp); downstream packages
+  // seed a per-subject stream with setSeedEng1(getRxSeed1(cores) + id) -- after
+  // setRxThreadId() sets the OpenMP thread -- then draw with rxNormEng().
+  typedef uint32_t (*getRxSeed1_t)(int ncores);
+  extern getRxSeed1_t getRxSeed1;
+  typedef void (*setSeedEng1_t)(uint32_t seed);
+  extern setSeedEng1_t setSeedEng1;
+  typedef void (*seedEng_t)(int ncores);
+  extern seedEng_t seedEng;
+  typedef double (*rxNormEng_t)(double mean, double sd);
+  extern rxNormEng_t rxNormEng;
+
   typedef int (*par_progress_t)(int c, int n, int d, int cores, clock_t t0, int stop);
   extern par_progress_t par_progress;
 
@@ -311,6 +323,10 @@ extern "C" {
       rxode2AdjointTrajSweep = (rxode2AdjointTrajSweep_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 67));
       rxSetSolveAtolRtol = (rxSetSolveAtolRtol_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 68));
       rxGetSolveAtolRtol = (rxGetSolveAtolRtol_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 69));
+      getRxSeed1 = (getRxSeed1_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 70));
+      setSeedEng1 = (setSeedEng1_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 71));
+      seedEng = (seedEng_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 72));
+      rxNormEng = (rxNormEng_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 73));
     }
     return R_NilValue;
   }
@@ -386,6 +402,10 @@ extern "C" {
   rxode2AdjointTrajSweep_t rxode2AdjointTrajSweep = NULL; \
   rxSetSolveAtolRtol_t rxSetSolveAtolRtol = NULL;        \
   rxGetSolveAtolRtol_t rxGetSolveAtolRtol = NULL;        \
+  getRxSeed1_t getRxSeed1 = NULL;                       \
+  setSeedEng1_t setSeedEng1 = NULL;                     \
+  seedEng_t seedEng = NULL;                             \
+  rxNormEng_t rxNormEng = NULL;                         \
   SEXP iniRxodePtrs(SEXP ptr) {                         \
     return iniRxodePtrs0(ptr);                          \
   }                                                     \

--- a/src/init.c
+++ b/src/init.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <stdint.h>
 #include <stdlib.h> // for NULL
 #define __DOINIT__
 #include "cbindThetaOmega.h"
@@ -405,6 +406,13 @@ void rxGetSolveAtolRtol(double *atol, double *rtol);
 // Cross-DLL OpenMP thread-id override (defined in rxData.cpp); see comment there.
 void setRxThreadId(int id);
 
+// threefry RNG engine entry points shared with downstream packages
+// (nlmixr2est importance sampling); defined in rxthreefry.cpp.
+uint32_t getRxSeed1(int ncores);
+void setSeedEng1(uint32_t seed);
+void seedEng(int ncores);
+double rxNormEng(double mean, double sd);
+
 SEXP _rxode2_rxode2Ptr(void) {
   int pro = 0;  // Counter for the number of PROTECT calls
   // Create an external pointer for _lotriLstToMat
@@ -489,8 +497,12 @@ SEXP _rxode2_rxode2Ptr(void) {
   SEXP rxode2AdjointTrajSweepPtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxode2AdjointTrajSweep, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2rxSetSolveAtolRtol = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxSetSolveAtolRtol, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2rxGetSolveAtolRtol = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxGetSolveAtolRtol, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2getRxSeed1 = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&getRxSeed1, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2setSeedEng1 = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setSeedEng1, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2seedEng = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&seedEng, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2rxNormEng = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxNormEng, R_NilValue, R_NilValue)); pro++;
 
-#define nVec 70
+#define nVec 74
   SEXP ret = PROTECT(Rf_allocVector(VECSXP, nVec)); pro++;
   SET_VECTOR_ELT(ret, 0, rxode2rxRmvnSEXP);
   SET_VECTOR_ELT(ret, 1, rxode2rxParProgress);
@@ -562,6 +574,10 @@ SEXP _rxode2_rxode2Ptr(void) {
   SET_VECTOR_ELT(ret, 67, rxode2AdjointTrajSweepPtr);
   SET_VECTOR_ELT(ret, 68, rxode2rxSetSolveAtolRtol);
   SET_VECTOR_ELT(ret, 69, rxode2rxGetSolveAtolRtol);
+  SET_VECTOR_ELT(ret, 70, rxode2getRxSeed1);
+  SET_VECTOR_ELT(ret, 71, rxode2setSeedEng1);
+  SET_VECTOR_ELT(ret, 72, rxode2seedEng);
+  SET_VECTOR_ELT(ret, 73, rxode2rxNormEng);
 
 
   SEXP retN = PROTECT(Rf_allocVector(STRSXP, nVec)); pro++;
@@ -635,6 +651,10 @@ SEXP _rxode2_rxode2Ptr(void) {
   SET_STRING_ELT(retN, 67, Rf_mkChar("rxode2AdjointTrajSweep"));
   SET_STRING_ELT(retN, 68, Rf_mkChar("rxode2rxSetSolveAtolRtol"));
   SET_STRING_ELT(retN, 69, Rf_mkChar("rxode2rxGetSolveAtolRtol"));
+  SET_STRING_ELT(retN, 70, Rf_mkChar("rxode2getRxSeed1"));
+  SET_STRING_ELT(retN, 71, Rf_mkChar("rxode2setSeedEng1"));
+  SET_STRING_ELT(retN, 72, Rf_mkChar("rxode2seedEng"));
+  SET_STRING_ELT(retN, 73, Rf_mkChar("rxode2rxNormEng"));
 
 #undef nVec
 

--- a/src/rxthreefry.cpp
+++ b/src/rxthreefry.cpp
@@ -1364,6 +1364,17 @@ extern "C" double rxnorm(double mean, double sd){
   return d(_eng[rx_get_thread(op_global.cores)]);
 }
 
+// Raw normal draw from the current thread's threefry engine, WITHOUT the inLhs
+// solve-context gate that rxnorm() applies.  Exposed via the function-pointer
+// table for downstream packages (nlmixr2est importance sampling) that seed a
+// per-subject stream with setSeedEng1(seed0 + id) -- after setRxThreadId() sets
+// the OpenMP thread id -- and then draw directly.
+extern "C" double rxNormEng(double mean, double sd){
+  if (ISNA(mean) || ISNA(sd)) return NA_REAL;
+  boost::random::normal_distribution<double> d(mean, sd);
+  return d(_eng[rx_get_thread(op_global.cores)]);
+}
+
 extern "C" double rinorm(int id, double mean, double sd) {
   rx_solving_options_ind* ind = &inds_thread[rx_get_thread(op_global.cores)];
   if (ind->isIni) {


### PR DESCRIPTION
Add getRxSeed1, setSeedEng1, seedEng, and a new rxNormEng (a raw normal draw from the current thread's threefry engine that bypasses rxnorm()'s inLhs solve-context gate) at function-pointer indices 70-73, so downstream packages (nlmixr2est importance sampling) can seed a per-subject stream with setSeedEng1(getRxSeed1(cores) + id) -- after setRxThreadId() sets the OpenMP thread id -- and draw thread-count-independent samples with rxNormEng().

Follows the CLAUDE.md function-pointer procedure: bump nVec 70 -> 74; add the PROTECT/SET_VECTOR_ELT/SET_STRING_ELT entries in src/init.c; add the typedef/extern/assignment/NULL-init entries in inst/include/rxode2ptr.h.