### PR TITLE
Fix rx_solve accessor regression that broke babelmixr2 loading

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -155,11 +155,16 @@
 - The C accessors exposed through the function-pointer API (`getRxNsub()`,
   `getSolvingOptions()`, `getSolvingOptionsInd()`, and the other `rx_solve*`
   accessors) no longer segfault when handed a `NULL` or uninitialized solve.
-  They now fall back to the global solve and, if it is still not set up, raise a
-  normal catchable R error stating that the solving environment is not set up,
-  instead of dereferencing a `NULL` pointer and crashing the R process.  This
-  hardens downstream packages that call an accessor before their solve pointer
-  has been populated (for example a cold first `nls`/`nlm` fit in `nlmixr2est`).
+  They fall back to the global solve; a scalar counter/flag accessor (`nsub`,
+  `nall`, `nobs`, `npars`, ...) simply reports zero before any solve, exactly as
+  before, so downstream code that probes those counts at load time keeps working
+  (for example babelmixr2's PopED integration, which queries them from
+  `.onLoad`).  An accessor that must dereference a per-subject record
+  (`getSolvingOptionsInd()`) instead raises a normal catchable R error stating
+  that the solving environment is not set up, rather than dereferencing a `NULL`
+  pointer and crashing the R process.  This hardens downstream packages that call
+  an accessor before their solve pointer has been populated (for example a cold
+  first `nls`/`nlm` fit in `nlmixr2est`).
 
 - A Jacobian entry `df(state)/dy(THETA[n])` or `df(state)/dy(ETA[n])` (a
   bracketed parameter reference, which the grammar accepts) no longer segfaults.

--- a/src/rx2api.c
+++ b/src/rx2api.c
@@ -24,14 +24,20 @@ rx_solve *getRxSolve_(void);
 //
 // Call sites pass `__func__` for `what` so the reported accessor name always
 // matches the calling function without manual upkeep across renames.
+// Shared "solve not set up" message body reused by the accessors below so the
+// wording cannot drift between call sites.  %s is the accessor name; the trailing
+// %s is a branch-specific clause describing exactly which piece is missing.
+#define RX_SOLVE_NOT_SETUP_FMT                                          \
+  "rxode2: cannot access the solve (%s): the solving environment is "   \
+  "not set up. This usually means a solve accessor was called before "  \
+  "rxSolve() populated the solving environment (%s)."
+
 static inline rx_solve *rxSolveOrError(rx_solve *rx, const char *what) {
   if (rx == NULL) {
     rx = getRxSolve_();
   }
   if (rx == NULL || rx->op == NULL) {
-    Rf_error("rxode2: cannot access the solve (%s): the solving environment is not set up. "
-             "This usually means a solve accessor was called before rxSolve() populated the "
-             "solving environment (rx_solve is NULL/uninitialized).", what);
+    Rf_error(RX_SOLVE_NOT_SETUP_FMT, what, "rx_solve is NULL/uninitialized");
   }
   return rx;
 }
@@ -45,15 +51,17 @@ rx_solving_options_ind *getSolvingOptionsInd(rx_solve *rx, int id) {
   rx = rxSolveOrError(rx, __func__);
   // Unlike the scalar accessors, this dereferences the subject array, so an
   // un-populated solve (subjects still NULL, before any rxSolve()) is fatal
-  // here -- raise the clean R error instead of crashing on NULL.
+  // here -- raise the clean R error instead of crashing on NULL.  The `rx`
+  // itself is the (non-NULL) global here, so the message names the actually
+  // missing piece: no solve has populated the subject array yet.
   if (rx->subjects == NULL) {
-    Rf_error("rxode2: cannot access the solve (%s): the solving environment is not set up. "
-             "This usually means a solve accessor was called before rxSolve() populated the "
-             "solving environment (rx_solve is NULL/uninitialized).", __func__);
+    Rf_error(RX_SOLVE_NOT_SETUP_FMT, __func__, "no solve has populated the subject array yet");
   }
-  uint32_t nall = rx->nsub*rx->nsim;
-  if (id < 0 || (uint32_t)id >= nall) {
-    Rf_error("[getSolvingOptionsInd]: id (%d) should be between [0, %u); nsub: %u nsim: %u", id, (unsigned int)nall, (unsigned int)rx->nsub, (unsigned int)rx->nsim);
+  // nsub/nsim are uint32_t; multiply in 64-bit so the product cannot wrap and
+  // corrupt the bounds check for large subject/simulation counts.
+  uint64_t nall = (uint64_t)rx->nsub*(uint64_t)rx->nsim;
+  if (id < 0 || (uint64_t)id >= nall) {
+    Rf_error("[getSolvingOptionsInd]: id (%d) should be between [0, %llu); nsub: %u nsim: %u", id, (unsigned long long)nall, (unsigned int)rx->nsub, (unsigned int)rx->nsim);
   }
   return &(rx->subjects[id]);
 }

--- a/src/rx2api.c
+++ b/src/rx2api.c
@@ -7,13 +7,20 @@ rx_solve *getRxSolve_(void);
 // function-pointer table and may hand us a NULL `rx` if their cached solve
 // pointer has not been populated yet (e.g. an accessor is called before
 // `rx = getRxSolve_()` on a cold first fit).  Rather than dereference NULL and
-// segfault the host process, fall back to the global solve structure and then
-// verify the solve has actually been set up.  If it has not, raise a clean R
-// error (which the caller can catch) instead of crashing somewhere downstream.
+// segfault the host process, fall back to the global solve structure so the
+// returned `rx` (and its `rx->op`) is always safe to read.
 //
 // The global solve struct (`&rx_global`) and its options (`&op_global`) are
-// static, so the meaningful "not set up" signal is `rx->subjects` (backed by
-// `inds_global`, which stays NULL until a solve allocates the subject array).
+// static storage, so reading a scalar counter/flag off `rx` or `rx->op` (nsub,
+// nall, nobs, npars, neq, nlhs, stiff, ...) is always memory-safe; before a
+// solve those scalars are simply zero.  Downstream code relies on this: e.g.
+// babelmixr2's PopED integration probes these counts at load time (in `.onLoad`
+// via `popedGetLoadedInfo()`), long before any `rxSolve()`, and expects zeros
+// rather than an error.  So this helper does NOT treat an un-populated solve as
+// fatal -- the "not set up" signal (`rx->subjects == NULL`, backed by
+// `inds_global`, which stays NULL until a solve allocates the subject array) is
+// checked at the one place that actually dereferences a subject
+// (`getSolvingOptionsInd`), where dereferencing NULL would crash.
 //
 // Call sites pass `__func__` for `what` so the reported accessor name always
 // matches the calling function without manual upkeep across renames.
@@ -21,7 +28,7 @@ static inline rx_solve *rxSolveOrError(rx_solve *rx, const char *what) {
   if (rx == NULL) {
     rx = getRxSolve_();
   }
-  if (rx == NULL || rx->op == NULL || rx->subjects == NULL) {
+  if (rx == NULL || rx->op == NULL) {
     Rf_error("rxode2: cannot access the solve (%s): the solving environment is not set up. "
              "This usually means a solve accessor was called before rxSolve() populated the "
              "solving environment (rx_solve is NULL/uninitialized).", what);
@@ -36,6 +43,14 @@ rx_solving_options* getSolvingOptions(rx_solve* rx) {
 
 rx_solving_options_ind *getSolvingOptionsInd(rx_solve *rx, int id) {
   rx = rxSolveOrError(rx, __func__);
+  // Unlike the scalar accessors, this dereferences the subject array, so an
+  // un-populated solve (subjects still NULL, before any rxSolve()) is fatal
+  // here -- raise the clean R error instead of crashing on NULL.
+  if (rx->subjects == NULL) {
+    Rf_error("rxode2: cannot access the solve (%s): the solving environment is not set up. "
+             "This usually means a solve accessor was called before rxSolve() populated the "
+             "solving environment (rx_solve is NULL/uninitialized).", __func__);
+  }
   uint32_t nall = rx->nsub*rx->nsim;
   if (id < 0 || (uint32_t)id >= nall) {
     Rf_error("[getSolvingOptionsInd]: id (%d) should be between [0, %u); nsub: %u nsim: %u", id, (unsigned int)nall, (unsigned int)rx->nsub, (unsigned int)rx->nsim);


### PR DESCRIPTION
## Reverse-dependency regression found on `main`

Doing a reverse-dependency check of `main` (`aa7ec2c99`) against the current
CRAN/dev reverse dependencies surfaced one hard break: **babelmixr2 fails to
load** under `main`, taking its entire test suite down at startup:

```
Error in popedGetLoadedInfo() :
  rxode2: cannot access the solve (getRxNsub): the solving environment is not
  set up. ... (rx_solve is NULL/uninitialized).
Calls: <Anonymous> ... run_pkg_hook -> popedGetLoadedInfo -> .Call
```

### Root cause

The #1143 accessor hardening (`rxSolveOrError` in `src/rx2api.c`) treats an
un-populated solve (`rx->subjects == NULL`, i.e. before any `rxSolve()`) as
**fatal for every accessor** -- including the scalar counters/flags
(`getRxNsub`, `getRxNall`, `getRxNobs`, `getRxNobs2`, `getRxNpars`, ...) that
only read a field of the always-valid global solve struct (`&rx_global` /
`&op_global`, static storage; zero before a solve).

Under CRAN rxode2 5.1.2 those scalar accessors returned **0** pre-solve, and
downstream code depends on that: babelmixr2's PopED integration probes these
counts at **package-load time** (`.onLoad` -> `popedGetLoadedInfo()` ->
`getRxNsub()`), long before any solve exists. babelmixr2 even guards
`if (rx == NULL) return zeros;`, but `getRxSolve_()` always returns the non-NULL
global, so the guard is bypassed and the hardened accessor throws.

`main`'s new behavior therefore broke a released reverse dependency.
Per repo policy, reverse-dependency compatibility is fixed here in rxode2 (a
released reverse dependency cannot be patched retroactively).

### Fix

- Reading a scalar off `&rx_global` / `&op_global` is always memory-safe, so
  `rxSolveOrError` no longer treats `subjects == NULL` as fatal -- it only guards
  `rx == NULL` / `rx->op == NULL`. Scalar accessors again report 0 pre-solve,
  exactly as CRAN 5.1.2 did.
- The `subjects == NULL` guard moves to `getSolvingOptionsInd()`, the one
  accessor that actually dereferences a per-subject record, so an out-of-order
  per-subject access still raises the same clean, catchable R error instead of
  segfaulting. (#1143's crash protection is preserved exactly where the deref
  happens.)
- `NEWS.md`: the #1143 bug-fix bullet is updated to describe the corrected
  behavior.

Only babelmixr2's `zzz.R` calls a solve accessor at load; no other reverse
dependency hits this path.

### Verification (against `main` + this fix)

| Reverse dependency | Result |
|---|---|
| babelmixr2 loads + `popedGetLoadedInfo()` pre-solve | now returns all-zeros (was: error) |
| babelmixr2 suite | 472 pass (1 unrelated failure: a dev babelmixr2/nlmixr2est `iterPrintControl$every` default skew, no rxode2 in the path) |
| nonmem2rx suite | FAIL 0 / PASS 1568 |
| monolix2rx suite | FAIL 0 / PASS 440 |
| nlmixr2est targeted (ar-est, cold-fit, focei) | FAIL 0 / PASS 22 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)