### PR TITLE
fix(rxFromSE): handle relationals in a Subs() over a Derivative()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # rxode2 5.1.3
 
+- Fix `rxFromSE()` on a `Subs()` over a `Derivative()` whose body carries a
+  relational (`rxGt`/`rxEq`/... -- e.g. from `abs()` or an occasion indicator).
+  The derivative conversion turns the relational into an R `>`/`==`, and the
+  substituted expression was converted a second time, so the bare operator
+  tripped the unknown-user-function check (`user function '>' requires 0
+  arguments`).  Bare relational/logical operators are now recognized on the
+  second pass.  This unblocks FOCEi IOV models that also have a between-subject
+  eta on a parameter without IOV.
+
 - Fix `calcJac=TRUE` model rewriting (also used by the on-the-fly Jacobian the
   stiff `ros4` / `dop853+ros4` path generates) for models that declare literal
   `THETA_n_`/`ETA_n_` parameters and use delays: (1) a suppressed constant

--- a/R/symengine.R
+++ b/R/symengine.R
@@ -73,7 +73,21 @@ regIfOrElse <- rex::rex(or(regIf, regElse))
   "R_pow"=c("(", ")^(", ")"),
   "R_pow_di"=c("(", ")^(", ")"),
   "Rx_pow"=c("(", ")^(", ")"),
-  "Rx_pow_di"=c("(", ")^(", ")")
+  "Rx_pow_di"=c("(", ")^(", ")"),
+  ## Bare R relational/logical operators.  These are not produced by symengine
+  ## directly (it uses rxEq/rxGt/...), but a Subs() over a Derivative whose body
+  ## carries a relational -- e.g. from abs() or an occasion indicator -- converts
+  ## rxGt/rxEq to R `>`/`==` and then re-runs .rxFromSE(); handle those infix so
+  ## the relational survives the second pass instead of tripping the unknown-user-
+  ## function check.
+  ">"=c("(", ">", ")"),
+  "<"=c("(", "<", ")"),
+  ">="=c("(", ">=", ")"),
+  "<="=c("(", "<=", ")"),
+  "=="=c("(", "==", ")"),
+  "!="=c("(", "!=", ")"),
+  "&&"=c("(", "&&", ")"),
+  "||"=c("(", "||", ")")
 )
 
 ## atan2

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -258,6 +258,20 @@ rxTest({
       rxFromSE("(2*a + b)*Subs(Derivative(rxTBS(_xi_1, b, c, d, f), _xi_1), (_xi_1), (a*b + a^2))"),
       "(2*a+b)*rxTBSd(a*b+Rx_pow_di(a,2),b,c,d,f)"
     )
+    ## A Subs() over a Derivative whose body carries a relational (rxGt/rxEq,
+    ## e.g. from abs() or an occasion indicator, as generated for FOCEi IOV
+    ## models) must not error: the Derivative conversion turns the relational
+    ## into an R `>`/`==`, and the substituted expression is converted a second
+    ## time, so those bare operators have to be recognized rather than treated as
+    ## unknown user functions (previously "user function '>' requires 0 arguments").
+    expect_equal(
+      rxFromSE("Subs(Derivative(rxTBS(_xi_1, rxGt(b, 0), c, d, f), _xi_1), (_xi_1), (a))"),
+      "rxTBSd(a,(b>0),c,d,f)"
+    )
+    expect_equal(
+      rxFromSE("Subs(Derivative(rxTBS(_xi_1, rxEq(occ, 1), c, d, f), _xi_1), (_xi_1), (a))"),
+      "rxTBSd(a,(occ==1),c,d,f)"
+    )
   })
 
   test_that("NN Activation functions derivatives", {


### PR DESCRIPTION
rxFromSE()'s Subs handler converts the Derivative subexpression to R (turning symengine rxGt/rxEq into bare R `>`/`==`), then re-runs .rxFromSE() on the substituted expression.  On that second pass the bare `>`/`==` were not in the symengine->R operator table, so they fell through to the unknown-user-function branch and errored ("user function '>' requires 0 arguments (supplied 2)").

This surfaces in FOCEi IOV models: the occasion indicator (occ==k) and the abs() in the sd/var IOV parameterization become rxEq/rxGt, and differentiating the opaque linCmtB w.r.t. a between-subject eta on a parameter without IOV produces Subs(Derivative(linCmtB(...rxGt...rxEq...))).  The whole FOCEi fit aborted at "calculate d(f)/d(eta)".

Add the bare relational/logical operators (>, <, >=, <=, ==, !=, &&, ||) to the symengine->R table so they are rendered infix on the second pass.  Regression tests in test-dsl.R.


Claude-Session: https://claude.ai/code/session_01P2pdgEBZVj2noUAEeKBFBf