### PR TITLE
Do not misreport summed population parameters as a mu-ref error (#471)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -149,6 +149,16 @@
   only and guards zero-length results, fixing an "argument is of length zero"
   error and silent substitution of user-workspace variables (#1109).
 
+### Model parsing / mu-referencing
+
+- Summing two or more population parameters in an expression that has no
+  random effect (for example a combined residual error
+  `W <- sqrt(sigma.1. + sigma.2.)`) is no longer misreported as
+  "2+ single population parameters in a single mu-referenced expression".
+  That check now fires only for a genuine mu-referenced expression (one that
+  also contains an eta), and the message names the parameters that were
+  actually summed instead of the first parameters in the model (#471).
+
 ### Delay models
 
 - `calcJac=TRUE` rewriting (also used by the stiff `ros4`/`dop853+ros4` path)

--- a/R/mu.R
+++ b/R/mu.R
@@ -700,10 +700,15 @@
   .wt <- which(.names %in% env$info$theta)
   .we <- which(.names %in% env$info$eta)
   .wl <- if (!is.null(env$info$level)) which(.names %in% env$info$level) else integer(0)
-  if (length(.wt) >= 2) {
+  if (length(.wt) >= 2 && length(.we) >= 1) {
+    # Only a genuine mu-referenced expression (ie one that also has an
+    # eta) with 2+ population parameters is ambiguous.  Summing
+    # population parameters with no random effect (eg a combined
+    # residual error 'sqrt(sigma.1. + sigma.2.)') is legitimate and must
+    # not be flagged.
     env$err <- unique(c(env$err,
                         paste0("syntax error: 2+ single population parameters in a single mu-referenced expression: '",
-                               paste(env$info$theta[.wt], collapse="', '"),
+                               paste(.names[.wt], collapse="', '"),
                                "'\nthis could occur when a between subject variability parameter is not initialized with a '~'")))
   } else if (length(.wt) == 1) {
     if (!is.null(.extraItems)) {

--- a/tests/testthat/test-mu.R
+++ b/tests/testthat/test-mu.R
@@ -37,6 +37,42 @@ rxTest({
   test_that("bad mu referencing examples (throw error)", {
     expect_error(.rxMuRef("a=theta1+theta2+theta3*wt+eta1", lmat))
     expect_error(.rxMuRef("a=theta1+theta2*wt+theta3*wt+eta1", lmat))
+    # the 2+ population parameter error must name the parameters that
+    # were actually summed (rxode2#471)
+    expect_error(.rxMuRef("a=theta2+theta3+eta1", lmat), "'theta2', 'theta3'")
+  })
+
+  test_that("summing population parameters without an eta is not a mu-ref error (rxode2#471)", {
+    # 'sqrt(sigma.1. + sigma.2.)'-style combined residual error sums two
+    # population parameters with no random effect; this is legitimate and
+    # must not be flagged as a mu-referenced expression
+    expect_error(.rxMuRef("a=theta1+theta2", lmat), NA)
+    expect_error(.rxMuRef("a=sqrt(theta1+theta2)", lmat), NA)
+
+    f <- function() {
+      ini({
+        theta1 <- c(0, 1.08, 10)
+        theta2 <- c(0, 0.814, 10)
+        theta3 <- fix(0.179)
+        eta1 ~ fix(0)
+        sigma.1. <- 0.422
+        sigma.2. <- 0.0364
+      })
+      model({
+        TVKGA <- 0
+        if (BACT == 2) TVKGA <- theta1
+        TVKGP <- 0
+        if (BACT == 1) TVKGP <- theta2
+        TVKK <- theta3
+        KGDXS <- 1
+        KGA <- KGDXS * TVKGA * exp(eta1)
+        KGP <- KGDXS * TVKGP * exp(eta1)
+        IPRED <- KGA + KGP + TVKK
+        W <- sqrt(sigma.1. + sigma.2.)
+        Y <- IPRED + W * eps1
+      })
+    }
+    expect_error(suppressMessages(rxode2(f)), NA)
   })
 
   testEnv <- function(env, ref) {


### PR DESCRIPTION
Fixes #471.

## Root cause

The mu-referencing analyzer's "2+ single population parameters in a single mu-referenced expression" check (`R/mu.R`, `.muRefHandlePlus`) fired on **any** expression that summed two or more population parameters -- even when no random effect (eta) was present. In the issue's model the trigger was the residual-error line:

```r
W <- sqrt(sigma.1. + sigma.2.)
```

Two error-model parameters summed inside `sqrt()` -- a legitimate combined residual error -- was rejected. The message was also wrong twice over: it isn't a mu-reference at all (no eta), and it indexed the theta vector *by position*, so it reported `theta1, theta2` instead of the sigmas that were actually summed.

## Fix

1. Gate the error on an eta being present (`length(.wt) >= 2 && length(.we) >= 1`). A mu-referenced expression contains an eta by definition; summing population parameters with no random effect is legitimate and now passes.
2. Report the parameters actually summed (`.names[.wt]`) instead of the first-N thetas.

Genuine mu-ref mistakes (`CL <- theta1 + theta2 + eta1`) still error, now with accurate names.

## Verification

- The full model from #471 now parses/compiles.
- `devtools::test(filter="mu")` -> 267 pass; `filter="err"` -> 278 pass (FAIL 0); `filter="ui"` -> 1758 pass. No regressions.

## Regression tests (`tests/testthat/test-mu.R`)

- The full issue model (with `sqrt(sigma.1. + sigma.2.)`) compiles without error.
- `.rxMuRef("a=theta1+theta2", ...)` and `sqrt(theta1+theta2)` do not error.
- `.rxMuRef("a=theta2+theta3+eta1", ...)` still errors and reports `'theta2', 'theta3'`, locking in the message-naming fix (the old positional bug would have said `theta1, theta2`).

NEWS.md gains an entry under a new `### Model parsing / mu-referencing` subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)