### PR TITLE
fix: move qs2 to Imports so legacy fits stay readable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -121,6 +121,7 @@ Imports:
     tools,
     utils,
     dparser (>= 1.3.1-12),
+    qs2,
     rxode2ll,
     data.table (>= 1.12.4),
     vctrs,

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,17 @@
 
 ## Bug fixes
 
+### Serialization
+
+- `qs2` moved to `Imports`.  `rxDeserialize()` used it without declaring it
+  anywhere, and because the call sites named the package as a string, the
+  dependency was invisible to `R CMD check` as well.  Environments that build
+  their library from the declared dependency graph could therefore end up
+  without `qs2` and fail to read objects stored while `qs2` was an allowed
+  `rxode2.serialize.type` -- for example the `origData` slot of fits saved by
+  earlier versions.  `qs2` is now only ever read, never written; `rxSerialize()`
+  writes `base`, `bzip2` or `xz`.
+
 ### Solving
 
 - Fixed an out-of-bounds thread index that could segfault a solve.  The

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# rxode2 (development version)
+# rxode2 5.1.5
 
 ## New features
 
@@ -9,62 +9,6 @@
   hook when the other namespace is not loaded yet, so the eager loads
   only added startup cost; the methods are still registered at the same
   point in time from the user's perspective.
-
-## Bug fixes
-
-### Serialization
-
-- `qs2` moved to `Imports`.  `rxDeserialize()` used it without declaring it
-  anywhere, and because the call sites named the package as a string, the
-  dependency was invisible to `R CMD check` as well.  Environments that build
-  their library from the declared dependency graph could therefore end up
-  without `qs2` and fail to read objects stored while `qs2` was an allowed
-  `rxode2.serialize.type` -- for example the `origData` slot of fits saved by
-  earlier versions.  `qs2` is now only ever read, never written; `rxSerialize()`
-  writes `base`, `bzip2` or `xz`.
-### Event tables
-
-- `as.data.frame()` on an event table again hides covariate columns that simply
-  rode along with an imported data frame (`et(data)`), while still showing
-  columns assigned explicitly on the event table (`ev$wt <- 70`, #1154).  The
-  covariate is still used when solving.  Showing every non-canonical column
-  broke code that imports events and then joins its own covariates back onto
-  `as.data.frame(ev)`, since the join produced `wt.x`/`wt.y` and the model
-  parameter disappeared.
-
-### Solving
-
-- Fixed an out-of-bounds thread index that could segfault a solve.  The
-  internal thread id used to slice the per-thread solving buffers was not
-  bounded by the number of threads those buffers were allocated for
-  (`op$cores`).  A larger id read past the end of `gInfusionRate[]` -- an
-  array of pointers -- and the resulting garbage pointer crashed
-  `iniSubject()`; the flat per-thread arrays were silently overrun in the
-  same way.  The id is now clamped to the last valid slot, matching what
-  `rx_get_thread()` already did.
-
-- `RcppParallel` is now a runtime import (added to `Imports` with an
-  `importFrom`), so its shared library is loaded into the process before
-  `rxode2`'s.  `rxode2` links against `RcppParallel` (`-lRcppParallel`); with
-  `RcppParallel` only in `LinkingTo` its DLL was not guaranteed to be loaded
-  first, so on Windows `library(rxode2)` could fail with `LoadLibrary failure:
-  The specified module could not be found`.  This surfaced with RcppParallel
-  6.0.0, which statically links TBB and no longer ships the `tbb.dll` stub that
-  previously happened to pull the library in.
-
-- The symbolic derivatives of the relational operators (`>`, `<`, `>=`, `<=`)
-  are now centered on the discontinuity `a == b`: the `atanh(2*tol - 1)` shift
-  that placed the smoothed nascent-delta bump at `a - b ~ +/-0.46` was removed.
-  Since the forward pass evaluates relationals as hard booleans, the shifted
-  bump gave sensitivity/exact-gradient consumers (e.g. FOCEI's analytic
-  gradient paths) a spurious derivative in a band next to the threshold; the
-  centered rule makes the derivative consistent with the forward value.  This
-  also makes the first derivatives of `abs()`, `min()`, and `max()` exact away
-  from the boundary (#1159).
-
-# rxode2 5.1.5
-
-## New features
 
 - `rxControl(sigdig=)` now derives the ODE solver tolerances with one
   solver-independent formula -- the same for stiff, non-stiff and auto-switching
@@ -99,13 +43,25 @@
   `PKG_CPPFLAGS` so it precedes the LinkingTo include flags; otherwise the
   older SUNDIALS copy bundled inside StanHeaders would shadow it.
 
-- Removed the dependency on `qs2` (and hence `stringfish`).
-  `rxSerialize()` now supports the base R types only (`"xz"`, `"bzip2"`,
-  `"base"`); `rxDeserialize()` still reads `qs2`/`qdata`-serialized data and
-  base91-encoded strings when the `qs2` package is installed. Test data was
-  converted from `.qs2` to `.rds`.
+- `rxSerialize()` now writes the base R types only (`"xz"`, `"bzip2"`,
+  `"base"`); `qs2` is no longer a write format.  `rxDeserialize()` still reads
+  `qs2`/`qdata`-serialized data and base91-encoded strings, so objects stored
+  by earlier versions remain readable.  Test data was converted from `.qs2` to
+  `.rds`.
 
 ## Bug fixes
+
+### Serialization
+
+- `qs2` moved to `Imports`.  `rxDeserialize()` used it without declaring it
+  anywhere, and because the call sites named the package as a string, the
+  dependency was invisible to `R CMD check` as well.  Environments that build
+  their library from the declared dependency graph could therefore end up
+  without `qs2` and fail to read objects stored while `qs2` was an allowed
+  `rxode2.serialize.type` -- for example the `origData` slot of fits saved by
+  earlier versions.  `qs2` is now only ever read, never written.
+
+### Error models / transformations
 
 - The first and second derivatives of the Yeo-Johnson transform (`rxTBSd()` and
   `rxTBSd2()`) had the wrong sign for negative values when `lambda` was exactly
@@ -141,22 +97,45 @@
     derivatives discontinuous (and ~15 orders of magnitude too small) at the
     boundary.  The clamp now feeds the usual formula, matching how every other
     transform in the family handles the guard.
-- On Windows with RcppParallel >= 6.0.0 (which statically links TBB through
-  Rtools and no longer loads `tbb.dll`), the stale `-ltbb`/`-ltbbmalloc` flags
-  and the `-L` path to RcppParallel's old dynamic TBB directory that
-  `StanHeaders::LdFlags()` still emits are stripped at configure time, so the
-  rxode2 DLL no longer records an unresolvable runtime dependency on
-  `tbb.dll`.  The strip is keyed to that stale `-L<RcppParallel/lib>`
-  signature, so a future StanHeaders that emits corrected flags -- or a
-  user-supplied TBB via `TBB_LINK_LIB`/`TBB_LIB` -- is left untouched (#1161).
 
-- The `parsed_md5` of a model no longer depends on how many models were built
-  before it in the session.  `linCmtSens` was folded into the hash but only
-  assigned *after* the model was parsed, so the first build of a session hashed
-  with an unset value and every later build hashed with the *previous* call's
-  value.  Because the compiled DLL is named from `parsed_md5`, the same model
-  could get two different cache keys (and hence a redundant recompile) depending
-  on build order.  It is now set before the parse.
+### Estimation / symengine translation
+
+- The symbolic derivatives of the relational operators (`>`, `<`, `>=`, `<=`)
+  are now centered on the discontinuity `a == b`: the `atanh(2*tol - 1)` shift
+  that placed the smoothed nascent-delta bump at `a - b ~ +/-0.46` was removed.
+  Since the forward pass evaluates relationals as hard booleans, the shifted
+  bump gave sensitivity/exact-gradient consumers (e.g. FOCEI's analytic
+  gradient paths) a spurious derivative in a band next to the threshold; the
+  centered rule makes the derivative consistent with the forward value.  This
+  also makes the first derivatives of `abs()`, `min()`, and `max()` exact away
+  from the boundary (#1159).
+
+### Solving
+
+- Fixed an out-of-bounds thread index that could segfault a solve.  The
+  internal thread id used to slice the per-thread solving buffers was not
+  bounded by the number of threads those buffers were allocated for
+  (`op$cores`).  A larger id read past the end of `gInfusionRate[]` -- an
+  array of pointers -- and the resulting garbage pointer crashed
+  `iniSubject()`; the flat per-thread arrays were silently overrun in the
+  same way.  The id is now clamped to the last valid slot, matching what
+  `rx_get_thread()` already did.
+
+- Fixed a cross-subject leak in batched multi-subject `linCmt()` solves: the
+  per-thread inter-event amount buffer was never cleared between subjects, so
+  with `cores < nSub` every subject after the first on a thread could start
+  from the previous subject's compartment amounts (surfaced by a modeled
+  `alag()`) (#1153; by Hidde van de Beek).
+
+- `delay()`/`past()` models containing an `if`/`else` block failed to solve
+  with `unexpected 'else'`: the DDE helpers parsed the `rxNorm()` text
+  directly, which puts `}` and `else` on separate top-level lines; the
+  normalized text is now parsed wrapped in a `{ }` block.  In addition, a
+  `past()` history inside an `if`/`else` branch is now rejected with a clear
+  error (it was invisible to validation), and delay-duration root-variable
+  resolution now sees assignments made inside `if`/`else` branches (#1151).
+
+### Event tables
 
 - `ev$id` on an event table now returns the per-row `id` column (matching
   `as.data.frame(ev)$id`) instead of the unique subject ids, so idiomatic
@@ -168,22 +147,47 @@
   previously hidden canonical columns such as `cmt`) now round-trip through
   `as.data.frame(ev)` (#1154).
 
-- `delay()`/`past()` models containing an `if`/`else` block failed to solve
-  with `unexpected 'else'`: the DDE helpers parsed the `rxNorm()` text
-  directly, which puts `}` and `else` on separate top-level lines; the
-  normalized text is now parsed wrapped in a `{ }` block.  In addition, a
-  `past()` history inside an `if`/`else` branch is now rejected with a clear
-  error (it was invisible to validation), and delay-duration root-variable
-  resolution now sees assignments made inside `if`/`else` branches (#1151).
+- `as.data.frame()` on an event table still hides covariate columns that simply
+  rode along with an imported data frame (`et(data)`), while showing columns
+  assigned explicitly on the event table (`ev$wt <- 70`, #1154).  The covariate
+  is still used when solving.  Showing every non-canonical column broke code
+  that imports events and then joins its own covariates back onto
+  `as.data.frame(ev)`, since the join produced `wt.x`/`wt.y` and the model
+  parameter disappeared.
+
+### Model compilation
+
+- The `parsed_md5` of a model no longer depends on how many models were built
+  before it in the session.  `linCmtSens` was folded into the hash but only
+  assigned *after* the model was parsed, so the first build of a session hashed
+  with an unset value and every later build hashed with the *previous* call's
+  value.  Because the compiled DLL is named from `parsed_md5`, the same model
+  could get two different cache keys (and hence a redundant recompile) depending
+  on build order.  It is now set before the parse.
+
+### Installation / linking
+
+- `RcppParallel` is now a runtime import (added to `Imports` with an
+  `importFrom`), so its shared library is loaded into the process before
+  `rxode2`'s.  `rxode2` links against `RcppParallel` (`-lRcppParallel`); with
+  `RcppParallel` only in `LinkingTo` its DLL was not guaranteed to be loaded
+  first, so on Windows `library(rxode2)` could fail with `LoadLibrary failure:
+  The specified module could not be found`.  This surfaced with RcppParallel
+  6.0.0, which statically links TBB and no longer ships the `tbb.dll` stub that
+  previously happened to pull the library in.
+
+- On Windows with RcppParallel >= 6.0.0 (which statically links TBB through
+  Rtools and no longer loads `tbb.dll`), the stale `-ltbb`/`-ltbbmalloc` flags
+  and the `-L` path to RcppParallel's old dynamic TBB directory that
+  `StanHeaders::LdFlags()` still emits are stripped at configure time, so the
+  rxode2 DLL no longer records an unresolvable runtime dependency on
+  `tbb.dll`.  The strip is keyed to that stale `-L<RcppParallel/lib>`
+  signature, so a future StanHeaders that emits corrected flags -- or a
+  user-supplied TBB via `TBB_LINK_LIB`/`TBB_LIB` -- is left untouched (#1161).
+
 - The vendored SUNDIALS `*NewEmpty` constructors now allocate with `calloc`
   instead of `malloc`, so any struct fields added by a newer SUNDIALS
   release are NULL (and safely ignored) rather than uninitialized (#1155).
-
-- Fixed a cross-subject leak in batched multi-subject `linCmt()` solves: the
-  per-thread inter-event amount buffer was never cleared between subjects, so
-  with `cores < nSub` every subject after the first on a thread could start
-  from the previous subject's compartment amounts (surfaced by a modeled
-  `alag()`) (#1153; by Hidde van de Beek).
 
 # rxode2 5.1.4
 

--- a/R/rxRaw.R
+++ b/R/rxRaw.R
@@ -35,15 +35,6 @@ rxGetDefaultSerialize <- function() {
   }
   op
 }
-#' Get an exported function from qs2 (an optional dependency)
-#'
-#' @param fun function name to get from qs2
-#' @return the function
-#' @noRd
-.qs2Fn <- function(fun) {
-  rxReq("qs2")
-  getExportedValue("qs2", fun)
-}
 #' Serialize an R Object to a Raw Vector
 #'
 #' @param x object to serialize
@@ -99,7 +90,7 @@ rxSerialize <- function(x, type=c("xz", "bzip2", "base")) {
 #'
 rxDeserialize <- function(x) {
   if (checkmate::testCharacter(x, len=1L, any.missing=FALSE)) {
-    .x <- try(.qs2Fn("base91_decode")(x), silent=TRUE)
+    .x <- try(qs2::base91_decode(x), silent=TRUE)
     if (inherits(.x, "try-error")) {
       stop("Input must be a raw vector or base91 encoded string")
     }
@@ -109,12 +100,14 @@ rxDeserialize <- function(x) {
     stop("Input must be a raw vector or base91 encoded string")
   }
   .type <- .Call(`_rxode2_rxGetSerialType_`, x)
+  # 'qs2'/'qdata' are only ever read, never written; they come from objects
+  # stored while 'qs2' was still an allowed 'rxode2.serialize.type'
   .ret <- try(switch(.type,
                      qs2 = {
-                       .qs2Fn("qs_deserialize")(x)
+                       qs2::qs_deserialize(x)
                      },
                      qdata = {
-                       .qs2Fn("qd_deserialize")(x)
+                       qs2::qd_deserialize(x)
                      },
                      qs = {
                        rxReq("qs")

--- a/tests/testthat/test-raw.R
+++ b/tests/testthat/test-raw.R
@@ -53,15 +53,14 @@ rxTest({
     expect_equal(rxGetSerialType_(as.raw(c(0x43, 0x0A, 0x0A))), "unknown")
   })
 
-  test_that("qs2 deserialization is supported when qs2 is installed", {
-    skip_if_not_installed("qs2")
-    qsSer <- getExportedValue("qs2", "qs_serialize")
-    qdSer <- getExportedValue("qs2", "qd_serialize")
-    expect_equal(rxDeserialize(qsSer(mv)), mv)
-    expect_equal(rxDeserialize(qdSer(mv)), mv)
-    expect_equal(rxDeserialize(qsSer(df)), df)
-    expect_equal(rxDeserialize(qdSer(df)), df)
-    expect_error(rxDeserialize(qsSer("not a good object")))
+  test_that("legacy qs2 objects can still be read back", {
+    # qs2 is only ever read, never written; these come from objects stored
+    # while 'qs2' was an allowed rxode2.serialize.type
+    expect_equal(rxDeserialize(qs2::qs_serialize(mv)), mv)
+    expect_equal(rxDeserialize(qs2::qd_serialize(mv)), mv)
+    expect_equal(rxDeserialize(qs2::qs_serialize(df)), df)
+    expect_equal(rxDeserialize(qs2::qd_serialize(df)), df)
+    expect_error(rxDeserialize(qs2::qs_serialize("not a good object")))
   })
 
 })


### PR DESCRIPTION
## Problem

`rxDeserialize()` reads `qs2`/`qdata` blobs, but `qs2` was **not declared anywhere** in `DESCRIPTION`:

```r
.qs2Fn <- function(fun) {
  rxReq("qs2")
  getExportedValue("qs2", fun)
}
```

Because both call sites name the package as a *string*, `R CMD check`'s dependency scan cannot see the usage either — which is how it went unnoticed. An environment that builds its library from the declared dependency graph therefore ends up without `qs2`.

That matters because objects stored while `qs2` was still an allowed `rxode2.serialize.type` can only be read back with `qs2` present. `rxGetDefaultSerialize()` used to validate against `c("qs2", "qdata", "base", "bzip2", "xz")` (commit `699855f93`) and now permits only `base`/`bzip2`/`xz`, so nothing new is written in that format — but plenty of saved objects are still in it. `nlmixr2est` picks the format via `rxode2::rxGetDefaultSerialize()`, so fits saved back then have qs2-serialized `origData`/`parHistData`/`phiM`, including the one shipped as `nlmixr2extra::theoFitOde`:

```r
e <- nlmixr2extra::theoFitOde$env
rxode2:::rxGetSerialType_(get("origData", envir = e))
#> "qs2"
```

Without `qs2` that slot cannot be decoded, `nmObjGetData` returns NULL, and downstream code fails — e.g. every `nlmixr2rpt` test that calls `fetch_fit_example()` dies in `.dataMergeStub()` with `seq_len(nrow(NULL))`.

## Change

- `qs2` moved to **`Imports`**, guaranteeing those objects stay readable.
- `rxDeserialize()` calls `qs2::qs_deserialize()` / `qs2::qd_deserialize()` / `qs2::base91_decode()` directly, so the dependency is visible to `R CMD check` and the `.qs2Fn()` string-lookup helper is gone.
- `qs2` is only ever **read**, never written — `rxSerialize()` writes `base`, `bzip2` or `xz`.

## Testing

- `test-raw.R`: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 28 ]` (the legacy round-trip test no longer needs a `skip_if_not_installed`)
- Full suite: `[ FAIL 0 | WARN 31 | SKIP 4 | PASS 79185 ]`

## Companion PRs

Downstream packages that were *writing* `qs2` now use base R serialization instead, so the format stops spreading:

- nlmixr2/nlmixr2lib#471 — ship `inst/modeldb.rds` instead of `modeldb.qs2`
- nlmixr2/nlmixr2shiny#14 — use the `nlmixr2lib::modeldb` dataset directly
- nlmixr2/babelmixr2#199 — NONMEM/Monolix fit cache via `saveRDS()`, with a migrating read of legacy `.qs2` caches
- LeidenPharmacology/admixr2#115 — compiled-model disk caches via `saveRDS()`

`nlmixr2est` had already dropped `qs2` (its `R/compat.R` looks the functions up only for legacy reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01421WVu1sXnGtEHgrjYwTXy