### PR TITLE
Fix rxSolve(useLinCmt=TRUE) regressions from automatic odeToLin conversion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -261,6 +261,18 @@
   whose nonlinearity is written through a state-derived observable (e.g.
   Michaelis-Menten via `Cc <- central / vc`).
 
+- The automatic `linCmt()` conversion no longer changes results when the event
+  data doses a compartment by the *name* of an ODE compartment the conversion
+  renames (e.g. an ODE `centre` compartment addressed as `CMT = "centre"`,
+  which the conversion renames to `central`).  Such a solve now falls back to
+  the original ODE model instead of routing the dose nowhere and returning
+  all-zero predictions.
+
+- Fixed the automatic `linCmt()` conversion cache reusing the first model's
+  initial estimates for a later model that shares the same `model({})`
+  equations but has a different `ini({})` block, which made structurally
+  identical models with different parameters return identical predictions.
+
 - Fixed the string form of the compartment argument in the adaptive dosing
   helpers (e.g. `bolus(50, cmt = "depot")`).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -262,11 +262,11 @@
   Michaelis-Menten via `Cc <- central / vc`).
 
 - The automatic `linCmt()` conversion no longer changes results when the event
-  data doses a compartment by the *name* of an ODE compartment the conversion
-  renames (e.g. an ODE `centre` compartment addressed as `CMT = "centre"`,
-  which the conversion renames to `central`).  Such a solve now falls back to
-  the original ODE model instead of routing the dose nowhere and returning
-  all-zero predictions.
+  data addresses a compartment (in a dose or an observation record) by the
+  *name* of an ODE compartment the conversion renames (e.g. an ODE `centre`
+  compartment addressed as `CMT = "centre"`, which the conversion renames to
+  `central`).  Such a solve now falls back to the original ODE model instead of
+  routing the record nowhere and returning all-zero predictions.
 
 - Fixed the automatic `linCmt()` conversion cache reusing the first model's
   initial estimates for a later model that shares the same `model({})`

--- a/R/odeToLin.R
+++ b/R/odeToLin.R
@@ -577,9 +577,55 @@
 ## with the same model.
 .odeToLinCache <- new.env(parent = emptyenv(), hash = TRUE)
 
-## Cheap cache key: normalized text of all model lines.
+## Cheap cache key: normalized text of all model lines plus the initial
+## estimates.  The converted model rebuilt by `.rebuildRxUiFromExpr()` bakes in
+## `ui$iniFun`, so two models that share the same `model({})` equations but
+## differ only in their `ini({})` block must map to distinct cache entries.
+## Keying on the equations alone caused the second model to reuse the first
+## model's parameters (see the rxSolve(useLinCmt=TRUE) regression).
 .odeToLinCacheKey <- function(ui) {
-  paste0(vapply(ui$lstExpr, deparse1, character(1)), collapse = "\n")
+  .model <- paste0(vapply(ui$lstExpr, deparse1, character(1)), collapse = "\n")
+  .ini <- if (length(ui$iniDf$cond) > 0L) deparse1(ui$iniFun) else ""
+  paste0(.model, "\n#### ini ####\n", .ini)
+}
+
+## Is a converted linCmt() model safe to use for the given solve data?
+##
+## The ODE->linCmt conversion renames compartments (e.g. an ODE `centre`
+## compartment becomes linCmt's `central`).  If the event data addresses a
+## compartment by the *name* of an original ODE compartment that the converted
+## model no longer has, doses (and observations) would silently be routed
+## nowhere -- producing all-zero predictions.  In that case fall back to the
+## original ODE model so behaviour matches solving without the linCmt
+## optimization.  Numeric compartment indices are preserved by the conversion,
+## and names that are not compartments in the original model (e.g. the special
+## "(default)" placeholder in an event table) are handled identically by both
+## models, so both are left untouched here.
+.odeToLinCmtCompatible <- function(converted, original, data) {
+  if (is.null(data) || !is.data.frame(data)) {
+    return(TRUE)
+  }
+  .nm <- names(data)
+  .col <- .nm[tolower(.nm) == "cmt"]
+  if (length(.col) == 0L) {
+    return(TRUE)
+  }
+  .cmt <- data[[.col[1L]]]
+  if (is.factor(.cmt)) {
+    .cmt <- as.character(.cmt)
+  }
+  if (!is.character(.cmt)) {
+    ## numeric indices are preserved by the conversion
+    return(TRUE)
+  }
+  .cmt <- unique(.cmt[!is.na(.cmt)])
+  if (length(.cmt) == 0L) {
+    return(TRUE)
+  }
+  ## a name only matters if it was a compartment in the original model that the
+  ## conversion renamed away
+  .lost <- setdiff(rxModelVars(original)$state, rxModelVars(converted)$state)
+  !any(.cmt %in% .lost)
 }
 
 ## Rebuild an rxUi from a modified lstExpr (following the linToOde pattern).

--- a/R/odeToLin.R
+++ b/R/odeToLin.R
@@ -589,19 +589,41 @@
   paste0(.model, "\n#### ini ####\n", .ini)
 }
 
+## Package-scope cache: maps the same model-text key used by `.odeToLinCache`
+## to the character vector of compartment names the conversion renamed away.
+## Deriving these requires `rxModelVars()` on both the original and converted
+## models, which is constant per converted model, so it is computed once here
+## rather than on every solve.
+.odeToLinLostCache <- new.env(parent = emptyenv(), hash = TRUE)
+
+## The compartment names the ODE->linCmt conversion renamed away (i.e. present
+## in the original model but not the converted one).  Cached by model key.
+.odeToLinLostStates <- function(cacheKey, original, converted) {
+  if (exists(cacheKey, envir = .odeToLinLostCache, inherits = FALSE)) {
+    return(get(cacheKey, envir = .odeToLinLostCache, inherits = FALSE))
+  }
+  .lost <- setdiff(rxModelVars(original)$state, rxModelVars(converted)$state)
+  assign(cacheKey, .lost, envir = .odeToLinLostCache)
+  .lost
+}
+
 ## Is a converted linCmt() model safe to use for the given solve data?
 ##
 ## The ODE->linCmt conversion renames compartments (e.g. an ODE `centre`
 ## compartment becomes linCmt's `central`).  If the event data addresses a
-## compartment by the *name* of an original ODE compartment that the converted
-## model no longer has, doses (and observations) would silently be routed
-## nowhere -- producing all-zero predictions.  In that case fall back to the
-## original ODE model so behaviour matches solving without the linCmt
-## optimization.  Numeric compartment indices are preserved by the conversion,
-## and names that are not compartments in the original model (e.g. the special
-## "(default)" placeholder in an event table) are handled identically by both
-## models, so both are left untouched here.
-.odeToLinCmtCompatible <- function(converted, original, data) {
+## compartment (in a dose or an observation record) by the *name* of an original
+## ODE compartment that the converted model no longer has, that record would
+## silently be routed nowhere -- producing all-zero predictions.  In that case
+## fall back to the original ODE model so behaviour matches solving without the
+## linCmt optimization.  `lost` is the (pre-computed) set of renamed-away
+## compartment names.  Numeric compartment indices are preserved by the
+## conversion, and names that are not compartments in the original model (e.g.
+## the special "(default)" placeholder in an event table) are handled
+## identically by both models, so both are left untouched here.
+.odeToLinCmtCompatible <- function(lost, data) {
+  if (length(lost) == 0L) {
+    return(TRUE)
+  }
   if (is.null(data) || !is.data.frame(data)) {
     return(TRUE)
   }
@@ -622,10 +644,7 @@
   if (length(.cmt) == 0L) {
     return(TRUE)
   }
-  ## a name only matters if it was a compartment in the original model that the
-  ## conversion renamed away
-  .lost <- setdiff(rxModelVars(original)$state, rxModelVars(converted)$state)
-  !any(.cmt %in% .lost)
+  !any(.cmt %in% lost)
 }
 
 ## Rebuild an rxUi from a modified lstExpr (following the linToOde pattern).

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -2157,7 +2157,7 @@ rxSolve.rxUi <- function(object, params = NULL, events = NULL, inits = NULL, ...
     if (!is.null(.linInfo)) {
       .cacheKey <- .odeToLinCacheKey(object) # nolint
       if (exists(.cacheKey, envir = .odeToLinCache, inherits = FALSE)) { # nolint
-        object <- .odeToLinCache[[.cacheKey]] # nolint
+        .converted <- .odeToLinCache[[.cacheKey]] # nolint
       } else {
         .linExpr   <- .odeToLinBuildExpr(object$lstExpr, .linInfo) # nolint
         # fall back to the original ODE model
@@ -2168,6 +2168,15 @@ rxSolve.rxUi <- function(object, params = NULL, events = NULL, inits = NULL, ...
           .converted <- object
         }
         assign(.cacheKey, .converted, envir = .odeToLinCache) # nolint
+      }
+      # Only adopt the converted linCmt() model when the solve data does not
+      # address a compartment by a name the conversion renames away (otherwise
+      # doses would be routed nowhere, giving all-zero predictions).
+      .solveData <- .rxSolveUiEventData(events) # nolint
+      if (is.null(.solveData)) {
+        .solveData <- .rxSolveUiEventData(params) # nolint
+      }
+      if (.odeToLinCmtCompatible(.converted, object, .solveData)) { # nolint
         object <- .converted
       }
     }

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -2171,13 +2171,19 @@ rxSolve.rxUi <- function(object, params = NULL, events = NULL, inits = NULL, ...
       }
       # Only adopt the converted linCmt() model when the solve data does not
       # address a compartment by a name the conversion renames away (otherwise
-      # doses would be routed nowhere, giving all-zero predictions).
-      .solveData <- .rxSolveUiEventData(events) # nolint
-      if (is.null(.solveData)) {
-        .solveData <- .rxSolveUiEventData(params) # nolint
-      }
-      if (.odeToLinCmtCompatible(.converted, object, .solveData)) { # nolint
+      # those records would be routed nowhere, giving all-zero predictions).
+      # The renamed-away compartment set is derived once per model and cached.
+      .lost <- .odeToLinLostStates(.cacheKey, object, .converted) # nolint
+      if (length(.lost) == 0L) {
         object <- .converted
+      } else {
+        .solveData <- .rxSolveUiEventData(events) # nolint
+        if (is.null(.solveData)) {
+          .solveData <- .rxSolveUiEventData(params) # nolint
+        }
+        if (.odeToLinCmtCompatible(.lost, .solveData)) { # nolint
+          object <- .converted
+        }
       }
     }
   }

--- a/tests/testthat/test-odeToLin.R
+++ b/tests/testthat/test-odeToLin.R
@@ -747,4 +747,63 @@ rxTest({
     expect_equal(.r$Cc, .rOde$Cc, tolerance = 1e-4)
   })
 
+  test_that("odeToLin cache distinguishes models that differ only in ini()", {
+    # Regression: the ODE->linCmt conversion cache was keyed on the model
+    # equations alone.  Two models with identical model({}) but different
+    # ini({}) collided, so the second rxSolve(useLinCmt=TRUE) reused the first
+    # model's parameters -- yielding identical predictions regardless of ini().
+    .mk <- function(tclVal, tvVal) {
+      .f <- function() {
+        ini({ tcl <- 0; tv <- 0; add.err <- 1 })
+        model({
+          cl <- exp(tcl); v <- exp(tv); k <- cl / v
+          d/dt(centre) <- -k * centre
+          cp <- centre / v
+          cp ~ add(add.err)
+        })
+      }
+      .f <- rxode2::ini(.f, tcl = tclVal, tv = tvVal)
+      suppressMessages(rxode2(.f))
+    }
+    .u1 <- .mk(-4.75, 0.22)
+    .u2 <- .mk(-2.60, -1.44)
+    .ev <- et(amt = 100, cmt = "centre") |> et(seq(0, 24, by = 4))
+    # Solve u1 first (populates the cache), then u2 (previously collided)
+    .s1 <- suppressWarnings(rxSolve(.u1, .ev))
+    .s2 <- suppressWarnings(rxSolve(.u2, .ev))
+    expect_false(isTRUE(all.equal(.s1$cp, .s2$cp)))  # must differ by ini()
+    # Each must match its own explicit-parameter / ODE solve
+    .g1 <- suppressWarnings(rxSolve(.u1, .ev, useLinCmt = FALSE))
+    .g2 <- suppressWarnings(rxSolve(.u2, .ev, useLinCmt = FALSE))
+    expect_equal(.s1$cp, .g1$cp, tolerance = 1e-4)
+    expect_equal(.s2$cp, .g2$cp, tolerance = 1e-4)
+  })
+
+  test_that("auto linCmt conversion is skipped when data doses a named ODE compartment", {
+    # Regression: odeToLin renames the ODE compartment (e.g. `centre`) to the
+    # linCmt compartment (`central`).  Event data that doses the compartment by
+    # its ODE name lost the dose after conversion, producing all-zero
+    # predictions.  The default solve must fall back to the ODE model and match
+    # useLinCmt = FALSE.
+    .mod <- suppressMessages(rxode2(function() {
+      ini({ tcl <- -4.75; tv <- 0.22; add.err <- 1 })
+      model({
+        cl <- exp(tcl); v <- exp(tv); k <- cl / v
+        d/dt(centre) <- -k * centre
+        cp <- centre / v
+        cp ~ add(add.err)
+      })
+    }))
+    .ev <- data.frame(ID = 1L,
+                      TIME = c(0, 2, 4, 8, 12, 24),
+                      AMT = c(100, 0, 0, 0, 0, 0),
+                      EVID = c(1L, 0L, 0L, 0L, 0L, 0L),
+                      CMT = "centre",
+                      stringsAsFactors = FALSE)
+    .rLin <- suppressWarnings(rxSolve(.mod, .ev))                     # default (useLinCmt=TRUE)
+    .rOde <- suppressWarnings(rxSolve(.mod, .ev, useLinCmt = FALSE))
+    expect_false(all(.rLin$cp == 0))            # the bug produced all-zero cp
+    expect_equal(.rLin$cp, .rOde$cp, tolerance = 1e-4)
+  })
+
 })

--- a/tests/testthat/test-odeToLin.R
+++ b/tests/testthat/test-odeToLin.R
@@ -767,14 +767,31 @@ rxTest({
     }
     .u1 <- .mk(-4.75, 0.22)
     .u2 <- .mk(-2.60, -1.44)
-    .ev <- et(amt = 100, cmt = "centre") |> et(seq(0, 24, by = 4))
+    # Default (unnamed) dosing so the linCmt conversion is actually adopted; a
+    # named `cmt = "centre"` would trigger the compatibility fallback and the
+    # cache path under test would never run.
+    .ev <- et(amt = 100) |> et(seq(0, 24, by = 4))
+
+    .getDll <- function(r) {
+      normalizePath(
+        get("dll", envir = attr(attr(r, "class"), ".rxode2.env"), inherits = FALSE),
+        winslash = "/", mustWork = FALSE)
+    }
+
     # Solve u1 first (populates the cache), then u2 (previously collided)
     .s1 <- suppressWarnings(rxSolve(.u1, .ev))
     .s2 <- suppressWarnings(rxSolve(.u2, .ev))
-    expect_false(isTRUE(all.equal(.s1$cp, .s2$cp)))  # must differ by ini()
-    # Each must match its own explicit-parameter / ODE solve
     .g1 <- suppressWarnings(rxSolve(.u1, .ev, useLinCmt = FALSE))
     .g2 <- suppressWarnings(rxSolve(.u2, .ev, useLinCmt = FALSE))
+
+    # The linCmt conversion must actually be in play, otherwise the cache path
+    # is never exercised: the default solve must use a different DLL than the
+    # ODE solve.
+    expect_false(identical(.getDll(.s1), .getDll(.g1)),
+                 label = "useLinCmt default must adopt the converted linCmt DLL")
+
+    expect_false(isTRUE(all.equal(.s1$cp, .s2$cp)))  # must differ by ini()
+    # Each must match its own explicit-parameter / ODE solve
     expect_equal(.s1$cp, .g1$cp, tolerance = 1e-4)
     expect_equal(.s2$cp, .g2$cp, tolerance = 1e-4)
   })


### PR DESCRIPTION
## Summary

The automatic ODE→`linCmt()` conversion in `rxSolve.rxUi()` (default `useLinCmt=TRUE`) is meant to be a transparent speed optimization, but two edge cases changed solve results. Both surfaced as a downstream `devtools::check()` **error** in `nlmixr2auto` (via `nlmixr2autoinit::getPPKinits()`), where the CRAN-released rxode2 passes:

```
Error in if (!keep[i]) next : missing value where TRUE/FALSE needed
```

### Bug 1 — named-compartment dosing collapses to zero (the check failure)

The conversion renames the ODE compartment (e.g. `centre` → linCmt's `central`). `nlmixr2autoinit` solves on data carrying a character `CMT = "centre"` column, so after conversion every dose was routed to a compartment that no longer exists → **all predictions became 0** → every candidate parameter set scored an identical saturated error metric → the ranking tied → `est.cl` became `numeric(0)` → an out-of-bounds index produced the `NA` above.

**Fix:** `.odeToLinCmtCompatible()` detects when the solve data doses a compartment by the *name* of an original ODE compartment the conversion renames away, and `rxSolve.rxUi()` falls back to the original ODE model (identical to `useLinCmt=FALSE`). Numeric compartment indices and non-compartment names like the event-table `"(default)"` placeholder are unaffected.

### Bug 2 — conversion cache ignored `ini()`

`.odeToLinCacheKey()` keyed only on the model *equations*, but the cached converted model bakes in `ini()`. Two models sharing the same `model({})` but differing in `ini({})` collided, so the second solve silently reused the first model's parameters (order-dependent). The key now also includes the ini block.

## Tests

- New regression tests in `test-odeToLin.R` for both cases.
- `test-odeToLin.R`, `test-lincmt-solve.R` (4579), `test-lincmt-cmt-ref.R` (54), `test-lincmt-parse.R` all pass, 0 failures.
- `devtools::check()` on `nlmixr2auto` now passes (0 errors, 0 warnings); the previously-crashing `--run-donttest` examples pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)