### PR TITLE
rxAppendModel(): warn instead of erroring when models share no variables (#520)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -126,6 +126,10 @@
 
 ## Bug fixes
 
+- `rxAppendModel()` now warns (instead of erroring) when the appended models
+  have no variables in common, so the combined model is still returned; use
+  `common=FALSE` to suppress the warning (#520).
+
 - `rxFixPop()` no longer tries to literally substitute a fixed mixture
   proportion (`mix()`).  A mixture proportion must stay a named model-block
   variable, so substituting its value made the re-parse throw from `mix()`

--- a/R/ui-bind.R
+++ b/R/ui-bind.R
@@ -23,7 +23,7 @@
 #'
 #' @param model1 rxUi type of model
 #' @param model2 rxUi type of model
-#' @param common boolean; when `TRUE` require models to have variables in common
+#' @param common boolean; when `TRUE` warn if the models have no variables in common
 #' @return rxUi combined model of model1 and model2
 #' @noRd
 #' @author Matthew L. Fidler
@@ -36,8 +36,8 @@ rxAppendModel_ <- function(model1, model2, common=TRUE) {
   .ini2 <- model2$iniDf
   .bind <- intersect(c(model1$mv0$lhs, model1$mv0$state), model2$allCovs)
   if (common && length(.bind) == 0) {
-    stop("not all the models have variables in common (use `common=FALSE` to allow this)",
-         call.=FALSE)
+    warning("the appended models have no variables in common (use `common=FALSE` to suppress this warning)",
+            call.=FALSE)
   }
   if (is.null(.ini1) && is.null(.ini2)) {
     return(.combineModelLines(model1, model2, NULL))
@@ -108,7 +108,7 @@ rxAppendModel_ <- function(model1, model2, common=TRUE) {
 #' Append two rxui models together
 #'
 #' @param ... models to append together
-#' @param common boolean that determines if you need a common value to bind
+#' @param common boolean; when `TRUE` warn if the models have no variables in common
 #' @return New model with both models appended together
 #' @author Matthew L. Fidler
 #' @export

--- a/man/rxAppendModel.Rd
+++ b/man/rxAppendModel.Rd
@@ -9,7 +9,7 @@ rxAppendModel(..., common = TRUE)
 \arguments{
 \item{...}{models to append together}
 
-\item{common}{boolean that determines if you need a common value to bind}
+\item{common}{boolean; when \code{TRUE} warn if the models have no variables in common}
 }
 \value{
 New model with both models appended together

--- a/tests/testthat/test-ui-mod-functions.R
+++ b/tests/testthat/test-ui-mod-functions.R
@@ -157,7 +157,7 @@ rxTest({
     expect_true("idr.sd" %in% m1$iniDf$name)
     expect_true("tv" %in% m1$iniDf$name)
 
-    expect_error(rxAppendModel(ocmt, idr))
+    expect_warning(rxAppendModel(ocmt, idr), "no variables in common")
 
     idr <- function() {
       ini({


### PR DESCRIPTION
## Summary

Revisits [#520](https://github.com/nlmixr2/rxode2/issues/520). The original complaint -- that `rxAppendModel()` required *"at least one population parameter in 'model1'"* (an `ini` block in the first model) -- has already been resolved; `rxAppendModel_()` now handles all four `ini` combinations, including `model1` having no `ini` at all.

What remained was a separate hard `stop()`: with `common=TRUE` (the default) and no variables shared between the two models, the call errored out entirely. This PR softens that to a **warning** so the combined model is still returned. `common=FALSE` suppresses the warning as before.

## Changes

- `R/ui-bind.R` -- `stop()` -> `warning()` for the no-common-variables case; updated the `@param common` docs.
- `man/rxAppendModel.Rd` -- updated `common` param description.
- `tests/testthat/test-ui-mod-functions.R` -- the no-common-variables case now uses `expect_warning(..., "no variables in common")` instead of `expect_error`. The covariance-duplication `expect_error` cases are unchanged.
- `NEWS.md` -- Bug fixes entry.

## Verification

Via `load_all`: the no-common-variables case now warns and returns the model, and `common=FALSE` stays silent and returns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)