### PR TITLE
Remove $predDf ar column; parse error-model literals to FIX $iniDf params

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,23 @@ devtools::document()
 - `rxUiGet` is an S3 dispatch system: `ui$property` calls `rxUiGet.property(x)`
 - Model piping (`R/piping*.R`) copies and modifies `rxUi` objects via `.copyUi()`
 
+> [!IMPORTANT]
+> **`$predDf` and `$iniDf` are a stable, exported interface — do not change
+> their schema without explicit user permission.** Their columns and structure
+> are relied on for model export/serialization and by reverse dependencies
+> (nlmixr2est, babelmixr2, nonmem2rx, …), including fits/UIs that were saved by
+> earlier versions. Adding, removing, renaming, or repurposing a column is a
+> breaking change: never do it as an incidental part of another change — ask
+> first. Prefer representing new information with the *existing* schema (e.g. a
+> literal residual value becomes an auto-generated FIX row in `$iniDf`, keyed to
+> its endpoint via the existing `err`/`condition` columns — see
+> `.rxErrLiteralToFixParam` in `R/err.R` — rather than a new `$predDf` column).
+>
+> **Reverse-dependency compatibility is fixed here, in rxode2.** When an rxode2
+> change breaks a reverse dependency, the released reverse dependency cannot be
+> patched retroactively, so the fix belongs in rxode2 — not in the reverse
+> dependency.
+
 **Event Table** (`src/et.cpp`, `src/etTran.cpp`, `R/et.R`):
 
 - `et()` constructs dosing/sampling event tables

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # rxode2 5.1.3
 
+## Breaking / compatibility changes
+
+- The `ar` column that had been added to `$predDf` was removed.  `$predDf` and
+  `$iniDf` are a stable, exported interface relied on by reverse dependencies
+  (nlmixr2est, babelmixr2, ...) and by fits saved with earlier versions, so
+  their schema must not grow.  Instead, a numeric literal supplied to an
+  error-model function (e.g. `add(0.7)`, `prop(0.1)`, `ar(0.5)`) is now parsed
+  into an auto-generated, uniquely named `rx`-prefixed **FIX** parameter in the
+  `$iniDf` (`rx.<endpoint>.<func>`), keyed to its endpoint through the existing
+  `err`/`condition` columns -- exactly like a user-written fixed residual
+  parameter.  (This also fixes literals such as `add(0.7)` that were previously
+  silently dropped.)  Estimated (`ar(rho)`) and modeled (`ar(corv)`)
+  correlations continue to work; the modeled correlation is recovered from the
+  endpoint's error expression rather than from a column.
+
 ## New features
 
 - `rxOptExpr()` gains `chunkLines` and `parallel`, to optimize a large

--- a/R/assert.R
+++ b/R/assert.R
@@ -195,10 +195,24 @@ assertRxUiNoMix <- function(ui, extra="", .var.name=.vname(ui)) {
 #' @export
 rxHasAr <- function(ui) {
   ui <- assertRxUi(ui)
-  .predDf <- ui$predDf
   .iniDf <- ui$iniDf
-  (!is.null(.predDf) && any(!is.na(.predDf$ar))) ||
-    (!is.null(.iniDf) && any(.iniDf$err == "ar", na.rm=TRUE))
+  # literal (auto-fixed) and estimated ar() correlations live in the $iniDf with
+  # err == "ar"
+  if (!is.null(.iniDf) && any(.iniDf$err == "ar", na.rm=TRUE)) return(TRUE)
+  # a modeled correlation (e.g. corv <- expit(tcor); ar(corv)) is not a
+  # parameter, so scan the endpoint error expressions for an ar() term
+  .lst <- tryCatch(ui$lstExpr, error=function(e) NULL)
+  if (is.null(.lst)) return(FALSE)
+  .hasAr <- function(e) {
+    if (is.call(e)) {
+      if (identical(e[[1]], quote(ar))) return(TRUE)
+      return(any(vapply(as.list(e), .hasAr, logical(1))))
+    }
+    FALSE
+  }
+  any(vapply(.lst, function(e) {
+    is.call(e) && identical(e[[1]], quote(`~`)) && .hasAr(e)
+  }, logical(1)))
 }
 
 #' @export
@@ -270,7 +284,7 @@ assertRxUiEstimatedResiduals <- function(ui, extra="", .var.name=.vname(ui)) {
   ui <- assertRxUi(ui, extra=extra, .var.name=.var.name)
   assertRxUiPrediction(ui)
   .predDf <- ui$predDf
-  if (!all(is.na(unlist(.predDf[ ,c("a", "b", "c", "d", "e", "f", "lambda", "ar")], use.names=FALSE)))) {
+  if (!all(is.na(unlist(.predDf[ ,c("a", "b", "c", "d", "e", "f", "lambda")], use.names=FALSE)))) {
     stop("'", .var.name, "' residual parameters cannot depend on the model calculated parameters", extra, call.=FALSE)
   }
   invisible(ui)

--- a/R/err-sim.R
+++ b/R/err-sim.R
@@ -73,14 +73,58 @@ rxGetDistributionSimulationLines <- function(line) {
 #'
 #' @param env parsed model environment
 #' @param pred1 single predDf row
-#' @return quoted correlation (name or number), or NULL when the endpoint
-#'   has no ar() term
+#' @return quoted correlation (parameter name, or the modeled correlation
+#'   variable), or NULL when the endpoint has no ar() term
 #' @author Matthew Fidler
 #' @noRd
 .rxGetArCorLang <- function(env, pred1) {
-  if (!is.na(pred1$ar)) return(str2lang(pred1$ar))
+  # ar() correlations backed by a parameter live in the $iniDf with err == "ar"
+  # (a literal ar(0.5) is parsed into an auto-generated FIX parameter, an
+  # estimated ar(rho) keeps its name); there is no dedicated $predDf column
   .w <- which(env$iniDf$err == "ar" & env$iniDf$condition == pred1$cond)
   if (length(.w) == 1L) return(str2lang(env$iniDf$name[.w]))
+  # otherwise the correlation is a modeled (calculated) variable, e.g.
+  # `corv <- expit(tcor); cp ~ add(add.sd) + ar(corv)` -- recover it directly
+  # from the endpoint's original error expression
+  .rxFindArArg(env, pred1$cond)
+}
+
+#' Find the `ar()` argument in an endpoint's error expression
+#'
+#' Scans the model's stored expressions (`env$lstExpr`) for the `~` error line
+#' whose left-hand side matches the endpoint `cond` and returns the (quoted)
+#' argument of its `ar()` term, if any.  Used to resolve modeled `ar()`
+#' correlations, which are not stored in `$iniDf`/`$predDf`.
+#'
+#' @param env parsed model environment (must carry `lstExpr`)
+#' @param cond endpoint condition (the error expression's left-hand side)
+#' @return the quoted `ar()` argument, or NULL when not found
+#' @author Matthew L. Fidler
+#' @noRd
+.rxFindArArg <- function(env, cond) {
+  .lst <- tryCatch(get("lstExpr", envir=env), error=function(e) NULL)
+  if (is.null(.lst)) return(NULL)
+  .findAr <- function(e) {
+    if (is.call(e)) {
+      if (identical(e[[1]], quote(ar)) && length(e) == 2L) return(e[[2]])
+      for (.i in seq_along(e)) {
+        .r <- .findAr(e[[.i]])
+        if (!is.null(.r)) return(.r)
+      }
+    }
+    NULL
+  }
+  for (.e in .lst) {
+    if (is.call(.e) && identical(.e[[1]], quote(`~`)) && length(.e) == 3L) {
+      .lhs <- .e[[2]]
+      # strip conditioning (lhs | cond) down to the endpoint variable
+      if (is.call(.lhs) && identical(.lhs[[1]], quote(`|`))) .lhs <- .lhs[[2]]
+      if (identical(deparse1(.lhs), as.character(cond))) {
+        .arg <- .findAr(.e[[3]])
+        if (!is.null(.arg)) return(.arg)
+      }
+    }
+  }
   NULL
 }
 

--- a/R/err-sim.R
+++ b/R/err-sim.R
@@ -119,6 +119,15 @@ rxGetDistributionSimulationLines <- function(line) {
       .lhs <- .e[[2]]
       # strip conditioning (lhs | cond) down to the endpoint variable
       if (is.call(.lhs) && identical(.lhs[[1]], quote(`|`))) .lhs <- .lhs[[2]]
+      # unwrap ll(x)/linCmt() the same way .errHandleLlOrLinCmt() sets the
+      # endpoint condition, so ll(cp) ~ ... + ar(corv) still matches cond
+      if (is.call(.lhs)) {
+        if (identical(.lhs[[1]], quote(`ll`)) && length(.lhs) == 2L) {
+          .lhs <- .lhs[[2]]
+        } else if (identical(.lhs[[1]], quote(`linCmt`))) {
+          .lhs <- quote(`rxLinCmt`)
+        }
+      }
       if (identical(deparse1(.lhs), as.character(cond))) {
         .arg <- .findAr(.e[[3]])
         if (!is.null(.arg)) return(.arg)

--- a/R/err.R
+++ b/R/err.R
@@ -676,20 +676,22 @@ rxErrTypeCombine <- function(oldErrType, newErrType) {
   .df <- env$df
   .base <- paste0("rx.", env$curCondition, ".", funName)
   .name <- .base
-  .i <- 1L
+  .i <- 0L
   while (.name %in% .df$name) {
     .i <- .i + 1L
     .name <- paste0(.base, ".", .i)
   }
   .ntheta <- suppressWarnings(max(.df$ntheta, na.rm=TRUE))
   if (!is.finite(.ntheta)) .ntheta <- 0L
-  # positive-support residual parameters get a lower bound of 0; ar() lives in
-  # [0, 1); everything else stays unbounded (the value is FIX regardless)
+  # positive-support residual parameters get a lower bound of 0; ar() is a
+  # correlation in [0, 1), so its upper bound is the strict-below-1 sup rather
+  # than an inclusive 1; everything else stays unbounded (the value is FIX
+  # regardless)
   .lower <- -Inf
   .upper <- Inf
   if (funName == "ar") {
     .lower <- 0
-    .upper <- 1
+    .upper <- 1 - .Machine$double.eps
   } else if (funName %in% .errDistsPositive) {
     .lower <- 0
   }

--- a/R/err.R
+++ b/R/err.R
@@ -643,11 +643,73 @@ rxErrTypeCombine <- function(oldErrType, newErrType) {
   cauchy=c("a", "b"),
   dgamma=c("a", "b"),
   nbinom=c("a", "b"),
-  nbinomMu=c("a", "b"),
-  ar="ar"
+  nbinomMu=c("a", "b")
 )
 
 .allowEstimatedParameters <- "ordinal"
+
+#' Convert a numeric literal error-model argument into a FIX `$iniDf` parameter
+#'
+#' A residual literal such as `add(0.7)`, `prop(0.1)` or `ar(0.5)` is turned
+#' into an auto-generated, uniquely named, `rx`-prefixed **FIX** parameter that
+#' is appended to `env$df` (the working `$iniDf`) and linked to the current
+#' endpoint through the `err`/`condition` columns -- exactly as a user-supplied
+#' estimated (fixed) residual parameter would be.  This keeps residual literals
+#' out of `$predDf` (so no dedicated columns like the former `ar` are needed)
+#' and lets them flow through every downstream path (estimation, simulation,
+#' export) unchanged.
+#'
+#' The generated name is `rx.<endpoint>.<func>`, de-duplicated with a numeric
+#' suffix if that name already exists.
+#'
+#' @param argumentNumber distribution argument index (1-based); argument 1 uses
+#'   the bare function name for `err`, later arguments append the index (matching
+#'   the named-parameter convention in [.errHandleSingleDistributionArgument]).
+#' @param funName error distribution function name
+#' @param value numeric literal value
+#' @param env parse environment (holds `df`, the working `$iniDf`, and
+#'   `curCondition`, the current endpoint variable)
+#' @return NULL, called for its side effect of appending a row to `env$df`
+#' @author Matthew L. Fidler
+#' @noRd
+.rxErrLiteralToFixParam <- function(argumentNumber, funName, value, env) {
+  .df <- env$df
+  .base <- paste0("rx.", env$curCondition, ".", funName)
+  .name <- .base
+  .i <- 1L
+  while (.name %in% .df$name) {
+    .i <- .i + 1L
+    .name <- paste0(.base, ".", .i)
+  }
+  .ntheta <- suppressWarnings(max(.df$ntheta, na.rm=TRUE))
+  if (!is.finite(.ntheta)) .ntheta <- 0L
+  # positive-support residual parameters get a lower bound of 0; ar() lives in
+  # [0, 1); everything else stays unbounded (the value is FIX regardless)
+  .lower <- -Inf
+  .upper <- Inf
+  if (funName == "ar") {
+    .lower <- 0
+    .upper <- 1
+  } else if (funName %in% .errDistsPositive) {
+    .lower <- 0
+  }
+  # build a one-row frame that matches env$df's columns exactly, then fill it
+  .row <- .df[0, , drop=FALSE]
+  .row[1, ] <- NA
+  .row$ntheta <- .ntheta + 1L
+  .row$neta1 <- NA_integer_
+  .row$neta2 <- NA_integer_
+  .row$name <- .name
+  .row$lower <- .lower
+  .row$est <- value
+  .row$upper <- .upper
+  .row$fix <- TRUE
+  .row$condition <- env$curCondition
+  .row$err <- if (argumentNumber == 1) funName else paste0(funName, argumentNumber)
+  env$df <- rbind(.df, .row)
+  assign("lastDistAssign", .name, envir=env)
+  invisible(NULL)
+}
 
 #' This handles the error distribution for a single argument.
 #'
@@ -682,6 +744,15 @@ rxErrTypeCombine <- function(oldErrType, newErrType) {
       .df$condition[.w] <- env$curCondition
       assign("df", .df, envir=env)
       assign("lastDistAssign", .curName, envir=env)
+    } else if (funName == "ar") {
+      # ar(<modeled variable>): the correlation is a model-calculated quantity
+      # (e.g. corv <- expit(tcor)) rather than an estimated parameter or a
+      # literal.  Nothing is stored in $iniDf/$predDf; .rxGetArCorLang() recovers
+      # the correlation directly from the endpoint's error expression.  The
+      # referenced variable is validated as a model quantity later, like other
+      # modeled residual references.
+      assign("lastDistAssign", .curName, envir=env)
+      return(NULL)
     } else {
       .w <- which(names(.namedArgumentsToPredDf) == funName)
       if (length(.w) == 1) {
@@ -699,17 +770,22 @@ rxErrTypeCombine <- function(oldErrType, newErrType) {
       }
     }
   } else if (.is.numeric(.cur, env)) {
-    if (.isLogitOrProbit) {
-      if (argumentNumber == 2 || argumentNumber == 3) {
-        env$trLimit[argumentNumber - 1] <- env$.numeric
-      }
-    } else if (funName == "ar") {
-      if (env$.numeric < 0 || env$.numeric >= 1) {
-        env$err <- c(env$err,
-                     "'ar()' correlation must be in [0, 1)")
-      } else {
-        env$ar <- as.character(env$.numeric)
-      }
+    if (.isLogitOrProbit && (argumentNumber == 2 || argumentNumber == 3)) {
+      # logitNorm()/probitNorm() transformation bounds are structural
+      # constants, not parameters
+      env$trLimit[argumentNumber - 1] <- env$.numeric
+    } else if (funName == "ar" && (env$.numeric < 0 || env$.numeric >= 1)) {
+      env$err <- c(env$err,
+                   "'ar()' correlation must be in [0, 1)")
+    } else {
+      # A numeric literal supplied to an error-model function (e.g. add(0.7),
+      # prop(0.1), ar(0.5)) is converted to an auto-generated, uniquely named
+      # FIX parameter in the $iniDf -- exactly as if the user had written
+      # `rx.<endpoint>.<func> <- fix(<value>)` and referenced it by name.  This
+      # keeps residual literals out of $predDf (no dedicated columns needed) and
+      # routes them through the same machinery as an estimated residual
+      # parameter.
+      .rxErrLiteralToFixParam(argumentNumber, funName, env$.numeric, env)
     }
   } else if (is.na(.cur)) {
     if (argumentNumber == 1 && funName %in% .allowDemoteAddDistributions) {
@@ -976,7 +1052,6 @@ rxErrTypeCombine <- function(oldErrType, newErrType) {
   env$linCmt <- FALSE
   env$var <- FALSE
   env$dv <- FALSE
-  env$ar <- NA_character_
   env$hasAr <- FALSE
   .left <- .errHandleLlOrLinCmt(expression[[2]], env)
   env$trLimit <- c(-Inf, Inf)
@@ -1026,8 +1101,7 @@ rxErrTypeCombine <- function(oldErrType, newErrType) {
                                      lambda=env$lambda,
                                      linCmt=env$linCmt,
                                      variance=env$var,
-                                     dv=env$dv,
-                                     ar=env$ar))
+                                     dv=env$dv))
       env$curDvid <- env$curDvid + 1L
 
     }
@@ -1056,8 +1130,7 @@ rxErrTypeCombine <- function(oldErrType, newErrType) {
                          lambda=env$lambda,
                          linCmt=env$linCmt,
                          variance=env$var,
-                         dv=env$dv,
-                         ar=env$ar)
+                         dv=env$dv)
       env$predDf <- rbind(env$predDf, .tmp)
       env$curDvid <- env$curDvid + 1L
     }
@@ -1089,7 +1162,7 @@ rxErrTypeCombine <- function(oldErrType, newErrType) {
   .iniDf <- env$iniDf
   .err <- env$dupErr
   for (.i in seq_along(.predDf$cond)) {
-    if (!any(!is.na(.predDf[.i, c("a", "b", "c", "d", "e", "f", "lambda", "ar")]))) {
+    if (!any(!is.na(.predDf[.i, c("a", "b", "c", "d", "e", "f", "lambda")]))) {
       if (!(.predDf[.i, "distribution"] %in% c("LL", "ordinal"))) {
         .cnd <- .predDf$cond[.i]
         .w <- which(.iniDf$condition == .cnd)
@@ -1463,7 +1536,7 @@ rxErrTypeCombine <- function(oldErrType, newErrType) {
                          "needToDemoteAdditiveExpression",
                          "top", "trLimit", ".numeric", "a", "b", "c", "d", "e", "f",  "lambda",
                          "curCmt", "errGlobal", "linCmt", "ll", "distribution", "rxUdfUiCount", "before", "after",
-                         "lhs", "earlyErr", "var", "dv", "ar", "hasAr"),
+                         "lhs", "earlyErr", "var", "dv", "hasAr"),
                        ls(envir=.env, all.names=TRUE))
       if (length(.rm) > 0) rm(list=.rm, envir=.env)
       if (checkMissing) .checkForMissingOrDupliacteInitials(.env)
@@ -1541,7 +1614,6 @@ rxErrTypeCombine <- function(oldErrType, newErrType) {
   .left <- .errHandleLlOrLinCmt(expr[[2]], .env)
   .env$trLimit <- c(-Inf, Inf)
   .env$a <- .env$b <- .env$c <- .env$d <- .env$e <- .env$f <- .env$lambda <- NA_character_
-  .env$ar <- NA_character_
   .env$hasAr <- FALSE
   .env$curCondition <- .env$curVar <- deparse1(.left)
   .env$hasNonErrorTerm <- FALSE

--- a/R/err.R
+++ b/R/err.R
@@ -659,8 +659,11 @@ rxErrTypeCombine <- function(oldErrType, newErrType) {
 #' and lets them flow through every downstream path (estimation, simulation,
 #' export) unchanged.
 #'
-#' The generated name is `rx.<endpoint>.<func>`, de-duplicated with a numeric
-#' suffix if that name already exists.
+#' The generated name is `rx.<endpoint>.<err>` where `<err>` is the endpoint's
+#' `err` specification (the function name for argument 1, the function name with
+#' the argument index appended otherwise, e.g. `pow` / `pow2`), so multiple
+#' fixed literals in one function get distinct names.  It is de-duplicated with
+#' a numeric suffix if that name already exists.
 #'
 #' @param argumentNumber distribution argument index (1-based); argument 1 uses
 #'   the bare function name for `err`, later arguments append the index (matching
@@ -674,7 +677,12 @@ rxErrTypeCombine <- function(oldErrType, newErrType) {
 #' @noRd
 .rxErrLiteralToFixParam <- function(argumentNumber, funName, value, env) {
   .df <- env$df
-  .base <- paste0("rx.", env$curCondition, ".", funName)
+  # the name mirrors the `err` specification (funName for argument 1, funName
+  # with the argument index appended otherwise), so a function with more than
+  # one fixed literal (e.g. pow(1.5, 2)) gets distinct names (rx.cp.pow,
+  # rx.cp.pow2) rather than colliding on the bare function name
+  .errName <- if (argumentNumber == 1L) funName else paste0(funName, argumentNumber)
+  .base <- paste0("rx.", env$curCondition, ".", .errName)
   .name <- .base
   .i <- 0L
   while (.name %in% .df$name) {
@@ -707,7 +715,7 @@ rxErrTypeCombine <- function(oldErrType, newErrType) {
   .row$upper <- .upper
   .row$fix <- TRUE
   .row$condition <- env$curCondition
-  .row$err <- if (argumentNumber == 1) funName else paste0(funName, argumentNumber)
+  .row$err <- .errName
   env$df <- rbind(.df, .row)
   assign("lastDistAssign", .name, envir=env)
   invisible(NULL)

--- a/R/mu.R
+++ b/R/mu.R
@@ -1071,10 +1071,8 @@
     .w <- which(.iniDf$condition == .cond)
     # endpoint has no estimated parameters, see if they are modeled
     # parameters
-    .ret <- as.character(.predDf[i, c("a", "b", "c", "d", "e", "f", "lambda", "ar")])
+    .ret <- as.character(.predDf[i, c("a", "b", "c", "d", "e", "f", "lambda")])
     .ret <- .ret[!is.na(.ret)]
-    # ar() may hold a numeric literal (e.g. ar(0.5)); those are not parameters
-    .ret <- .ret[is.na(suppressWarnings(as.numeric(.ret)))]
     .ini <- .mv$ini
     .ini <- .ini[!is.na(.ini)]
     .names <- c(.mv$lhs, names(.ini))

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,39 @@
+# rxode2 5.1.3
+
+## Reverse-dependency note (pre-existing `nlmixr2est` segfault)
+
+Reverse-dependency checks of `nlmixr2est` (6.0.1) and, through it,
+`nlmixr2autoinit` (1.0.1) can segfault in examples that run a "cold"
+`nls`/`nlm` fit as the very first model operation in a fresh session
+(e.g. `nlmixr2autoinit::Fit_1cmpt_iv(..., est.method = "nls")`).
+
+This crash is **not** caused by or new to this `rxode2` submission.  It
+is a pre-existing use-before-initialization bug in the *released*
+`nlmixr2est` 6.0.1: in `nlmSetup()` (src/nlm.cpp) it calls the rxode2
+accessor `getRxNsub(rx)` before `rx` has been assigned via
+`rx = getRxSolve_()`, so on a cold first fit `rx` is `NULL` and is
+dereferenced.
+
+We confirmed this is version-independent by reproducing the identical
+crash with the *current CRAN* stack -- `rxode2` 5.1.2 + `nlmixr2est`
+6.0.1 + `nlmixr2autoinit` 1.0.1 -- giving the same backtrace
+(`getRxNsub(rx = 0x0)` from `nlmSetup` at `nlm.cpp:146`).  Both the
+current CRAN `rxode2` (5.1.2) and this submission (5.1.3) crash
+identically, so no regression is introduced here.
+
+The fix belongs in `nlmixr2est` (reorder so `rx = getRxSolve_()`
+precedes the `getRxNsub(rx)` call) and is already in place in the
+development version of `nlmixr2est`; an updated `nlmixr2est` will be
+submitted to CRAN.
+
+In addition, this `rxode2` release hardens the C accessors exposed
+through the function-pointer API so that being handed an
+un-initialized solve no longer crashes the R process: instead of
+dereferencing a NULL/unset `rx_solve`, they now raise a normal,
+catchable R error stating that the solving environment is not set up.
+This turns the pre-existing `nlmixr2est` 6.0.1 crash into a graceful
+error while the `nlmixr2est` fix propagates through CRAN.
+
 # rxode2 5.1.2
 
 * CRAN has asked us to fix `nlmixr2est` `m1-san` which seems to be

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -7,7 +7,7 @@ Reverse-dependency checks of `nlmixr2est` (6.0.1) and, through it,
 `nls`/`nlm` fit as the very first model operation in a fresh session
 (e.g. `nlmixr2autoinit::Fit_1cmpt_iv(..., est.method = "nls")`).
 
-This crash is **not** caused by or new to this `rxode2` submission.  It
+This crash is **not** caused by nor new to this `rxode2` submission.  It
 is a pre-existing use-before-initialization bug in the *released*
 `nlmixr2est` 6.0.1: in `nlmSetup()` (src/nlm.cpp) it calls the rxode2
 accessor `getRxNsub(rx)` before `rx` has been assigned via
@@ -28,7 +28,7 @@ submitted to CRAN.
 
 In addition, this `rxode2` release hardens the C accessors exposed
 through the function-pointer API so that being handed an
-un-initialized solve no longer crashes the R process: instead of
+uninitialized solve no longer crashes the R process: instead of
 dereferencing a NULL/unset `rx_solve`, they now raise a normal,
 catchable R error stating that the solving environment is not set up.
 This turns the pre-existing `nlmixr2est` 6.0.1 crash into a graceful

--- a/tests/testthat/test-ar.R
+++ b/tests/testthat/test-ar.R
@@ -44,6 +44,28 @@ rxTest({
     expect_equal(.lit$iniDf$err[.wl], "ar")
     expect_equal(.lit$iniDf$condition[.wl], "cp")
 
+    # numeric literals in other error functions (add()/prop()) are likewise
+    # turned into FIX $iniDf params (rx.<endpoint>.<func>) rather than being
+    # silently dropped
+    .litAddProp <- function() {
+      ini({tcl <- log(1)})
+      model({cl <- exp(tcl); cp <- cl; cp ~ add(0.7) + prop(0.1)})
+    }
+    .lap <- rxode2(.litAddProp)
+    .wa <- which(.lap$iniDf$name == "rx.cp.add")
+    expect_equal(length(.wa), 1L)
+    expect_true(.lap$iniDf$fix[.wa])
+    expect_equal(.lap$iniDf$est[.wa], 0.7)
+    expect_equal(.lap$iniDf$err[.wa], "add")
+    expect_equal(.lap$iniDf$condition[.wa], "cp")
+    expect_equal(.lap$iniDf$lower[.wa], 0)
+    .wp <- which(.lap$iniDf$name == "rx.cp.prop")
+    expect_equal(length(.wp), 1L)
+    expect_true(.lap$iniDf$fix[.wp])
+    expect_equal(.lap$iniDf$est[.wp], 0.1)
+    expect_equal(.lap$iniDf$err[.wp], "prop")
+    expect_equal(.lap$iniDf$condition[.wp], "cp")
+
     # a modeled correlation (a calculated model variable) is neither a parameter
     # nor a $predDf column; it is recovered from the endpoint error expression
     .modCor <- function() {

--- a/tests/testthat/test-ar.R
+++ b/tests/testthat/test-ar.R
@@ -19,15 +19,33 @@ rxTest({
       })
     }
     ui <- rxode2(.estCor)
-    # estimated correlation lives in iniDf (err == "ar"), predDf$ar is NA
-    expect_true(is.na(ui$predDf$ar))
+    # estimated correlation lives in iniDf (err == "ar"); there is no $predDf
+    # ar column (it must never be added -- reverse dependencies rely on the
+    # $predDf schema)
+    expect_false("ar" %in% colnames(ui$predDf))
     .w <- which(ui$iniDf$name == "ar1.cor")
     expect_equal(ui$iniDf$err[.w], "ar")
     expect_equal(ui$iniDf$condition[.w], "cp")
     expect_equal(ui$iniDf$lower[.w], 0)
     expect_equal(ui$iniDf$upper[.w], 1)
 
-    # modeled correlation lands in predDf$ar
+    # a numeric literal correlation becomes an auto-generated FIX parameter in
+    # the $iniDf (rx.<endpoint>.ar), not a $predDf entry
+    .litCor <- function() {
+      ini({tcl <- log(1); add.sd <- 0.5})
+      model({cl <- exp(tcl); cp <- cl; cp ~ add(add.sd) + ar(0.5)})
+    }
+    .lit <- rxode2(.litCor)
+    expect_false("ar" %in% colnames(.lit$predDf))
+    .wl <- which(.lit$iniDf$name == "rx.cp.ar")
+    expect_equal(length(.wl), 1L)
+    expect_true(.lit$iniDf$fix[.wl])
+    expect_equal(.lit$iniDf$est[.wl], 0.5)
+    expect_equal(.lit$iniDf$err[.wl], "ar")
+    expect_equal(.lit$iniDf$condition[.wl], "cp")
+
+    # a modeled correlation (a calculated model variable) is neither a parameter
+    # nor a $predDf column; it is recovered from the endpoint error expression
     .modCor <- function() {
       ini({tcl <- log(1); tv <- log(10); add.sd <- 0.5; tcor <- 0.3})
       model({
@@ -37,14 +55,10 @@ rxTest({
         cp ~ add(add.sd) + ar(corv)
       })
     }
-    expect_equal(rxode2(.modCor)$predDf$ar, "corv")
-
-    # numeric literal correlation
-    .litCor <- function() {
-      ini({tcl <- log(1); add.sd <- 0.5})
-      model({cl <- exp(tcl); cp <- cl; cp ~ add(add.sd) + ar(0.5)})
-    }
-    expect_equal(rxode2(.litCor)$predDf$ar, "0.5")
+    .mod <- rxode2(.modCor)
+    expect_false("ar" %in% colnames(.mod$predDf))
+    expect_false("corv" %in% .mod$iniDf$name)
+    expect_true(rxHasAr(.mod))
   })
 
   test_that("ar() works with a variety of transformably-normal error models", {

--- a/tests/testthat/test-ar.R
+++ b/tests/testthat/test-ar.R
@@ -66,6 +66,44 @@ rxTest({
     expect_equal(.lap$iniDf$err[.wp], "prop")
     expect_equal(.lap$iniDf$condition[.wp], "cp")
 
+    # multi-argument error functions (pow(alpha, exponent)): a literal in a
+    # non-first argument is fixed into $iniDf and named after its `err` spec
+    # (rx.<endpoint>.<func><argno>), keeping an estimated first argument
+    .litPow <- function() {
+      ini({tcl <- log(1); pw <- 0.5})
+      model({cl <- exp(tcl); cp <- cl; cp ~ pow(pw, 1.5)})
+    }
+    .lp <- rxode2(.litPow)
+    # the estimated first argument stays a normal parameter
+    .we <- which(.lp$iniDf$name == "pw")
+    expect_equal(length(.we), 1L)
+    expect_false(.lp$iniDf$fix[.we])
+    expect_equal(.lp$iniDf$err[.we], "pow")
+    # the literal exponent becomes a FIX param named rx.cp.pow2 (err == "pow2")
+    .wpow2 <- which(.lp$iniDf$name == "rx.cp.pow2")
+    expect_equal(length(.wpow2), 1L)
+    expect_true(.lp$iniDf$fix[.wpow2])
+    expect_equal(.lp$iniDf$est[.wpow2], 1.5)
+    expect_equal(.lp$iniDf$err[.wpow2], "pow2")
+    expect_equal(.lp$iniDf$condition[.wpow2], "cp")
+
+    # both pow() arguments literal: distinct names keyed to their err specs
+    # (rx.cp.pow / rx.cp.pow2), no collision on the bare function name
+    .litPow2 <- function() {
+      ini({tcl <- log(1)})
+      model({cl <- exp(tcl); cp <- cl; cp ~ pow(1.5, 2)})
+    }
+    .lp2 <- rxode2(.litPow2)
+    .wp1 <- which(.lp2$iniDf$name == "rx.cp.pow")
+    .wp2 <- which(.lp2$iniDf$name == "rx.cp.pow2")
+    expect_equal(length(.wp1), 1L)
+    expect_equal(length(.wp2), 1L)
+    expect_equal(.lp2$iniDf$est[.wp1], 1.5)
+    expect_equal(.lp2$iniDf$est[.wp2], 2)
+    expect_equal(.lp2$iniDf$err[.wp1], "pow")
+    expect_equal(.lp2$iniDf$err[.wp2], "pow2")
+    expect_true(all(.lp2$iniDf$fix[c(.wp1, .wp2)]))
+
     # a modeled correlation (a calculated model variable) is neither a parameter
     # nor a $predDf column; it is recovered from the endpoint error expression
     .modCor <- function() {


### PR DESCRIPTION
## Why

`$predDf` and `$iniDf` are a **stable, exported interface** relied on by reverse dependencies (nlmixr2est, babelmixr2, nonmem2rx, …) and by fits/UIs saved with earlier versions. The recently-added `ar` column (for the `ar()` AR(1) residual term) broke that contract:

- The released CRAN **nlmixr2est** and previously-stored UIs lack the column, so `.rxGetArCorLang()`'s `is.na(pred1$ar)` errored with *"argument is of length zero"*.
- Stale/older fits failed in `predict()` and `saemModelPred`.

Since a released reverse dependency cannot be patched retroactively, the fix belongs here in rxode2.

## What changed

- **Error-model literals → FIX `$iniDf` params.** A numeric literal in any error function (`add(0.7)`, `prop(0.1)`, `ar(0.5)`) is now parsed into an auto-generated, uniquely named, `rx`-prefixed **FIX** parameter (`rx.<endpoint>.<func>`), keyed to its endpoint via the existing `err`/`condition` columns — exactly like a user-written fixed residual parameter (`.rxErrLiteralToFixParam`). This also fixes literals like `add(0.7)` that were previously **silently dropped**.
- **Removed the `ar` column from `$predDf`** and updated every consumer (`.rxGetArCorLang`, `rxHasAr`, `assertRxUiEstimatedResiduals`, the mu-ref parameter check).
- **All three `ar()` forms keep working:** literal → FIX param; estimated `ar(rho)` → keeps its `err=="ar"` iniDf linkage; modeled `ar(corv)` (a calculated variable) → recovered directly from the endpoint's error expression (`.rxFindArArg`), with `rxHasAr()` scanning error lines to detect it — no new column needed.
- **CLAUDE.md guardrail:** `$predDf`/`$iniDf` schema changes require explicit permission; reverse-dependency compat fixes belong in rxode2, not in the reverse dependency.
- NEWS entry + updated `test-ar.R`.

## Verification

- rxode2 (`load_all`): `test-ar` (34), `test-ui-err` (229), `test-rxFix`, `test-parsing`, and a 174-test sim/focei/deparse regression sweep — **all pass, 0 failures**.
- Reverse-dep: **unpatched** nlmixr2est against the rebuilt rxode2 — `predict` (11), `issue-281` (14), `issue-502` (1), `keep` (96) — all pass.

Note: the original `packageVersion("rxode2")` *"no package called 'rxode2'"* errors were a `load_all`-without-install artifact, not a real rxode2 break — they do not occur when rxode2 is installed (the real reverse-dep/CRAN scenario).

🤖 Generated with [Claude Code](https://claude.com/claude-code)