### PR TITLE
Export rxUnifEng (threefry uniform driver) via the function-pointer table

### DIFF
--- a/inst/include/rxode2ptr.h
+++ b/inst/include/rxode2ptr.h
@@ -38,6 +38,8 @@ extern "C" {
   extern seedEng_t seedEng;
   typedef double (*rxNormEng_t)(double mean, double sd);
   extern rxNormEng_t rxNormEng;
+  typedef double (*rxUnifEng_t)(double low, double hi);
+  extern rxUnifEng_t rxUnifEng;
 
   // Per-individual ODE solve buffer-pointer swap (nlmixr2est impmap gradient):
   // save the originals, install private larger buffers for a higher-state
@@ -346,6 +348,7 @@ extern "C" {
       setSeedEng1 = (setSeedEng1_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 71));
       seedEng = (seedEng_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 72));
       rxNormEng = (rxNormEng_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 73));
+      rxUnifEng = (rxUnifEng_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 81));
       setIndSolvePtr = (setIndSolvePtr_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 74));
       getIndSolveSave = (getIndSolveSave_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 75));
       setIndSolveSave = (setIndSolveSave_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 76));
@@ -432,6 +435,7 @@ extern "C" {
   setSeedEng1_t setSeedEng1 = NULL;                     \
   seedEng_t seedEng = NULL;                             \
   rxNormEng_t rxNormEng = NULL;                         \
+  rxUnifEng_t rxUnifEng = NULL;                         \
   setIndSolvePtr_t setIndSolvePtr = NULL;               \
   getIndSolveSave_t getIndSolveSave = NULL;             \
   setIndSolveSave_t setIndSolveSave = NULL;             \

--- a/src/init.c
+++ b/src/init.c
@@ -412,6 +412,7 @@ uint32_t getRxSeed1(int ncores);
 void setSeedEng1(uint32_t seed);
 void seedEng(int ncores);
 double rxNormEng(double mean, double sd);
+double rxUnifEng(double low, double hi);
 
 // per-individual ODE solve buffer-pointer accessors (defined in rx2api.c); let a
 // downstream caller swap in private, larger solve buffers for a higher-state
@@ -512,6 +513,7 @@ SEXP _rxode2_rxode2Ptr(void) {
   SEXP rxode2setSeedEng1 = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setSeedEng1, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2seedEng = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&seedEng, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2rxNormEng = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxNormEng, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2rxUnifEng = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxUnifEng, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2setIndSolvePtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setIndSolvePtr, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2getIndSolveSave = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&getIndSolveSave, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2setIndSolveSave = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setIndSolveSave, R_NilValue, R_NilValue)); pro++;
@@ -520,7 +522,7 @@ SEXP _rxode2_rxode2Ptr(void) {
   SEXP rxode2getIndSolveLast2 = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&getIndSolveLast2, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2setIndSolveLast2 = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setIndSolveLast2, R_NilValue, R_NilValue)); pro++;
 
-#define nVec 81
+#define nVec 82
   SEXP ret = PROTECT(Rf_allocVector(VECSXP, nVec)); pro++;
   SET_VECTOR_ELT(ret, 0, rxode2rxRmvnSEXP);
   SET_VECTOR_ELT(ret, 1, rxode2rxParProgress);
@@ -603,6 +605,7 @@ SEXP _rxode2_rxode2Ptr(void) {
   SET_VECTOR_ELT(ret, 78, rxode2setIndSolveLast);
   SET_VECTOR_ELT(ret, 79, rxode2getIndSolveLast2);
   SET_VECTOR_ELT(ret, 80, rxode2setIndSolveLast2);
+  SET_VECTOR_ELT(ret, 81, rxode2rxUnifEng);
 
 
   SEXP retN = PROTECT(Rf_allocVector(STRSXP, nVec)); pro++;
@@ -687,6 +690,7 @@ SEXP _rxode2_rxode2Ptr(void) {
   SET_STRING_ELT(retN, 78, Rf_mkChar("rxode2setIndSolveLast"));
   SET_STRING_ELT(retN, 79, Rf_mkChar("rxode2getIndSolveLast2"));
   SET_STRING_ELT(retN, 80, Rf_mkChar("rxode2setIndSolveLast2"));
+  SET_STRING_ELT(retN, 81, Rf_mkChar("rxode2rxUnifEng"));
 
 #undef nVec
 

--- a/src/rxthreefry.cpp
+++ b/src/rxthreefry.cpp
@@ -1375,6 +1375,17 @@ extern "C" double rxNormEng(double mean, double sd){
   return d(_eng[rx_get_thread(op_global.cores)]);
 }
 
+// Raw uniform(low, hi) draw from the current thread's threefry engine, the
+// uniform peer of rxNormEng() (no inLhs solve-context gate).  Exposed via the
+// function-pointer table so downstream packages can draw threefry uniforms from
+// a seeded per-subject stream (setSeedEng1 + setRxThreadId), e.g. for MCMC
+// accept/reject steps.
+extern "C" double rxUnifEng(double low, double hi){
+  if (ISNA(low) || ISNA(hi)) return NA_REAL;
+  std::uniform_real_distribution<double> d(low, hi);
+  return d(_eng[rx_get_thread(op_global.cores)]);
+}
+
 extern "C" double rinorm(int id, double mean, double sd) {
   rx_solving_options_ind* ind = &inds_thread[rx_get_thread(op_global.cores)];
   if (ind->isIni) {


### PR DESCRIPTION
## Summary

Adds `rxUnifEng(low, hi)` -- the uniform peer of the existing `rxNormEng(mean, sd)` -- and registers it in the rxode2 function-pointer table so downstream packages can draw threefry uniforms from a seeded per-subject stream.

`rxUnifEng` draws a raw `uniform(low, hi)` from the current thread's threefry engine, with no `inLhs` solve-context gate (mirroring `rxNormEng`). Combined with the already-exported `setSeedEng1` / `setRxThreadId` / `getRxSeed1`, this lets a caller build a fully seeded, thread-independent, bit-reproducible stream of uniforms -- needed for MCMC accept/reject steps where the number of iterations may change dynamically at runtime.

## Motivation

`nlmixr2est` is converting its SAEM/fSAEM/importance-sampling/VAE Metropolis kernels to draw all random numbers from the threefry engine with an iteration-indexed seed, so a fit can be paused, extended, and resumed bit-identically. The normal driver (`rxNormEng`) was already exported; the accept/reject step needs the uniform peer, which was previously only available through the solve-gated path.

## Changes

- `src/rxthreefry.cpp` -- add `extern "C" double rxUnifEng(double low, double hi)`.
- `src/init.c` -- forward decl, `PROTECT` the external pointer, register at table index 81, bump `nVec` 81 -> 82, add the name entry.
- `inst/include/rxode2ptr.h` -- typedef/extern, wire index 81 in the loader, and NULL-init in the per-package definition macro.

Purely additive: no existing table index changes, so already-compiled downstream packages are unaffected until they opt in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)