### PR TITLE
Invalidate cached simulation model when piping models with persistent meta

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,18 @@
 
 ## Bug fixes
 
+### Model piping
+
+- Model piping now invalidates the cached simulation model
+  (`$meta$.simModelBase`) when a model that keeps a persistent `meta`
+  environment is modified.  `.newModelAdjust()` copies the previous model's
+  `meta` env (to retain sticky items), which also carried the stale
+  `.simModelBase` cache; `.copyUi()`/`.copyEnv()` already drop it, but this
+  path did not.  As a result, appending a compartment/state to such a model
+  (e.g. a `nonmem2rx` import: `mod %>% model(d/dt(AUC) <- f, append=TRUE)`)
+  silently dropped the new state from the solved output.  The stale cache is
+  now cleared so the modified model rebuilds it.
+
 ### Compilation
 
 - Silenced the CRAN `-Wlto-type-mismatch` warnings seen with LTO/gcc builds.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,15 +4,16 @@
 
 ### Model piping
 
-- Model piping now invalidates the cached simulation model
-  (`$meta$.simModelBase`) when a model that keeps a persistent `meta`
-  environment is modified.  `.newModelAdjust()` copies the previous model's
-  `meta` env (to retain sticky items), which also carried the stale
-  `.simModelBase` cache; `.copyUi()`/`.copyEnv()` already drop it, but this
-  path did not.  As a result, appending a compartment/state to such a model
-  (e.g. a `nonmem2rx` import: `mod %>% model(d/dt(AUC) <- f, append=TRUE)`)
-  silently dropped the new state from the solved output.  The stale cache is
-  now cleared so the modified model rebuilds it.
+- Model piping no longer shares the `meta` environment by reference between
+  the original and the piped model.  `.newModelAdjust()` assigned the previous
+  model's `meta` env directly (to retain sticky items), so both models shared
+  one env -- including the cached simulation model (`$meta$.simModelBase`).
+  Whichever model was solved first cached its simulation model for both, so a
+  piped model could silently drop an appended compartment/state (e.g. a
+  `nonmem2rx` import: `mod %>% model(d/dt(AUC) <- f, append=TRUE)`) or the
+  original model could silently gain the piped model's states/estimates.  The
+  meta env is now copied via `.copyEnv()` (which drops `.simModelBase`), so
+  each model keeps its own cache.
 
 ### Compilation
 

--- a/R/piping.R
+++ b/R/piping.R
@@ -1,3 +1,27 @@
+#' Fork a model's meta environment for piping
+#'
+#' Shallow copy: only the meta environment itself is new, so the piped and
+#' original model no longer share the `.simModelBase` cache slot (which is
+#' dropped here, as in .copyEnv/.copyUi).  Bindings are carried over as-is --
+#' nested environments stay shared and closures keep their environment -- so
+#' reference-semantics metadata behaves exactly as it did when meta was shared.
+#'
+#' @param env meta environment to fork
+#'
+#' @return New meta environment
+#' @author Matthew L. Fidler
+#' @noRd
+.copyMetaForPiping <- function(env) {
+  .ret <- new.env(parent=parent.env(env))
+  lapply(ls(envir=env, all.names=TRUE), function(item) {
+    if (item == ".simModelBase") {
+      return(NULL)
+    }
+    assign(item, get(item, envir=env), envir=.ret)
+  })
+  .ret
+}
+
 #' Copy an environment and all of its contents
 #'
 #' This is a recursive copy that creates a new environment for every

--- a/R/ui-assign-parts.R
+++ b/R/ui-assign-parts.R
@@ -123,13 +123,14 @@
   lapply(c("meta", "sticky", "model", "modelName"), function(x) {
     if (exists(x, envir=oldModel)) {
       if (x == "meta") {
-        # meta must be copied, not shared by reference: the simulation-model
-        # cache (`.simModelBase`) lives in meta, so a shared env would let
-        # either model pick up the other's cached simulation model after
-        # piping.  .copyEnv() drops `.simModelBase`, matching .copyUi() and
-        # the invariant in rxUiGet.simulationModel that piping creates a new
-        # meta env.
-        assign(x, .copyEnv(get(x, envir=oldModel)), envir=newModel)
+        # meta must be forked, not shared by reference: the simulation-model
+        # cache (`.simModelBase`) lives in meta, so a shared env lets either
+        # model pick up the other's cached simulation model after piping.
+        # This is the invariant rxUiGet.simulationModel documents and
+        # .copyUi() already follows.  The fork is shallow (see
+        # .copyMetaForPiping) so metadata carried over keeps the reference
+        # semantics it had when meta was shared.
+        assign(x, .copyMetaForPiping(get(x, envir=oldModel)), envir=newModel)
       } else {
         assign(x, get(x, envir=oldModel), envir=newModel)
       }

--- a/R/ui-assign-parts.R
+++ b/R/ui-assign-parts.R
@@ -125,6 +125,18 @@
       assign(x, get(x, envir=oldModel), envir=newModel)
     }
   })
+  # The meta env copied above carries the cached simulation model
+  # (`.simModelBase`), which describes the *old* model.  It must be dropped so
+  # the modified model rebuilds it -- consistent with .copyUi()/.copyEnv(),
+  # which already exclude `.simModelBase`.  Without this, models that keep a
+  # persistent meta env across piping (e.g. nonmem2rx imports) reuse the stale
+  # cache and silently drop newly appended compartments/states from solves.
+  if (exists("meta", envir=newModel)) {
+    .metaEnv <- get("meta", envir=newModel)
+    if (exists(".simModelBase", envir=.metaEnv, inherits=FALSE)) {
+      rm(list=".simModelBase", envir=.metaEnv)
+    }
+  }
   if (rename || .modelsNearlySame(newModel, oldModel)) {
     lapply(.getAllSigEnv(oldModel),
            function(x) {

--- a/R/ui-assign-parts.R
+++ b/R/ui-assign-parts.R
@@ -122,21 +122,19 @@
   oldModel <- rxUiDecompress(oldModel)
   lapply(c("meta", "sticky", "model", "modelName"), function(x) {
     if (exists(x, envir=oldModel)) {
-      assign(x, get(x, envir=oldModel), envir=newModel)
+      if (x == "meta") {
+        # meta must be copied, not shared by reference: the simulation-model
+        # cache (`.simModelBase`) lives in meta, so a shared env would let
+        # either model pick up the other's cached simulation model after
+        # piping.  .copyEnv() drops `.simModelBase`, matching .copyUi() and
+        # the invariant in rxUiGet.simulationModel that piping creates a new
+        # meta env.
+        assign(x, .copyEnv(get(x, envir=oldModel)), envir=newModel)
+      } else {
+        assign(x, get(x, envir=oldModel), envir=newModel)
+      }
     }
   })
-  # The meta env copied above carries the cached simulation model
-  # (`.simModelBase`), which describes the *old* model.  It must be dropped so
-  # the modified model rebuilds it -- consistent with .copyUi()/.copyEnv(),
-  # which already exclude `.simModelBase`.  Without this, models that keep a
-  # persistent meta env across piping (e.g. nonmem2rx imports) reuse the stale
-  # cache and silently drop newly appended compartments/states from solves.
-  if (exists("meta", envir=newModel)) {
-    .metaEnv <- get("meta", envir=newModel)
-    if (exists(".simModelBase", envir=.metaEnv, inherits=FALSE)) {
-      rm(list=".simModelBase", envir=.metaEnv)
-    }
-  }
   if (rename || .modelsNearlySame(newModel, oldModel)) {
     lapply(.getAllSigEnv(oldModel),
            function(x) {

--- a/tests/testthat/test-ui-piping.R
+++ b/tests/testthat/test-ui-piping.R
@@ -2367,8 +2367,9 @@ rxTest({
 
   test_that("piping appends a state after the simulation model is cached (persistent meta)", {
     # Realizing $simulationModel populates meta$.simModelBase.  Piping copies
-    # the previous model's meta env (to keep sticky items), so the cache must
-    # be invalidated -- otherwise the appended state is missing from the solve.
+    # the previous model's meta env (to keep sticky items); the copy must not
+    # share the env by reference -- otherwise either model can pick up the
+    # other's cached simulation model, in whichever order they are solved.
     f <- function() {
       ini({
         ke <- 1
@@ -2385,10 +2386,36 @@ rxTest({
     expect_false(is.null(m$simulationModel))
 
     m2 <- m %>% model(d/dt(AUC) <- cp, append = TRUE)
+    # the meta env must not be shared by reference after piping
+    expect_false(identical(rxUiDecompress(m)$meta, rxUiDecompress(m2)$meta))
     # the appended state must be present in the (rebuilt) simulation model
     expect_true("AUC" %in% rxModelVars(m2$simulationModel)$state)
 
-    s <- suppressWarnings(rxSolve(m2, et(amt = 100, cmt = "CENTRAL") %>% et(0:5)))
+    .ev <- et(amt = 100, cmt = "CENTRAL") %>% et(0:5)
+    s <- suppressWarnings(rxSolve(m2, .ev))
     expect_true("AUC" %in% names(s))
+
+    # solving the piped model must not contaminate the original model
+    expect_false("AUC" %in% rxModelVars(m$simulationModel)$state)
+    s1 <- suppressWarnings(rxSolve(m, .ev))
+    expect_false("AUC" %in% names(s1))
+
+    # reverse order: solve the original first, then the piped model
+    m3 <- rxode2(f)
+    expect_false(is.null(m3$simulationModel))
+    m4 <- m3 %>% model(d/dt(AUC) <- cp, append = TRUE)
+    s3 <- suppressWarnings(rxSolve(m3, .ev))
+    expect_false("AUC" %in% names(s3))
+    s4 <- suppressWarnings(rxSolve(m4, .ev))
+    expect_true("AUC" %in% names(s4))
+
+    # ini() piping must not leak the piped estimates into the original's
+    # cached simulation model (theta is stored on the cached TOS)
+    m5 <- rxode2(f)
+    expect_false(is.null(m5$simulationModel))
+    m6 <- m5 %>% ini(ke = 5)
+    expect_false(is.null(m6$simulationModel))
+    expect_equal(m5$simulationModel$theta[["ke"]], 1)
+    expect_equal(m6$simulationModel$theta[["ke"]], 5)
   })
 })

--- a/tests/testthat/test-ui-piping.R
+++ b/tests/testthat/test-ui-piping.R
@@ -2364,4 +2364,31 @@ rxTest({
 
 
   })
+
+  test_that("piping appends a state after the simulation model is cached (persistent meta)", {
+    # Realizing $simulationModel populates meta$.simModelBase.  Piping copies
+    # the previous model's meta env (to keep sticky items), so the cache must
+    # be invalidated -- otherwise the appended state is missing from the solve.
+    f <- function() {
+      ini({
+        ke <- 1
+        sd <- 0.1
+      })
+      model({
+        d/dt(CENTRAL) <- -ke * CENTRAL
+        cp <- CENTRAL
+        cp ~ add(sd)
+      })
+    }
+    m <- rxode2(f)
+    # prime the cached simulation model before modifying the model
+    expect_false(is.null(m$simulationModel))
+
+    m2 <- m %>% model(d/dt(AUC) <- cp, append = TRUE)
+    # the appended state must be present in the (rebuilt) simulation model
+    expect_true("AUC" %in% rxModelVars(m2$simulationModel)$state)
+
+    s <- suppressWarnings(rxSolve(m2, et(amt = 100, cmt = "CENTRAL") %>% et(0:5)))
+    expect_true("AUC" %in% names(s))
+  })
 })

--- a/tests/testthat/test-ui-piping.R
+++ b/tests/testthat/test-ui-piping.R
@@ -2418,4 +2418,45 @@ rxTest({
     expect_equal(m5$simulationModel$theta[["ke"]], 1)
     expect_equal(m6$simulationModel$theta[["ke"]], 5)
   })
+
+  test_that("forking the meta env on piping preserves metadata semantics", {
+    # Only the meta env itself is new; metadata carried over must behave as it
+    # did when meta was shared -- nested envs stay shared (reference
+    # semantics), closures keep working, and parent chains are intact.
+    f <- function() {
+      ini({
+        ke <- 1
+        sd <- 0.1
+      })
+      model({
+        d/dt(CENTRAL) <- -ke * CENTRAL
+        cp <- CENTRAL
+        cp ~ add(sd)
+      })
+    }
+    m <- rxode2(f)
+
+    .ctx <- new.env(parent = baseenv())
+    evalq({
+      k <- 1
+      getK <- function() k
+      expr <- quote(sum(1, 2))
+    }, .ctx)
+    m$ctx <- .ctx
+    m$plainMeta <- "kept"
+
+    m2 <- m %>% model(d/dt(AUC) <- cp, append = TRUE)
+
+    # plain metadata carries over
+    expect_equal(m2$ctx$k, 1)
+    expect_equal(m2$plainMeta, "kept")
+    # closures stored in meta still evaluate
+    expect_equal(m2$ctx$getK(), 1)
+    # parent chain of a nested env survives (baseenv() -> sum() visible)
+    expect_equal(eval(m2$ctx$expr, m2$ctx), 3)
+    # nested envs keep reference semantics: still the same env, not a clone
+    expect_true(identical(m2$ctx, .ctx))
+    m2$ctx$k <- 5
+    expect_equal(.ctx$getK(), 5)
+  })
 })


### PR DESCRIPTION
## Problem

Solving a piped model that keeps a persistent `meta` environment (e.g. a `nonmem2rx` import) silently drops states appended via model piping:

```r
mod    <- nonmem2rx(...)                                  # 2-cmt PK import
modAuc <- mod %>% model(d/dt(AUC) <- f, append=TRUE)     # add a running-AUC state
s      <- rxSolve(modAuc, ev)
plot(s, AUC)     # Error: the items requested in the plot do not exist in the solved object: AUC
```

`rxState(modAuc)` correctly lists `CENTRAL, PERI, AUC`, but `modAuc$simulationModel` (the model actually solved) has only `CENTRAL, PERI`.

## Root cause

The simulation model is cached in `$meta$.simModelBase`. `.copyUi()`/`.copyEnv()` drop that cache when they copy a UI, but `.newModelAdjust()` (run on piping) assigned the previous model's `meta` env **by reference** to retain sticky items. So after piping, the original and the piped model share one `meta` env, and with it one `.simModelBase` slot. Whichever model realizes `$simulationModel` first caches its compiled model for **both**:

- old model's cache already primed -> the piped model solves the pre-append model (the reported bug);
- piped model solved first -> the *original* model silently gains the piped model's states/estimates.

Models that reuse the same meta env across piping (nonmem2rx marks NONMEM metadata sticky) hit the first case reliably; plain models hit it whenever `$simulationModel` was touched before piping.

## Fix

`.newModelAdjust()` now forks the meta env instead of sharing it by reference, via a new `.copyMetaForPiping()`. The fork is deliberately shallow: only the meta env itself is new, so the two models stop sharing the `.simModelBase` slot, while nested environments stay shared and closures keep their environment -- metadata behaves exactly as it did when meta was shared. Each model keeps its own cache in either solve order, and the original model's primed cache survives piping.

An intermediate version used the recursive `.copyEnv()` here; that broke the parent chain of any environment stored in meta (`new.env(parent=emptyenv())`) and left closures pointing at the original model's state. The shallow fork avoids both, and avoids deep-copying large metadata on every piping step.

An earlier iteration of this PR only deleted `.simModelBase` once at piping time; that fixed the reported symptom but left the shared env, so the bug returned on the next solve. Independent reviews (Claude, GitHub Copilot, Antigravity/Gemini) all converged on the shared reference as the real defect.

## Verification

`rxSolve(modAuc, ev)` outputs `AUC`; solving the original model is unaffected in either order. The regression test covers both solve orders, meta-env separation, and `ini()` piping (cached `theta` isolation). `devtools::test(filter="piping|rename|assign-model")`: 903 passing, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

