### PR TITLE
Keep the delay() dense history for the output data frame's lhs recalculation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -198,6 +198,13 @@
   `dop853` (dense) instead of `liblsoda`, which recorded no delay history and
   silently returned pre-history values.
 
+- An lhs reading `delay()` is now reported correctly in the output data frame
+  (#1140).  The dense delay history was freed at the end of each subject's
+  solve, so the post-solve lhs recalculation returned the constant pre-history
+  (0) at every record even though the delayed value drove the ODE.  The history
+  is now kept until `rxSolveFree()` releases the subject, which also plugs a
+  leak on the discrete-adjoint (`rk4s`) path where it was never freed.
+
 ### `linCmt()` models
 
 - Fixed a compartment-indexing bug where a model with both an error model and

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -6126,16 +6126,10 @@ extern "C" void ind_dop0_dense(rx_solve *rx, rx_solving_options *op, int solveid
     last_key_i = i;
     ind->solvedIdx = i;
   }
-  // Release this subject's delay history (only needed during its own solve).
-  if (ind->delayHist != NULL) {
-    free(ind->delayHist);
-    ind->delayHist = NULL;
-    ind->delayHistCap = 0;
-    ind->delayHistStride = 0;
-    ind->delayHistNeq = 0;
-  }
-  ind->delayHistN = 0;
-  ind->delayHistOn = 0;
+  // Keep this subject's delay history: the output data frame recalculates lhs
+  // after the solve (rxode2_df), so an lhs reading delay() still needs to
+  // interpolate it.  rxFreeInd() releases it with the other per-subject
+  // buffers; the next solve resets delayHistN and reuses the allocation.
   ind->solveTime += ((double)(clock() - t0))/CLOCKS_PER_SEC;
 }
 

--- a/src/ros4.cpp
+++ b/src/ros4.cpp
@@ -280,16 +280,10 @@ extern "C" void ind_ros4_0(rx_solve *rx, rx_solving_options *op, int solveid, in
     }
     ind->solvedIdx = i;
   }
-  // release this subject's delay history (only needed during its own solve)
-  if (ind->delayHist != NULL) {
-    free(ind->delayHist);
-    ind->delayHist = NULL;
-    ind->delayHistCap = 0;
-    ind->delayHistStride = 0;
-    ind->delayHistNeq = 0;
-  }
-  ind->delayHistN = 0;
-  ind->delayHistOn = 0;
+  // Keep this subject's delay history: the output data frame recalculates lhs
+  // after the solve (rxode2_df), so an lhs reading delay() still needs to
+  // interpolate it.  rxFreeInd() releases it with the other per-subject
+  // buffers; the next solve resets delayHistN and reuses the allocation.
   ind->solveTime += ((double)(clock() - t0))/CLOCKS_PER_SEC;
 }
 

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -1867,6 +1867,16 @@ static void rxFreeInd(rx_solving_options_ind *ind) {
     free(ind->idose);      ind->idose = NULL;
     ind->indOwnAlloc = 0;
   }
+  // The delay() dense history is allocated by the solver (rxDelayHistSlot) and
+  // kept after the solve so the output data frame's lhs recalculation can still
+  // interpolate delayed states; it is released here with the subject.
+  free(ind->delayHist);
+  ind->delayHist = NULL;
+  ind->delayHistCap = 0;
+  ind->delayHistStride = 0;
+  ind->delayHistNeq = 0;
+  ind->delayHistN = 0;
+  ind->delayHistOn = 0;
 }
 
 extern "C" void gFree(){

--- a/tests/testthat/test-dde.R
+++ b/tests/testthat/test-dde.R
@@ -249,4 +249,29 @@ rxTest({
     fd <- (sb(pp) - sb(pm)) / (2 * hh)
     expect_lt(max(abs(sj[["rx__sens_central_BY_tau__"]] - fd)), 5e-3)
   })
+
+  test_that("an lhs reading delay() is reported correctly in the output (#1140)", {
+    # The output data frame recalculates lhs after the solve; the delay history
+    # used to be freed at the end of each subject's solve, so such an lhs
+    # reported the constant pre-history (0) at every record even though the
+    # delayed value drove the ODE.
+    .m <- rxode2("a = 0.5 * delay(x, tau)\nd/dt(x) = -k * x + a")
+    .ev <- et(amt = 10, cmt = "x") %>% et(seq(0, 24, by = 0.5))
+    # tau = 2 lands t - tau on the output grid, so a[t] must match 0.5 * x[t - 2]
+    .check <- function(.s) {
+      .d <- as.data.frame(.s)
+      expect_true(all(.d$a[.d$time < 2] == 0))          # zero pre-history
+      .i <- which(.d$time > 2)
+      expect_equal(.d$a[.i], 0.5 * .d$x[.i - 4L], tolerance = 1e-6)
+    }
+    .check(rxSolve(.m, c(k = 0.3, tau = 2), .ev))                    # dop853+ros4 default
+    .check(rxSolve(.m, c(k = 0.3, tau = 2), .ev, method = "ros4"))   # stiff path
+    # multi-subject parallel solve: each subject keeps its own history
+    .p <- data.frame(k = seq(0.1, 0.9, length.out = 4), tau = 2)
+    .d <- as.data.frame(rxSolve(.m, .p, .ev, cores = 2))
+    for (.di in split(.d, .d$sim.id)) {
+      .i <- which(.di$time > 2)
+      expect_equal(.di$a[.i], 0.5 * .di$x[.i - 4L], tolerance = 1e-6)
+    }
+  })
 })

--- a/tests/testthat/test-dde.R
+++ b/tests/testthat/test-dde.R
@@ -260,18 +260,19 @@ rxTest({
     # tau = 2 lands t - tau on the output grid, so a[t] must match 0.5 * x[t - 2]
     .check <- function(.s) {
       .d <- as.data.frame(.s)
-      expect_true(all(.d$a[.d$time < 2] == 0))          # zero pre-history
+      # at t = tau the lookup time equals the solve start (td <= delayT0), so
+      # the boundary record still legitimately reports the pre-history (0)
+      expect_equal(.d$a[.d$time <= 2], rep(0, sum(.d$time <= 2)), tolerance = 1e-12)
+      # match the delayed lookup by time rather than a row offset
+      .j <- match(.d$time - 2, .d$time)
       .i <- which(.d$time > 2)
-      expect_equal(.d$a[.i], 0.5 * .d$x[.i - 4L], tolerance = 1e-6)
+      expect_equal(.d$a[.i], 0.5 * .d$x[.j[.i]], tolerance = 1e-6)
     }
     .check(rxSolve(.m, c(k = 0.3, tau = 2), .ev))                    # dop853+ros4 default
     .check(rxSolve(.m, c(k = 0.3, tau = 2), .ev, method = "ros4"))   # stiff path
     # multi-subject parallel solve: each subject keeps its own history
     .p <- data.frame(k = seq(0.1, 0.9, length.out = 4), tau = 2)
-    .d <- as.data.frame(rxSolve(.m, .p, .ev, cores = 2))
-    for (.di in split(.d, .d$sim.id)) {
-      .i <- which(.di$time > 2)
-      expect_equal(.di$a[.i], 0.5 * .di$x[.i - 4L], tolerance = 1e-6)
-    }
+    .d <- rxSolve(.m, .p, .ev, cores = 2)
+    for (.di in split(as.data.frame(.d), .d$sim.id)) .check(.di)
   })
 })


### PR DESCRIPTION
Closes #1140

## Summary

An lhs reading `delay(state, T)` was reported as the constant pre-history (0) at every output record, even though the delayed value clearly drove the ODE. The dense delay history was freed and `delayHistOn` cleared at the end of each subject's solve (`ind_dop0_dense` in `par_solve.cpp`, `ind_ros4_0` in `ros4.cpp`) -- but the output data frame recalculates lhs *after* the solve (`calc_lhs` in `rxode2_df.cpp`), so `_rxDelay` fell into its pre-history branch.

## Fix

- The two drivers no longer free or clear the history at end-of-solve, matching what the rk4s discrete-adjoint driver already did.
- `rxFreeInd()` now releases the buffer with the subject's other owned arrays. All three paths that recycle ind memory -- `rxSolve_` entry, teardown, and the serialization restore (`rxRestoreState`) -- call `rxSolveFree()` first, so nothing leaks. This also plugs a pre-existing leak on the rk4s path, where the history was never freed at all.
- No struct or generated-code changes, so cached compiled models stay compatible.

One boundary note: at exactly `t = tau` the lookup time equals the solve start and legitimately returns pre-history (`td <= delayT0`); the fix and tests respect that.

## Testing

- Issue repro now gives `a(2.5) = 4.30354 = 0.5 * x(0.5)` exactly; zero before `t = tau` (correct zero pre-history).
- Verified on the default `dop853+ros4` composite, the pure `ros4` stiff path (err ~7e-15 vs the shifted state), an 8-subject parallel solve (`cores = 4`, every subject correct against its own history), and 25 repeated solves plus `rxSolveFree()` with no crash.
- New regression test in `test-dde.R` covering the default composite, `ros4`, and a multi-subject parallel solve; all 113 DDE tests and the basic/serialize test files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)