### PR TITLE
fix(eventSens): correct doubled jump sensitivity at observations coincident with a modeled-lag dose arrival

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -263,6 +263,7 @@ reference:
   - .modelHandleModelLines
   - .quoteCallInfoLines
   - .rxLinCmtGen
+  - .rxSensStrippable
   - .rxWithOptions
   - .rxWithWd
   - .rxode2ptrs

--- a/inst/include/rxMemoryCalc.h
+++ b/inst/include/rxMemoryCalc.h
@@ -26,7 +26,7 @@ typedef struct {
   /* --- gsolve components (all double) --- */
   int64_t n0;          /* nall * state_size * nsim  -- ODE output matrix      */
   int64_t nlin;        /* linB * 7 * nsub * nsim    -- linCmt scratch          */
-  int64_t nsave;       /* neq * cores               -- used x3 (Save/Last/Last2) */
+  int64_t nsave;       /* neq * cores               -- used x4 (Save/Last/Last2/EsPendingJump) */
   int64_t n2;          /* nMtime * nsub * nsim      -- mtime arrays            */
   int64_t n3a_c;       /* (neq + extraCmt) * cores  -- gTlastS/firstS/CurDose  */
   int64_t n4;          /* initsC.size()  (~ neq for estimates)                */
@@ -98,7 +98,7 @@ static inline void rxFillMemLayout(
   out->gsolve_total =
     out->n0        +
     out->nlin      +
-    3 * out->nsave +
+    4 * out->nsave +  /* gSolveSave, gSolveLast, gSolveLast2, gEsPendingJump */
     out->n2        +
     out->n4        +
     out->n5_c      +

--- a/inst/include/rxode2parseHandleEvid.h
+++ b/inst/include/rxode2parseHandleEvid.h
@@ -485,6 +485,67 @@ static inline int pushUniqueDosingEvent(double time, double amt, int evid,
 static inline void updateRate(int idx, rx_solving_options_ind *ind, double *yp);
 static inline void updateDur(int idx, rx_solving_options_ind *ind, double *yp);
 
+// Event ("jump") sensitivities: apply a 1st-order dtau/alag moving-boundary jump
+// to sensitivity compartment `slot` (state esK, param p), or DEFER it.  The
+// dosed compartment (esK == cmt) jumps in VALUE at the arrival time tau -- its
+// reported state at an output coincident with tau is post-dose, so its
+// sensitivity must be the post-jump value; apply immediately.  A NON-dosed
+// compartment (esK != cmt) is physically continuous at tau -- its reported state
+// at a coincident output is the pre-arrival (left-continuous) value, so its
+// reported sensitivity must be the pre-jump left limit.  Its jump is genuine for
+// t > tau, so we accumulate it into the per-thread pending buffer tagged with
+// tau; preSolve() flushes it into yp at the first step that advances past tau.
+// Deferring vs. applying at the event yields an identical yp for every t > tau
+// (no integration happens in between), so this only changes the coincident-time
+// output.  When the pending buffer is unavailable (e.g. op->neq == 0) fall back
+// to applying immediately (old behavior).  Used by the replace/multiply dtau
+// rows, whose 1st-order jump is the LAST sensitivity write of the event (no
+// higher-order row reads it back), so it can be deferred out of yp immediately.
+static inline void _esApplyOrDeferJump(rx_solving_options_ind *ind, double *yp,
+                                       int slot, int esK, int cmt,
+                                       double value, double tau) {
+  if (esK == cmt || ind->esPendingJump == NULL) {
+    yp[slot] += value;
+    return;
+  }
+  ind->esPendingJump[slot] += value;
+  ind->esHasPending = 1;
+  ind->esPendingTau = tau;
+}
+
+// Additive-bolus variant: the same event's 2nd/3rd-order Leibniz rows read yp's
+// POST-jump 1st-order sensitivity block (via dydt of a scratch copy), so the
+// non-dosed 1st-order jump must be in yp while those rows run.  Apply it in place
+// for ALL compartments here, and separately RECORD the non-dosed part into a
+// per-event scratch `deferBuf` (indexed by slot-ns over the ns*np first-order
+// block); _esMoveDeferredToPending() moves it out of yp into the pending buffer
+// once the higher-order rows have run.
+static inline void _esApplyJumpRecordNonDosed(double *yp, double *deferBuf,
+                                              int ns, int slot, int esK, int cmt,
+                                              double value) {
+  yp[slot] += value;
+  if (esK != cmt && deferBuf != NULL) deferBuf[slot - ns] += value;
+}
+
+// Move a recorded per-event non-dosed 1st-order jump out of yp and into the
+// pending buffer, so an output coincident with tau reports the pre-jump left
+// limit while preSolve() restores the post-jump value for t > tau.  No-op
+// without a pending buffer (leaves the in-place jump -- old behavior).
+static inline void _esMoveDeferredToPending(rx_solving_options_ind *ind, double *yp,
+                                            double *deferBuf, int ns, int np,
+                                            double tau) {
+  if (deferBuf == NULL || ind->esPendingJump == NULL) return;
+  int _any = 0;
+  for (int _r = 0; _r < ns * np; _r++) {
+    if (deferBuf[_r] != 0.0) {
+      yp[ns + _r] -= deferBuf[_r];
+      ind->esPendingJump[ns + _r] += deferBuf[_r];
+      _any = 1;
+    }
+  }
+  if (_any) { ind->esHasPending = 1; ind->esPendingTau = tau; }
+}
+
 // Event ("jump") sensitivities: physical Jacobian column J[.,cmt] and
 // f_cmt = dydt(pre-event state)[cmt], needed by the dtau (event-time) jump
 // rows in the paper's replace/additive/multiplicative tables.  Source
@@ -1528,7 +1589,9 @@ static inline int handle_evid(int evid, int neq,
                 for (int _esK = 0; _esK < _ns; _esK++) {
                   double _esTerm = _esJcol[_esK] * (_esX1 - _esXi);
                   if (_esK == cmt) _esTerm -= _esFc;
-                  yp[_ns + _p * _ns + _esK] += _esTerm * _esDLagP;
+                  // non-dosed compartments deferred to preSolve (coincident-time fix)
+                  _esApplyOrDeferJump(ind, yp, _ns + _p * _ns + _esK, _esK, cmt,
+                                      _esTerm * _esDLagP, xout);
                 }
               }
             }
@@ -1601,7 +1664,9 @@ static inline int handle_evid(int evid, int neq,
                 if (_esDLagP != 0.0) {
                   for (int _esK = 0; _esK < _ns; _esK++) {
                     double _esTerm = _esOneMAlpha * (_esJcol[_esK] * _esX1 - (_esK == cmt ? _esFc : 0.0));
-                    yp[_ns + _p * _ns + _esK] += _esTerm * _esDLagP;
+                    // non-dosed compartments deferred to preSolve (coincident-time fix)
+                    _esApplyOrDeferJump(ind, yp, _ns + _p * _ns + _esK, _esK, cmt,
+                                        _esTerm * _esDLagP, xout);
                   }
                 }
               }
@@ -1662,6 +1727,12 @@ static inline int handle_evid(int evid, int neq,
               memcpy(_esSensPre, yp + _ns, (size_t)_ns * _np * sizeof(double));
             }
           }
+          // Per-event scratch for the deferred non-dosed 1st-order dtau jump
+          // (coincident-time fix).  Filled in place by the dtau row below and
+          // moved to the pending buffer at the end of this block, AFTER the
+          // 2nd/3rd-order Leibniz rows have read yp's post-jump 1st-order block.
+          double *_esDeferBuf = (ind->esPendingJump != NULL) ?
+            (double*) calloc((size_t)_ns * _np, sizeof(double)) : NULL;
           // ddelta row (bioavailability)
           if (dF != NULL) {
             double *_dFB = (double*) calloc((size_t)_ns * _np, sizeof(double));
@@ -1767,7 +1838,11 @@ static inline int handle_evid(int evid, int neq,
                 double _esDLagP = _esDLagB[cmt * _np + _p];
                 if (_esDLagP != 0.0) {
                   for (int _esK = 0; _esK < _ns; _esK++) {
-                    yp[_ns + _p * _ns + _esK] += -_esJcol[_esK] * _esDelta * _esDLagP;
+                    // apply in place (2nd/3rd-order rows read the post-jump block);
+                    // non-dosed part recorded for deferral (coincident-time fix)
+                    _esApplyJumpRecordNonDosed(yp, _esDeferBuf, _ns,
+                                               _ns + _p * _ns + _esK, _esK, cmt,
+                                               -_esJcol[_esK] * _esDelta * _esDLagP);
                   }
                 }
               }
@@ -1949,6 +2024,10 @@ static inline int handle_evid(int evid, int neq,
             if (_esJacQB != NULL) free(_esJacQB);
             if (_esDLagQB != NULL) free(_esDLagQB);
           }
+          // Now that the 2nd/3rd-order rows have read yp's post-jump 1st-order
+          // block, defer the non-dosed 1st-order jump (coincident-time fix).
+          _esMoveDeferredToPending(ind, yp, _esDeferBuf, _ns, _np, xout);
+          if (_esDeferBuf != NULL) free(_esDeferBuf);
           if (_esDydtPre != NULL) free(_esDydtPre);
           if (_esSensPre != NULL) free(_esSensPre);
         }

--- a/inst/include/rxode2parseStruct.h
+++ b/inst/include/rxode2parseStruct.h
@@ -360,6 +360,17 @@ struct rx_solving_options_ind_s {
   double  delayT0;         /* initial time; history before this is the IC */
   double  delayMinT;       /* smallest delay duration seen; caps the step size */
   int     delayWarmed;     /* 1 once the RHS has been evaluated to learn delays */
+  // Event ("jump") sensitivities: deferred moving-boundary jump for non-dosed
+  // compartments.  At a modeled-lag dose the sensitivity of a compartment that
+  // does NOT receive the bolus has a genuine jump discontinuity at the arrival
+  // time tau; its reported value at an output coincident with tau must be the
+  // pre-jump left limit (matching the reported left-continuous state), while
+  // t > tau must see the post-jump value.  handle_evid accumulates the non-dosed
+  // jump here instead of into yp; preSolve flushes it into yp at the first step
+  // that advances past tau.  Per-thread slice of _globals.gEsPendingJump.
+  double *esPendingJump;   /* per-thread neq buffer, or NULL when unused */
+  double  esPendingTau;    /* event time the pending jump belongs to */
+  int     esHasPending;    /* 1 while a deferred jump is waiting to be flushed */
   rx_fn_pointers *fns;
   rx_solving_options *op;
   rx_solve *rx;

--- a/src/par_solve.h
+++ b/src/par_solve.h
@@ -155,6 +155,14 @@ extern "C" void cvode_solveWith1Pt(int *neq, double *yp, double *xp_ptr, double 
 		ind->lastIsSs2 = false;
     ind->idxLow=0;
     ind->idxHi=0;
+    // Event ("jump") sensitivities: clear any deferred non-dosed dtau jump so it
+    // does not leak across subjects; keep the buffer zeroed when idle (the flush
+    // in preSolve re-zeros it after each use).
+    ind->esHasPending = 0;
+    ind->esPendingTau = NA_REAL;
+    if (ind->esPendingJump != NULL) {
+      memset(ind->esPendingJump, 0, rxEffNeq(ind, op)*sizeof(double));
+    }
 		// neq[0] = op->neq
     int ncmt = (op->neq + op->extraCmt);
 		for (int j = ncmt; j--;) {
@@ -375,6 +383,22 @@ static inline int handleExtraDose(int *neq,
 
 static inline void preSolve(rx_solving_options *op, rx_solving_options_ind *ind,
                             double &xp, double &xout, double *yp) {
+  // Event ("jump") sensitivities: flush the deferred non-dosed dtau jump.  It is
+  // recorded at a modeled-lag dose arrival time tau but withheld from yp so that
+  // any output coincident with tau reports the pre-jump left limit for
+  // compartments that did not receive the bolus.  This is the first integration
+  // step that advances past tau (preSolve is only called when xout != xp), so
+  // adding the jump here makes every t > tau see the post-jump value -- identical
+  // to applying it at the dose event, since no integration occurred in between.
+  // Invariant: a flush happens between any two distinct event times, so all
+  // pending accumulation shares the single time esPendingTau.
+  if (ind->esHasPending && ind->esPendingJump != NULL &&
+      isSameTime(ind->esPendingTau, xp)) {
+    int _n = rxEffNeq(ind, op);
+    for (int j = _n; j--;) yp[j] += ind->esPendingJump[j];
+    memset(ind->esPendingJump, 0, (size_t)_n*sizeof(double));
+    ind->esHasPending = 0;
+  }
   // First set the last values of time and compartment values
   if (op->numLin > 0) {
     ind->linCmtAlast = yp + op->linOffset;

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -1607,6 +1607,7 @@ extern "C" void _setIndPointersByThread(rx_solving_options_ind *ind) {
     ind->solveSave = _globals.gSolveSave + op->neq*_rxTid();
     ind->solveLast = _globals.gSolveLast + op->neq*_rxTid();
     ind->solveLast2 = _globals.gSolveLast2 + op->neq*_rxTid();
+    ind->esPendingJump = _globals.gEsPendingJump + op->neq*_rxTid();
   } else {
     ind->InfusionRate = NULL;
     ind->tlastS = NULL;
@@ -1616,6 +1617,7 @@ extern "C" void _setIndPointersByThread(rx_solving_options_ind *ind) {
     ind->solveSave = NULL;
     ind->solveLast = NULL;
     ind->solveLast2 = NULL;
+    ind->esPendingJump = NULL;
     ind->linCmtSave = NULL;
   }
   if (rx->nMtime > 0) {
@@ -6330,7 +6332,8 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
     _globals.gSolveSave  = _globals.gLlikSave   + _mem.nllik_c;
     _globals.gSolveLast  = _globals.gSolveSave  + _mem.nsave;
     _globals.gSolveLast2 = _globals.gSolveLast  + _mem.nsave;
-    _globals.gmtime      = _globals.gSolveLast2 + _mem.nsave;
+    _globals.gEsPendingJump = _globals.gSolveLast2 + _mem.nsave;
+    _globals.gmtime      = _globals.gEsPendingJump + _mem.nsave;
     // gInfusionRate is now allocated per-thread independently (see below)
     _globals.ginits      = _globals.gmtime      + _mem.n2;
     std::copy(rxSolveDat->initsC.begin(), rxSolveDat->initsC.end(), &_globals.ginits[0]);

--- a/src/rxGlobals.h
+++ b/src/rxGlobals.h
@@ -6,6 +6,7 @@ struct rx_globals {
   double *gSolveLast2;
   double *gSolveLast;
   double *gSolveSave;
+  double *gEsPendingJump;  // per-thread neq scratch: deferred non-dosed dtau jump
   int *gon;
   double *gIndSim;
   double *gsolve;

--- a/src/rxSerialize.cpp
+++ b/src/rxSerialize.cpp
@@ -785,7 +785,8 @@ SEXP rxRestoreState_(SEXP rawSexp) {
   _globals.gSolveSave  = _globals.gLlikSave   + _mem.nllik_c;
   _globals.gSolveLast  = _globals.gSolveSave  + _mem.nsave;
   _globals.gSolveLast2 = _globals.gSolveLast  + _mem.nsave;
-  _globals.gmtime      = _globals.gSolveLast2 + _mem.nsave;
+  _globals.gEsPendingJump = _globals.gSolveLast2 + _mem.nsave;
+  _globals.gmtime      = _globals.gEsPendingJump + _mem.nsave;
   _globals.ginits      = _globals.gmtime      + _mem.n2;
   op->inits            = &_globals.ginits[0];
   _globals.glhs        = _globals.ginits      + _mem.n4;
@@ -1137,6 +1138,7 @@ SEXP rxRestoreState_(SEXP rawSexp) {
     ind->solveSave = _globals.gSolveSave;
     ind->solveLast = _globals.gSolveLast;
     ind->solveLast2= _globals.gSolveLast2;
+    ind->esPendingJump = _globals.gEsPendingJump;
     ind->lhs       = _globals.glhs;
     ind->llikSave  = _globals.gLlikSave;
     ind->linCmtSave= _globals.gLinSave;

--- a/tests/testthat/test-event-sensitivities.R
+++ b/tests/testthat/test-event-sensitivities.R
@@ -418,6 +418,56 @@ rxTest({
     expect_equal(sj[["rx__sens_central_BY_eta_ka__"]], fdK, tolerance = 1e-4)
   })
 
+  test_that("additive-bolus lag jump: coincident-time output uses one-sided limits", {
+    # Regression for the doubled-sensitivity bug when an observation time exactly
+    # equals a modeled-lag dose arrival.  alag(depot) = 2 * exp(eta_lag): with
+    # eta_lag = 0 the dose (t = 0) arrives at EXACTLY t = 2, where an observation
+    # is placed.  At that coincident time the sensitivity has a genuine jump
+    # discontinuity; the reported value must match the STATE's reported side:
+    #   - central (not dosed, continuous): reported state is the pre-arrival
+    #     value, so its sensitivity must be the pre-jump (right/forward) limit.
+    #   - depot (dosed): reported state is post-dose, so its sensitivity keeps the
+    #     post-jump (left/backward) limit.
+    # Before the fix the coincident central sensitivity was the post-jump
+    # (backward) limit -- the wrong side, ~2x a symmetric FD -- which inflated the
+    # FOCEi objective on models whose observations land on lagged arrivals.
+    .mod <- "
+      ka <- exp(tka); cl <- exp(tcl); v <- exp(tv)
+      alag(depot) <- 2 * exp(eta_lag)
+      d/dt(depot)   <- -ka * depot
+      d/dt(central) <-  ka * depot - cl / v * central
+    "
+    pars <- c(tka = log(1.15), tcl = log(0.135), tv = log(8), eta_lag = 0)
+    e <- et(amt = 100, cmt = "depot") |> et(c(1.9, 2.0, 2.1, 4))
+    m <- rxode2(.mod, calcSens = "eta_lag", eventSens = "jump")
+    sj <- rxSolve(m, e, pars)
+    h <- 1e-5
+    pp <- pars; pp["eta_lag"] <-  h
+    pm <- pars; pm["eta_lag"] <- -h
+    s0 <- rxSolve(m, e, pars)
+    sP <- rxSolve(m, e, pp)
+    sM <- rxSolve(m, e, pm)
+    .at <- function(s, tm, col) s[[col]][which(abs(s$time - tm) < 1e-8)[1]]
+    # one-sided finite differences of the STATE at the coincident time t = 2
+    fwdCentral <- (.at(sP, 2, "central") - .at(s0, 2, "central")) / h   # right
+    bwdCentral <- (.at(s0, 2, "central") - .at(sM, 2, "central")) / h   # left
+    bwdDepot   <- (.at(s0, 2, "depot")   - .at(sM, 2, "depot"))   / h
+    ajCentral <- .at(sj, 2, "rx__sens_central_BY_eta_lag__")
+    ajDepot   <- .at(sj, 2, "rx__sens_depot_BY_eta_lag__")
+    # central: analytic == pre-jump (forward/right) limit (~0 here), and clearly
+    # NOT the old doubled (backward/left) value.
+    expect_equal(ajCentral, fwdCentral, tolerance = 1e-3)
+    expect_true(abs(ajCentral - bwdCentral) > 0.1 * abs(bwdCentral))
+    # depot: dosed compartment keeps the post-jump (backward/left) limit.
+    expect_equal(ajDepot, bwdDepot, tolerance = 1e-2)
+    # off-dose observations still match a two-sided central difference.
+    for (tm in c(1.9, 2.1, 4)) {
+      fd <- (.at(sP, tm, "central") - .at(sM, tm, "central")) / (2 * h)
+      expect_equal(.at(sj, tm, "rx__sens_central_BY_eta_lag__"), fd,
+                   tolerance = 1e-3)
+    }
+  })
+
   test_that("additive-bolus jumps accumulate across a multi-dose regimen", {
     # alag(depot)=exp(tlag+eta_lag), F=expit(tf+eta_f): every dose contributes
     # both a dtau and a ddelta jump.  The rows use method "add", so the jumps


### PR DESCRIPTION
## Problem

With `eventSens="jump"`, when an observation time exactly equals a modeled-lag dose arrival time τ, the 1st-order dtau moving-boundary jump for a **non-dosed, physically-continuous** compartment (e.g. `central`) was reported as the post-jump right limit, while the reported *state* is the pre-arrival (left-continuous) value. State and sensitivity sat on opposite sides of the discontinuity — roughly **2× a symmetric finite difference**.

This inflated the FOCEi objective on models whose observations land on lagged arrivals. Flagged by nlmixr2est `test-lag.R` (warfarin, `lag(gut) <- tlag`): `eventSens="jump"` gave objf ~2191 vs the historically-correct ~240 from `eventSens="fd"`.

## Fix

Defer the non-dosed-compartment 1st-order dtau jump out of `yp` until the first integration step past τ:

- The **dosed** compartment keeps its post-jump sensitivity immediately (matching its post-dose reported state).
- The **non-dosed** compartments' jump is withheld from the coincident-time output and flushed back into `yp` at the next `preSolve` (the single choke point shared by all ~80 integrator backends). Because no integration happens between the dose event and that step, every `t > τ` is byte-identical to before — only the coincident-time output changes.

Implementation:
- New per-thread `ind->esPendingJump` buffer (a 4th `nsave`-sized slice of the solve pool), plus `esPendingTau`/`esHasPending`; reset in `iniSubject`, flushed in `preSolve`.
- `handle_evid`: the additive-bolus block applies the jump in place so its 2nd/3rd-order Leibniz rows still read the post-jump 1st-order block, then moves the non-dosed part to pending *after* those rows run (`_esApplyJumpRecordNonDosed` / `_esMoveDeferredToPending`). Replace/multiply defer immediately (their dtau row is last).
- New regression test in `test-event-sensitivities.R` for a coincident observation (central → pre-jump/forward-FD limit ~0; depot → post-jump/backward-FD limit).

## Scope

1st-order ODE (the objf-affecting path). The 2nd-order coincident-time *output* and the linCmt jump path share the same theoretical issue and are a documented follow-up — they do not affect the objf value.

## Verification

Built on this base and ran: `test-event-sensitivities` (185 pass / 0 fail, including the coincident-time test and the two 2nd-order Leibniz tests), plus `alag` (359), `lag` (495), `state-dep-lag` (39), `lhs-lag` (14) — zero failures.

Follow-up (separate, nlmixr2est repo): revert the `test-lag.R` threshold `f\$objf < 2300` → `< 500` and reconfirm warfarin objf ~240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwVDp22R3CgEP22sXJB7ZU