### PR TITLE
Fix the sign of the Yeo-Johnson derivatives at lambda == 2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,14 @@
 
 ## Bug fixes
 
+- The first and second derivatives of the Yeo-Johnson transform (`rxTBSd()` and
+  `rxTBSd2()`) had the wrong sign for negative values when `lambda` was exactly
+  `2`.  There `yj(x) = -log(1 - x)`, so the derivatives are `1/(1 - x)` and
+  `1/(1 - x)^2`, both positive; the special case returned them negated, which
+  also contradicted the general formula's limit and made the derivative
+  discontinuous in `lambda` at `2`.  Since Yeo-Johnson is monotone increasing,
+  its first derivative must be positive everywhere.
+
 - The `parsed_md5` of a model no longer depends on how many models were built
   before it in the session.  `linCmtSens` was folded into the hash but only
   assigned *after* the model was parsed, so the first build of a session hashed

--- a/NEWS.md
+++ b/NEWS.md
@@ -70,6 +70,12 @@
     missing the `probit + yeoJohnson` case (returned `NA`).  The log-Jacobian
     itself (`powerL`) clamped the wrong term in its `logit` guard, giving an
     unprotected `log(0)` at the upper bound.
+  - For `boxCox`/`lnorm`, `rxTBSd()` and `rxTBSd2()` returned the clamp
+    constant `sqrt(.Machine$double.eps)` itself for `x` at or below the clamp
+    instead of clamping `x` and evaluating the derivative formula, making the
+    derivatives discontinuous (and ~15 orders of magnitude too small) at the
+    boundary.  The clamp now feeds the usual formula, matching how every other
+    transform in the family handles the guard.
 
 - The `parsed_md5` of a model no longer depends on how many models were built
   before it in the session.  `linCmtSens` was folded into the hash but only

--- a/NEWS.md
+++ b/NEWS.md
@@ -66,10 +66,11 @@
   - The `lambda` gradient of the transform log-Jacobian (`powerDL`, used by
     estimation routines) was wrong on the negative Yeo-Johnson branch
     (`-log1p(x)` instead of `-log1p(-x)`, `NaN` for `x < -1`), returned a
-    spurious `0` at exactly `lambda == 1` for `boxCox`/`yeoJohnson`, and was
-    missing the `probit + yeoJohnson` case (returned `NA`).  The log-Jacobian
-    itself (`powerL`) clamped the wrong term in its `logit` guard, giving an
-    unprotected `log(0)` at the upper bound.
+    spurious `0` at exactly `lambda == 1` for `boxCox`/`yeoJohnson`, was
+    missing the `probit + yeoJohnson` case (returned `NA`), and returned a
+    spurious `log(x)` (instead of `0`) for the lambda-free `lnorm` transform.
+    The log-Jacobian itself (`powerL`) clamped the wrong term in its `logit`
+    guard, giving an unprotected `log(0)` at the upper bound.
   - For `boxCox`/`lnorm`, `rxTBSd()` and `rxTBSd2()` returned the clamp
     constant `sqrt(.Machine$double.eps)` itself for `x` at or below the clamp
     instead of clamping `x` and evaluating the derivative formula, making the

--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,26 @@
   discontinuous in `lambda` at `2`.  Since Yeo-Johnson is monotone increasing,
   its first derivative must be positive everywhere.
 
+- Review of the fix above found further errors in the same transform family
+  (all pre-existing, none introduced by that fix):
+  - `rxTBSd2()` returned a wrong second derivative for the `logit` transform
+    (an algebra error in the closed form) and for the composed
+    `logit + yeoJohnson` / `probit + yeoJohnson` transforms, where the chain
+    rule used the first Yeo-Johnson derivative in place of the second and
+    dropped the inner-transform curvature term.
+  - `rxTBSi()` did not invert the composed `logit + yeoJohnson` /
+    `probit + yeoJohnson` transforms: it applied the forward Yeo-Johnson
+    transform (or skipped it entirely) instead of the inverse, so
+    `rxTBSi(rxTBS(x))` did not return `x` for `lambda != 1`.  This affected
+    simulation back-transforms of those error models.
+  - The `lambda` gradient of the transform log-Jacobian (`powerDL`, used by
+    estimation routines) was wrong on the negative Yeo-Johnson branch
+    (`-log1p(x)` instead of `-log1p(-x)`, `NaN` for `x < -1`), returned a
+    spurious `0` at exactly `lambda == 1` for `boxCox`/`yeoJohnson`, and was
+    missing the `probit + yeoJohnson` case (returned `NA`).  The log-Jacobian
+    itself (`powerL`) clamped the wrong term in its `logit` guard, giving an
+    unprotected `log(0)` at the upper bound.
+
 - The `parsed_md5` of a model no longer depends on how many models were built
   before it in the session.  `linCmtSens` was folded into the hash but only
   assigned *after* the model was parsed, so the first build of a session hashed

--- a/R/utils.R
+++ b/R/utils.R
@@ -455,6 +455,27 @@ gammapInva <- function(x, p) {
   }
 }
 
+#' Transform log-Jacobian (powerL) and its lambda gradient (powerDL)
+#'
+#' Internal test hook; the underlying C functions are only shared through
+#' `R_RegisterCCallable()` (consumed by nlmixr2est) and are otherwise
+#' unreachable from R.
+#'
+#' @param x numeric vector on the transformed scale
+#' @param lambda transform parameter
+#' @param low,high transform bounds
+#' @param transform integer transform code (same coding as `.rxTransform`)
+#' @param dLambda when `TRUE` return the lambda gradient (`powerDL`) instead
+#'   of the log-Jacobian (`powerL`)
+#' @return numeric vector
+#' @author Matthew L. Fidler
+#' @noRd
+.rxTransformL <- function(x, lambda = 1.0, low = 0.0, high = 1.0,
+                          transform = 2L, dLambda = FALSE) {
+  .Call(`_rxode2_powerLDL`, as.double(x), as.double(low), as.double(high),
+        as.double(lambda), as.integer(transform), as.integer(dLambda))
+}
+
 #' logit and inverse logit (expit) functions
 #'
 #' @param x Input value(s) in range \[low,high\] to translate -Inf to

--- a/inst/include/rxode2.h
+++ b/inst/include/rxode2.h
@@ -165,34 +165,12 @@ static inline double _powerDi(double x, double lambda, int yj0, double low, doub
   _splitYj(&yj0, &dist,  &yj);
   switch(yj){
   case 7: // inverse-Yeo Johnson followed by pnorm
-    if (lambda == 1.0) {
-      yjd = x;
-    } else if (x >= 0){
-      if (lambda == 0) yjd = log1p(x);
-      else yjd = (pow(x + 1.0, lambda) - 1.0)/lambda;
-    } else {
-      if (lambda == 2.0) yjd = -log1p(-x);
-      else {
-	l2 = 2.0 - lambda;
-	yjd = (1.0 - pow(1.0 - x, l2))/l2;
-      }
-    }
-    return (high-low)*Rf_pnorm5(x, 0, 1, 1, 0)+low;
+    yjd = _powerDi(x, lambda, 1, low, high);
+    return (high-low)*Rf_pnorm5(yjd, 0, 1, 1, 0)+low;
   case 6: // probitInverse
     return (high-low)*Rf_pnorm5(x, 0, 1, 1, 0)+low;
   case 5: // inverse-Yeo-Johnson followed by expit
-    if (lambda == 1.0) {
-      yjd = x;
-    } else if (x >= 0){
-      if (lambda == 0) yjd = log1p(x);
-      else yjd = (pow(x + 1.0, lambda) - 1.0)/lambda;
-    } else {
-      if (lambda == 2.0) yjd = -log1p(-x);
-      else {
-	l2 = 2.0 - lambda;
-	yjd = (1.0 - pow(1.0 - x, l2))/l2;
-      }
-    }
+    yjd = _powerDi(x, lambda, 1, low, high);
     return (high-low)/(1+exp(-yjd))+low;
   case 4:
     return (high-low)/(1+exp(-x))+low; // expit
@@ -353,29 +331,33 @@ static inline double _powerDD(double x, double lambda, int yj0, double low, doub
 static inline double _powerDDD(double x, double lambda, int yj0, double low, double high) __attribute__((unused));
 static inline double _powerDDD(double x, double lambda, int yj0, double low, double high){
   if (!R_finite(x)) return NA_REAL;
-  double x0 = x, hl, hl2, xl,  t1, dL, eri;
+  double x0 = x, hl, xl,  t1, dL, eri;
   int yj, dist;
   _splitYj(&yj0, &dist,  &yj);
   switch(yj){
   case 7:
+    // yj''(probit(x))*probit'(x)^2 + yj'(probit(x))*probit''(x)
     dL = _powerDD(x, lambda, 6, low, high);
-    return dL*dL*_powerDD(_powerD(x, lambda, 6, low, high), lambda, 1, low, high);
+    t1 = _powerD(x, lambda, 6, low, high);
+    return dL*dL*_powerDDD(t1, lambda, 1, low, high) +
+      _powerDD(t1, lambda, 1, low, high)*_powerDDD(x, lambda, 6, low, high);
   case 6: // derivative
     //10.026513098524*exp(erfinv(-1+2*(-low+x)/(high-low))^2)*M_SQRT_PI/2*exp((erfinv(-1+2*(-low+x)/(high-low)))^2)*erfinv(-1+2*(-low+x)/(high-low))/(high-low)^2
     hl = (high-low);
     eri = erfinv(-1+2*(-low+x)/hl);
     return 8.885765876316728650863*exp(2*eri*eri)*eri/(hl*hl);
   case 5:
-    //Derivative(logit(x), x)^2*Subs(Derivative(yeoJohnson(_xi_1), _xi_1, _xi_1), (_xi_1), (logit(x))) + Subs(Derivative(yeoJohnson(_xi_1), _xi_1), (_xi_1), (logit(x)))*Derivative(logit(x), x, x)
+    // yj''(logit(x))*logit'(x)^2 + yj'(logit(x))*logit''(x)
     dL = _powerDD(x, lambda, 4, low, high);
-    return dL*dL*_powerDD(_powerD(x, lambda, 4, low, high), lambda, 1, low, high);
+    t1 = _powerD(x, lambda, 4, low, high);
+    return dL*dL*_powerDDD(t1, lambda, 1, low, high) +
+      _powerDD(t1, lambda, 1, low, high)*_powerDDD(x, lambda, 4, low, high);
   case 4: // logit
-    // (high - low)^2/((-low + x)^4*(-1 + (high - low)/(-low + x))^2) - 2*(high - low)/((-low + x)^3*(-1 + (high - low)/(-low + x)))
+    // d2/dx2 logit((x-low)/(high-low)) = 1/(high-x)^2 - 1/(x-low)^2
     hl = (high - low);
-    hl2 = hl*hl;
     xl = (-low + x);
-    t1 = (-1.0 + hl/xl);
-    return 1.0*hl2/(hl2*hl2*t1*t1) - 2.0*hl/(xl*xl*xl*t1);
+    t1 = hl - xl;
+    return 1.0/(t1*t1) - 1.0/(xl*xl);
   case 3:
     if (x <= _eps) x0 = _eps;
     return -1/(x0*x0);
@@ -521,7 +503,7 @@ static inline double _powerL(double x, double lambda, int yj0, double low, doubl
     if (xl <= _eps) xl = _eps;
     hl = (high - low);
     hl2 = hl-xl;
-    if (xl <= _eps) hl2 = _eps;
+    if (hl2 <= _eps) hl2 = _eps;
     return log(hl)-log(xl)-log(hl2);
     /* return 0; */
   case 3:
@@ -564,6 +546,8 @@ static inline double _powerDL(double x, double lambda, int yj0, double low, doub
   int yj, dist;
   _splitYj(&yj0, &dist,  &yj);
   switch (yj){
+  case 7:
+    return _powerDL(_powerD(x, lambda, 6, low, hi), lambda, 1, low, hi);
   case 6:
     return 0; // does not depend on lambda
   case 5:
@@ -578,13 +562,13 @@ static inline double _powerDL(double x, double lambda, int yj0, double low, doub
     // For normal transform no dependence of lambda
     return 0;
   case 0:
-    if (lambda == 1.0) return 0;
+    // d/dlambda[(lambda-1)*log(x)] = log(x) for every lambda
     if (x <= _eps) x0 = _eps;
     return log(x0);
   case 1:
-    if (lambda == 1.0) return 0;
+    // d/dlambda[(lambda-1)*log1p(x)] and d/dlambda[(1-lambda)*log1p(-x)]
     if (x >= 0) return log1p(x);
-    return -log1p(x);
+    return -log1p(-x);
   }
   return NA_REAL;
   // d = 0.0 for cox box

--- a/inst/include/rxode2.h
+++ b/inst/include/rxode2.h
@@ -343,7 +343,7 @@ static inline double _powerDD(double x, double lambda, int yj0, double low, doub
       if (lambda == 0.0) return 1.0/(x + 1.0);
       return pow(x + 1.0, lambda-1.0);
     } else {
-      if (lambda == 2.0) return -1/(1.0 - x);
+      if (lambda == 2.0) return 1/(1.0 - x);
       return pow(1.0 - x, 1.0-lambda);
     }
   }
@@ -393,7 +393,7 @@ static inline double _powerDDD(double x, double lambda, int yj0, double low, dou
       if (lambda ==  0.0) return -1/((x + 1.0)*(x + 1.0));
       return (lambda-1.0)*pow(x + 1.0, lambda-2.0);
     } else {
-      if (lambda == 2.0) return -1/((1.0 - x)*(1.0 - x));
+      if (lambda == 2.0) return 1/((1.0 - x)*(1.0 - x));
       return -(1.0-lambda)*pow(1.0 - x, -lambda);
     }
   }

--- a/inst/include/rxode2.h
+++ b/inst/include/rxode2.h
@@ -305,13 +305,13 @@ static inline double _powerDD(double x, double lambda, int yj0, double low, doub
     hl = (high - low);
     return hl/(xl*(hl-xl));
   case 3:
-    if (x <= _eps) return x0 = _eps;
+    if (x <= _eps) x0 = _eps;
     return 1/x0;
   case 2:
     return 1.0;
   case 0:
     if (lambda == 1.0) return 1.0;
-    if (x <= _eps) return x0 = _eps;
+    if (x <= _eps) x0 = _eps;
     if (lambda == 0.0) return 1/x0;
     // pow(x,lambda)/lambda - 1/lambda
     return pow(x0, lambda-1);
@@ -365,7 +365,7 @@ static inline double _powerDDD(double x, double lambda, int yj0, double low, dou
     return 0;
   case 0:
     if (lambda == 1.0) return 0;
-    if (x <= _eps) return x0 = _eps;
+    if (x <= _eps) x0 = _eps;
     if (lambda == 0.0) return -1/(x0*x0);
     // pow(x,lambda)/lambda - 1/lambda
     return (lambda-1)*pow(x0, lambda-2);

--- a/inst/include/rxode2.h
+++ b/inst/include/rxode2.h
@@ -556,8 +556,8 @@ static inline double _powerDL(double x, double lambda, int yj0, double low, doub
     // For logit norm, no dependence on lambda
     return 0;
   case 3:
-    if (x <= _eps) x0 = _eps;
-    return log(x0);
+    // log-Jacobian of logNorm is -log(x): no dependence on lambda
+    return 0;
   case 2:
     // For normal transform no dependence of lambda
     return 0;

--- a/src/init.c
+++ b/src/init.c
@@ -709,6 +709,8 @@ SEXP _rxode2_rxode2Ptr(void) {
 
 SEXP _rxode2_powerD(SEXP, SEXP, SEXP, SEXP, SEXP,
                     SEXP);
+SEXP _rxode2_powerLDL(SEXP, SEXP, SEXP, SEXP, SEXP,
+                      SEXP);
 SEXP _rxode2_activationF(SEXP xS, SEXP typeS);
 SEXP _rxode2_activationF2(SEXP xS, SEXP aS, SEXP typeS);
 SEXP _rxode2_macros2micros(SEXP p1, SEXP v1,
@@ -763,6 +765,7 @@ void R_init_rxode2(DllInfo *info){
     {"_rxode2_itoletter", (DL_FUNC) &_rxode2_itoletter, 2},
     {"_rxode2_itostr", (DL_FUNC) &_rxode2_itostr, 2},
     {"_rxode2_powerD", (DL_FUNC) &_rxode2_powerD, 6},
+    {"_rxode2_powerLDL", (DL_FUNC) &_rxode2_powerLDL, 6},
     {"_rxode2_rxode2Ptr", (DL_FUNC) &_rxode2_rxode2Ptr, 0},
     {"_rxode2_iniDparserPtr", (DL_FUNC) &_rxode2_iniDparserPtr, 1},
     {"_iniPreciseSumsPtr", (DL_FUNC) &iniPreciseSumsPtr, 1},

--- a/src/utilc.cpp
+++ b/src/utilc.cpp
@@ -969,6 +969,9 @@ extern "C" SEXP _rxode2_powerLDL(SEXP xS, SEXP lowS, SEXP highS, SEXP lambdaS,
   int d = INTEGER(dS)[0];
   double low = REAL(lowS)[0], high = REAL(highS)[0],
     lambda = REAL(lambdaS)[0];
+  if (high <= low) {
+    (Rf_errorcall)(R_NilValue, _("'high' must be greater than 'low'"));
+  }
   double *xD = REAL(xS);
   int lenx = Rf_length(xS);
   SEXP ret = rx_protect.protect(Rf_allocVector(REALSXP, lenx));

--- a/src/utilc.cpp
+++ b/src/utilc.cpp
@@ -941,6 +941,45 @@ extern "C" SEXP _rxode2_powerD(SEXP xS, SEXP lowS, SEXP highS, SEXP lambdaS, SEX
   return ret;
 }
 
+// Internal test hook for the transform log-Jacobian (_powerL) and its
+// lambda gradient (_powerDL); these are only exported through
+// R_RegisterCCallable so they are otherwise unreachable from R.
+extern "C" SEXP _rxode2_powerLDL(SEXP xS, SEXP lowS, SEXP highS, SEXP lambdaS,
+                                 SEXP yjS, SEXP dS) {
+  rxProtect rx_protect;
+  if (Rf_length(yjS) != 1 || TYPEOF(yjS) != INTSXP) {
+    (Rf_errorcall)(R_NilValue, _("'yj' must be an integer of length 1"));
+  }
+  if (Rf_length(dS) != 1 || TYPEOF(dS) != INTSXP) {
+    (Rf_errorcall)(R_NilValue, _("'d' must be an integer of length 1"));
+  }
+  if (Rf_length(lambdaS) != 1 || TYPEOF(lambdaS) != REALSXP) {
+    (Rf_errorcall)(R_NilValue, _("'lambda' must be a numeric of length 1"));
+  }
+  if (Rf_length(lowS) != 1 || TYPEOF(lowS) != REALSXP) {
+    (Rf_errorcall)(R_NilValue, _("'low' must be a numeric of length 1"));
+  }
+  if (Rf_length(highS) != 1 || TYPEOF(highS) != REALSXP) {
+    (Rf_errorcall)(R_NilValue, _("'high' must be a numeric of length 1"));
+  }
+  if (TYPEOF(xS) != REALSXP) {
+    (Rf_errorcall)(R_NilValue, _("'x' must be a numeric vector"));
+  }
+  int yj = INTEGER(yjS)[0];
+  int d = INTEGER(dS)[0];
+  double low = REAL(lowS)[0], high = REAL(highS)[0],
+    lambda = REAL(lambdaS)[0];
+  double *xD = REAL(xS);
+  int lenx = Rf_length(xS);
+  SEXP ret = rx_protect.protect(Rf_allocVector(REALSXP, lenx));
+  double *retD = REAL(ret);
+  for (int i = lenx; i--;) {
+    retD[i] = d ? _powerDL(xD[i], lambda, yj, low, high) :
+      _powerL(xD[i], lambda, yj, low, high);
+  }
+  return ret;
+}
+
 extern "C" SEXP _vecDF(SEXP cv, SEXP n_) {
   rxProtect rx_protect;
   int n=0;

--- a/tests/testthat/test-yeojohnson-derivative.R
+++ b/tests/testthat/test-yeojohnson-derivative.R
@@ -101,4 +101,38 @@ rxTest({
     }
   })
 
+  # boxCox (yj = 0) and lnorm (yj = 3) clamp x at sqrt(.Machine$double.eps)
+  # for stability; the clamped x is then run through the usual derivative
+  # formula, so the derivatives are continuous at the clamp boundary (they
+  # used to return the clamp constant ~1.5e-8 itself below the boundary).
+  test_that("boxCox/lnorm derivatives clamp x and evaluate the formula", {
+    .eps <- sqrt(.Machine$double.eps)
+    x <- c(0, .eps, 0.5, 2)
+    xc <- pmax(x, .eps)
+    r <- .tbs(x, 1.0, 3)
+    expect_equal(r$d1, 1 / xc)
+    expect_equal(r$d2, -1 / (xc * xc))
+    for (lambda in c(0, 0.5, 2.0)) {
+      r <- .tbs(x, lambda, 0)
+      if (lambda == 0) {
+        expect_equal(r$d1, 1 / xc)
+        expect_equal(r$d2, -1 / (xc * xc))
+      } else {
+        expect_equal(r$d1, xc^(lambda - 1))
+        expect_equal(r$d2, (lambda - 1) * xc^(lambda - 2))
+      }
+    }
+  })
+
+  test_that("clamped boxCox/lnorm derivatives are continuous at the boundary", {
+    .eps <- sqrt(.Machine$double.eps)
+    x <- c(0, .eps * (1 + 1e-8))
+    r <- .tbs(x, 0.5, 0)
+    expect_equal(r$d1[1], r$d1[2], tolerance = 1e-6)
+    expect_equal(r$d2[1], r$d2[2], tolerance = 1e-6)
+    r <- .tbs(x, 1.0, 3)
+    expect_equal(r$d1[1], r$d1[2], tolerance = 1e-6)
+    expect_equal(r$d2[1], r$d2[2], tolerance = 1e-6)
+  })
+
 })

--- a/tests/testthat/test-yeojohnson-derivative.R
+++ b/tests/testthat/test-yeojohnson-derivative.R
@@ -174,6 +174,8 @@ rxTest({
     }
     # logit log-Jacobian is finite at the upper bound (clamped)
     expect_true(is.finite(.pL(1, 1, 4)))
+    expect_error(rxode2:::.rxTransformL(0.5, low = 1, high = 0, transform = 4L),
+                 "'high' must be greater than 'low'")
   })
 
 })

--- a/tests/testthat/test-yeojohnson-derivative.R
+++ b/tests/testthat/test-yeojohnson-derivative.R
@@ -54,4 +54,51 @@ rxTest({
     }
   })
 
+  # General transform model: yj code and bounds as covariates.  Codes: 4 logit,
+  # 5 logit + yeoJohnson, 6 probit, 7 probit + yeoJohnson; x in (lo, hi).  For
+  # yj 5/7, x below the midpoint gives a negative inner logit/probit value, so
+  # these also exercise the negative Yeo-Johnson branch (including lambda == 2).
+  .tbsModel <- function() {
+    model({
+      v <- rxTBS(xv, lam, yjc, lo, hi)
+      d1 <- rxTBSd(xv, lam, yjc, lo, hi)
+      d2 <- rxTBSd2(xv, lam, yjc, lo, hi)
+      vi <- rxTBSi(v, lam, yjc, lo, hi)
+    })
+  }
+
+  .tbs <- function(x, lambda, yjc, lo = 0, hi = 1) {
+    .et <- et(seq_along(x))
+    .et$xv <- x
+    .et$lam <- lambda
+    .et$yjc <- yjc
+    .et$lo <- lo
+    .et$hi <- hi
+    as.data.frame(rxSolve(.tbsModel, .et, cores = 1L))[, c("v", "d1", "d2", "vi")]
+  }
+
+  test_that("logit/probit (+ yeoJohnson) derivatives match finite differences", {
+    x <- c(0.15, 0.35, 0.5, 0.75, 0.9)
+    h <- 1e-6
+    for (yjc in c(4, 5, 7)) {
+      for (lambda in c(2.0, 1.0, 0.5, 0)) {
+        r <- .tbs(x, lambda, yjc)
+        fp <- .tbs(x + h, lambda, yjc)
+        fm <- .tbs(x - h, lambda, yjc)
+        expect_equal(r$d1, (fp$v - fm$v) / (2 * h), tolerance = 1e-4)
+        expect_equal(r$d2, (fp$d1 - fm$d1) / (2 * h), tolerance = 1e-4)
+      }
+    }
+  })
+
+  test_that("rxTBSi() inverts rxTBS() for the composed transforms", {
+    x <- c(0.15, 0.35, 0.5, 0.75, 0.9)
+    for (yjc in c(4, 5, 6, 7)) {
+      for (lambda in c(2.0, 1.0, 0.5, 0)) {
+        r <- .tbs(x, lambda, yjc)
+        expect_equal(r$vi, x, tolerance = 1e-6)
+      }
+    }
+  })
+
 })

--- a/tests/testthat/test-yeojohnson-derivative.R
+++ b/tests/testthat/test-yeojohnson-derivative.R
@@ -1,0 +1,57 @@
+rxTest({
+
+  # The Yeo-Johnson transform is monotone increasing, so rxTBSd() must be
+  # positive everywhere.  On the negative branch lambda == 2 is a special case
+  # (yj(x) = -log(1 - x)); it used to return the derivative with the wrong sign,
+  # which also made it disagree with the general formula in the limit.
+
+  .yjModel <- function() {
+    model({
+      v <- rxTBS(xv, lam, 1, 1, 0)
+      d1 <- rxTBSd(xv, lam, 1, 1, 0)
+      d2 <- rxTBSd2(xv, lam, 1, 1, 0)
+    })
+  }
+
+  .yj <- function(x, lambda) {
+    .et <- et(seq_along(x))
+    .et$xv <- x
+    .et$lam <- lambda
+    as.data.frame(rxSolve(.yjModel, .et, cores = 1L))[, c("v", "d1", "d2")]
+  }
+
+  test_that("yeoJohnson derivatives at lambda = 2 have the right sign (negative branch)", {
+    x <- c(-3, -1, -0.5)
+    r <- .yj(x, 2.0)
+    # yj(x) = -log(1 - x); yj'(x) = 1/(1 - x); yj''(x) = 1/(1 - x)^2
+    expect_equal(r$v, -log1p(-x))
+    expect_equal(r$d1, 1 / (1 - x))
+    expect_equal(r$d2, 1 / ((1 - x) * (1 - x)))
+    expect_true(all(r$d1 > 0))
+    expect_true(all(r$d2 > 0))
+  })
+
+  test_that("yeoJohnson derivatives are continuous in lambda at lambda = 2", {
+    x <- c(-3, -1, -0.5)
+    at2 <- .yj(x, 2.0)
+    lo <- .yj(x, 2.0 - 1e-6)
+    hi <- .yj(x, 2.0 + 1e-6)
+    expect_equal(at2$d1, lo$d1, tolerance = 1e-5)
+    expect_equal(at2$d1, hi$d1, tolerance = 1e-5)
+    expect_equal(at2$d2, lo$d2, tolerance = 1e-5)
+    expect_equal(at2$d2, hi$d2, tolerance = 1e-5)
+  })
+
+  test_that("yeoJohnson derivatives match finite differences on both branches", {
+    x <- c(-3, -1, -0.5, 0.5, 2)
+    h <- 1e-4
+    for (lambda in c(2.0, 0.5, 1.5, 0)) {
+      r <- .yj(x, lambda)
+      fp <- .yj(x + h, lambda)$v
+      fm <- .yj(x - h, lambda)$v
+      expect_equal(r$d1, (fp - fm) / (2 * h), tolerance = 1e-5)
+      expect_equal(r$d2, (fp - 2 * r$v + fm) / (h * h), tolerance = 1e-3)
+    }
+  })
+
+})

--- a/tests/testthat/test-yeojohnson-derivative.R
+++ b/tests/testthat/test-yeojohnson-derivative.R
@@ -80,7 +80,7 @@ rxTest({
   test_that("logit/probit (+ yeoJohnson) derivatives match finite differences", {
     x <- c(0.15, 0.35, 0.5, 0.75, 0.9)
     h <- 1e-6
-    for (yjc in c(4, 5, 7)) {
+    for (yjc in c(4, 5, 6, 7)) {
       for (lambda in c(2.0, 1.0, 0.5, 0)) {
         r <- .tbs(x, lambda, yjc)
         fp <- .tbs(x + h, lambda, yjc)
@@ -133,6 +133,47 @@ rxTest({
     r <- .tbs(x, 1.0, 3)
     expect_equal(r$d1[1], r$d1[2], tolerance = 1e-6)
     expect_equal(r$d2[1], r$d2[2], tolerance = 1e-6)
+  })
+
+  # powerL (log-Jacobian) and powerDL (its lambda gradient) are only shared
+  # via R_RegisterCCallable (nlmixr2est), so they are pinned through the
+  # internal .rxTransformL() test hook.
+  test_that("powerL/powerDL log-Jacobian and lambda gradient", {
+    .pL <- function(x, lambda, yj) {
+      rxode2:::.rxTransformL(x, lambda, transform = yj)
+    }
+    .pDL <- function(x, lambda, yj) {
+      rxode2:::.rxTransformL(x, lambda, transform = yj, dLambda = TRUE)
+    }
+    # yeoJohnson log-Jacobian: (lambda-1)*log1p(x) for x >= 0,
+    # (1-lambda)*log1p(-x) for x < 0
+    expect_equal(.pL(c(2, -0.5, -2), 0.5, 1),
+                 c(-0.5 * log1p(2), 0.5 * log1p(0.5), 0.5 * log1p(2)))
+    # lambda gradient log1p(x) / -log1p(-x), including at exactly lambda == 1
+    # (used to return 0 there) and x < -1 (used to be NaN)
+    for (lam in c(0.25, 1, 1.75)) {
+      expect_equal(.pDL(c(2, -0.5, -2), lam, 1),
+                   c(log1p(2), -log1p(0.5), -log1p(2)))
+    }
+    # boxCox gradient log(x), including at exactly lambda == 1
+    expect_equal(.pDL(2, 1, 0), log(2))
+    # lambda-free transforms have a zero gradient (norm, lnorm, logit, probit)
+    for (yj in c(2, 3, 4, 6)) {
+      expect_equal(.pDL(0.5, 0.7, yj), 0)
+    }
+    # composed transforms chain through the inner logit/probit value
+    # (yj = 7 used to return NA)
+    expect_equal(.pDL(0.25, 0.5, 5), -log1p(log(1 / 0.25 - 1)))
+    expect_equal(.pDL(0.25, 0.5, 7), -log1p(-qnorm(0.25)))
+    # powerDL is the lambda derivative of powerL
+    h <- 1e-6
+    for (yj in c(0, 1, 5, 7)) {
+      x <- c(2, -0.5, 0.35, 0.35)[match(yj, c(0, 1, 5, 7))]
+      fd <- (.pL(x, 0.75 + h, yj) - .pL(x, 0.75 - h, yj)) / (2 * h)
+      expect_equal(.pDL(x, 0.75, yj), fd, tolerance = 1e-6)
+    }
+    # logit log-Jacobian is finite at the upper bound (clamped)
+    expect_true(is.finite(.pL(1, 1, 4)))
   })
 
 })


### PR DESCRIPTION
## Summary

The `lambda == 2` special cases in the Yeo-Johnson derivative code return the
derivatives with the wrong sign on the negative branch.

For `x < 0` the Yeo-Johnson transform at `lambda == 2` is `yj(x) = -log(1 - x)`,
so

* `yj'(x)  = 1/(1 - x)`
* `yj''(x) = 1/(1 - x)^2`

both strictly positive. `inst/include/rxode2.h` returned `-1/(1 - x)` and
`-1/((1 - x)*(1 - x))`.

## Why the special cases are wrong, not the general formulas

Two checks that do not depend on redoing the derivation:

**1. They contradict their own general formula in the limit.** The lines
immediately following each special case handle general `lambda` and are correct:

* `pow(1 - x, 1 - lambda)` at `lambda = 2` is `(1 - x)^-1 = +1/(1 - x)`
* `-(1 - lambda)*pow(1 - x, -lambda)` at `lambda = 2` is `+1/(1 - x)^2`

Both have the opposite sign to the special case sitting directly above them, so
the derivative was discontinuous in `lambda` at exactly 2. On 5.1.4, at `x = -3`:

| lambda | `rxTBSd()` |
|---|---|
| 1.999999 | +0.25000035 |
| **2.0** | **-0.25** |
| 2.000001 | +0.24999965 |

**2. Yeo-Johnson is monotone increasing**, so its first derivative must be
positive for every `x` and every `lambda`. A negative value is impossible
regardless of any derivation.

## Reproduction

```r
m <- function() {
  model({
    v  <- rxTBS(xv, lam, 1, 1, 0)   # yj = 1 -> yeoJohnson
    d1 <- rxTBSd(xv, lam, 1, 1, 0)
    d2 <- rxTBSd2(xv, lam, 1, 1, 0)
  })
}
et <- et(1:3); et$xv <- c(-3, -1, -0.5); et$lam <- 2
rxSolve(m, et)[, c("v", "d1", "d2")]
```

Before:

```
          v         d1          d2
 -1.3862944 -0.2500000 -0.06250000
 -0.6931472 -0.5000000 -0.25000000
 -0.4054651 -0.6666667 -0.44444444
```

The values are right; both derivatives are negated. The closed form gives
`+0.25, +0.50, +0.667` and `+0.0625, +0.25, +0.4444`, which is also what a
central finite difference of `v` returns.

## Changes

Two characters, in `inst/include/rxode2.h`:

* `_powerDD()` (Yeo-Johnson first derivative, `x < 0`, `lambda == 2`):
  `-1/(1.0 - x)` becomes `1/(1.0 - x)`
* `_powerDDD()` (second derivative, same branch):
  `-1/((1.0 - x)*(1.0 - x))` becomes `1/((1.0 - x)*(1.0 - x))`

The composite `logit`-then-Yeo-Johnson and `probit`-then-Yeo-Johnson transforms
(`yj` cases 5 and 7) call this code recursively rather than repeating the
special case, so they are corrected by the same change. The forward transform
and the inverse were already correct, as are the `x >= 0` special cases at
`lambda == 0`, which agree with their general formula's limit.

## Scope and reachability

This is reachable only when `lambda` is **exactly** `2.0` -- every other value
takes the correct general branch. I did not find any code path that bounds
`lambda` at 2, so an optimiser will not land there by itself; the realistic
route is a user fixing `yeoJohnson(2)`. Low impact, but a clear correctness bug
with a two-character fix.

## Verification

Built from source and checked against the patched build:

* At `lambda = 2` on the negative branch, `rxTBSd()` and `rxTBSd2()` now match
  the closed forms `1/(1 - x)` and `1/(1 - x)^2` with an error of exactly 0.
* Both derivatives match central finite differences of `rxTBS()` at
  `lambda` in {0, 0.5, 1.5, 1.999999, 2, 2.000001} over `x` in
  {-3, -1, -0.5, 0.5, 2}, spanning both branches.
* The discontinuity in `lambda` is gone: the gap between `lambda = 2` and
  `lambda = 2 +/- 1e-6` falls from 1.33 to 3.5e-7 for the first derivative and
  from 0.89 to 2.6e-7 for the second.
* `rxTBSd()` is positive everywhere tested, as a monotone transform requires.
* `tests/testthat/test-dsl.R`: 1008 expectations, 0 failures.

## Tests

No existing test pinned these values, so nothing had to be updated -- but that
is also why the sign error survived. Adds
`tests/testthat/test-yeojohnson-derivative.R` (17 expectations) covering the
closed form at `lambda == 2`, continuity in `lambda` across the special case,
and finite differences on both branches for several `lambda`.

Built and tested on Windows, R 4.5.3.
