### PR TITLE
Correct the rxEffNeq() note about linCmt() in nlmixr2est's FOCEi flow

### DIFF
--- a/inst/include/rxode2.h
+++ b/inst/include/rxode2.h
@@ -34,8 +34,11 @@
 // individual pred-mode solve writes and reads at the same compact stride
 // without mutating shared op->neq from a parallel worker thread.
 // NOTE: getAdvan() + neqOverride is unsupported when op->numLin > 0
-// (op->linOffset is computed from the full neq layout).  In nlmixr2est's
-// FOCEi flow the predNoLhs model has numLin == 0, so this is fine.
+// (op->linOffset is computed from the full neq layout).  A linCmt() model
+// mixed with ODEs does reach nlmixr2est's FOCEi flow with numLin > 0 on the
+// predNoLhs model, so this is NOT covered by the model itself; nlmixr2est
+// translates those models with linToOde() before estimating (its issue #286),
+// which leaves numLin == 0 here.
 static inline int rxEffNeq(const rx_solving_options_ind *ind,
                            const rx_solving_options *op) {
   int o = ind->neqOverride;


### PR DESCRIPTION
Comment only -- no code change.

The note above `rxEffNeq()` in `inst/include/rxode2.h` claimed:

> `getAdvan()` + `neqOverride` is unsupported when `op->numLin > 0` (`op->linOffset` is computed from the full neq layout).  **In nlmixr2est's FOCEi flow the predNoLhs model has `numLin == 0`, so this is fine.**

That last sentence is false. A model mixing `linCmt()` with ODEs reaches nlmixr2est's FOCEi flow with `numLin > 0` on the `predNoLhs` model -- the `linCmt()` block is still there. Nothing about the flow itself guarantees `numLin == 0`.

What actually makes the assumption hold is on the nlmixr2est side: it translates those models with `linToOde()` before estimating (nlmixr2/nlmixr2est#286, nlmixr2/nlmixr2est#781), which removes the `linCmt()` block and leaves `numLin == 0` here. The comment now says that, so the invariant is attributed to the thing that enforces it.

## How this surfaced

While fixing nlmixr2est#286. `op->linOffset = op->neq - numLin - numLinSens` pins the linear compartments to the tail of the state vector, so `depot`'s compartment number is `(#ODE states) + 1`. The FOCEi inner model adds an ODE state per eta, which shifts the linear compartments away from the numbers the data was translated against -- the dose then lands in a sensitivity compartment and every prediction comes back `0`.

Worth recording for anyone who finds this later: the tempting fix -- reordering states in `sortStateVectors()` (`src/genModelVars.h`) so the `rx__sens_*` states sort after the real compartments -- **does not work**. It makes the numbering stable, but it violates the `linOffset` invariant: the integrators advance only `neq - numLin - numLinSens` equations and splice the analytic block in at `linOffset`, so moving `depot`/`central` into the middle makes the runtime write that block over the wrong slots. It heap-corrupts (`malloc(): unaligned tcache chunk detected`). Appending the linear compartments last is load-bearing, not incidental.

Ordering note: this comment describes the state of things once nlmixr2/nlmixr2est#781 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)