### PR TITLE
Guard nlmixr2data dataset use in tests with skip_if_not_installed() (#95)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -134,6 +134,11 @@
   otherwise-successful mixture fits.  Fixed mixture proportions are now excluded
   from the substitution.
 
+- Tests that use datasets from the suggested `nlmixr2data` package (`theo_sd`,
+  `warfarin`, `nmtest`) now guard their use with
+  `skip_if_not_installed("nlmixr2data")`, so the test suite runs cleanly when
+  `nlmixr2data` is not installed (#95).
+
 ### Estimation / symengine translation (`rxFromSE()`)
 
 - Convert raw R comparison/logical operators (`>`, `==`, `&`, ...), not only

--- a/tests/testthat/test-adjoint-discrete.R
+++ b/tests/testthat/test-adjoint-discrete.R
@@ -414,6 +414,7 @@ rxTest({
   test_that("STIFF adjoint solvers (Rosenbrock/implicit): non-ss nmtest gradients match FD", {
     skip_on_cran()
     skip_on_ci()
+    skip_if_not_installed("nlmixr2data")
 
     d0 <- nlmixr2data::nmtest
     mt <- paste("d/dt(depot)=-ka*depot", "d/dt(central)=ka*depot-(cl/v)*central",

--- a/tests/testthat/test-altrep-output.R
+++ b/tests/testthat/test-altrep-output.R
@@ -164,6 +164,7 @@ rxTest({
 
       test_that(sprintf("nStud > 1 makes event-table and keep columns ALTREP (theo_sd / WT) %s %s", rt, ad), {
 
+        skip_if_not_installed("nlmixr2data")
         one.cmt <- function() {
           ini({
             tka <- 0.45
@@ -296,6 +297,7 @@ rxTest({
     })
 
     test_that(sprintf("TBS columns are ALTREP via nStud path (addDosing=%s)", ad), {
+      skip_if_not_installed("nlmixr2data")
       one.cmt <- function() {
         ini({
           tka <- 0.45

--- a/tests/testthat/test-cmt-order.R
+++ b/tests/testthat/test-cmt-order.R
@@ -1,4 +1,5 @@
 rxTest({
+  skip_if_not_installed("nlmixr2data")
   warfarin <- nlmixr2data::warfarin
 
   test_that("cmt() syntax makes sense", {

--- a/tests/testthat/test-etTrans.R
+++ b/tests/testthat/test-etTrans.R
@@ -1,6 +1,7 @@
 rxTest({ # mostly tested in 'rxode2et'
   test_that("warfarin model", {
 
+    skip_if_not_installed("nlmixr2data")
     warfarin <- nlmixr2data::warfarin
 
     mod <- rxode2({
@@ -928,6 +929,7 @@ d/dt(blood)     = a*intestine - b*blood
     })
 
     test_that("Missing evid gives the same results", {
+      skip_if_not_installed("nlmixr2data")
       theoSd <- nlmixr2data::theo_sd
       d <- theoSd[, names(theoSd) != "EVID"]
 

--- a/tests/testthat/test-keep.R
+++ b/tests/testthat/test-keep.R
@@ -89,6 +89,7 @@ rxTest({
 
     test_that("rxSolve 'keep' maintains character output (#190/#622)", {
 
+      skip_if_not_installed("nlmixr2data")
       one.cmt <- function() {
         ini({
           tka <- 0.45

--- a/tests/testthat/test-lhs-param.R
+++ b/tests/testthat/test-lhs-param.R
@@ -136,6 +136,7 @@ rxTest({
 
   test_that("dual order lhs mixed with non dual-order gives right order", {
 
+    skip_if_not_installed("nlmixr2data")
     m <- rxode2({
       param(THETA[1], THETA[2], THETA[3], THETA[4], Nominal)
       rx_yj_ ~ 162

--- a/tests/testthat/test-lincmt-solve.R
+++ b/tests/testthat/test-lincmt-solve.R
@@ -3,6 +3,7 @@ if (tolower(Sys.info()[["sysname"]]) == "linux") {
 
     test_that("table step for linCmtB", {
 
+      skip_if_not_installed("nlmixr2data")
       pars <- test_path("lincmt-solve-focei-sol.qs2")
       skip_if_not(file.exists(pars))
       pars <- qs2::qs_read(pars)

--- a/tests/testthat/test-mdv.R
+++ b/tests/testthat/test-mdv.R
@@ -1,6 +1,7 @@
 rxTest({
   if (!.Call(`_rxode2_isIntel`)) {
     test_that("mdv means EVID=2 when amt=0", {
+      skip_if_not_installed("nlmixr2data")
       theoSd <- nlmixr2data::theo_sd
 
       d <- theoSd[, names(theoSd) != "EVID"]

--- a/tests/testthat/test-nmtest.R
+++ b/tests/testthat/test-nmtest.R
@@ -2,6 +2,7 @@ rxTest({
 
   ## devtools::load_all()
 
+  skip_if_not_installed("nlmixr2data")
   d <- nlmixr2data::nmtest
   # internally rxode2 treats lag time evids differently than
   # non-lagged events

--- a/tests/testthat/test-null-assign.R
+++ b/tests/testthat/test-null-assign.R
@@ -17,6 +17,7 @@ rxTest({
     })
   }
 
+  skip_if_not_installed("nlmixr2data")
   d <- nlmixr2data::theo_sd
   d$SEX <- ifelse(d$ID < 7, "M", "F")
   d$fSEX <- factor(d$SEX)

--- a/tests/testthat/test-par-dop853.R
+++ b/tests/testthat/test-par-dop853.R
@@ -74,6 +74,7 @@ rxTest({
   })
 
   # nmtest dataset: dense vs non-dense must give identical cp for ODE model
+  skip_if_not_installed("nlmixr2data")
   d <- nlmixr2data::nmtest
 
   f <- rxode2({

--- a/tests/testthat/test-rk4.R
+++ b/tests/testthat/test-rk4.R
@@ -52,6 +52,7 @@ rxTest({
 
 
   # nmtest dataset: dense vs non-dense must give identical cp for ODE model
+  skip_if_not_installed("nlmixr2data")
   d <- nlmixr2data::nmtest
 
   f <- rxode2({


### PR DESCRIPTION
Fixes #95.

## Background

The nlmixr datasets (`theo_sd`, `warfarin`, `nmtest`) now live in the suggested `nlmixr2data` package, and the tests already reference them via `nlmixr2data::`. However most test files used them **unconditionally**, which fails when the suggested package is not installed (a CRAN policy violation for a `Suggests` dependency).

## Change

Added `skip_if_not_installed("nlmixr2data")` guards, placed to preserve maximum coverage:

- **File-scope dataset loads** (`test-nmtest`, `test-cmt-order`, `test-null-assign`, `test-par-dop853`, `test-rk4`): guard immediately before the load. Any data-free tests earlier in the file still run; everything from the load onward skips (the file otherwise can't source).
- **Dataset used only inside specific `test_that()` blocks** (`test-altrep-output`, `test-etTrans`, `test-keep`, `test-lhs-param`, `test-lincmt-solve`, `test-mdv`): per-test guards, so unrelated tests keep running.
- Closed the one remaining unguarded usage in `test-adjoint-discrete`.
- NEWS.md entry under `## Bug fixes`.

## Verification

- Confirmed (standalone repro of `rxValidate`'s exact `withCallingHandlers(force(type), ...)` structure) that a top-level skip inside `rxTest({...})` skips the rest of the file while keeping earlier tests, and per-test skips work.
- All 13 files parse cleanly.
- Ran `devtools::test(filter="mdv")` and `filter="null-assign")` with `nlmixr2data` present -- all pass, nothing skipped (the guard is a no-op when installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)