### PR TITLE
Harden rx_solve accessors against a NULL/un-initialized solve

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -137,6 +137,15 @@
 
 ## Bug fixes
 
+- The C accessors exposed through the function-pointer API (`getRxNsub()`,
+  `getSolvingOptions()`, `getSolvingOptionsInd()`, and the other `rx_solve*`
+  accessors) no longer segfault when handed a `NULL` or un-initialized solve.
+  They now fall back to the global solve and, if it is still not set up, raise a
+  normal catchable R error stating that the solving environment is not set up,
+  instead of dereferencing a `NULL` pointer and crashing the R process.  This
+  hardens downstream packages that call an accessor before their solve pointer
+  has been populated (for example a cold first `nls`/`nlm` fit in `nlmixr2est`).
+
 - A Jacobian entry `df(state)/dy(THETA[n])` or `df(state)/dy(ETA[n])` (a
   bracketed parameter reference, which the grammar accepts) no longer segfaults.
   The synthetic `_THETA_n_`/`_ETA_n_` symbol was never registered, so its index

--- a/src/rx2api.c
+++ b/src/rx2api.c
@@ -3,11 +3,36 @@
 
 rx_solve *getRxSolve_(void);
 
+// ABI-boundary guard: downstream packages resolve these accessors through the
+// function-pointer table and may hand us a NULL `rx` if their cached solve
+// pointer has not been populated yet (e.g. an accessor is called before
+// `rx = getRxSolve_()` on a cold first fit).  Rather than dereference NULL and
+// segfault the host process, fall back to the global solve structure and then
+// verify the solve has actually been set up.  If it has not, raise a clean R
+// error (which the caller can catch) instead of crashing somewhere downstream.
+//
+// The global solve struct (`&rx_global`) and its options (`&op_global`) are
+// static, so the meaningful "not set up" signal is `rx->subjects` (backed by
+// `inds_global`, which stays NULL until a solve allocates the subject array).
+static inline rx_solve *rxSolveOrError(rx_solve *rx, const char *what) {
+  if (rx == NULL) {
+    rx = getRxSolve_();
+  }
+  if (rx == NULL || rx->op == NULL || rx->subjects == NULL) {
+    Rf_error("rxode2: cannot access the solve (%s): the solving environment is not set up. "
+             "This usually means a solve accessor was called before rxSolve() populated the "
+             "solving environment (rx_solve is NULL/uninitialized).", what);
+  }
+  return rx;
+}
+
 rx_solving_options* getSolvingOptions(rx_solve* rx) {
+  rx = rxSolveOrError(rx, "getSolvingOptions");
   return rx->op;
 }
 
 rx_solving_options_ind *getSolvingOptionsInd(rx_solve *rx, int id) {
+  rx = rxSolveOrError(rx, "getSolvingOptionsInd");
   uint32_t nall = rx->nsub*rx->nsim;
   if (id < 0 || (uint32_t)id >= nall) {
     Rf_error("[getSolvingOptionsInd]: id (%d) should be between [0, %u); nsub: %u nsim: %u", id, (unsigned int)nall, (unsigned int)rx->nsub, (unsigned int)rx->nsim);
@@ -80,6 +105,7 @@ void setIndMixest(rx_solving_options_ind* ind, int mixest) {
 
 int getRxMixnum(rx_solve *rx) {
   // This is the number of mixtures
+  rx = rxSolveOrError(rx, "getRxMixnum");
   return rx->mixnum;
 }
 
@@ -263,38 +289,47 @@ void resetOpBadSolve(rx_solving_options* op) {
 ////////////////////////////////////////////////////////////////////////
 
 int getRxNsub(rx_solve *rx) {
+  rx = rxSolveOrError(rx, "getRxNsub");
   return (int)rx->nsub;
 }
 
 int hasRxLimit(rx_solve *rx) {
+  rx = rxSolveOrError(rx, "hasRxLimit");
   return rx->limit;
 }
 
 int hasRxCens(rx_solve *rx) {
+  rx = rxSolveOrError(rx, "hasRxCens");
   return rx->cens;
 }
 
 int getRxNall(rx_solve *rx) {
+  rx = rxSolveOrError(rx, "getRxNall");
   return rx->nall;
 }
 
 int getRxNobs(rx_solve *rx) {
+  rx = rxSolveOrError(rx, "getRxNobs");
   return rx->nobs;
 }
 
 int getRxNobs2(rx_solve *rx) {
+  rx = rxSolveOrError(rx, "getRxNobs2");
   return rx->nobs2;
 }
 
 int getRxNsim(rx_solve *rx) {
+  rx = rxSolveOrError(rx, "getRxNsim");
   return (int)rx->nsim;
 }
 
 int getRxNpars(rx_solve *rx) {
+  rx = rxSolveOrError(rx, "getRxNpars");
   return rx->npars;
 }
 
 int getOrdId(rx_solve *rx, int solveid) {
+  rx = rxSolveOrError(rx, "getOrdId");
   return rx->ordId[solveid];
 }
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

The C accessors exposed through the rxode2 function-pointer API (`getRxNsub()`, `getSolvingOptions()`, `getSolvingOptionsInd()`, and the other `rx_solve*` accessors) dereferenced their `rx_solve*` argument unconditionally. A downstream package that calls one **before its cached solve pointer is populated** passed `NULL` and **segfaulted the R process**.

This routes every `rx_solve*` accessor through a new `rxSolveOrError()` helper that:

1. falls back to the global solve (`getRxSolve_()`) when `rx` is `NULL`;
2. verifies the solve is actually set up (`op` and `subjects` non-NULL — `subjects` is backed by `inds_global`, which stays `NULL` until a solve allocates the subject array);
3. otherwise raises a normal, **catchable R error** naming the accessor, instead of dereferencing `NULL` and crashing somewhere downstream.

Legitimate solves are unaffected.

## Motivating case

The released `nlmixr2est` 6.0.1 has a use-before-init bug in `nlmSetup()` (src/nlm.cpp:146): it calls `getRxNsub(rx)` before `rx = getRxSolve_()`. On a cold first `nls`/`nlm` fit in a fresh session the global `rx` is `NULL`, so the accessor segfaults. This reproduces identically on the current CRAN stack (**rxode2 5.1.2 + nlmixr2est 6.0.1 + nlmixr2autoinit 1.0.1**) — backtrace `getRxNsub(rx=0x0)` from `nlmSetup` at `nlm.cpp:146` — so it is pre-existing and version-independent, not introduced by any rxode2 release.

The real fix belongs in `nlmixr2est` (reorder so `rx = getRxSolve_()` precedes the `getRxNsub(rx)` call; already present in the development version). This PR is defense-in-depth at the ABI boundary so an un-initialized solve produces a clean diagnostic rather than a hard crash while that fix propagates through CRAN.

## Verification

Built and tested against the exact CRAN `nlmixr2est` 6.0.1 / `nlmixr2autoinit` 1.0.1:

- Cold `nls` fit (rx not set up): **was** `*** caught segfault *** address 0x10`; **now** a clean R error — `rxode2: cannot access the solve (getRxNsub): the solving environment is not set up.` (no core dump).
- Plain `rxSolve()`: works, no false positive.
- `nls` fit after a solve has set up `rx`: succeeds — the guard only fires when the solve is genuinely not set up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)