### PR TITLE
rxFixPop(): do not literally substitute a fixed mixture proportion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -126,6 +126,14 @@
 
 ## Bug fixes
 
+- `rxFixPop()` no longer tries to literally substitute a fixed mixture
+  proportion (`mix()`).  A mixture proportion must stay a named model-block
+  variable, so substituting its value made the re-parse throw from `mix()`
+  ("the probabilities in a mixture must be in the model block ..."); a downstream
+  caller wrapping `rxFixPop()` in `try()` leaked that error to the console during
+  otherwise-successful mixture fits.  Fixed mixture proportions are now excluded
+  from the substitution.
+
 ### Estimation / symengine translation (`rxFromSE()`)
 
 - Convert raw R comparison/logical operators (`>`, `==`, `&`, ...), not only

--- a/R/ui-fix.R
+++ b/R/ui-fix.R
@@ -117,7 +117,12 @@ rxFixPop <- function(ui, returnNull=FALSE) {
   .model <- rxUiDecompress(assertRxUi(ui))
   .model <- .copyUi(.model)
   .iniDf <- .model$iniDf
-  .w <- which(!is.na(.iniDf$ntheta) & is.na(.iniDf$err) & .iniDf$fix)
+  # a mixture proportion (ui$mixProbs) is structural: mix() requires it as a named
+  # model-block variable, so it cannot be literally substituted with its (fixed)
+  # value -- doing so makes the re-parse below throw from mix().  Exclude it.
+  .mixProbs <- tryCatch(.model$mixProbs, error=function(e) NULL)
+  .w <- which(!is.na(.iniDf$ntheta) & is.na(.iniDf$err) & .iniDf$fix &
+                !(.iniDf$name %in% .mixProbs))
   if (length(.w) == 0L) {
     if (returnNull) return(NULL)
     return(.model)

--- a/tests/testthat/test-rxFix.R
+++ b/tests/testthat/test-rxFix.R
@@ -165,5 +165,35 @@ rxTest({
 
   })
 
+  test_that("rxFixPop excludes a fixed mixture proportion (mix() needs it named)", {
+    # a fixed mixture proportion must NOT be literally substituted -- mix() requires
+    # the proportion to be a named model-block variable, so re-parsing the
+    # substituted model would throw from mix() (the error leaked to the console when
+    # a downstream caller wrapped rxFixPop in try()).
+    .mixMod <- function() {
+      ini({
+        tcl1 <- log(2); tcl2 <- log(0.5); tv <- log(32)
+        eta.v ~ 0.1
+        p1 <- fix(0.5)
+        add.sd <- 0.7
+      })
+      model({
+        v <- exp(tv + eta.v)
+        cl <- mix(exp(tcl1), p1, exp(tcl2))
+        ke <- cl / v
+        d/dt(depot) <- -depot
+        d/dt(center) <- depot - ke * center
+        cp <- center / v
+        cp ~ add(add.sd)
+      })
+    }
+    .ui <- rxode2(.mixMod)
+    # the only fixed theta is the mixture proportion, so there is nothing to
+    # substitute -> NULL, and crucially no error from re-parsing mix().
+    expect_error(.res <- rxFixPop(.ui, returnNull = TRUE), NA)
+    expect_null(.res)
+    # p1 is still a named parameter in the model
+    expect_true("p1" %in% .ui$iniDf$name)
+  })
 
 })


### PR DESCRIPTION
## Problem

Fitting a `mix()` model with a **fixed** mixture proportion (e.g. `p1 <- fix(0.5)`) prints spurious errors to the console during an otherwise-successful fit:

```
Error in mix(exp(tcl1), 0.5, exp(tcl2)) :
  the probabilities in a mixture must be in the model block, these variables were not: '0.5'
```

## Root cause

`rxFixPop()` substitutes every fixed population theta with its literal value and re-parses the model. The fixed **mixture proportion** was included in that set, so the re-parse produced `mix(exp(tcl1), 0.5, exp(tcl2))`. But `mix()` requires its proportion to be a *named* model-block variable, so it throws `the probabilities in a mixture must be in the model block`.

A downstream caller wraps `rxFixPop(ui, returnNull=TRUE)` in a (non-silent) `try()` (nlmixr2est's literal-fix preprocessing), which catches the error and falls back correctly -- but R prints the caught error, leaking it to the console.

## Fix

Exclude parameters in `ui$mixProbs` from the literal substitution in `rxFixPop()`. A mixture proportion is structural (it must stay named for `mix()` and the mixture machinery), so it is never a substitution candidate.

- Non-mixture fixed thetas are still substituted, unchanged.
- A model whose only fixed theta is the mixture proportion now returns `NULL` under `returnNull=TRUE` (nothing to substitute) instead of erroring.

## Tests

Added a `test-rxFix.R` case: a mixture model with a fixed proportion runs `rxFixPop(..., returnNull=TRUE)` without error, returns `NULL`, and leaves `p1` a named parameter. Full `test-rxFix.R` passes (FAIL=0 PASS=7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)