### PR TITLE
fix(eventSens): downgrade linCmt() models to finite differences + reserved-name guard

### DIFF
--- a/R/eventSens.R
+++ b/R/eventSens.R
@@ -231,10 +231,36 @@
 #' @param map `.rxEventSensMap(obj)` result.
 #' @return Filtered map list, or `NULL` when jump should be disabled.
 #' @noRd
+#' Detect an ODE compartment name colliding with a linCmt() reserved name
+#'
+#' An explicit `d/dt()` on a linCmt()-reserved compartment name
+#' (depot/central/peripheralN) conflates the ODE and linCmt compartments -- the
+#' ODE state loses its sensitivity expansion (its `rx__sens_<state>_BY_*`
+#' compartment is never generated), so both the continuous sensitivity ODE and
+#' the analytic jump come out wrong.
+#'
+#' @param obj Anything `rxModelVars()`/`rxNorm()` accepts.
+#' @return character vector of colliding compartment names (empty when none).
+#' @noRd
+.rxLinCmtNameCollision <- function(obj) {
+  .mv <- rxModelVars(obj)
+  if (.rxLinNcmt(.mv)["numLin"] <= 0L) return(character(0))
+  .reservedPhys <- grep("^rx__sens_", .rxLinCmt(.mv), value = TRUE, invert = TRUE)
+  if (length(.reservedPhys) == 0L) return(character(0))
+  .norm <- rxNorm(obj)
+  .reservedPhys[vapply(.reservedPhys, function(.nm)
+    grepl(paste0("d/dt(", .nm, ")"), .norm, fixed = TRUE), logical(1))]
+}
+
 .rxEventSensFilterMap <- function(obj, map) {
   .mv <- rxModelVars(obj)
   .lin <- .rxLinNcmt(.mv)
   if (.lin["numLin"] <= 0L) return(map)
+  ## Defensive: a linCmt reserved-name collision (see .rxLinCmtNameCollision)
+  ## yields silently-incorrect sensitivities; disable jump.  (linCmt models now
+  ## downgrade to FD upstream via .rxEventSensEffectiveMode, so this is a guard
+  ## for any path that still reaches here.)
+  if (length(.rxLinCmtNameCollision(obj)) > 0L) return(NULL)
   .odeStates <- setdiff(.mv$normal.state, .rxLinCmt(.mv))
   if (length(.odeStates) == 0L) return(map)
   .stateCmt <- unname(map$stateCmt[.odeStates])
@@ -286,8 +312,14 @@
 #' @noRd
 .rxEventSensEffectiveMode <- function(requested, mv) {
   if (identical(requested, "fdAll")) return("fd")
-  .lin <- .rxLinNcmt(mv)["numLin"] > 0L
-  if (.lin && identical(requested, "fd")) return("jump")
+  ## linCmt() models downgrade to finite differences for event-timing
+  ## sensitivities.  The analytic moving-boundary (jump) sensitivity for a
+  ## modeled alag()/f() on a linCmt compartment is not implemented (see
+  ## nlmixr2/rxode2#1119); rather than emit an incomplete/incorrect analytic
+  ## jump, all linCmt models use FD for event sensitivities (the FOCEi/nlmixr2est
+  ## finite-difference event path).  Structural-parameter linCmt sensitivities
+  ## are unaffected (they are continuous and handled by linCmtB directly).
+  if (.rxLinNcmt(mv)["numLin"] > 0L) return("fd")
   requested
 }
 
@@ -312,6 +344,48 @@
   .lag <- .bit(4L)
   if (length(.lag) == 0L && !is.null(mv$alag)) .lag <- sort(as.integer(mv$alag))
   list(lagCmt = .lag, fCmt = .bit(2L), rateCmt = .bit(8L), durCmt = .bit(16L))
+}
+
+#' Identify (linCmt compartment, event-timing parameter) pairs needing sensitivities
+#'
+#' For a linCmt() model, a modeled alag()/f() on a linCmt compartment driven by a
+#' `calcSens` parameter has an event-timing (moving-boundary) sensitivity that the
+#' structural linCmt Jacobian (wrt p1/v1/ka/...) does not capture.  This returns
+#' the (linCmt state, driving parameter) pairs so the linCmt solve can carry the
+#' extra sensitivity columns (Part B of nlmixr2/rxode2#1119).
+#'
+#' @param obj Built model (rxUi, rxode2, modelVars).
+#' @param calcSens Character vector of first-order sensitivity parameters.
+#' @return data.frame(state, param, kind, cmt) (1-based `cmt`), or `NULL` when
+#'   the model has no linCmt event-timing sensitivities.
+#' @noRd
+.rxLinCmtEventSensPairs <- function(obj, calcSens) {
+  if (is.null(calcSens) || length(calcSens) == 0L) return(NULL)
+  .mv <- rxModelVars(obj)
+  if (.rxLinNcmt(.mv)["numLin"] <= 0L) return(NULL)
+  ## linCmt physical compartments (reserved names that are not sens compartments)
+  .linPhys <- grep("^rx__sens_", .rxLinCmt(.mv), value = TRUE, invert = TRUE)
+  if (length(.linPhys) == 0L) return(NULL)
+  .norm <- strsplit(rxNorm(obj), "\n", fixed = TRUE)[[1]]
+  .rows <- list()
+  for (.kind in c("alag", "f")) {
+    .re <- paste0("^", .kind, "\\(([^)]+)\\)=(.*);$")
+    for (.line in grep(.re, .norm, value = TRUE)) {
+      .cmt <- sub(.re, "\\1", .line)
+      if (!(.cmt %in% .linPhys)) next
+      .rhs <- sub(.re, "\\2", .line)
+      .vars <- tryCatch(all.vars(str2lang(.rhs)), error = function(e) character(0))
+      for (.p in intersect(.vars, calcSens)) {
+        .rows[[length(.rows) + 1L]] <-
+          data.frame(state = .cmt, param = .p, kind = .kind,
+                     stringsAsFactors = FALSE)
+      }
+    }
+  }
+  if (length(.rows) == 0L) return(NULL)
+  .df <- do.call(rbind, .rows)
+  .df$cmt <- unname(.mv$stateOrd[.df$state])
+  .df[!duplicated(.df[c("state", "param")]), , drop = FALSE]
 }
 
 #' Free symbols of a dosing expression in symengine (SE-mangled) names

--- a/R/eventSens.R
+++ b/R/eventSens.R
@@ -221,16 +221,6 @@
   )
 }
 
-#' Restrict jump sensitivities to ODE states for mixed ODE+linCmt models
-#'
-#' For pure linCmt models (no ODE states), event sensitivities are handled by the
-#' finite-difference linCmt path, so jump metadata is disabled (`NULL`).  For
-#' mixed models, keep only ODE-scoped states/parameters in the jump map.
-#'
-#' @param obj Model object accepted by `rxModelVars()`.
-#' @param map `.rxEventSensMap(obj)` result.
-#' @return Filtered map list, or `NULL` when jump should be disabled.
-#' @noRd
 #' Detect an ODE compartment name colliding with a linCmt() reserved name
 #'
 #' An explicit `d/dt()` on a linCmt()-reserved compartment name
@@ -252,6 +242,16 @@
     grepl(paste0("d/dt(", .nm, ")"), .norm, fixed = TRUE), logical(1))]
 }
 
+#' Restrict jump sensitivities to ODE states for mixed ODE+linCmt models
+#'
+#' For pure linCmt models (no ODE states), event sensitivities are handled by the
+#' finite-difference linCmt path, so jump metadata is disabled (`NULL`).  For
+#' mixed models, keep only ODE-scoped states/parameters in the jump map.
+#'
+#' @param obj Model object accepted by `rxModelVars()`.
+#' @param map `.rxEventSensMap(obj)` result.
+#' @return Filtered map list, or `NULL` when jump should be disabled.
+#' @noRd
 .rxEventSensFilterMap <- function(obj, map) {
   .mv <- rxModelVars(obj)
   .lin <- .rxLinNcmt(.mv)
@@ -303,8 +303,9 @@
 
 #' Resolve effective event-sensitivity mode for linCmt-containing models
 #'
-#' `fdAll` is the explicit full finite-difference fallback. For models that
-#' include linCmt, `fd` resolves to jump/symbolic event handling.
+#' `fdAll` is the explicit full finite-difference fallback. Models that include
+#' linCmt() always resolve to `fd` regardless of the requested mode (see the
+#' comment in the body); the requested mode is honored otherwise.
 #'
 #' @param requested Requested mode from `.rxEventSensMode()`.
 #' @param mv Parsed model vars.

--- a/R/rxode2.R
+++ b/R/rxode2.R
@@ -461,6 +461,17 @@ rxode2 <- # nolint
     .env$calcJac <- calcJac
     .env$calcSens <- calcSens
     .eventSensEffectiveMode <- .rxEventSensEffectiveMode(.eventSensMode, .env$.mv)
+    ## Warn when sensitivities are requested on a linCmt() model whose ODE
+    ## compartment name collides with a linCmt reserved name: the ODE state loses
+    ## its sensitivity expansion, so its sensitivities are silently incorrect.
+    if (!is.null(calcSens)) {
+      .linCollide <- .rxLinCmtNameCollision(.env$.mv)
+      if (length(.linCollide) > 0L) {
+        warning("ODE compartment(s) '", paste(.linCollide, collapse = "', '"),
+                "' share a name with linCmt() reserved compartments; ",
+                "sensitivities will be incorrect -- rename them", call. = FALSE)
+      }
+    }
     .indLinSens <- length(.env$.mv$indLin) > 0L &&
       length(.env$.mv$sens) > 0L
     if (.indLinSens) {

--- a/tests/testthat/test-event-sensitivities.R
+++ b/tests/testthat/test-event-sensitivities.R
@@ -124,13 +124,14 @@ rxTest({
     expect_null(m$eventSensInfo)
   })
 
-  test_that("eventSens='jump' works with linCmt()+mtime() models", {
+  test_that("eventSens on a linCmt()+mtime() model downgrades to fd", {
     m <- rxode2({
       C2 <- linCmt(CL, V)
       mtime(t1) <- mt1
       mtime(t2) <- mt2
     }, eventSens = "jump", linCmtSens = "linCmtA", linCmtSensType = "A")
-    expect_equal(m$eventSens, "jump")
+    # linCmt models downgrade to finite differences for event sensitivities (#1119)
+    expect_equal(m$eventSens, "fd")
     expect_null(m$eventSensInfo)
     e <- eventTable() |>
       add.dosing(dose = 3, nbr.doses = 2, dosing.interval = 8) |>
@@ -139,16 +140,16 @@ rxTest({
     expect_true(all(c(0.5, 1.75) %in% s$time))
   })
 
-  test_that("eventSens='fd' resolves to hybrid jump for mixed ODE+linCmt", {
+  test_that("mixed ODE+linCmt downgrades to fd for event sensitivities", {
     m <- rxode2({
       C2 <- linCmt(CL, V)
       alag(eff) <- exp(tlag + eta_lag)
       d/dt(eff) <- kin - kout * eff
     }, calcSens = "eta_lag", eventSens = "fd",
     linCmtSens = "linCmtA", linCmtSensType = "A")
-    expect_equal(m$eventSens, "jump")
-    expect_false(is.null(m$eventSensInfo))
-    expect_equal(m$eventSensInfo$map$states, "eff")
+    # any linCmt model downgrades to FD (#1119): no jump metadata
+    expect_equal(m$eventSens, "fd")
+    expect_null(m$eventSensInfo)
   })
 
   test_that("eventSens='fdAll' keeps full finite-difference fallback", {
@@ -191,14 +192,15 @@ rxTest({
     }
   })
 
-  test_that("eventSens='fd' resolves to symbolic jump for pure linCmt", {
+  test_that("pure linCmt with modeled alag downgrades to fd", {
     m <- rxode2({
       C2 <- linCmt(CL, V)
       alag(central) <- exp(tlag + eta_lag)
     }, calcSens = "eta_lag", eventSens = "fd",
     linCmtSens = "linCmtA", linCmtSensType = "A")
-    expect_equal(m$eventSens, "jump")
-    expect_false(is.null(m$eventSensInfo))
+    # pure linCmt downgrades to FD (#1119)
+    expect_equal(m$eventSens, "fd")
+    expect_null(m$eventSensInfo)
   })
 
   test_that("pure linCmt hybrid event path matches the ODE equivalent", {
@@ -223,18 +225,46 @@ rxTest({
     expect_equal(sLin$central, sOde$central, tolerance = 1e-5)
   })
 
-  test_that("mixed ODE+linCmt jump keeps only ODE-scoped jump sensitivities", {
+  test_that("mixed ODE+linCmt with explicit jump still downgrades to fd", {
+    # Even eventSens="jump" downgrades to FD when linCmt() is present (#1119):
+    # the linCmt-compartment moving-boundary jump is not implemented, so all
+    # linCmt models use finite differences for event sensitivities.
     m <- rxode2({
       C2 <- linCmt(CL, V)
       alag(eff) <- exp(tlag + eta_lag)
       d/dt(eff) <- kin - kout * eff
     }, calcSens = "eta_lag", eventSens = "jump",
     linCmtSens = "linCmtA", linCmtSensType = "A")
-    .info <- m$eventSensInfo
-    expect_equal(.info$map$states, "eff")
-    expect_equal(.info$map$sensParams, "eta_lag")
-    expect_equal(unique(.info$map$map$state), "eff")
-    expect_equal(.info$map$lagCmt, 1L)
+    expect_equal(m$eventSens, "fd")
+    expect_null(m$eventSensInfo)
+  })
+
+  test_that("ODE d/dt() colliding with a linCmt reserved compartment name warns", {
+    # Naming an ODE compartment `depot` alongside an oral/multi-cmt linCmt (which
+    # reserves `depot`) conflates the two compartments: the ODE state loses its
+    # sensitivity expansion, so its sensitivities are silently incorrect.  Warn.
+    expect_warning(
+      rxode2({
+        ka <- exp(tka)
+        alag(depot) <- 2 * exp(eta_lag)
+        d/dt(depot)   <- -ka * depot
+        d/dt(peri)    <-  ka * depot - 0.3 * peri
+        C2 <- linCmt(CL, V)
+      }, calcSens = "eta_lag", eventSens = "jump",
+      linCmtSens = "linCmtA", linCmtSensType = "A"),
+      "share a name with linCmt"
+    )
+    # a valid (non-colliding) linCmt model: no warning; downgrades to fd (#1119)
+    mOk <- suppressWarnings(rxode2({
+      ka <- exp(tka)
+      alag(gut) <- 2 * exp(eta_lag)
+      d/dt(gut) <- -ka * gut
+      d/dt(eff) <-  ka * gut - 0.3 * eff
+      C2 <- linCmt(CL, V)
+    }, calcSens = "eta_lag", eventSens = "fd",
+    linCmtSens = "linCmtA", linCmtSensType = "A"))
+    expect_equal(mOk$eventSens, "fd")
+    expect_null(mOk$eventSensInfo)
   })
 
   test_that("mixed ODE+linCmt hybrid event path matches the ODE equivalent", {


### PR DESCRIPTION
Follow-up to the merged coincident-time jump fix #1118; resolves the linCmt() event-sensitivity issues investigated in #1119. **Single clean commit; R-only.**

## What this does

1. **Downgrade linCmt() models to finite differences** for event-timing (modeled `alag`/`f`) sensitivities. The analytic moving-boundary (jump) sensitivity for a linCmt compartment is not implemented; rather than emit an incomplete/incorrect analytic result, all linCmt models (`numLin > 0`) resolve `eventSens` to `"fd"` and use the FOCEi/nlmixr2est finite-difference event path. Structural-parameter linCmt sensitivities are unaffected (continuous, handled by `linCmtB`). — `.rxEventSensEffectiveMode()`.

2. **Reserved-name collision guard.** Naming an ODE compartment `depot`/`central`/`peripheralN` alongside an oral/multi-cmt `linCmt()` conflates the ODE and linCmt compartments, so the ODE state loses its sensitivity expansion and its sensitivities are silently incorrect. This now warns at build time (`rxode2()`), via `.rxLinCmtNameCollision()`, so it fires even under the FD downgrade.

3. **`.rxLinCmtEventSensPairs()`** — detects `(linCmt compartment, calcSens param)` pairs with a modeled `alag`/`f`; kept for a future analytic implementation.

## Background

#1119 established that the originally-reported "mixed ODE+linCmt jump = 0" was a malformed model (an ODE compartment named `depot` colliding with an oral linCmt's `depot`), and that linCmt sensitivities materialize as chain-ruled `linCmtB(which=-2,j)` LHS assignments in the FOCEi inner model, not as solve-compartments. A proper analytic linCmt moving-boundary sensitivity is a larger cross-package (rxode2 + nlmixr2est) effort tracked in #1119; this PR ships the safe FD downgrade + collision guard.

## Testing

Via `devtools::load_all`: event-sensitivities **185 pass / 0 fail**, lincmt-solve **1569 pass / 0 fail**.

Supersedes #1120 (same fixes, cleaner single-commit history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwVDp22R3CgEP22sXJB7ZU