### PR TITLE
chore: gitignore R build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,9 @@ src/StanHeaders.def
 /.cache/
 tests/testthat/Rplots.pdf
 tests/testthat/_problems/
+
+# Build artifacts (R CMD build/INSTALL/check output)
+*.Rcheck/
+*.tar.gz
+*.tgz
+inst/tools/*.Rout


### PR DESCRIPTION
These are produced by R CMD INSTALL/build/check on a normal developer machine and were showing up as untracked in every status, which also blocks 'git pull --ff-only' on the default branch.