### PR TITLE
Add getIndCmt accessor: per-observation endpoint from the CMT covariate

### DIFF
--- a/inst/include/rxode2.h
+++ b/inst/include/rxode2.h
@@ -107,6 +107,7 @@ void rxode2AdjointTrajSweep(double *tg, double *J, double *dP, int ns, int np,
 rx_solve *getRxSolve_(void);
 void rxSetSolveAtolRtol(double atol, double rtol);
 void rxGetSolveAtolRtol(double *atol, double *rtol);
+int getIndCmt(rx_solving_options* op, rx_solving_options_ind* ind, int kk);
 #endif
 rx_solve *getRxSolve2_(void);
 rx_solve *getRxSolve(SEXP ptr);

--- a/inst/include/rxode2parseStruct.h
+++ b/inst/include/rxode2parseStruct.h
@@ -165,6 +165,7 @@ typedef struct {
   int    adjDlagOff;           /* lhs index where dlag/dtheta block starts (k*np+p); -1 if no modeled alag() (transversality) */
   int    adjDrateOff;          /* lhs index where drate/dtheta block starts (k*np+p); -1 if no modeled rate() (infusion dual) */
   int    adjSensOff;            /* solve-vector index where rx__sens_* output slots begin */
+  int    cmtCov;               /* covariate index (into par_cov/cov_ptr) of the CMT covariate, cached at setup; -1 if the model has no CMT covariate (single endpoint) */
 } rx_solving_options;
 
 

--- a/inst/include/rxode2ptr.h
+++ b/inst/include/rxode2ptr.h
@@ -40,6 +40,8 @@ extern "C" {
   extern rxNormEng_t rxNormEng;
   typedef double (*rxUnifEng_t)(double low, double hi);
   extern rxUnifEng_t rxUnifEng;
+  typedef int (*getIndCmt_t)(rx_solving_options* op, rx_solving_options_ind* ind, int kk);
+  extern getIndCmt_t getIndCmt;
 
   // Per-individual ODE solve buffer-pointer swap (nlmixr2est impmap gradient):
   // save the originals, install private larger buffers for a higher-state
@@ -349,6 +351,7 @@ extern "C" {
       seedEng = (seedEng_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 72));
       rxNormEng = (rxNormEng_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 73));
       rxUnifEng = (rxUnifEng_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 81));
+      getIndCmt = (getIndCmt_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 82));
       setIndSolvePtr = (setIndSolvePtr_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 74));
       getIndSolveSave = (getIndSolveSave_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 75));
       setIndSolveSave = (setIndSolveSave_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 76));
@@ -436,6 +439,7 @@ extern "C" {
   seedEng_t seedEng = NULL;                             \
   rxNormEng_t rxNormEng = NULL;                         \
   rxUnifEng_t rxUnifEng = NULL;                         \
+  getIndCmt_t getIndCmt = NULL;                         \
   setIndSolvePtr_t setIndSolvePtr = NULL;               \
   getIndSolveSave_t getIndSolveSave = NULL;             \
   setIndSolveSave_t setIndSolveSave = NULL;             \

--- a/src/init.c
+++ b/src/init.c
@@ -514,6 +514,7 @@ SEXP _rxode2_rxode2Ptr(void) {
   SEXP rxode2seedEng = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&seedEng, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2rxNormEng = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxNormEng, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2rxUnifEng = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxUnifEng, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2getIndCmt = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&getIndCmt, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2setIndSolvePtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setIndSolvePtr, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2getIndSolveSave = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&getIndSolveSave, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2setIndSolveSave = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setIndSolveSave, R_NilValue, R_NilValue)); pro++;
@@ -522,7 +523,7 @@ SEXP _rxode2_rxode2Ptr(void) {
   SEXP rxode2getIndSolveLast2 = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&getIndSolveLast2, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2setIndSolveLast2 = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setIndSolveLast2, R_NilValue, R_NilValue)); pro++;
 
-#define nVec 82
+#define nVec 83
   SEXP ret = PROTECT(Rf_allocVector(VECSXP, nVec)); pro++;
   SET_VECTOR_ELT(ret, 0, rxode2rxRmvnSEXP);
   SET_VECTOR_ELT(ret, 1, rxode2rxParProgress);
@@ -606,6 +607,7 @@ SEXP _rxode2_rxode2Ptr(void) {
   SET_VECTOR_ELT(ret, 79, rxode2getIndSolveLast2);
   SET_VECTOR_ELT(ret, 80, rxode2setIndSolveLast2);
   SET_VECTOR_ELT(ret, 81, rxode2rxUnifEng);
+  SET_VECTOR_ELT(ret, 82, rxode2getIndCmt);
 
 
   SEXP retN = PROTECT(Rf_allocVector(STRSXP, nVec)); pro++;
@@ -691,6 +693,7 @@ SEXP _rxode2_rxode2Ptr(void) {
   SET_STRING_ELT(retN, 79, Rf_mkChar("rxode2getIndSolveLast2"));
   SET_STRING_ELT(retN, 80, Rf_mkChar("rxode2setIndSolveLast2"));
   SET_STRING_ELT(retN, 81, Rf_mkChar("rxode2rxUnifEng"));
+  SET_STRING_ELT(retN, 82, Rf_mkChar("rxode2getIndCmt"));
 
 #undef nVec
 

--- a/src/rx2api.c
+++ b/src/rx2api.c
@@ -207,6 +207,21 @@ int getIndIdx(rx_solving_options_ind* ind) {
   return ind->idx;
 }
 
+// Per-observation endpoint (compartment) from the CMT time-varying covariate.  The
+// covariate index is cached in op->cmtCov at setup (getIndCmt does no name lookup).
+// Returns the raw CMT value at observation row kk, or 1 when the model has no CMT
+// covariate (a single-endpoint model) or the value is missing.  CMT values are the
+// data's compartment numbers (distinct, not necessarily sequential).
+int getIndCmt(rx_solving_options* op, rx_solving_options_ind* ind, int kk) {
+  if (op == NULL || op->cmtCov < 0) return 1;
+  if (kk < 0 || kk >= ind->n_all_times) {
+    Rf_error("[getIndCmt]: kk (%d) should be between [0, %d)", kk, ind->n_all_times);
+  }
+  double v = ind->cov_ptr[(size_t)ind->n_all_times * (size_t)op->cmtCov + (size_t)kk];
+  if (ISNA(v)) return 1;
+  return (int) v;
+}
+
 ////////////////////////////////////////////////////////////////////////
 // Solving options (rx->op)
 ////////////////////////////////////////////////////////////////////////

--- a/src/rx2api.h
+++ b/src/rx2api.h
@@ -73,6 +73,9 @@ extern "C" {
   // Get the index of the current solve
   int getIndIdx(rx_solving_options_ind* ind);
 
+  // Per-observation endpoint from the CMT covariate (cached op->cmtCov); 1 if none
+  int getIndCmt(rx_solving_options* op, rx_solving_options_ind* ind, int kk);
+
   // Get the mixest of the current solve
   int getIndMixest(rx_solving_options_ind* ind);
 

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -4027,6 +4027,7 @@ static inline void rxSolve_datSetupHmax(const RObject &obj, const List &rxContro
     IntegerVector interp0 = as<IntegerVector>(rxSolveDat->mv[RxMv_interp]);
     //
     bool isLinearOrMidpointInterp = op->is_locf == 0 || op->is_locf == 3;
+    op->cmtCov = -1;   // covariate index of the CMT covariate; -1 = none (single endpoint)
     for (i = dfN; i--;){
       for (j = rx->npars; j--;){
         if (pars[j] == dfNames[i]){
@@ -4036,6 +4037,11 @@ static inline void rxSolve_datSetupHmax(const RObject &obj, const List &rxContro
           // the rxControl() object
           const char *curDf = dfNames[i];
           int curDfN = strlen(curDf);
+          // cache the CMT covariate's covariate-index so getIndCmt can read the
+          // per-observation endpoint (cov_ptr) without a per-call name comparison.
+          if (op->cmtCov < 0 && curDfN == 3 && !strncmpci(curDf, "CMT", 3)) {
+            op->cmtCov = ncov;
+          }
           _globals.gpar_covInterp[ncov] = interp0[j] - 2;
           if ((isLinearOrMidpointInterp &&
                _globals.gpar_covInterp[ncov] == -1) ||


### PR DESCRIPTION
## Summary

Adds a `getIndCmt` C entry point so downstream packages (nlmixr2est's native NPAG/NPB
engines) can read each observation's endpoint -- the CMT time-varying covariate -- to
attribute a per-endpoint residual moment in a multiple-endpoint model.

## What it does

- `rx_solving_options` gains a cached `cmtCov` (the covariate index of the `CMT`
  covariate, or `-1` if the model has none).  It is set once in the covariate-setup
  loop in `rxData.cpp`, so `getIndCmt` does no per-call name comparison.
- `getIndCmt(op, ind, kk)` returns the raw `CMT` covariate value at observation `kk`
  (the data's compartment number -- values are distinct, not necessarily sequential),
  or `1` when `cmtCov < 0` (a single-endpoint model) or the value is missing.
- Exposed through the function-pointer table at a new index (82; `nVec` 82 -> 83) per
  the `CLAUDE.md` recipe: `rx2api.c`/`.h`, `init.c`, `inst/include/rxode2ptr.h`,
  `inst/include/rxode2.h`.  Appending at a new index is backward compatible (older
  consumers read the lower indices and ignore the new one).

## Why

The native NPAG/NPB engines in nlmixr2est (`est="npag"`/`est="npb"`) estimate the
residual error with a SAEM-style per-endpoint moment; for a multi-endpoint model each
observation must be mapped to its endpoint.  The endpoint is the CMT covariate, which
had no C accessor.

Needed by the companion nlmixr2est PR (branch `npag`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
