### PR TITLE
Add per-individual solve buffer-pointer accessors for downstream buff…

### DIFF
--- a/inst/include/rxode2ptr.h
+++ b/inst/include/rxode2ptr.h
@@ -39,6 +39,25 @@ extern "C" {
   typedef double (*rxNormEng_t)(double mean, double sd);
   extern rxNormEng_t rxNormEng;
 
+  // Per-individual ODE solve buffer-pointer swap (nlmixr2est impmap gradient):
+  // save the originals, install private larger buffers for a higher-state
+  // sensitivity solve (with setOpNeq), then restore.  getIndSolve() already
+  // returns ind->solve.
+  typedef void (*setIndSolvePtr_t)(rx_solving_options_ind* ind, double* solve);
+  extern setIndSolvePtr_t setIndSolvePtr;
+  typedef double *(*getIndSolveSave_t)(rx_solving_options_ind* ind);
+  extern getIndSolveSave_t getIndSolveSave;
+  typedef void (*setIndSolveSave_t)(rx_solving_options_ind* ind, double* solveSave);
+  extern setIndSolveSave_t setIndSolveSave;
+  typedef double *(*getIndSolveLast_t)(rx_solving_options_ind* ind);
+  extern getIndSolveLast_t getIndSolveLast;
+  typedef void (*setIndSolveLast_t)(rx_solving_options_ind* ind, double* solveLast);
+  extern setIndSolveLast_t setIndSolveLast;
+  typedef double *(*getIndSolveLast2_t)(rx_solving_options_ind* ind);
+  extern getIndSolveLast2_t getIndSolveLast2;
+  typedef void (*setIndSolveLast2_t)(rx_solving_options_ind* ind, double* solveLast2);
+  extern setIndSolveLast2_t setIndSolveLast2;
+
   typedef int (*par_progress_t)(int c, int n, int d, int cores, clock_t t0, int stop);
   extern par_progress_t par_progress;
 
@@ -327,6 +346,13 @@ extern "C" {
       setSeedEng1 = (setSeedEng1_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 71));
       seedEng = (seedEng_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 72));
       rxNormEng = (rxNormEng_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 73));
+      setIndSolvePtr = (setIndSolvePtr_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 74));
+      getIndSolveSave = (getIndSolveSave_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 75));
+      setIndSolveSave = (setIndSolveSave_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 76));
+      getIndSolveLast = (getIndSolveLast_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 77));
+      setIndSolveLast = (setIndSolveLast_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 78));
+      getIndSolveLast2 = (getIndSolveLast2_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 79));
+      setIndSolveLast2 = (setIndSolveLast2_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 80));
     }
     return R_NilValue;
   }
@@ -406,6 +432,13 @@ extern "C" {
   setSeedEng1_t setSeedEng1 = NULL;                     \
   seedEng_t seedEng = NULL;                             \
   rxNormEng_t rxNormEng = NULL;                         \
+  setIndSolvePtr_t setIndSolvePtr = NULL;               \
+  getIndSolveSave_t getIndSolveSave = NULL;             \
+  setIndSolveSave_t setIndSolveSave = NULL;             \
+  getIndSolveLast_t getIndSolveLast = NULL;             \
+  setIndSolveLast_t setIndSolveLast = NULL;             \
+  getIndSolveLast2_t getIndSolveLast2 = NULL;           \
+  setIndSolveLast2_t setIndSolveLast2 = NULL;           \
   SEXP iniRxodePtrs(SEXP ptr) {                         \
     return iniRxodePtrs0(ptr);                          \
   }                                                     \

--- a/src/init.c
+++ b/src/init.c
@@ -413,6 +413,17 @@ void setSeedEng1(uint32_t seed);
 void seedEng(int ncores);
 double rxNormEng(double mean, double sd);
 
+// per-individual ODE solve buffer-pointer accessors (defined in rx2api.c); let a
+// downstream caller swap in private, larger solve buffers for a higher-state
+// sensitivity model and restore them afterward (nlmixr2est impmap gradient).
+void setIndSolvePtr(rx_solving_options_ind* ind, double* solve);
+double *getIndSolveSave(rx_solving_options_ind* ind);
+void setIndSolveSave(rx_solving_options_ind* ind, double* solveSave);
+double *getIndSolveLast(rx_solving_options_ind* ind);
+void setIndSolveLast(rx_solving_options_ind* ind, double* solveLast);
+double *getIndSolveLast2(rx_solving_options_ind* ind);
+void setIndSolveLast2(rx_solving_options_ind* ind, double* solveLast2);
+
 SEXP _rxode2_rxode2Ptr(void) {
   int pro = 0;  // Counter for the number of PROTECT calls
   // Create an external pointer for _lotriLstToMat
@@ -501,8 +512,15 @@ SEXP _rxode2_rxode2Ptr(void) {
   SEXP rxode2setSeedEng1 = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setSeedEng1, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2seedEng = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&seedEng, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2rxNormEng = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxNormEng, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2setIndSolvePtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setIndSolvePtr, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2getIndSolveSave = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&getIndSolveSave, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2setIndSolveSave = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setIndSolveSave, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2getIndSolveLast = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&getIndSolveLast, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2setIndSolveLast = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setIndSolveLast, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2getIndSolveLast2 = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&getIndSolveLast2, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2setIndSolveLast2 = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setIndSolveLast2, R_NilValue, R_NilValue)); pro++;
 
-#define nVec 74
+#define nVec 81
   SEXP ret = PROTECT(Rf_allocVector(VECSXP, nVec)); pro++;
   SET_VECTOR_ELT(ret, 0, rxode2rxRmvnSEXP);
   SET_VECTOR_ELT(ret, 1, rxode2rxParProgress);
@@ -578,6 +596,13 @@ SEXP _rxode2_rxode2Ptr(void) {
   SET_VECTOR_ELT(ret, 71, rxode2setSeedEng1);
   SET_VECTOR_ELT(ret, 72, rxode2seedEng);
   SET_VECTOR_ELT(ret, 73, rxode2rxNormEng);
+  SET_VECTOR_ELT(ret, 74, rxode2setIndSolvePtr);
+  SET_VECTOR_ELT(ret, 75, rxode2getIndSolveSave);
+  SET_VECTOR_ELT(ret, 76, rxode2setIndSolveSave);
+  SET_VECTOR_ELT(ret, 77, rxode2getIndSolveLast);
+  SET_VECTOR_ELT(ret, 78, rxode2setIndSolveLast);
+  SET_VECTOR_ELT(ret, 79, rxode2getIndSolveLast2);
+  SET_VECTOR_ELT(ret, 80, rxode2setIndSolveLast2);
 
 
   SEXP retN = PROTECT(Rf_allocVector(STRSXP, nVec)); pro++;
@@ -655,6 +680,13 @@ SEXP _rxode2_rxode2Ptr(void) {
   SET_STRING_ELT(retN, 71, Rf_mkChar("rxode2setSeedEng1"));
   SET_STRING_ELT(retN, 72, Rf_mkChar("rxode2seedEng"));
   SET_STRING_ELT(retN, 73, Rf_mkChar("rxode2rxNormEng"));
+  SET_STRING_ELT(retN, 74, Rf_mkChar("rxode2setIndSolvePtr"));
+  SET_STRING_ELT(retN, 75, Rf_mkChar("rxode2getIndSolveSave"));
+  SET_STRING_ELT(retN, 76, Rf_mkChar("rxode2setIndSolveSave"));
+  SET_STRING_ELT(retN, 77, Rf_mkChar("rxode2getIndSolveLast"));
+  SET_STRING_ELT(retN, 78, Rf_mkChar("rxode2setIndSolveLast"));
+  SET_STRING_ELT(retN, 79, Rf_mkChar("rxode2getIndSolveLast2"));
+  SET_STRING_ELT(retN, 80, Rf_mkChar("rxode2setIndSolveLast2"));
 
 #undef nVec
 

--- a/src/rx2api.c
+++ b/src/rx2api.c
@@ -133,6 +133,39 @@ double *getIndSolve(rx_solving_options_ind* ind) {
   return ind->solve;
 }
 
+// Buffer-pointer accessors: get/set the per-individual ODE solve buffers so a
+// caller can temporarily swap in privately-owned, larger buffers (e.g. to solve
+// a higher-state sensitivity model against the same event table) and restore the
+// originals afterward.  Pair with setOpNeq() to keep the effective state count
+// consistent with the swapped buffers.
+void setIndSolvePtr(rx_solving_options_ind* ind, double* solve) {
+  ind->solve = solve;
+}
+
+double *getIndSolveSave(rx_solving_options_ind* ind) {
+  return ind->solveSave;
+}
+
+void setIndSolveSave(rx_solving_options_ind* ind, double* solveSave) {
+  ind->solveSave = solveSave;
+}
+
+double *getIndSolveLast(rx_solving_options_ind* ind) {
+  return ind->solveLast;
+}
+
+void setIndSolveLast(rx_solving_options_ind* ind, double* solveLast) {
+  ind->solveLast = solveLast;
+}
+
+double *getIndSolveLast2(rx_solving_options_ind* ind) {
+  return ind->solveLast2;
+}
+
+void setIndSolveLast2(rx_solving_options_ind* ind, double* solveLast2) {
+  ind->solveLast2 = solveLast2;
+}
+
 double getIndDv(rx_solving_options_ind* ind, int j) {
   if (j < 0 || j >= ind->n_all_times) {
     Rf_error("[getIndDv]: j (%d) should be between [0, %d)", j, ind->n_all_times);


### PR DESCRIPTION
…er swapping

Expose get/set accessors for ind->solve (setIndSolvePtr; getIndSolve already existed), ind->solveSave, ind->solveLast and ind->solveLast2 through the rxode2 function-pointer table (entries 74-80, nVec 74->81).  These let a downstream package (nlmixr2est importance-sampling gradient) temporarily swap in privately-owned, larger solve buffers to run a higher-state sensitivity model against the same event table -- pairing with the existing setOpNeq() -- and restore the originals afterward, without a second global rx_solve context.