### PR TITLE
rxOptExpr(): chunk and parallelize by default, driven by rxControl(cores=)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -89,7 +89,6 @@ Suggests:
     rootSolve,
     memuse,
     arrow,
-    mirai,
     fst,
     duckdb,
     DBI
@@ -104,6 +103,7 @@ Imports:
     lotri (>= 1.0.4),
     memoise,
     methods,
+    mirai,
     rex,
     sys,
     tools,

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,10 +9,18 @@
   common subexpression search -- is what dominates: optimizing a 275-line
   augmented model takes ~113s, of which the subexpression search is only ~15s.
   Chunking amortizes that parse, since each chunk is normalized on its own,
-  taking the same model to ~11s (10.7x; 5.7x at 149 lines, 2.5x at 119).  An
-  ordinary model is far too small to gain anything, which is why the default
-  (`chunkLines = 0`) leaves behaviour exactly as before.  `parallel` optionally
-  optimizes the chunks in `mirai` daemons.
+  taking the same model to ~11s (10.7x; 5.7x at 149 lines, 2.5x at 119).
+
+  Chunking is now the default: a model over `chunkLines` (default 40) lines is
+  chunked, and the chunks are optimized in parallel `mirai` daemons.  `parallel`
+  carries `rxControl(cores=)`'s semantics and defaults to that control's
+  `cores`, so CRAN and users tune it with the same knob as the solver
+  (`setRxThreads()`, `OMP_THREAD_LIMIT`, or `parallel=` directly; `1` runs
+  serially).  An existing `mirai` daemon pool is used as-is; otherwise a pool is
+  started only when the model splits into at least 4 chunks (its startup costs a
+  few seconds) and shut down when the call returns.  A model at or under
+  `chunkLines` lines is optimized whole, exactly as before; `chunkLines = 0`
+  forces that for any model.  `mirai` moved from `Suggests` to `Imports`.
 
   Common subexpressions are only shared within a chunk, so chunking does not give
   the same optimized text as the whole-model call -- it carries more temporaries

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,10 +13,10 @@
 
   Chunking is now the default: a model over `chunkLines` (default 40) lines is
   chunked, and the chunks are optimized in parallel `mirai` daemons.  `parallel`
-  carries `rxControl(cores=)`'s semantics and defaults to that control's
-  `cores`, so CRAN and users tune it with the same knob as the solver
-  (`setRxThreads()`, `OMP_THREAD_LIMIT`, or `parallel=` directly; `1` runs
-  serially).  An existing `mirai` daemon pool is used as-is; otherwise a pool is
+  carries `rxControl(cores=)`'s semantics: `0` (the default) resolves to the
+  rxode2 thread setting `rxCores()`, so CRAN and users tune it with the same
+  knob as the solver (`setRxThreads()`, `OMP_THREAD_LIMIT`, or `parallel=`
+  directly; `1` runs serially).  An existing `mirai` daemon pool is used as-is; otherwise a pool is
   started only when the model splits into at least 4 chunks (its startup costs a
   few seconds) and shut down when the call returns.  A model at or under
   `chunkLines` lines is optimized whole, exactly as before; `chunkLines = 0`

--- a/R/rxOptExpr.R
+++ b/R/rxOptExpr.R
@@ -660,11 +660,11 @@
 #'
 #' @param parallel Integer; number of `mirai` daemons used to optimize
 #'     the chunks in parallel.  Only used when the model is chunked.  It
-#'     carries the same semantics as `rxControl(cores=)`, and defaults to
-#'     that control's `cores`: `0` (the `rxControl()` default) means the
-#'     rxode2 thread setting `rxCores()`, so CRAN and users tune it with
-#'     the same knob as the solver (`setRxThreads()`, `OMP_THREAD_LIMIT`)
-#'     or by passing `parallel=` directly; `1` runs the chunks serially.
+#'     carries the same semantics as `rxControl(cores=)`: `0` (the
+#'     default) means the rxode2 thread setting `rxCores()`, so CRAN and
+#'     users tune it with the same knob as the solver (`setRxThreads()`,
+#'     `OMP_THREAD_LIMIT`) or by passing `parallel=` directly; `1` runs
+#'     the chunks serially.
 #'     It is capped by the number of chunks and by `rxCores()`, so it
 #'     will not oversubscribe past the threads the user asked for.
 #'
@@ -682,7 +682,7 @@
 #' @author Matthew L. Fidler
 #' @export
 rxOptExpr <- function(x, msg = "model", chunkLines = 40L,
-                      parallel = rxControl()$cores) {
+                      parallel = 0L) {
   .chunkLines <- as.integer(chunkLines)
   if (!is.na(.chunkLines) && .chunkLines > 0L) {
     return(.rxOptExprChunked(x, msg = msg, chunkLines = .chunkLines, parallel = parallel))

--- a/R/rxOptExpr.R
+++ b/R/rxOptExpr.R
@@ -479,7 +479,7 @@
 # .rxOptExprChunked(), which falls back to the whole model.
 .rxOptExprChunk <- function(i, chunks, msg) {
   .txt <- paste(chunks[[i]], collapse = "\n")
-  .o <- suppressMessages(rxOptExpr(.txt, msg))
+  .o <- suppressMessages(rxOptExpr(.txt, msg, chunkLines = 0L))
   .re <- "\\brx_expr_[0-9]+\\b"
   .new <- setdiff(unique(regmatches(.o, gregexpr(.re, .o))[[1]]),
                   unique(regmatches(.txt, gregexpr(.re, .txt))[[1]]))
@@ -516,14 +516,14 @@
   .txt <- if (is.character(x)) paste(x, collapse = "\n") else rxNorm(x)
   .ln <- strsplit(.txt, "\n", fixed = TRUE)[[1]]
   if (length(.ln) <= chunkLines) {
-    return(rxOptExpr(.txt, msg = msg))
+    return(rxOptExpr(.txt, msg = msg, chunkLines = 0L))
   }
   # Chunking introduces names of its own into the model's namespace: rx_expr_c<i>_ for the
   # temporaries a chunk contributes, and rx__disg_ while a compartment-scoped line is
   # disguised.  A model that already uses such a name would have it silently captured --
   # renaming or restoring would rewrite the model's own variable -- so do not chunk it.
   if (grepl("rx_expr_c[0-9]", .txt) || grepl("rx__disg_", .txt, fixed = TRUE)) {
-    return(rxOptExpr(.txt, msg = msg))
+    return(rxOptExpr(.txt, msg = msg, chunkLines = 0L))
   }
 
   # Disguise compartment-scoped left-hand sides so that every chunk parses standalone.
@@ -531,19 +531,36 @@
                                mean(pmax(1L, nchar(.ln))) * chunkLines)
   .nChunks <- length(.chunks)
 
-  # Never start more daemons than there are chunks, nor more threads than the user asked
-  # for with setRxThreads() (which rxCores() reports).
+  # `parallel` carries rxControl(cores=)'s semantics: 0 means the rxode2 thread setting
+  # (rxCores(), which setRxThreads()/OMP_THREAD_LIMIT control -- so CRAN and users tune
+  # this with the same knob as the solver), n > 0 means n.  Never use more daemons than
+  # there are chunks, nor more than that thread setting; a single daemon has no
+  # parallelism to offer, only dispatch overhead, so 1 runs serially.
   .nDaemons <- as.integer(parallel)
-  if (is.na(.nDaemons)) .nDaemons <- 0L
-  if (.nDaemons > 0L) .nDaemons <- min(.nDaemons, .nChunks, max(1L, as.integer(rxCores())))
-  .useMirai <- .nDaemons > 0L && requireNamespace("mirai", quietly = TRUE)
+  if (is.na(.nDaemons) || .nDaemons < 0L) .nDaemons <- 0L
+  if (.nDaemons == 0L) .nDaemons <- max(1L, as.integer(rxCores()))
+  .nDaemons <- min(.nDaemons, .nChunks, max(1L, as.integer(rxCores())))
+  .useMirai <- .nDaemons > 1L
+  # A caller's existing mirai pool is used as-is and never shut down; a pool of our own
+  # is only worth starting (a few seconds: each daemon loads rxode2) when there are
+  # enough chunks for the parallel win to beat that startup.
+  .ownDaemons <- FALSE
+  if (.useMirai) {
+    .have <- tryCatch(sum(mirai::status()$connections) > 0L, error = function(e) FALSE)
+    if (!.have) {
+      .ownDaemons <- .nChunks >= 4L
+      .useMirai <- .ownDaemons
+    }
+  }
   .malert(sprintf("optimizing duplicate expressions in %s (%d chunks%s)...", msg, .nChunks,
                   if (.useMirai) sprintf(", %d daemons", .nDaemons) else ""))
 
   .opt <- tryCatch({
     if (.useMirai) {
-      mirai::daemons(.nDaemons)
-      on.exit(mirai::daemons(0), add = TRUE)
+      if (.ownDaemons) {
+        mirai::daemons(.nDaemons)
+        on.exit(mirai::daemons(0), add = TRUE)
+      }
       # `.rxOptExprChunk` is passed as an argument, carrying the rxode2 namespace as its
       # environment, so a chunk is optimized by the same code path serially and in parallel.
       .tasks <- mirai::mirai_map(
@@ -583,7 +600,7 @@
   # (A chunk with nothing left to reduce returns its text and does not error, so an ordinary
   # model never lands here.)
   if (is.null(.opt)) {
-    return(rxOptExpr(.txt, msg = msg))
+    return(rxOptExpr(.txt, msg = msg, chunkLines = 0L))
   }
   .rxRestoreCmt(paste(.opt, collapse = "\n"))
 }
@@ -602,14 +619,14 @@
 #'
 #'  finding duplicate expressions in model...
 #'
-#' @param chunkLines Integer; when positive, optimize the model in
-#'     contiguous cost-balanced chunks of roughly this many lines
-#'     (40 is a reasonable value) instead of in a single pass.  `0`,
-#'     the default, optimizes the whole model at once and is exactly
-#'     the previous behaviour.
+#' @param chunkLines Integer; when positive (the default is 40),
+#'     a model longer than this many lines is optimized in contiguous
+#'     cost-balanced chunks of roughly this many lines instead of in a
+#'     single pass; a model at or under it is optimized whole, exactly
+#'     as before.  `0` always optimizes the whole model at once.
 #'
-#'     This is worth doing only for a large machine-generated model --
-#'     a sensitivity- or Jacobian-augmented model, say.  Normalizing a
+#'     Chunking pays off for a large machine-generated model -- a
+#'     sensitivity- or Jacobian-augmented model, say.  Normalizing a
 #'     model (`rxNorm()`, i.e. parsing it) is strongly superlinear in
 #'     its size, and for such a model it, not the common subexpression
 #'     search, is what dominates: optimizing a 275-line augmented model
@@ -619,14 +636,11 @@
 #'
 #'     \tabular{rrrr}{
 #'       lines \tab whole \tab chunked \tab \cr
-#'       34 \tab 0.5s \tab 0.5s \tab (a typical model: no gain) \cr
+#'       34 \tab 0.5s \tab 0.5s \tab (a typical model: not chunked) \cr
 #'       119 \tab 2.0s \tab 0.8s \tab 2.5x \cr
 #'       149 \tab 22.2s \tab 3.9s \tab 5.7x \cr
 #'       275 \tab 112.7s \tab 10.6s \tab 10.7x \cr
 #'     }
-#'
-#'     An ordinary model is small enough that there is nothing to gain,
-#'     which is why this is off by default.
 #'
 #'     Common subexpressions are then only shared within a chunk, so the
 #'     model is equivalent but carries more temporaries.  That costs no
@@ -645,16 +659,20 @@
 #'     states and parameters, the same solution, and the same errors.
 #'
 #' @param parallel Integer; number of `mirai` daemons used to optimize
-#'     the chunks in parallel (`0`, the default, is serial).  Only used
-#'     when `chunkLines` is positive.  Requires the `mirai` package.
+#'     the chunks in parallel.  Only used when the model is chunked.  It
+#'     carries the same semantics as `rxControl(cores=)`, and defaults to
+#'     that control's `cores`: `0` (the `rxControl()` default) means the
+#'     rxode2 thread setting `rxCores()`, so CRAN and users tune it with
+#'     the same knob as the solver (`setRxThreads()`, `OMP_THREAD_LIMIT`)
+#'     or by passing `parallel=` directly; `1` runs the chunks serially.
 #'     It is capped by the number of chunks and by `rxCores()`, so it
-#'     will not oversubscribe past the threads the user asked for with
-#'     `setRxThreads()`.
+#'     will not oversubscribe past the threads the user asked for.
 #'
-#'     The daemons are started for the call and shut down when it
-#'     returns.  That startup (and loading rxode2 into each daemon) costs
-#'     a few seconds, which is a large part of what there is to gain
-#'     here, so this is only worth using on a genuinely large model.
+#'     An existing `mirai` daemon pool is used as-is and left running.
+#'     Otherwise a pool is started for the call and shut down when it
+#'     returns; that startup (loading rxode2 into each daemon) costs a
+#'     few seconds, so a pool is only started when the model splits into
+#'     at least 4 chunks, where the parallel win covers it.
 #'
 #' @return Optimized rxode2 model text.  The order and type lhs and
 #'     state variables is maintained while the evaluation is sped up.
@@ -663,7 +681,8 @@
 #'
 #' @author Matthew L. Fidler
 #' @export
-rxOptExpr <- function(x, msg = "model", chunkLines = 0L, parallel = 0L) {
+rxOptExpr <- function(x, msg = "model", chunkLines = 40L,
+                      parallel = rxControl()$cores) {
   .chunkLines <- as.integer(chunkLines)
   if (!is.na(.chunkLines) && .chunkLines > 0L) {
     return(.rxOptExprChunked(x, msg = msg, chunkLines = .chunkLines, parallel = parallel))

--- a/man/rxOptExpr.Rd
+++ b/man/rxOptExpr.Rd
@@ -4,7 +4,7 @@
 \alias{rxOptExpr}
 \title{Optimize rxode2 for computer evaluation}
 \usage{
-rxOptExpr(x, msg = "model", chunkLines = 0L, parallel = 0L)
+rxOptExpr(x, msg = "model", chunkLines = 40L, parallel = rxControl()$cores)
 }
 \arguments{
 \item{x}{rxode2 model that can be accessed by rxNorm}
@@ -16,31 +16,28 @@ optimizing the model:
 
 finding duplicate expressions in model...}
 
-\item{chunkLines}{Integer; when positive, optimize the model in
-contiguous cost-balanced chunks of roughly this many lines
-(40 is a reasonable value) instead of in a single pass.  \code{0},
-the default, optimizes the whole model at once and is exactly
-the previous behaviour.
+\item{chunkLines}{Integer; when positive (the default is 40),
+a model longer than this many lines is optimized in contiguous
+cost-balanced chunks of roughly this many lines instead of in a
+single pass; a model at or under it is optimized whole, exactly
+as before.  \code{0} always optimizes the whole model at once.
 
-This is worth doing only for a large machine-generated model --
-a sensitivity- or Jacobian-augmented model, say.  Normalizing a
-model (\code{rxNorm()}, i.e. parsing it) is strongly superlinear in
+\if{html}{\out{<div class="sourceCode">}}\preformatted{Chunking pays off for a large machine-generated model -- a
+sensitivity- or Jacobian-augmented model, say.  Normalizing a
+model (`rxNorm()`, i.e. parsing it) is strongly superlinear in
 its size, and for such a model it, not the common subexpression
 search, is what dominates: optimizing a 275-line augmented model
 takes ~113s, of which the subexpression search is only ~15s.
-Chunking amortizes that parse -- \code{rxOptExpr()} normalizes each
+Chunking amortizes that parse -- `rxOptExpr()` normalizes each
 chunk on its own -- taking the same model to ~11s:
 
-\tabular{rrrr}{
-  lines \tab whole \tab chunked \tab \cr
-  34 \tab 0.5s \tab 0.5s \tab (a typical model: no gain) \cr
-  119 \tab 2.0s \tab 0.8s \tab 2.5x \cr
-  149 \tab 22.2s \tab 3.9s \tab 5.7x \cr
-  275 \tab 112.7s \tab 10.6s \tab 10.7x \cr
-}
-
-An ordinary model is small enough that there is nothing to gain,
-which is why this is off by default.
+\\tabular\{rrrr\}\{
+  lines \\tab whole \\tab chunked \\tab \\cr
+  34 \\tab 0.5s \\tab 0.5s \\tab (a typical model: not chunked) \\cr
+  119 \\tab 2.0s \\tab 0.8s \\tab 2.5x \\cr
+  149 \\tab 22.2s \\tab 3.9s \\tab 5.7x \\cr
+  275 \\tab 112.7s \\tab 10.6s \\tab 10.7x \\cr
+\}
 
 Common subexpressions are then only shared within a chunk, so the
 model is equivalent but carries more temporaries.  That costs no
@@ -56,19 +53,25 @@ rare path.
 Chunking therefore does not give the same optimized text as the
 whole-model call -- it shares fewer subexpressions and so carries
 more temporaries -- but it gives an equivalent model: the same
-states and parameters, the same solution, and the same errors.}
+states and parameters, the same solution, and the same errors.
+}\if{html}{\out{</div>}}}
 
 \item{parallel}{Integer; number of \code{mirai} daemons used to optimize
-the chunks in parallel (\code{0}, the default, is serial).  Only used
-when \code{chunkLines} is positive.  Requires the \code{mirai} package.
+the chunks in parallel.  Only used when the model is chunked.  It
+carries the same semantics as \code{rxControl(cores=)}, and defaults to
+that control's \code{cores}: \code{0} (the \code{rxControl()} default) means the
+rxode2 thread setting \code{rxCores()}, so CRAN and users tune it with
+the same knob as the solver (\code{setRxThreads()}, \code{OMP_THREAD_LIMIT})
+or by passing \verb{parallel=} directly; \code{1} runs the chunks serially.
 It is capped by the number of chunks and by \code{rxCores()}, so it
-will not oversubscribe past the threads the user asked for with
-\code{setRxThreads()}.
+will not oversubscribe past the threads the user asked for.
 
-The daemons are started for the call and shut down when it
-returns.  That startup (and loading rxode2 into each daemon) costs
-a few seconds, which is a large part of what there is to gain
-here, so this is only worth using on a genuinely large model.}
+\if{html}{\out{<div class="sourceCode">}}\preformatted{An existing `mirai` daemon pool is used as-is and left running.
+Otherwise a pool is started for the call and shut down when it
+returns; that startup (loading rxode2 into each daemon) costs a
+few seconds, so a pool is only started when the model splits into
+at least 4 chunks, where the parallel win covers it.
+}\if{html}{\out{</div>}}}
 }
 \value{
 Optimized rxode2 model text.  The order and type lhs and

--- a/man/rxOptExpr.Rd
+++ b/man/rxOptExpr.Rd
@@ -4,7 +4,7 @@
 \alias{rxOptExpr}
 \title{Optimize rxode2 for computer evaluation}
 \usage{
-rxOptExpr(x, msg = "model", chunkLines = 40L, parallel = rxControl()$cores)
+rxOptExpr(x, msg = "model", chunkLines = 40L, parallel = 0L)
 }
 \arguments{
 \item{x}{rxode2 model that can be accessed by rxNorm}
@@ -58,11 +58,11 @@ states and parameters, the same solution, and the same errors.
 
 \item{parallel}{Integer; number of \code{mirai} daemons used to optimize
 the chunks in parallel.  Only used when the model is chunked.  It
-carries the same semantics as \code{rxControl(cores=)}, and defaults to
-that control's \code{cores}: \code{0} (the \code{rxControl()} default) means the
-rxode2 thread setting \code{rxCores()}, so CRAN and users tune it with
-the same knob as the solver (\code{setRxThreads()}, \code{OMP_THREAD_LIMIT})
-or by passing \verb{parallel=} directly; \code{1} runs the chunks serially.
+carries the same semantics as \code{rxControl(cores=)}: \code{0} (the
+default) means the rxode2 thread setting \code{rxCores()}, so CRAN and
+users tune it with the same knob as the solver (\code{setRxThreads()},
+\code{OMP_THREAD_LIMIT}) or by passing \verb{parallel=} directly; \code{1} runs
+the chunks serially.
 It is capped by the number of chunks and by \code{rxCores()}, so it
 will not oversubscribe past the threads the user asked for.
 

--- a/tests/testthat/test-opt-expr.R
+++ b/tests/testthat/test-opt-expr.R
@@ -49,15 +49,20 @@ rxTest({
             "rx_pred_=center*exp(THETA[3])"), collapse = "\n")
   }
 
-  test_that("chunkLines=0 (the default) is exactly the unchunked behaviour", {
+  test_that("the default chunks a large model; chunkLines=0 optimizes it whole", {
     .m <- .chunkModel()
-    suppressMessages(expect_identical(rxOptExpr(.m, "model"),
-                                      rxOptExpr(.m, "model", chunkLines = 0L)))
+    .def <- suppressMessages(rxOptExpr(.m, "model"))
+    # per-chunk rx_expr_c<i>_ names prove the default took the chunked path
+    expect_true(grepl("rx_expr_c[0-9]+_", .def))
+    expect_identical(.def, suppressMessages(rxOptExpr(.m, "model", chunkLines = 40L)))
+    # chunkLines = 0 still forces the single whole-model pass
+    .whole <- suppressMessages(rxOptExpr(.m, "model", chunkLines = 0L))
+    expect_false(grepl("rx_expr_c[0-9]+_", .whole))
   })
 
   test_that("chunked optimization yields an equivalent model", {
     .m <- .chunkModel()
-    .whole <- suppressMessages(rxOptExpr(.m, "model"))
+    .whole <- suppressMessages(rxOptExpr(.m, "model", chunkLines = 0L))
     .chunk <- suppressMessages(rxOptExpr(.m, "model", chunkLines = 40L))
     # the compartment-scoped lines survive, in place, and the chunked model still builds
     expect_true(grepl("depot(0)=", .chunk, fixed = TRUE))
@@ -73,10 +78,10 @@ rxTest({
     expect_identical(.rv(.whole), .rv(.chunk))
   })
 
-  test_that("a model at or below chunkLines is not chunked", {
+  test_that("a model at or below chunkLines is untouched by the default", {
     .m <- "d/dt(depot)=-ka*depot\nd/dt(center)=ka*depot-cl/v*center"
-    suppressMessages(expect_identical(rxOptExpr(.m, "model", chunkLines = 40L),
-                                      rxOptExpr(.m, "model")))
+    suppressMessages(expect_identical(rxOptExpr(.m, "model"),
+                                      rxOptExpr(.m, "model", chunkLines = 0L)))
   })
 
   test_that("compartment-scoped disguise/restore round-trips exactly", {
@@ -158,7 +163,7 @@ rxTest({
                     paste0("cp=center*", .nm)), collapse = "\n")
       .chunked <- suppressMessages(rxOptExpr(.m, "model", chunkLines = 40L))
       # falls back to the whole-model call, so the model's own variable is untouched
-      expect_identical(.chunked, suppressMessages(rxOptExpr(.m, "model")))
+      expect_identical(.chunked, suppressMessages(rxOptExpr(.m, "model", chunkLines = 0L)))
       expect_true(grepl(.nm, .chunked, fixed = TRUE))
     }
   })
@@ -205,7 +210,7 @@ rxTest({
                      "d/dt(center)=exp(THETA[1])*depot-exp(THETA[2])*center",
                      .pad, "f(depot) <- exp(THETA[3])", "rx_pred_=center"), collapse = "\n")
     .out <- suppressMessages(rxOptExpr(.frag, "model", chunkLines = 40L))
-    expect_identical(.out, suppressMessages(rxOptExpr(.frag, "model")))
+    expect_identical(.out, suppressMessages(rxOptExpr(.frag, "model", chunkLines = 0L)))
     expect_true(grepl("rx_expr_", .out))   # fell back, so it is still fully optimized
     expect_error(rxModelVars(.out), NA)
 
@@ -216,13 +221,29 @@ rxTest({
   })
 
   test_that("parallel chunking gives the identical model and leaves no daemons behind", {
-    skip_if_not_installed("mirai")
-    .m <- .chunkModel()
-    .seq <- suppressMessages(rxOptExpr(.m, "model", chunkLines = 40L))
+    # daemons only start when the model splits into at least 4 chunks, so use a model
+    # large enough to cross that threshold
+    .m <- .chunkModel(150L)
+    .seq <- suppressMessages(rxOptExpr(.m, "model", chunkLines = 40L, parallel = 1L))
     .par <- suppressMessages(rxOptExpr(.m, "model", chunkLines = 40L, parallel = 2L))
     # optimizing the chunks in daemons must not change the model at all
     expect_identical(.seq, .par)
     # the pool is started for the call and shut down when it returns
+    expect_equal(sum(mirai::status()$connections), 0L)
+    # the default parallel (rxControl()$cores, 0 = the rxode2 thread setting) is the
+    # same model too, and equally leaves no pool behind
+    .def <- suppressMessages(rxOptExpr(.m, "model"))
+    expect_identical(.def, .seq)
+    expect_equal(sum(mirai::status()$connections), 0L)
+  })
+
+  test_that("too few chunks do not pay for a daemon pool", {
+    # .chunkModel() splits into only 2 chunks: even with parallel forced on, no pool is
+    # started (its startup would cost more than it saves) and none is left behind
+    .m <- .chunkModel()
+    .par <- suppressMessages(rxOptExpr(.m, "model", chunkLines = 40L, parallel = 2L))
+    .seq <- suppressMessages(rxOptExpr(.m, "model", chunkLines = 40L, parallel = 1L))
+    expect_identical(.par, .seq)
     expect_equal(sum(mirai::status()$connections), 0L)
   })
 })

--- a/tests/testthat/test-opt-expr.R
+++ b/tests/testthat/test-opt-expr.R
@@ -230,8 +230,8 @@ rxTest({
     expect_identical(.seq, .par)
     # the pool is started for the call and shut down when it returns
     expect_equal(sum(mirai::status()$connections), 0L)
-    # the default parallel (rxControl()$cores, 0 = the rxode2 thread setting) is the
-    # same model too, and equally leaves no pool behind
+    # the default parallel (0 = the rxode2 thread setting) is the same model too,
+    # and equally leaves no pool behind
     .def <- suppressMessages(rxOptExpr(.m, "model"))
     expect_identical(.def, .seq)
     expect_equal(sum(mirai::status()$connections), 0L)


### PR DESCRIPTION
Follow-up to #1122: chunked optimization is now the default, so every `rxOptExpr()` caller (including all of nlmixr2est's) gets it without opting in.

## What changes

- **`chunkLines` defaults to 40.** A model longer than that is optimized in cost-balanced chunks; a model at or under it is optimized whole, byte-for-byte as before -- so ordinary hand-written models are untouched. `chunkLines = 0` forces the single-pass behavior for any model.
- **`parallel` defaults to `rxControl()$cores`** and carries `rxControl(cores=)`'s semantics: `0` (the `rxControl()` default) resolves to the rxode2 thread setting (`rxCores()`), so CRAN and users tune the parallelism with the same knob as the solver -- `setRxThreads()`, `OMP_THREAD_LIMIT`, or `parallel=` directly. `1` runs the chunks serially.
- **Daemon hygiene.** An existing `mirai` pool is used as-is and never shut down (a caller's pool is not clobbered). A pool of our own is only started when the model splits into at least 4 chunks -- its startup (loading rxode2 into each daemon) costs a few seconds, which a 2-3-chunk model would not win back -- and is shut down when the call returns, so nothing is left running.
- **No recursion.** Every internal fallback call (small model, name-collision guard, failed-chunk fallback, per-chunk optimization) pins `chunkLines = 0L`, so the new default can never re-enter the chunked path.
- **`mirai` moves from `Suggests` to `Imports`.**

## Validation

`test-opt-expr.R`: 66 tests pass against an installed build (the parallel/daemon tests require the installed rxode2 to be this version, since daemons `library(rxode2)` the installed copy -- under a stale library + `devtools::test()` the daemon chunks fall back to the whole-model pass by design). New/updated tests cover: the default chunks a large model and `chunkLines=0` forces the whole-model pass; a model at or under 40 lines is byte-identical to before; the default `parallel` (0 -> `rxCores()`) gives the identical model to serial chunking and leaves no daemons behind; and a model with too few chunks does not pay for a daemon pool.

Companion PR in nlmixr2est removes its hand-rolled chunker in favor of this default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)