### PR TITLE
fix(dde): delay()/past() models with an if/else block failed to solve (#1151)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,10 @@
 - `delay()`/`past()` models containing an `if`/`else` block failed to solve
   with `unexpected 'else'`: the DDE helpers parsed the `rxNorm()` text
   directly, which puts `}` and `else` on separate top-level lines; the
-  normalized text is now parsed wrapped in a `{ }` block (#1151).
+  normalized text is now parsed wrapped in a `{ }` block.  In addition, a
+  `past()` history inside an `if`/`else` branch is now rejected with a clear
+  error (it was invisible to validation), and delay-duration root-variable
+  resolution now sees assignments made inside `if`/`else` branches (#1151).
 
 - Fixed a cross-subject leak in batched multi-subject `linCmt()` solves: the
   per-thread inter-event amount buffer was never cleared between subjects, so

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,11 @@
 
 ## Bug fixes
 
+- `delay()`/`past()` models containing an `if`/`else` block failed to solve
+  with `unexpected 'else'`: the DDE helpers parsed the `rxNorm()` text
+  directly, which puts `}` and `else` on separate top-level lines; the
+  normalized text is now parsed wrapped in a `{ }` block (#1151).
+
 - Fixed a cross-subject leak in batched multi-subject `linCmt()` solves: the
   per-thread inter-event amount buffer was never cleared between subjects, so
   with `cores < nSub` every subject after the first on a thread could start

--- a/R/dde.R
+++ b/R/dde.R
@@ -12,8 +12,20 @@
 #' @return list of top-level statements (language objects).
 #' @noRd
 .rxNormStatements <- function(model) {
-  .e <- parse(text = paste0("{\n", rxNorm(model), "\n}"))[[1L]]
+  .e <- parse(text = paste0("{\n", paste(rxNorm(model), collapse = "\n"), "\n}"))[[1L]]
   as.list(.e)[-1L]
+}
+
+#' Is a statement a `past(state, tau) <- expr` assignment?
+#'
+#' @param x a language object.
+#' @return logical.
+#' @noRd
+.rxIsPastAssign <- function(x) {
+  is.call(x) && (identical(x[[1L]], quote(`=`)) ||
+                   identical(x[[1L]], quote(`<-`))) &&
+    is.call(x[[2L]]) && identical(x[[2L]][[1L]], quote(past)) &&
+    length(x[[2L]]) == 3L
 }
 
 #' Catalog the delay(state, T) terms in a model
@@ -96,14 +108,11 @@
   for (.i in seq_along(.e)) {
     .st <- .e[[.i]]
     ## past(state, tau) = expr  parses as `=`(past(state, tau), expr)
-    if (is.call(.st) && (identical(.st[[1L]], quote(`=`)) ||
-                           identical(.st[[1L]], quote(`<-`)))) {
+    if (.rxIsPastAssign(.st)) {
       .lhs <- .st[[2L]]
-      if (is.call(.lhs) && identical(.lhs[[1L]], quote(past)) && length(.lhs) == 3L) {
-        .found[[length(.found) + 1L]] <- list(state = deparse1(.lhs[[2L]]),
-                                              tau = deparse1(.lhs[[3L]]),
-                                              expr = deparse1(.st[[3L]]))
-      }
+      .found[[length(.found) + 1L]] <- list(state = deparse1(.lhs[[2L]]),
+                                            tau = deparse1(.lhs[[3L]]),
+                                            expr = deparse1(.st[[3L]]))
     }
   }
   if (length(.found) == 0L) return(NULL)
@@ -120,6 +129,23 @@
 #' @return invisibly NULL; errors on an invalid past() line.
 #' @noRd
 .rxValidatePast <- function(model) {
+  ## a past() history inside an if/else branch is invisible to the top-level
+  ## scan (and its conditional C emission would leave the history undefined on
+  ## the other branch): reject it outright
+  .assertNoNestedPast <- function(x) {
+    if (is.call(x)) {
+      if (.rxIsPastAssign(x)) {
+        stop(sprintf("past(%s, %s) must be at the top level of the model (not inside if/else)",
+                     deparse1(x[[2L]][[2L]]), deparse1(x[[2L]][[3L]])),
+             call. = FALSE)
+      }
+      for (.i in seq_along(x)) .assertNoNestedPast(x[[.i]])
+    }
+  }
+  for (.st in .rxNormStatements(model)) {
+    if (.rxIsPastAssign(.st)) next
+    .assertNoNestedPast(.st)
+  }
   .past <- .rxPastTerms(model)
   if (is.null(.past)) return(invisible(NULL))
   .states <- rxode2::rxStateOde(model)
@@ -153,25 +179,36 @@
 #' Named list of explicit assignments (lhs = rhs) in a model
 #'
 #' Skips ODE (`d/dt(...)`) and compartment-property lines; used to resolve a
-#' delay-duration expression down to its root symbols.
+#' delay-duration expression down to its root symbols.  Recurses into
+#' `if`/`else` branches; an lhs assigned more than once maps to a
+#' `(rhs1)+(rhs2)` union of its rhs texts so root-variable resolution stays
+#' conservative (any branch may execute).
 #'
 #' @param model anything `rxNorm()` accepts.
 #' @return named character vector mapping each assigned lhs to its rhs text.
 #' @noRd
 .rxModelDefs <- function(model) {
-  .e <- .rxNormStatements(model)
   .defs <- character(0)
-  for (.i in seq_along(.e)) {
-    .st <- .e[[.i]]
-    if (is.call(.st) && (identical(.st[[1]], quote(`=`)) ||
-                           identical(.st[[1]], quote(`<-`)))) {
-      .lhs <- .st[[2]]
+  .collect <- function(x) {
+    if (!is.call(x)) return(invisible(NULL))
+    if (identical(x[[1L]], quote(`=`)) || identical(x[[1L]], quote(`<-`))) {
+      .lhs <- x[[2L]]
       ## only simple `name = rhs` assignments (skip d/dt(x), f(x), etc.)
       if (is.name(.lhs)) {
-        .defs[[as.character(.lhs)]] <- deparse1(.st[[3]])
+        .nm <- as.character(.lhs)
+        .rhs <- deparse1(x[[3L]])
+        if (.nm %in% names(.defs) && !identical(.defs[[.nm]], .rhs)) {
+          .defs[[.nm]] <<- paste0("(", .defs[[.nm]], ")+(", .rhs, ")")
+        } else {
+          .defs[[.nm]] <<- .rhs
+        }
       }
+    } else if (identical(x[[1L]], quote(`if`)) || identical(x[[1L]], quote(`{`))) {
+      for (.i in seq_along(x)[-1L]) .collect(x[[.i]])
     }
+    invisible(NULL)
   }
+  for (.st in .rxNormStatements(model)) .collect(.st)
   .defs
 }
 

--- a/R/dde.R
+++ b/R/dde.R
@@ -2,6 +2,20 @@
 ## the delay(state, T) terms and splice the variational delayed term
 ## d f_i / d[delay(y_j, T)] * delay(S_j, T) into each sensitivity ODE.
 
+#' Top-level statements of a model's normalized text
+#'
+#' `rxNorm()` emits `if`/`else` with `}` and `else` on separate top-level
+#' lines, which is only valid R inside a `{ }` block; wrap before parsing
+#' (#1151).
+#'
+#' @param model anything `rxNorm()` accepts.
+#' @return list of top-level statements (language objects).
+#' @noRd
+.rxNormStatements <- function(model) {
+  .e <- parse(text = paste0("{\n", rxNorm(model), "\n}"))[[1L]]
+  as.list(.e)[-1L]
+}
+
 #' Catalog the delay(state, T) terms in a model
 #'
 #' Returns one row per distinct delayed term with a surrogate symbol name so
@@ -15,8 +29,7 @@
 #' @keywords internal
 #' @noRd
 .rxDelayTerms <- function(model) {
-  .norm <- rxNorm(model)
-  .e <- parse(text = .norm)
+  .e <- .rxNormStatements(model)
   .found <- list()
   .walk <- function(x) {
     if (is.call(x)) {
@@ -78,8 +91,7 @@
 #' @return list of {state, tau, expr} (character), or NULL if none.
 #' @noRd
 .rxPastTerms <- function(model) {
-  .norm <- rxNorm(model)
-  .e <- parse(text = .norm)
+  .e <- .rxNormStatements(model)
   .found <- list()
   for (.i in seq_along(.e)) {
     .st <- .e[[.i]]
@@ -147,8 +159,7 @@
 #' @return named character vector mapping each assigned lhs to its rhs text.
 #' @noRd
 .rxModelDefs <- function(model) {
-  .norm <- rxNorm(model)
-  .e <- parse(text = .norm)
+  .e <- .rxNormStatements(model)
   .defs <- character(0)
   for (.i in seq_along(.e)) {
     .st <- .e[[.i]]

--- a/tests/testthat/test-dde.R
+++ b/tests/testthat/test-dde.R
@@ -275,4 +275,71 @@ rxTest({
     .d <- rxSolve(.m, .p, .ev, cores = 2)
     for (.di in split(as.data.frame(.d), .d$sim.id)) .check(.di)
   })
+
+  test_that("delay()/past() models with an if/else block solve (#1151)", {
+    # rxNorm() emits `}` and `else` on separate top-level lines, which is only
+    # valid R inside a `{ }` block; .rxDelayTerms()/.rxPastTerms()/.rxModelDefs()
+    # used to parse the bare normalized text and choke on the `else`.
+    .m <- rxode2({
+      if (FLAG == 1) {
+        kx <- 0
+      } else {
+        kx <- 5
+      }
+      d/dt(A1) <- 1 - kg * A1
+      d/dt(A2) <- kx * delay(A1, tau1)
+    })
+    .dt <- .rxDelayTerms(.m)
+    expect_equal(.dt$state, "A1")
+    expect_equal(.dt$tau, "tau1")
+    expect_null(.rxPastTerms(.m))
+    expect_equal(.rxModelDefs(.m), character(0))
+
+    # past() line alongside the if/else still catalogs at the top level
+    .mp <- rxode2({
+      if (FLAG == 1) {
+        kx <- 0
+      } else {
+        kx <- 5
+      }
+      past(A1, tau1) <- 7
+      kel <- kg * 2
+      d/dt(A1) <- 1 - kg * A1
+      d/dt(A2) <- kx * delay(A1, tau1)
+    })
+    .pt <- .rxPastTerms(.mp)
+    expect_equal(.pt[[1L]]$state, "A1")
+    expect_equal(.pt[[1L]]$tau, "tau1")
+    expect_equal(.pt[[1L]]$expr, "7")
+    expect_equal(.rxModelDefs(.mp), c(kel = "kg * 2"))
+
+    # end-to-end solve of the issue reproducer
+    f <- function() {
+      ini({
+        kg <- 0.4
+        k4 <- 0.3
+        tau1 <- 5
+        prop.sd <- 0.1
+      })
+      model({
+        if (FLAG == 1) {
+          kx <- 0
+        } else {
+          kx <- 5
+        }
+        d/dt(A1) <- 1 - kg * A1
+        d/dt(A2) <- k4 * A1 - kx * delay(A1, tau1)
+        cp <- A2
+        cp ~ prop(prop.sd)
+      })
+    }
+    .ev <- et(seq(0, 20, by = 1))
+    .ev$FLAG <- 1
+    .s <- suppressWarnings(rxSolve(rxode2(f), .ev))
+    expect_true(all(is.finite(.s$cp)))
+
+    # and with an explicit past() history line
+    .s2 <- suppressWarnings(rxSolve(.mp, c(kg = 0.4, tau1 = 5), .ev))
+    expect_true(all(is.finite(.s2$A2)))
+  })
 })

--- a/tests/testthat/test-dde.R
+++ b/tests/testthat/test-dde.R
@@ -293,7 +293,8 @@ rxTest({
     expect_equal(.dt$state, "A1")
     expect_equal(.dt$tau, "tau1")
     expect_null(.rxPastTerms(.m))
-    expect_equal(.rxModelDefs(.m), character(0))
+    # branch assignments are collected as a conservative (rhs1)+(rhs2) union
+    expect_equal(.rxModelDefs(.m), c(kx = "(0)+(5)"))
 
     # past() line alongside the if/else still catalogs at the top level
     .mp <- rxode2({
@@ -311,7 +312,7 @@ rxTest({
     expect_equal(.pt[[1L]]$state, "A1")
     expect_equal(.pt[[1L]]$tau, "tau1")
     expect_equal(.pt[[1L]]$expr, "7")
-    expect_equal(.rxModelDefs(.mp), c(kel = "kg * 2"))
+    expect_equal(.rxModelDefs(.mp), c(kx = "(0)+(5)", kel = "kg * 2"))
 
     # end-to-end solve of the issue reproducer
     f <- function() {
@@ -341,5 +342,40 @@ rxTest({
     # and with an explicit past() history line
     .s2 <- suppressWarnings(rxSolve(.mp, c(kg = 0.4, tau1 = 5), .ev))
     expect_true(all(is.finite(.s2$A2)))
+  })
+
+  test_that("past() inside an if/else branch is rejected, not silently skipped (#1151)", {
+    # a conditional past() is invisible to the top-level scan and its C emission
+    # would leave the history undefined on the other branch
+    .m <- rxode2({
+      if (FLAG == 1) {
+        past(A1, tau1) <- 7
+      } else {
+        past(A1, tau1) <- 5
+      }
+      d/dt(A1) <- 1 - kg * A1
+      d/dt(A2) <- delay(A1, tau1)
+    })
+    expect_error(.rxValidatePast(.m), "top level")
+    .ev <- et(seq(0, 10, by = 1))
+    .ev$FLAG <- 1
+    expect_error(suppressWarnings(rxSolve(.m, c(kg = 0.4, tau1 = 5), .ev)),
+                 "top level")
+  })
+
+  test_that("a delay duration alias assigned inside if/else is still validated (#1151)", {
+    # tau resolves through a branch assignment; the sensitivity-parameter check
+    # must still see the dependence
+    .m <- rxode2({
+      if (FLAG == 1) {
+        tau1 <- exp(ltau)
+      } else {
+        tau1 <- 1
+      }
+      d/dt(A1) <- 1 - kg * A1
+      d/dt(A2) <- delay(A1, tau1)
+    })
+    expect_error(.rxDelayValidateTau(.m, "ltau"), "not yet supported")
+    expect_true(.rxDelayValidateTau(.m, "kg"))
   })
 })


### PR DESCRIPTION
Fixes #1151.

## Problem

`rxNorm()` emits `}` and `else` on separate top-level lines, which is only valid R inside a `{ }` block. `.rxDelayTerms()`, `.rxPastTerms()` and `.rxModelDefs()` parsed the bare normalized text with `parse()`, so every `delay()`/`past()` model that also contained an `if`/`else` block (routine for covariate logic, and emitted by nonmem2rx DDE translation) failed to solve with `unexpected 'else'`.

## Fix

- New shared helper `.rxNormStatements()` parses the normalized text wrapped in `{ }` and returns the top-level statement list; the three helpers use it.
- A side benefit: `.rxSensStrippable()` previously swallowed the parse error via `tryCatch` and could treat delayed sensitivity states as strippable in if/else DDE models; it now detects them correctly.

## Hardening from independent review (Gemini + GPT second-opinion reviews)

- `past()` inside an `if`/`else` branch is now rejected with a clear error at solve time instead of silently skipping validation (its conditional C emission would leave the history undefined on the other branch).
- `.rxModelDefs()` recurses into `if`/`else` branches (repeated lhs union as `(rhs1)+(rhs2)`), so `.rxDelayValidateTau()` still detects a parameter-dependent delay duration assigned conditionally.
- `.rxNormStatements()` collapses the `rxNorm()` output before wrapping so a zero-length input cannot recycle `paste0()` to `character(0)` and crash.

## Tests

Regression tests in `tests/testthat/test-dde.R`: helper-level checks, the full issue reproducer (plus a `past()` variant) solving end-to-end, the conditional-`past()` rejection, and the conditional delay-duration-alias validation. All 141 DDE tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)