### PR TITLE
Fix rxFromSE dropping trig argument for compound-numerator division

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -164,6 +164,15 @@
   only and guards zero-length results, fixing an "argument is of length zero"
   error and silent substitution of user-workspace variables (#1109).
 
+- A trig function (`sin`/`cos`/`tan`) whose argument is a compound expression
+  divided by something (for example `sin(2 * 3.14 * (time - mtime1) / period)`)
+  no longer drops its whole argument.  The division branch fell through without
+  returning when the numerator was not a single token, so the argument became
+  `NULL` and the emitted C code was `sin()` -- which failed to compile with "too
+  few arguments to function 'sin'".  Such models (for example an enterohepatic
+  gallbladder model with a sinusoidal release) now build and fit
+  (nlmixr2/nlmixr2est#513).
+
 ### Model parsing / mu-referencing
 
 - Summing two or more population parameters in an expression that has no

--- a/R/symengine.R
+++ b/R/symengine.R
@@ -2379,7 +2379,6 @@ rxFromSE <- function(x, unknownDerivatives = c("forward", "central", "error"),
         }
       } else if (identical(x[[1]], quote(`/`))) {
         .x2 <- as.character(x[[2]])
-        .x3 <- as.character(x[[3]])
         if (length(.x2) == 1) {
           if (.x2 == "pi") {
             envir$found <- TRUE
@@ -2391,6 +2390,16 @@ rxFromSE <- function(x, unknownDerivatives = c("forward", "central", "error"),
             .f(x[[3]], envir)
           ))
         }
+        ## Compound numerator (eg sin(2*(time-a)/period)): recurse into both
+        ## sides so a `pi` factor buried in the numerator is still stripped and
+        ## the argument is not dropped (else the whole arg became NULL -> sin()).
+        ## Parenthesize the numerator unless it is already parenthesized so the
+        ## `/` precedence is preserved after any pi-factor stripping.
+        .num <- .f(x[[2]], envir)
+        if (!identical(x[[2]][[1]], quote(`(`))) {
+          .num <- paste0("(", .num, ")")
+        }
+        return(paste0(.num, "/", .f(x[[3]], envir)))
       } else {
         return(.rxFromSE(x))
       }

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -91,6 +91,18 @@ rxTest({
     expect_equal(rxFromSE(tan(pi * a)), "tanpi(a)")
     expect_equal(rxFromSE("tan(pi/2)"), "tanpi(1/2)")
 
+    ## nlmixr2est#513: a trig argument that is a compound expression divided by
+    ## something (eg sin(2*3.14*(time-mtime1)/period)) must keep its argument;
+    ## the `/` branch used to fall through and drop the whole argument -> sin()
+    expect_equal(rxFromSE("sin(2 * 3.14 * (time-mtime1)/period)"),
+                 "sin((2*3.14*(time-mtime1))/period)")
+    expect_equal(rxFromSE("cos((time-mtime1)/period)"),
+                 "cos((time-mtime1)/period)")
+    ## a pi factor buried in a compound numerator still folds to sinpi and keeps
+    ## precedence-correct parentheses
+    expect_equal(rxFromSE("sin(pi * (time-mtime1)/period)"),
+                 "sinpi((time-mtime1)/period)")
+
     expect_equal(rxToSE(log1pmx(a)), "(log(1+a)-(a))")
     expect_equal(rxToSE(expm1(a)), "(exp(a)-1)")
     expect_equal(rxToSE(pow(a, b)), "(a)^(b)")


### PR DESCRIPTION
## Problem

Fitting a model with a trig function whose argument is a compound expression divided by something -- e.g. an enterohepatic gallbladder model with a sinusoidal release:

```r
SINE = sin(2 * 3.14 * (time - mtime1) / period)
```

fails to compile with:

```
error: too few arguments to function 'sin'
  879 |   rx_expr_0 =sin();
```

The FOCEi sensitivity/inner model text emitted `sin()` / `cos()` with **no argument**.

## Root cause

`rxFromSE()` uses `.rxM1rmF()` to strip a `pi` factor (so `sin(pi*x)` -> `sinpi(x)`). Its `/` branch only returned for an **atomic** numerator:

```r
} else if (identical(x[[1]], quote(`/`))) {
  .x2 <- as.character(x[[2]])
  if (length(.x2) == 1) {           # atomic numerator only
    ...
    return(paste0(.f(x[[2]], envir), "/", .f(x[[3]], envir)))
  }
  # compound numerator: NO return -> falls through -> NULL
}
```

For a compound numerator like `2*3.14*(time-mtime1)`, the branch fell through with no return, so the reconstructed argument became `NULL` and the caller emitted `sin()`. Only trig functions (`sin`/`cos`/`tan`) are affected, since only they route through `.rxM1rmF()`.

## Fix

Recurse into both sides of the division for a compound numerator, so a buried `pi` factor is still folded and the argument is preserved. The numerator is parenthesized (unless already parenthesized) to keep `/` precedence after any `pi` stripping.

Round-trips now:

| input | output |
| --- | --- |
| `sin(2 * 3.14 * (time-mtime1)/period)` | `sin((2*3.14*(time-mtime1))/period)` |
| `cos((time-mtime1)/period)` | `cos((time-mtime1)/period)` |
| `sin(pi * (time-mtime1)/period)` | `sinpi((time-mtime1)/period)` |

Existing `sinpi`/`cospi`/`tanpi` behavior is unchanged.

## Tests

Regression tests added to `tests/testthat/test-dsl.R`; existing trig assertions still pass.

Fixes nlmixr2/nlmixr2est#513

🤖 Generated with [Claude Code](https://claude.com/claude-code)