### PR TITLE
fix(et): hide imported covariate columns again in as.data.frame() (SimuRg revdep)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,16 @@
 
 ## Bug fixes
 
+### Event tables
+
+- `as.data.frame()` on an event table again hides covariate columns that simply
+  rode along with an imported data frame (`et(data)`), while still showing
+  columns assigned explicitly on the event table (`ev$wt <- 70`, #1154).  The
+  covariate is still used when solving.  Showing every non-canonical column
+  broke code that imports events and then joins its own covariates back onto
+  `as.data.frame(ev)`, since the join produced `wt.x`/`wt.y` and the model
+  parameter disappeared.
+
 ### Solving
 
 - Fixed an out-of-bounds thread index that could segfault a solve.  The

--- a/R/et-methods.R
+++ b/R/et-methods.R
@@ -74,6 +74,7 @@
   env$ndose <- .retEnv$ndose
   env$randomType <- .retEnv$randomType
   env$canResize <- .retEnv$canResize
+  .etAddExtraCols(env, .etExtraCols(.retEnv)) # nolint
   invisible(NULL)
 }
 
@@ -492,6 +493,7 @@
   .newEnv$ndose      <- env$ndose
   .newEnv$randomType <- env$randomType
   .newEnv$canResize  <- env$canResize
+  .newEnv$extraCols  <- .etExtraCols(env) # nolint
   .newEnv$methods <- .etBuildMethods(.newEnv)
   .cp <- list()
   attr(.cp, "names")     <- character(0)

--- a/R/et.R
+++ b/R/et.R
@@ -742,6 +742,7 @@ names.rxEt <- function(x) {
     .newEnv$show       <- .env0$show
     .newEnv$randomType <- .env0$randomType
     .newEnv$canResize  <- FALSE
+    .newEnv$extraCols  <- .etExtraCols(.env0) # nolint
     .newEnv$chunks     <- list()
     if (nrow(.sub) > 0L) {
       .newEnv$ids  <- sort(unique(as.integer(.sub$id)))
@@ -776,15 +777,47 @@ names.rxEt <- function(x) {
   invisible(NULL)
 }
 
+#' Non-canonical columns that were explicitly assigned on an event table
+#'
+#' Columns that merely rode along with an imported data frame are not
+#' listed here, so they stay hidden in the default `as.data.frame()`
+#' output the way they were before #1154.
+#'
+#' @param env event table environment (or `NULL`)
+#' @return character vector of column names, possibly empty
+#' @noRd
+.etExtraCols <- function(env) {
+  if (!is.environment(env)) return(character(0))
+  .extra <- env$extraCols
+  if (is.null(.extra)) return(character(0))
+  as.character(.extra)
+}
+
+#' Record a non-canonical column as explicitly assigned
+#'
+#' @param env event table environment to modify by reference
+#' @param cols character vector of column names to add
+#' @return nothing, called for the side effect on `env`
+#' @noRd
+.etAddExtraCols <- function(env, cols) {
+  if (!is.environment(env) || length(cols) == 0L) return(invisible(NULL))
+  env$extraCols <- unique(c(.etExtraCols(env), as.character(cols))) # nolint
+  invisible(NULL)
+}
+
 #' @export
 `$<-.rxEt` <- function(x, name, value) {
   .df <- .etMaterialize(x) # nolint
   .df[[name]] <- value
   .ret <- .rxEtRebuildShell(x, .df) # nolint
-  # an explicitly assigned canonical column should display, so the
-  # default as.data.frame() output reflects what will be solved (#1154)
+  # an explicitly assigned column should display, so the default
+  # as.data.frame() output reflects what will be solved (#1154)
   .env <- .rxEtEnv(.ret) # nolint
-  if (name %in% names(.env$show)) .env$show[name] <- TRUE
+  if (name %in% names(.env$show)) {
+    .env$show[name] <- TRUE
+  } else {
+    .etAddExtraCols(.env, name) # nolint
+  }
   .ret
 }
 
@@ -905,6 +938,7 @@ simulate.rxEt <- function(object, nsim = 1, seed = NULL, ...) {
       .newEnv$ndose      <- .env0$ndose
       .newEnv$randomType <- NA_integer_
       .newEnv$canResize  <- FALSE
+      .newEnv$extraCols  <- .etExtraCols(.env0) # nolint
       .newEnv$groups     <- .sim$groups
       .newEnv$chunks     <- .sim$chunks
       return(structure(c(list(.env = .newEnv),
@@ -1255,6 +1289,9 @@ etSeq <- function(..., samples = c("clear", "use"),
   .newEnv$ndose      <- .ndose
   .newEnv$randomType <- NA_integer_
   .newEnv$canResize  <- FALSE
+  .newEnv$extraCols  <- unique(unlist(lapply(.etItems, function(.a) {
+    .etExtraCols(.rxEtEnv(.a)) # nolint
+  }), use.names = FALSE))
   if (length(.newEnv$ids) > 1L) {
     .newEnv$show["id"] <- TRUE
   }
@@ -1397,6 +1434,9 @@ etRbind <- function(..., samples = c("use", "clear"),
   .newEnv$ndose      <- .ndose
   .newEnv$randomType <- NA_integer_
   .newEnv$canResize  <- FALSE
+  .newEnv$extraCols  <- unique(unlist(lapply(Filter(is.rxEt, .ets), function(.a) { # nolint
+    .etExtraCols(.rxEtEnv(.a)) # nolint
+  }), use.names = FALSE))
   if (length(.newEnv$ids) > 1L) {
     .newEnv$show["id"] <- TRUE
   }
@@ -1521,8 +1561,9 @@ as.data.frame.rxEt <- function(x, row.names = NULL, optional = FALSE, ...) {
   } else {
     .showCols <- names(.show)[.show]
     .showCols <- intersect(.showCols, names(.full))
-    # keep user-added columns (e.g. covariates from ev$wt <- ...), #1154
-    .extraCols <- setdiff(names(.full), names(.show))
+    # keep explicitly assigned columns (e.g. covariates from ev$wt <- ...), #1154
+    .extraCols <- intersect(.etExtraCols(.env), names(.full)) # nolint
+    .extraCols <- setdiff(.extraCols, .showCols)
     .full[, c(.showCols, .extraCols), drop = FALSE]
   }
 
@@ -1607,6 +1648,7 @@ etExpand <- function(et) {
   }
   .newEnv$randomType <- NA_integer_
   .newEnv$canResize  <- FALSE
+  .newEnv$extraCols  <- .etExtraCols(.env) # nolint
   structure(c(list(.env = .newEnv),
               .etBuildMethods(.newEnv)), # nolint
             class = "rxEt")

--- a/R/et.R
+++ b/R/et.R
@@ -805,6 +805,18 @@ names.rxEt <- function(x) {
   invisible(NULL)
 }
 
+#' Forget a non-canonical column that was removed from an event table
+#'
+#' @param env event table environment to modify by reference
+#' @param cols character vector of column names to drop
+#' @return nothing, called for the side effect on `env`
+#' @noRd
+.etDropExtraCols <- function(env, cols) {
+  if (!is.environment(env) || length(cols) == 0L) return(invisible(NULL))
+  env$extraCols <- setdiff(.etExtraCols(env), as.character(cols)) # nolint
+  invisible(NULL)
+}
+
 #' @export
 `$<-.rxEt` <- function(x, name, value) {
   .df <- .etMaterialize(x) # nolint
@@ -813,7 +825,10 @@ names.rxEt <- function(x) {
   # an explicitly assigned column should display, so the default
   # as.data.frame() output reflects what will be solved (#1154)
   .env <- .rxEtEnv(.ret) # nolint
-  if (name %in% names(.env$show)) {
+  if (is.null(value)) {
+    # the column was deleted, so it is neither shown nor tracked
+    .etDropExtraCols(.env, name) # nolint
+  } else if (name %in% names(.env$show)) {
     .env$show[name] <- TRUE
   } else {
     .etAddExtraCols(.env, name) # nolint

--- a/R/etNew.R
+++ b/R/etNew.R
@@ -598,6 +598,7 @@
   .env$ndose      <- 0L
   .env$randomType <- NA_integer_
   .env$canResize  <- TRUE
+  .env$extraCols  <- character(0)
   .env$methods <- .etBuildMethods(.env)
   .obj <- list(
     id = integer(0), low = numeric(0), time = numeric(0), high = numeric(0),
@@ -1372,6 +1373,7 @@ is.rxEt <- function(x) {
   .env$show[names(.env0$show)] <- .env$show[names(.env0$show)] | .env0$show
   .env$randomType <- .env0$randomType
   .env$canResize <- .env0$canResize
+  .etAddExtraCols(.env, .etExtraCols(.env0)) # nolint
   .et
 }
 

--- a/R/etVctrs.R
+++ b/R/etVctrs.R
@@ -22,7 +22,8 @@ NULL
     units = c(dosing = NA_character_, time = NA_character_),
     show = .etDefaultShow(), # nolint
     randomType = NA_integer_,
-    canResize = TRUE
+    canResize = TRUE,
+    extraCols = character(0)
   )
   .env <- tryCatch(.rxEtEnv(x), error = function(e) NULL) # nolint
   if (is.environment(.env)) {
@@ -30,6 +31,7 @@ NULL
     .meta$show <- .env$show
     .meta$randomType <- .env$randomType
     .meta$canResize <- .env$canResize
+    .meta$extraCols <- .etExtraCols(.env) # nolint
   }
   .lst <- attr(attr(x, "class"), ".rxode2.lst", exact = TRUE)
   if (is.na(.meta$randomType) && !is.null(.lst$randomType)) {
@@ -108,7 +110,8 @@ NULL
     ),
     show = .show,
     randomType = suppressWarnings(max(c(.x$randomType, .y$randomType), na.rm = TRUE)),
-    canResize = isTRUE(.x$canResize) && isTRUE(.y$canResize)
+    canResize = isTRUE(.x$canResize) && isTRUE(.y$canResize),
+    extraCols = unique(c(.x$extraCols, .y$extraCols))
   )
 }
 
@@ -128,7 +131,8 @@ NULL
     units = c(dosing = NA_character_, time = NA_character_),
     show = .etDefaultShow(), # nolint
     randomType = NA_integer_,
-    canResize = TRUE
+    canResize = TRUE,
+    extraCols = character(0)
   )
   if (is.null(meta)) return(.ret)
   if (!is.null(meta$units)) .ret$units[names(meta$units)] <- meta$units
@@ -137,6 +141,7 @@ NULL
   }
   if (!is.null(meta$randomType)) .ret$randomType <- as.integer(meta$randomType)
   if (!is.null(meta$canResize)) .ret$canResize <- isTRUE(meta$canResize)
+  if (!is.null(meta$extraCols)) .ret$extraCols <- as.character(meta$extraCols)
   if (is.infinite(.ret$randomType)) .ret$randomType <- NA_integer_
   .ret
 }
@@ -177,6 +182,7 @@ NULL
     .env$randomType <- .meta$randomType
   }
   .env$canResize <- .meta$canResize
+  .etAddExtraCols(.env, .meta$extraCols) # nolint
   .proxy <- .etMaterialize(.et) # nolint
   attr(.proxy, "class") <- c("rxEt", "data.frame")
   attr(.proxy, ".rxEtEnv") <- .env

--- a/tests/testthat/test-et.R
+++ b/tests/testthat/test-et.R
@@ -43,6 +43,28 @@ rxTest({
     expect_equal(unique(as.data.frame(.evc)$cmt), "depot")
   })
 
+  test_that("covariates riding along on an imported data frame stay hidden", {
+    # a covariate that came in with the imported data frame is not shown by
+    # default; downstream packages join it back on and would otherwise get
+    # duplicated `wt.x`/`wt.y` columns
+    .ev <- et(data.frame(id = 1, time = 0, evid = 1, cmt = 1, amt = 10, wt = 70))
+    expect_false("wt" %in% names(as.data.frame(.ev)))
+    expect_true("wt" %in% names(as.data.frame(.ev, all = TRUE)))
+    # the hidden covariate is still used when solving
+    .ev <- add.sampling(.ev, 0:3)
+    expect_false("wt" %in% names(as.data.frame(.ev)))
+    .m <- rxode2("v = 10 * (wt / 70)\nd/dt(ac) = -0.1 * ac\ncc = ac / v")
+    expect_equal(suppressWarnings(unique(rxSolve(.m, .ev)$v)), 10)
+    # an explicitly assigned covariate is still shown, and survives copies,
+    # row subsets and rbind
+    .ev$wt2 <- 80
+    expect_true("wt2" %in% names(as.data.frame(.ev)))
+    expect_true("wt2" %in% names(as.data.frame(.ev$copy())))
+    expect_true("wt2" %in% names(as.data.frame(.ev[1:2, ])))
+    expect_true("wt2" %in% names(as.data.frame(etRbind(.ev, .ev))))
+    expect_false("wt" %in% names(as.data.frame(etRbind(.ev, .ev))))
+  })
+
   test_that("et import rate=-2", {
 
     d <- data.frame(id = c(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),

--- a/tests/testthat/test-et.R
+++ b/tests/testthat/test-et.R
@@ -63,6 +63,17 @@ rxTest({
     expect_true("wt2" %in% names(as.data.frame(.ev[1:2, ])))
     expect_true("wt2" %in% names(as.data.frame(etRbind(.ev, .ev))))
     expect_false("wt" %in% names(as.data.frame(etRbind(.ev, .ev))))
+    # ... and through the vctrs rebuild path (vec_slice/vec_restore/vec_c)
+    expect_true("wt2" %in% names(as.data.frame(vctrs::vec_slice(.ev, 1))))
+    expect_false("wt" %in% names(as.data.frame(vctrs::vec_slice(.ev, 1))))
+    expect_true("wt2" %in% names(as.data.frame(vctrs::vec_c(.ev, .ev))))
+    # deleting the column forgets it rather than recording it
+    .ev$wt2 <- NULL
+    expect_false("wt2" %in% names(as.data.frame(.ev)))
+    expect_false("wt2" %in% .rxEtEnv(.ev)$extraCols)
+    .evn <- et(0:5)
+    .evn$never <- NULL
+    expect_equal(.rxEtEnv(.evn)$extraCols, character(0))
   })
 
   test_that("et import rate=-2", {


### PR DESCRIPTION
## Problem

The current `main` breaks the CRAN package [SimuRg](https://cran.r-project.org/package=SimuRg), which blocks the rxode2 CRAN submission.

`R CMD check` of SimuRg 0.2.0 (same tarball, only rxode2 differing):

| rxode2 | Result |
|---|---|
| `main` (b1d052a5c) | **Status: 1 ERROR** -- `[ FAIL 11 \| PASS 364 ]` |
| this branch | **Status: OK** |

## Root cause

#1154 changed `as.data.frame.rxEt()` to show **every** column that is not a canonical event-table column:

```r
.extraCols <- setdiff(names(.full), names(.show))
```

The intent was that a covariate assigned with `ev$wt <- 70` should be visible. But it also exposed covariates that merely rode along with an imported data frame. SimuRg's `sg_sim()` does `et(data)` to import events and then `dplyr::left_join()`s its own covariate frame onto `as.data.frame(ev)` -- correct under the released behavior, where the covariate was dropped. With the column now present the join produced `WTBL.x`/`WTBL.y`, the model parameter disappeared, and `rxSolve()` failed with:

```
The following parameter(s) are required for solving: WTBL
```

## Fix

Track the columns assigned *explicitly* on the event table in `env$extraCols` (set by `` `$<-.rxEt` ``) instead of inferring them from "not a canonical column", and propagate that set through every rxEt environment-construction site: `.newRxEt`, `.rxEtRebuildShell`, `[.rxEt`, `simulate.rxEt`, `etExpand`, `etSeq`, `etRbind`, `.etMethodCopy`, `.etMethodAddDosing`, and the vctrs rebuild path (`.rxEtMeta` / `.rxEtNormalizeMeta` / `.rxEtMetaCombine` / `.rxEtRebuild`).

Net behavior:

- `ev$wt <- 70` still displays -- #1154's intent is preserved.
- A covariate that came in with `et(data)` is hidden again, as it was in the released version.
- Either way the covariate is still used when solving, and remains reachable via `as.data.frame(ev, all = TRUE)`.
- `ev$wt <- NULL` now forgets the name rather than recording it.

## Review

Reviewed independently with Antigravity (`gemini-3.1-pro-high`). Two findings were confirmed and fixed in the second commit:

1. **Missed propagation site**: `.rxEtMeta()`/`.rxEtRebuild()` rebuild from a meta list rather than the source environment, so `extraCols` was dropped and an explicitly assigned covariate vanished after any vctrs-mediated operation (`vctrs::vec_slice(ev, 1)`).
2. **Stale `extraCols` on delete**: `` `$<-.rxEt` `` recorded the name even when the assignment removed the column.

Two further findings were checked and rejected as pre-existing rather than regressions from this change:

- `names(ev)` lists ride-along columns that `names(as.data.frame(ev))` does not. `names.rxEt` already behaved this way at the 5.1.5 version bump (3e4a3a5a8), before #1154; this PR restores exactly that shipped pairing rather than introducing a new mismatch.
- `print.rxEt` keys off the `show` flags only, so an explicitly assigned `ev$wt2 <- 80` is not printed even though `as.data.frame()` shows it. That gap came in with #1154 and is display-only; left alone here to keep the CRAN-blocking fix narrow.

## Testing

- New regression test in `tests/testthat/test-et.R` covering: imported covariate hidden but still solved; explicitly assigned covariate surviving `copy()`, row subset, `etRbind`, `vec_slice`, `vec_c`; and `NULL` assignment forgetting the column.
- Full rxode2 suite: `[ FAIL 0 | WARN 31 | SKIP 4 | PASS 79200 ]`
- SimuRg suite against this branch: 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01421WVu1sXnGtEHgrjYwTXy