### PR TITLE
rxFromSE(): handle raw comparison/logical operators (fixes IOV + linCmt() FOCEi, nlmixr2#390)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # rxode2 5.1.3
 
+- `rxFromSE()` now converts raw R comparison/logical operators (`>`, `<`, `>=`,
+  `<=`, `==`, `!=`, `&`, `|`, `%%`), not only their `rxGt()`/`rxEq()` symengine
+  forms.  This fixes a "user function '>' requires 0 arguments" error when a
+  linear-compartment (`linCmt()`) parameter contains a comparison, e.g. FOCEi
+  models with inter-occasion variability (`iov ~ ... | occ`) (nlmixr2/nlmixr2#390).
+
 - Fix `calcJac=TRUE` model rewriting (also used by the on-the-fly Jacobian the
   stiff `ros4` / `dop853+ros4` path generates) for models that declare literal
   `THETA_n_`/`ETA_n_` parameters and use delays: (1) a suppressed constant

--- a/R/symengine.R
+++ b/R/symengine.R
@@ -70,6 +70,20 @@ regIfOrElse <- rex::rex(or(regIf, regElse))
   "rxLt" = c("(", "<", ")"),
   "rxAnd" = c("(", "&&", ")"),
   "rxOr" = c("(", "||", ")"),
+  # raw R comparison/logical operators map to themselves so rxFromSE() can
+  # re-consume its own output; the Subs handler re-parses converted text with
+  # R's parser, turning rxGt()/rxEq() back into `>`/`==` operator calls
+  "==" = c("(", "==", ")"),
+  "!=" = c("(", "!=", ")"),
+  ">=" = c("(", ">=", ")"),
+  "<=" = c("(", "<=", ")"),
+  ">" = c("(", ">", ")"),
+  "<" = c("(", "<", ")"),
+  "&&" = c("(", "&&", ")"),
+  "&" = c("(", "&&", ")"),
+  "||" = c("(", "||", ")"),
+  "|" = c("(", "||", ")"),
+  "%%" = c("(", "%%", ")"),
   "R_pow"=c("(", ")^(", ")"),
   "R_pow_di"=c("(", ")^(", ")"),
   "Rx_pow"=c("(", ")^(", ")"),

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -13,6 +13,27 @@ rxTest({
     expect_equal(rxFromSE(tmp), "d/dt(E)")
   })
 
+  test_that("rxFromSE() round-trips raw comparison/logical operators", {
+    # The Subs handler re-parses converted text with R's parser, which turns
+    # rxGt()/rxEq() back into raw `>`/`==` operator calls; .rxFromSE() must
+    # accept those so a comparison inside a Derivative(linCmtB(...)) does not
+    # error with "user function '>' requires 0 arguments" (nlmixr2/nlmixr2#390).
+    expect_equal(rxFromSE("a > b"), "(a>b)")
+    expect_equal(rxFromSE("a < b"), "(a<b)")
+    expect_equal(rxFromSE("a >= b"), "(a>=b)")
+    expect_equal(rxFromSE("a <= b"), "(a<=b)")
+    expect_equal(rxFromSE("a == b"), "(a==b)")
+    expect_equal(rxFromSE("a != b"), "(a!=b)")
+    expect_equal(rxFromSE("exp(x + (a > 0))"), "exp(x+((a>0)))")
+    # the derivative of a linCmtB() whose parameter contains a comparison
+    # (as produced for IOV + linCmt() FOCEi models) must convert without error
+    .x <- paste0("Subs(Derivative(linCmtB(rx__PTR__, t, 2.0, 1.0, 1.0, -1.0, ",
+                 "-1.0, 1.0, exp(THETA_2_ + rxGt(THETA_5_, 0.0)*rxEq(occ, 1.0)), ",
+                 "exp(THETA_3_), 0.0, 0.0, 0.0, 0.0, _xi_15), _xi_15), ",
+                 "(_xi_15), (exp(THETA_1_)))")
+    expect_error(rxFromSE(.x), NA)
+  })
+
   test_that("df(x)/dy(x) parsing", {
     expect_equal(rxToSE(df(matt) / dy(ruth)), "rx__df_matt_dy_ruth__")
     expect_equal(rxFromSE(rx__df_matt_dy_ruth__), "df(matt)/dy(ruth)")


### PR DESCRIPTION
## Problem

A FOCEi model that combines `linCmt()` with inter-occasion variability (`iov ~ ... | occ`) aborts during the symbolic `d(f)/d(eta)` step:

```
Error: Aborted calculation
user function '>' requires 0 arguments (supplied 2)
```

Reproducible example (from nlmixr2/nlmixr2#390):

```r
d <- nlmixr2data::theo_sd
d$occ <- ifelse(d$TIME <= median(d$TIME), 1, 2)
mod <- function() {
  ini({ tka<-0.45; tcl<-1; tv<-3.45; eta.ka~0.6; eta.cl~0.3; eta.v~0.1; add.sd<-0.7; iov.cl~0.1|occ })
  model({ ka<-exp(tka+eta.ka); cl<-exp(tcl+eta.cl+iov.cl); v<-exp(tv+eta.v); linCmt()~add(add.sd) })
}
nlmixr2::nlmixr2(mod, d, "focei")   # errors
```

`ODE + IOV` works and `linCmt()` without IOV works; only the combination fails.

## Root cause

IOV expands to an `abs()`/occasion-indicator transform, so the `linCmt` clearance parameter carries comparison operators, which reach `rxFromSE()` as the symengine functions `rxGt()`/`rxEq()` nested inside a `linCmtB()` call. The `linCmtB` gradient is taken via `Subs(Derivative(linCmtB(...), _xi), _xi, ...)`.

`rxFromSE()`'s `Subs` handler converts the inner expression to rxode2 text, then **re-parses that text with R's parser** and re-runs `.rxFromSE()` on the result. R's parser turns the already-converted `(a > b)` back into a raw `` `>`(a, b) `` operator call. `.rxFromSE()` only had reverse mappings for the symengine names (`rxGt`, `rxEq`, ...), not the raw R operators, so it fell through to the generic "user function" branch and raised `user function '>' requires 0 arguments (supplied 2)`.

Arithmetic operators (`+ - * / ^`) already round-tripped, which is why non-IOV models were fine.

## Fix

Add the raw R comparison/logical operators (`> < >= <= == != & | %%`) to the `.SEdouble` reverse-conversion table so `.rxFromSE()` can re-consume its own output. One-line-per-operator, mapping each to its infix form (matching the existing `rxGt`/`rxAnd` canonicalization).

## Verification

- The isolated failing `Subs(Derivative(linCmtB(...)))` expression now converts without error.
- The full IOV + `linCmt()` FOCEi fit above builds and converges end-to-end.
- Added round-trip assertions in `test-dsl.R`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)