### PR TITLE
fix(symengine): guard .rxFromSEnum against empty input and stop workspace leakage in rxFromSE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # rxode2 5.1.3
 
+- Fix `rxFromSE()` erroring with "argument is of length zero" (via
+  `.rxFromSEnum()`) and, worse, silently substituting user-workspace variable
+  values into converted expressions: the numeric-constant canonicalization now
+  evaluates operands in `baseenv()` only and guards zero-length results (#1109).
+
 - Fix `calcJac=TRUE` model rewriting (also used by the on-the-fly Jacobian the
   stiff `ros4` / `dop853+ros4` path generates) for models that declare literal
   `THETA_n_`/`ETA_n_` parameters and use delays: (1) a suppressed constant

--- a/R/symengine.R
+++ b/R/symengine.R
@@ -2440,7 +2440,7 @@ rxFromSE <- function(x, unknownDerivatives = c("forward", "central", "error"),
 .rxFromSEnum <- function(x) {
   .ret <- as.character(x)
   .retl <- nchar(.ret)
-  if (.retl > 5) {
+  if (length(.retl) == 1L && .retl > 5) {
     .op <- options()
     options(digits = 22)
     on.exit(options(.op))
@@ -2538,8 +2538,12 @@ rxFromSE <- function(x, unknownDerivatives = c("forward", "central", "error"),
         .x2 <- .rxFromSE(.x2)
         .x3 <- x[[3]]
         .x3 <- .rxFromSE(.x3)
-        .x3v <- try(eval(parse(text = .x3)), silent = TRUE)
-        if (inherits(.x3v, "numeric")) {
+        # eval in baseenv() so only numeric-constant subexpressions
+        # canonicalize; the default frame's scope chain reaches the user's
+        # global environment, leaking workspace variables into the
+        # conversion (nlmixr2/rxode2#1109)
+        .x3v <- try(eval(parse(text = .x3), envir = baseenv()), silent = TRUE)
+        if (inherits(.x3v, "numeric") && length(.x3v) == 1L) {
           .x3 <- .rxFromSEnum(.x3v)
         }
         if (.x1 == "^" && .x3 == "1") {

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -1416,5 +1416,23 @@ rxTest({
     }
   }
 
+  test_that(".rxFromSEnum handles empty input (#1109)", {
+    expect_equal(.rxFromSEnum(numeric(0)), character(0))
+    expect_equal(.rxFromSEnum(character(0)), character(0))
+  })
+
+  test_that("rxFromSE does not leak user-workspace variables (#1109)", {
+    # a variable in the global environment named like a model symbol must
+    # neither error (zero-length) nor be substituted into the conversion
+    assign("rxFromSE1109center", numeric(0), envir = globalenv())
+    on.exit(rm("rxFromSE1109center", envir = globalenv()), add = TRUE)
+    .x <- symengine::S("exp(ETA_3_ + THETA_3_ - (ETA_3_ + THETA_3_))*rx__sens_x_BY_ETA_1___/rxFromSE1109center")
+    expect_equal(
+      rxFromSE(.x),
+      "exp(ETA[3]+THETA[3]-(ETA[3]+THETA[3]))*rx__sens_x_BY_ETA_1___/rxFromSE1109center")
+    assign("rxFromSE1109center", 42, envir = globalenv())
+    .y <- symengine::S("rx__sens_x_BY_ETA_1___/rxFromSE1109center")
+    expect_equal(rxFromSE(.y), "rx__sens_x_BY_ETA_1___/rxFromSE1109center")
+  })
 
 })


### PR DESCRIPTION
Closes #1109

## Problem

`.rxFromSEnum()` errored with `argument is of length zero` on empty input, which broke `rxFromSE()` for some 2nd-order sensitivity expressions (e.g. nlmixr2est's analytic FOCEI/FOCE covariance build for lnorm/logitNorm error models).

Tracing how the empty operand arises revealed the root cause: the numeric-constant canonicalization in `.rxFromSE`'s binary-operator branch ran `eval(parse(text = .x3))` in the function frame, whose scope chain reaches the **user's global environment** (namespace -> base namespace -> globalenv). Any workspace variable named like a model symbol leaked into the conversion:

- a zero-length variable (e.g. `center <- numeric(0)` with a `center` state in the model) produced `numeric(0)` -> the reported error;
- worse, a non-empty variable (`center <- 42`) was **silently substituted** into the converted expression (`x/center` -> `x/42`) with no error at all.

## Fix

- Evaluate the operand in `baseenv()` (parent = empty environment), so only genuine numeric-constant subexpressions canonicalize; require a length-1 numeric result.
- Make the `.rxFromSEnum` `nchar` guard length-safe so empty input is returned unchanged (the issue's suggested defensive fix).

## Verification

- Both issue reproductions and the representative lnorm sensitivity expression now convert correctly; workspace variables are neither substituted nor error-inducing (regression tests added in `test-dsl.R`).
- Constant canonicalization unchanged: `a^2.0` -> `Rx_pow_di(a,2)`, `a^0.5` -> `sqrt(a)`, `2*pi*a` -> `2*a*M_PI`, `a^-1.0` -> `(1/(a))`.
- `devtools::test` on all files exercising `rxFromSE` (dsl, fun, gammap, named-id, lhs-str, udf, event-sensitivities): 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)