### PR TITLE
Fix heap corruption and chunking failure for past() DDE models

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -132,6 +132,25 @@
 
 ## Bug fixes
 
+- `past(state, tau)` on a state with no `d/dt(state)` now reports that cleanly
+  instead of corrupting the heap.  The error path appended nothing to the
+  message buffer and then trimmed a trailing `', ` that was never written,
+  moving the write offset before the start of the buffer; the damage surfaced
+  as a `double free or corruption` abort on a *later*, unrelated parse rather
+  than at the offending model.  The message now names the property
+  (`'past(G)' present, but d/dt(G) not defined`), and a property with no
+  message branch can no longer underflow the buffer.
+
+- `rxOptExpr()` no longer fails on a model that uses `past(state, tau)` and is
+  long enough to be optimized in chunks.  A `past()` line only parses in a
+  chunk that also holds the matching `d/dt()`, and sensitivity augmentation
+  appends `past()` after every `d/dt()` -- so it reliably landed in a chunk of
+  its own.  It is now disguised for the duration of the optimization like any
+  other compartment-scoped left-hand side, and restored byte-exactly
+  afterwards.  Together with the fix above this unblocks estimating a
+  non-constant-history DDE (e.g. the rheumatoid arthritis model of Koch et al.
+  2014, J Pharmacokinet Pharmacodyn 41:291-318, Example 6).
+
 - `rxAppendModel()` now warns (instead of erroring) when the appended models
   have no variables in common, so the combined model is still returned; use
   `common=FALSE` to suppress the warning (#520).

--- a/R/rxOptExpr.R
+++ b/R/rxOptExpr.R
@@ -397,7 +397,8 @@
   unname(split(lines, findInterval(cumsum(.w), seq_len(.k - 1L) * sum(.w) / .k)))
 }
 
-# A state initial condition (state(0)=) or a dosing modifier (f/F/alag/lag/rate/dur(cmt)=)
+# A state initial condition (state(0)=), a dosing modifier (f/F/alag/lag/rate/dur(cmt)=)
+# or a delay pre-history (past(cmt, tau)=)
 # is a syntax error in a chunk that lacks the matching d/dt() ("'W(0)' present, but
 # d/dt(W) not defined").  Such a line cannot simply be moved to the chunk that has the
 # d/dt(): its right-hand side may read a variable that a later line reassigns, so its
@@ -409,6 +410,8 @@
 # left-hand side embeds the compartment name bare (readable), while a spacing variant
 # the grammar also accepts (`depot (0)=`, `f( depot )=`) is hex-encoded whole, so the
 # disguised name is always a valid identifier and the restore is byte-exact either way.
+# past(cmt, tau)= always takes the hex form: its second argument is an arbitrary
+# expression (`past(G, exp(THETA[8]))`), which no canonical bare-name form could carry.
 # A construct not recognised here is left alone; its chunk then fails and falls back to
 # the whole model.
 .rxDisguiseCmt <- function(modTxt) {
@@ -422,11 +425,13 @@
   .id <- "[a-zA-Z][a-zA-Z0-9_.]*"
   .icRe <- paste0("^(", .id, ")[ \t]*\\(0\\)$")
   .modRe <- paste0("^([fF]|alag|lag|rate|dur)[ \t]*\\([ \t]*(", .id, ")[ \t]*\\)$")
+  .pastRe <- paste0("^past[ \t]*\\([ \t]*", .id, "[ \t]*,.*\\)$")
   .isIc <- .eq > 0L & grepl(.icRe, .lhs)
   .isMod <- .eq > 0L & grepl(.modRe, .lhs)
+  .isPast <- .eq > 0L & grepl(.pastRe, .lhs)
   .icCan <- .isIc & grepl(paste0("^", .id, "\\(0\\)$"), .lhs)
   .modCan <- .isMod & grepl(paste0("^([fF]|alag|lag|rate|dur)\\(", .id, "\\)$"), .lhs)
-  .hex <- (.isIc | .isMod) & !(.icCan | .modCan)
+  .hex <- (.isIc | .isMod | .isPast) & !(.icCan | .modCan)
   .new <- .lhs
   .new[.icCan] <- paste0("rx__disg_ic__", sub("\\(0\\)$", "", .lhs[.icCan]), "__")
   .mm <- regmatches(.lhs[.modCan], regexec("^([a-zA-Z]+)\\((.*)\\)$", .lhs[.modCan]))
@@ -435,7 +440,7 @@
   .new[.hex] <- vapply(.lhs[.hex], function(.l) {
     paste0("rx__disg_lhs__", paste(as.character(charToRaw(.l)), collapse = ""), "__")
   }, character(1), USE.NAMES = FALSE)
-  paste(ifelse(.isIc | .isMod, paste0(.lead, .new, .trail, .rhs), .ln),
+  paste(ifelse(.isIc | .isMod | .isPast, paste0(.lead, .new, .trail, .rhs), .ln),
         collapse = "\n")
 }
 

--- a/src/genModelVars.h
+++ b/src/genModelVars.h
@@ -243,6 +243,12 @@ static inline int sortStateVectorsErrHandle(int prop, int i) {
   }
   char *buf = NULL;
   buf = tb.ss.line[tb.di[i]];
+  // Every property that reaches here appends "'<name>', " below, and the
+  // trailing "', " is then trimmed with sbt.o -= 2.  A property with no branch
+  // appends nothing, so that trim would move sbt.o *before* the start of the
+  // buffer and write there -- corrupting the heap rather than reporting the
+  // error.  Remember where this message starts so the trim can be anchored.
+  int sbtStart = sbt.o;
   if ((prop & prop0) != 0) {
     sAppend(&sbt, "'%s(0)', ", buf);
   }
@@ -293,6 +299,17 @@ static inline int sortStateVectorsErrHandle(int prop, int i) {
   }
   if ((prop & propDose0) != 0) {
     sAppend(&sbt, "'dose0(%s)', ", buf);
+  }
+  // past(state, tau) <- expr supplies the pre-history that delay(state, tau)
+  // interpolates, so it too requires the state to have a d/dt().
+  if ((prop & propPast) != 0) {
+    sAppend(&sbt, "'past(%s)', ", buf);
+  }
+  if (sbt.o == sbtStart) {
+    // No branch above matched, so there is no trailing "', " to trim and
+    // nothing to report; a property known only to the guard above is not an
+    // error the user can act on.  Trimming here would underflow the buffer.
+    return 1;
   }
   // Take off trailing "',
   sbt.o -= 2;

--- a/tests/testthat/test-dde-past.R
+++ b/tests/testthat/test-dde-past.R
@@ -96,4 +96,54 @@ rxTest({
       expect_equal(.s[[.col]], .fd, tolerance = 1e-3)
     }
   })
+
+  # past(state, tau) without a d/dt(state) is a user error.  Reporting it used to
+  # append nothing to the error buffer and then trim a trailing "', " that was
+  # never written, moving the write offset before the start of the buffer; the
+  # heap corruption surfaced as a double free on a *later*, unrelated parse.
+  test_that("past() without d/dt() errors cleanly and leaves the parser usable", {
+    .bad <- "a=1\nb=0.5\nT=12.8\npast(G, T) = a*exp(b*t)\nR2 = a\n"
+    expect_error(suppressMessages(rxModelVars(.bad)), "syntax error")
+    # the message names the offending property rather than a mangled fragment
+    expect_output(try(suppressMessages(rxModelVars(.bad)), silent = TRUE),
+                  "'past(G)' present, but d/dt(G) not defined", fixed = TRUE)
+    # parsing again, and parsing a good model afterwards, must still work
+    expect_error(suppressMessages(rxModelVars(.bad)), "syntax error")
+    expect_true(inherits(rxModelVars("d/dt(G)=-G\n"), "rxModelVars"))
+  })
+
+  # A past() line is compartment-scoped: it only parses in a chunk that also has
+  # the matching d/dt().  .rxDelaySensAugment() appends past() after every d/dt(),
+  # so on a model long enough to chunk it lands in the last chunk, away from its
+  # d/dt() -- .rxDisguiseCmt() must hide it for the chunk to parse standalone.
+  test_that("past() survives chunked expression optimization", {
+    .filler <- paste(sprintf("v%d = %d * exp(kg * t) + sin(v0 * %d)", 1:45, 1:45, 1:45),
+                     collapse = "\n")
+    .mod <- paste0(
+      "a = 1\nb = 0.5\nT = 12.8\nk3 = 5\nkg = 0.4\nk4 = 0.3\nk5 = 0.1\nv0 = 2\n",
+      "G(0) = a\nd/dt(G) = k3 - kg * G\n",
+      "I(0) = 0\nd/dt(I) = k4 * G - k4 * delay(G, T)\n",
+      "D(0) = 0\nd/dt(D) = k4 * delay(G, T) - k5 * D\n",
+      .filler, "\n", "R2 = D + v1 + v45\n",
+      "past(G, T) = a * exp(b * t)\n")
+
+    .dg <- rxode2:::.rxDisguiseCmt(.mod)
+    # the past line is hidden as an ordinary assignment, so a chunk parses alone
+    expect_false(any(grepl("^past", strsplit(.dg, "\n")[[1]])))
+    expect_true(any(grepl("^rx__disg_lhs__", strsplit(.dg, "\n")[[1]])))
+    # ... and is restored byte-exactly, spacing included
+    expect_equal(strsplit(rxode2:::.rxRestoreCmt(.dg), "\n")[[1]],
+                 strsplit(.mod, "\n")[[1]])
+
+    .o <- suppressMessages(rxOptExpr(.mod, "m", chunkLines = 40L))
+    expect_true(any(grepl("^past\\(G, *T\\)", strsplit(.o, "\n")[[1]])))
+    expect_false(grepl("rx__disg_", .o, fixed = TRUE))
+    # optimizing must not change what the model means
+    .ev <- et(seq(0, 30, by = 1))
+    .s1 <- rxSolve(rxode2(.mod), .ev, method = "dop853", atol = 1e-10, rtol = 1e-10,
+                   dense = TRUE)
+    .s2 <- rxSolve(rxode2(.o), .ev, method = "dop853", atol = 1e-10, rtol = 1e-10,
+                   dense = TRUE)
+    expect_equal(.s1$R2, .s2$R2, tolerance = 1e-8)
+  })
 })


### PR DESCRIPTION
Estimating a non-constant-history DDE (`past(state, tau) <- expr`) aborted the
R session. Two independent bugs, found while building a `nlmixr2` vignette for
Koch et al. 2014 (*J Pharmacokinet Pharmacodyn* 41:291-318) Example 6, the
rheumatoid arthritis model.

## 1. Heap corruption in the `past()` error path (`src/genModelVars.h`)

`past(G, T)` on a state with no `d/dt(G)` reaches `sortStateVectorsErrHandle()`
with only `propPast` set. `propPast` is not in the guard's exclusion mask, so it
gets past the early return — but it has **no message branch**, so nothing is
appended to `sbt`. The unconditional

```c
sbt.o -= 2;        // take off trailing "', "
sbt.s[sbt.o] = 0;
```

then moves the write offset to **-2** and writes there, before the start of the
buffer.

The damage did not surface at the offending model. The first parse reported a
(mangled) error and returned; a **later, unrelated** parse aborted the process
with `double free or corruption (out)`. The mangling was the tell — the message
was read back from two bytes before its start, so `" present, but d/dt(G) not
defined"` printed as `"resent, but d/dt(G) not defined"`.

Fixed by adding the missing `propPast` branch and anchoring the trim to where
the message started, so a property with no branch returns instead of
underflowing. The error is now reported cleanly:

```
'past(G)' present, but d/dt(G) not defined
```

## 2. `past()` did not survive chunked optimization (`R/rxOptExpr.R`)

A `past()` line only parses in a chunk that also holds the matching `d/dt()`,
and `.rxDelaySensAugment()` appends `past()` *after* every `d/dt()` — so on a
model long enough to chunk it reliably landed in a chunk of its own and failed.
`.rxDisguiseCmt()` already exists for exactly this (it hides `state(0)=`,
`f/alag/rate/dur(cmt)=`), but did not know about `past`.

`past(cmt, tau)=` always takes the existing hex form: its second argument is an
arbitrary expression (`past(G, exp(THETA[8]))`), which no canonical bare-name
form could carry. The restore is byte-exact, spacing included.

## Verification

- New regression tests in `tests/testthat/test-dde-past.R` cover both: the error
  path (clean message; parser still usable for repeated and subsequent parses),
  and the chunking path (disguise/restore round-trip, `past()` present after
  optimization, and — the property that matters — the optimized model solving
  **identically** to the unoptimized one).
- `test-dde-past.R` (27), `test-opt-expr.R` (66), `test-dde.R` (36) and
  `test-dde-sens.R` (52) all pass: 181 tests, 0 failures.
- With these, Koch Example 6 fits under `est="ifoceif"` in `nlmixr2`.

## Note / possible follow-up (not in this PR)

`delay(x, tau)` on the *right*-hand side has the same chunk-locality
requirement: a chunk holding `delay(x, tau)` needs `d/dt(x)`. When the boundary
splits them the chunk fails, `.rxOptExprChunked()` falls back to the whole
model, and the result is correct — but the fallback prints the parser's `:ERR:`
block to the console during an otherwise successful fit, and a large DDE
sensitivity model silently loses the chunking speedup. Worth addressing
separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)