### PR TITLE
Fix Windows build with new RcppParallel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rxode2
-Version: 5.1.5
+Version: 5.1.6
 Title: Facilities for Simulating from ODE-Based Models
 Authors@R: c(
    person("Matthew L.","Fidler", role = c("aut", "cre"), email = "matthew.fidler@gmail.com", comment=c(ORCID="0000-0001-8538-6691")),
@@ -87,7 +87,7 @@ Suggests:
     tidyr,
     usethis,
     withr,
-    xgxr,
+    xgxr (>= 1.1.6),
     pillar,
     tibble,
     units (>= 0.6-0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,45 @@
+# rxode2 5.1.6
+
+## Bug fixes
+
+### Dependencies
+
+- The suggested `xgxr` is now required to be `>= 1.1.6`.  Its
+  `xgx_scale_x_log10()`/`xgx_scale_y_log10()` return the `ggplot2` scale
+  itself from that version on, rather than a length-one list wrapping it.
+
+### Installation / linking
+
+- Fixed the Windows build against `RcppParallel` 6.2.0, which no longer ships
+  the TBB library there (6.0.0 still built).  `configure` already dropped the
+  `-ltbb`/`-ltbbmalloc`
+  link flags when they are unavailable, but still compiled with `-DSTAN_THREADS`
+  and `-DRCPP_PARALLEL_USE_TBB=1`, which pulls `stan::math`'s `ad_tape_observer`
+  (a `tbb::task_scheduler_observer`) into the objects and left undefined
+  references to `tbb::detail::r1::observe` at link time.  Those defines are now
+  dropped together with the link flags, `stan-math`'s `init_chainablestack.hpp`
+  is kept out of the build, and the main thread's AD tape -- which that
+  observer would otherwise have created -- is constructed in `src/linCmt.cpp`
+  instead (by Jeroen Ooms).
+
+### Solving
+
+- Fixed heap corruption when `simeta()`/`simeps()` resample inside a solve.
+  Both go through `simvar()`, which reseeded its threefry stream with
+  `getRxSeed1()`; unless `rxSetSeed()` had been called that draws from R's own
+  random number generator, which allocates R objects and can trigger a garbage
+  collection.  Doing so from an OpenMP worker thread corrupted R's heap, and
+  the session then failed later in an unrelated place (`cannot get data pointer
+  of 'NULL' objects`, `'rho' must be an environment`, `corrupted double-linked
+  list`, or a segfault).  The in-solve resample now draws from a per-thread
+  engine seeded on the main thread and touches no R API.
+
+- The `simeta()`/`simeps()` resample no longer replays the simulated
+  parameters.  Its engines are keyed off a threefry draw rather than off the
+  `runif()`-derived seed handed out at solve setup, which `rxSolve()` goes on
+  to reuse for the simulated `omega`/`sigma` deviates; a resampled `eta` could
+  therefore come out exactly equal to another subject's simulated `eta`.
+
 # rxode2 5.1.5
 
 ## New features

--- a/inst/tools/workaround.R
+++ b/inst/tools/workaround.R
@@ -76,6 +76,9 @@ if (inherits(versionInfo, "try-error")) {
 
 .sl <- paste(capture.output(StanHeaders:::LdFlags()),
              capture.output(RcppParallel:::RcppParallelLibs()))
+# Set when the TBB link flags are stripped below; the compile-time
+# STAN_THREADS/TBB defines must then be stripped too (see @SH@ handling).
+.rxDisableTbb <- FALSE
 if (.Platform$OS.type == "windows") {
   # rpath is not meaningful on Windows and can generate noisy linker flags.
   # The path is shQuote()d by StanHeaders, so match quoted forms first;
@@ -108,6 +111,7 @@ if (.Platform$OS.type == "windows") {
       .sl <- gsub("-ltbbmalloc\\b", "", .sl)
       .sl <- gsub("-ltbb\\b", "", .sl)
       .sl <- gsub("\\s+", " ", trimws(.sl))
+      .rxDisableTbb <- TRUE
     }
   }
 }
@@ -420,13 +424,23 @@ close(.ie_out)
 
 
 .badStan <- ""
-.in <- gsub("@SH@", gsub("-I", "-@ISYSTEM@",
-                         paste(capture.output(StanHeaders:::CxxFlags()), # nolint
-                               capture.output(RcppParallel:::CxxFlags()), # nolint
-                               paste0("-@ISYSTEM@'", system.file('include', package = 'StanHeaders', mustWork = TRUE), "'"),
-                               paste0("-@ISYSTEM@'", system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE), "'"),
-                               .badStan)),
-            .in)
+.sh <- paste(capture.output(StanHeaders:::CxxFlags()), # nolint
+             capture.output(RcppParallel:::CxxFlags()), # nolint
+             paste0("-@ISYSTEM@'", system.file('include', package = 'StanHeaders', mustWork = TRUE), "'"),
+             paste0("-@ISYSTEM@'", system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE), "'"),
+             .badStan)
+if (.rxDisableTbb) {
+  # The -ltbb/rxode2/-ltbbmalloc link flags were stripped above (RcppParallel >=
+  # 6.0.0 on Windows no longer provides libtbb).  Compiling with
+  # -DSTAN_THREADS / -DRCPP_PARALLEL_USE_TBB=1 would still pull stan::math's
+  # ad_tape_observer (a tbb::task_scheduler_observer) into the objects,
+  # leaving undefined references to tbb::detail::r1::observe at link time.
+  # Drop the defines so Stan math and RcppParallel compile without TBB.
+  .sh <- gsub("-DSTAN_THREADS\\b", "", .sh)
+  .sh <- gsub("-DRCPP_PARALLEL_USE_TBB=1", "-DRCPP_PARALLEL_USE_TBB=0", .sh)
+  .sh <- gsub("\\s+", " ", trimws(.sh))
+}
+.in <- gsub("@SH@", gsub("-I", "-@ISYSTEM@", .sh), .in)
 
 
 

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -10,6 +10,16 @@
 #include "linCmt.h"
 #include "linCmtSensType.h"
 
+#ifdef RXODE2_NO_STAN_TBB_OBSERVER
+// stan-math's init_chainablestack.hpp is kept out of the build (no TBB on
+// Windows, see rxode2_sundials_stan_compat.h).  Its global ad_tape_observer
+// was also what created the main thread's AD tape; without STAN_THREADS the
+// tape is a plain (shared) global, so constructing one ChainableStack here
+// initializes it for the whole DLL.
+namespace {
+stan::math::ChainableStack rxode2MainThreadAdTape;
+}
+#endif
 
 extern rx_solving_options op_global;
 extern t_update_inis update_inis;

--- a/src/rxode2_sundials_stan_compat.h
+++ b/src/rxode2_sundials_stan_compat.h
@@ -40,4 +40,19 @@ typedef sunrealtype realtype;
 #endif
 #endif
 
+/*
+ * RcppParallel >= 6.0.0 statically links TBB on Windows and no longer exports
+ * the oneTBB runtime symbols (tbb::detail::r1::observe) that stan-math's
+ * ad_tape_observer (stan/math/rev/core/init_chainablestack.hpp) needs, so
+ * configure strips -DSTAN_THREADS and no TBB library is linked (see
+ * inst/tools/workaround.R).  Pre-define that header's include guard so the
+ * TBB task_scheduler_observer never enters the build.  The main-thread AD
+ * tape that observer would have created is created in linCmt.cpp instead,
+ * keyed on RXODE2_NO_STAN_TBB_OBSERVER.
+ */
+#if defined(_WIN32) && !defined(STAN_THREADS) && defined(__cplusplus)
+#define STAN_MATH_REV_CORE_INIT_CHAINABLESTACK_HPP
+#define RXODE2_NO_STAN_TBB_OBSERVER
+#endif
+
 #endif

--- a/src/rxode2_sundials_stan_compat.h
+++ b/src/rxode2_sundials_stan_compat.h
@@ -41,7 +41,7 @@ typedef sunrealtype realtype;
 #endif
 
 /*
- * RcppParallel >= 6.0.0 statically links TBB on Windows and no longer exports
+ * RcppParallel 6.2.0 statically links TBB on Windows and no longer exports
  * the oneTBB runtime symbols (tbb::detail::r1::observe) that stan-math's
  * ad_tape_observer (stan/math/rev/core/init_chainablestack.hpp) needs, so
  * configure strips -DSTAN_THREADS and no TBB library is linked (see

--- a/src/rxthreefry.cpp
+++ b/src/rxthreefry.cpp
@@ -830,20 +830,42 @@ arma::mat rxMvrandn_(NumericMatrix A_,
 }
 
 std::vector<sitmo::threefry> _eng;
+// Engines reserved for the in-solve simeta()/simeps() resample; see
+// simEngKey() for why they cannot share _eng.
+std::vector<sitmo::threefry> _engSim;
+
+// rxSolve() restores R's RNG state between seedEng() and the parameter
+// simulation, so the runif()-derived seeds handed out by getRxSeed1() repeat
+// there: _eng's keys are the same ones cvPost()/rxRmvn_() go on to use for the
+// simulated etas.  Keying the resample engines off a threefry draw instead of
+// off `seed` itself keeps simeta()/simeps() from replaying those parameters.
+static inline uint32_t simEngKey(uint32_t seed) {
+  sitmo::threefry k;
+  k.seed(seed);
+  return (uint32_t)(k() & 0xffffffffU);
+}
 
 extern "C" void seedEng(int ncores) {
   uint32_t seed = getRxSeed1(ncores);
   _eng.clear();
+  _engSim.clear();
   for (int i= 0; i < ncores; i++) {
     sitmo::threefry eng0;
     eng0.seed(seed + i);
     _eng.push_back(eng0);
+    sitmo::threefry engSim0;
+    engSim0.seed(simEngKey(seed + i));
+    _engSim.push_back(engSim0);
   }
   seed = getRxSeed1(ncores);
 }
 
 extern "C" void setSeedEng1(uint32_t seed) {
-  (_eng[rx_get_thread(op_global.cores)]).seed(seed);
+  int thread = rx_get_thread(op_global.cores);
+  (_eng[thread]).seed(seed);
+  if (thread < (int)_engSim.size()) {
+    (_engSim[thread]).seed(simEngKey(seed));
+  }
 }
 
 //' This seeds the engine based on the number of cores used in random number generation
@@ -1689,6 +1711,98 @@ void rxRmvnA(arma::mat & A_, arma::rowvec & mu, arma::mat &sigma,
   }
 }
 
+// Serial variant of rxRmvn2_() that draws from an already seeded engine.
+static void rxRmvn2Eng(arma::mat& A, const arma::rowvec& mu, const arma::mat& sigma,
+                       sitmo::threefry& eng, bool isChol=false) {
+  int n = A.n_rows;
+  int d = mu.n_elem;
+  if (n < 1 || d < 1) return;
+  arma::mat ch;
+  if (sigma.is_zero()) {
+    ch = sigma;
+  } else if (isChol) {
+    ch = arma::trimatu(sigma);
+  } else {
+    ch = arma::trimatu(arma::chol(sigma));
+  }
+  boost::random::normal_distribution<> snorm(0.0, 1.0);
+  for (int i = 0; i < n*d; ++i) {
+    A[i] = snorm(eng);
+  }
+  if (d == 1) {
+    double sd = ch(0, 0);
+    for (int i = 0; i < n; ++i) {
+      A[i] = A[i]*sd + mu(0);
+    }
+  } else {
+    arma::rowvec work(d);
+    for (int ir = 0; ir < n; ++ir) {
+      for (int ic = d; ic--;) {
+        double acc = 0.0;
+        for (int ii = 0; ii <= ic; ++ii) {
+          acc += A.at(ir, ii) * ch.at(ii, ic);
+        }
+        work.at(ic) = acc;
+      }
+      work += mu;
+      A(arma::span(ir), arma::span::all) = work;
+    }
+  }
+}
+
+// Serial variant of rxMvrandn__() that draws from an already seeded engine.
+static void rxMvrandnEng(arma::mat& A, const arma::rowvec& mu, const arma::mat& sigma,
+                         const arma::vec& lower, const arma::vec& upper,
+                         sitmo::threefry& eng, double a=0.4, double tol=2.05,
+                         double nlTol=1e-10, int nlMaxiter=100) {
+  int n = A.n_rows;
+  int d = mu.n_elem;
+  if (n < 1 || d < 1) return;
+  if (sigma.is_zero()) {
+    if (d == 1) {
+      for (int i = 0; i < n; ++i) A[i] = mu(0);
+    } else {
+      A.zeros();
+      A.each_row() += mu;
+    }
+    return;
+  }
+  arma::vec low = lower - trans(mu);
+  arma::vec up  = upper - trans(mu);
+  if (d == 1) {
+    double sd = sqrt(sigma(0, 0));
+    double l = low(0)/sd;
+    double u = up(0)/sd;
+    for (int i = 0; i < n; ++i) {
+      A[i] = sd*trandn(l, u, eng, a, tol) + mu(0);
+    }
+  } else {
+    arma::mat ret = mvrandn(low, up, sigma, n, eng, a, tol, nlTol, nlMaxiter, 1);
+    ret.each_row() += mu;
+    std::copy(ret.begin(), ret.end(), A.begin());
+  }
+}
+
+// Armadillo-only simulation drawing from an already seeded engine; this is the
+// in-solve counterpart of rxRmvnA().
+static void rxRmvnAEng(arma::mat& A, const arma::rowvec& mu, const arma::mat& sigma,
+                       arma::vec& lower, arma::vec& upper, sitmo::threefry& eng,
+                       bool isChol=false, double a=0.4, double tol=2.05,
+                       double nlTol=1e-10, int nlMaxiter=100) {
+  bool trunc = anyFinite(lower) || anyFinite(upper);
+  if (trunc) {
+    arma::mat sigma0 = sigma;
+    if (isChol) {
+      sigma0 = sigma * sigma.t();
+    }
+    arma::vec lower0 = fillVec(lower, A.n_cols);
+    arma::vec upper0 = fillVec(upper, A.n_cols);
+    rxMvrandnEng(A, mu, sigma0, lower0, upper0, eng, a, tol, nlTol, nlMaxiter);
+  } else {
+    rxRmvn2Eng(A, mu, sigma, eng, isChol);
+  }
+}
+
 void simvar(double *out, int type, int csim, rx_solve* rx) {
   int n = 0;
   if (type == 0) { // eps
@@ -1702,8 +1816,20 @@ void simvar(double *out, int type, int csim, rx_solve* rx) {
   arma::rowvec mu(n, arma::fill::zeros);
   arma::mat sigma = getArmaMat(type, csim, rx);
 
+  // simeta()/simeps() run inside the parallel solve, so the draw has to come
+  // from this thread's engine (seeded on the main thread by seedEng() and
+  // setSeedEng1()).  rxRmvnA() would re-seed with getRxSeed1(), which uses R's
+  // RNG and must never be called from an OpenMP worker thread.
+  int thread = rx_get_thread(op_global.cores);
   // FIXME? allow changing of a, tol nlTol and nlMaxiter?
-  rxRmvnA(A, mu, sigma, lower, upper, 1, false, 0.4, 2.05, 1e-10, 100);
+  if (thread < 0 || thread >= (int)_engSim.size()) {
+    // Not seeded; should not happen during a solve.  Use a per-thread stream
+    // rather than reaching for R's RNG off the main thread.
+    static thread_local sitmo::threefry engFallback;
+    rxRmvnAEng(A, mu, sigma, lower, upper, engFallback, false, 0.4, 2.05, 1e-10, 100);
+    return;
+  }
+  rxRmvnAEng(A, mu, sigma, lower, upper, _engSim[thread], false, 0.4, 2.05, 1e-10, 100);
 }
 // ---------------------------------------------------------------------------
 // rxPreGenEta: pre-generate all nsolve * neta eta draws before the parallel

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -1,5 +1,15 @@
 rxTest({
 
+  # A log scale is either a bare ggplot2 scale object or a length-one list
+  # wrapping one (xgxr <= 1.1.2 and old ggplot2 return the list form).
+  expect_scale <- function(o, cls) {
+    if (is.list(o)) {
+      expect_length(o, 1)
+      o <- o[[1]]
+    }
+    expect_s3_class(o, cls)
+  }
+
   expect_plotlog <- function(o, timex, logx, logy, dat) {
     # Checking for the correct type for logx and logy is nontrivial, so j
     expect_named(o, c("timex", "logx", "logy", "dat"))
@@ -11,16 +21,12 @@ rxTest({
     if (is.null(logx)) {
       expect_null(o$logx)
     } else {
-      expect_type(o$logx, "list")
-      expect_length(o$logx, 1)
-      expect_s3_class(o$logx[[1]], logx)
+      expect_scale(o$logx, logx)
     }
     if (is.null(logy)) {
       expect_null(o$logy)
     } else {
-      expect_type(o$logy, "list")
-      expect_length(o$logy, 1)
-      expect_s3_class(o$logy[[1]], logy)
+      expect_scale(o$logy, logy)
     }
     expect_equal(o$dat, dat)
   }

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -916,6 +916,41 @@ rxTest({
     })
   })
 
+  test_that("simeps() resampling in a threaded solve does not touch R's RNG", {
+    # simeps()/simeta() run on the solving threads; drawing the replacement
+    # deviate used to reseed with getRxSeed1(), which calls R's RNG and
+    # corrupted R's heap when more than one thread resampled at once.  The
+    # damage only surfaced in a later, unrelated allocation, so gc() between
+    # solves is what makes a regression visible here.
+    rx <- rxode2({
+      c <- 0 + err
+      i <- 0
+      while (c < 0) {
+        simeps()
+        c <- 0 + err
+        i <- i + 1
+        if (i > 10) break
+      }
+    })
+
+    e <- et(0, 10)
+
+    .threads <- rxCores()
+    on.exit(setRxThreads(.threads), add = TRUE)
+    setRxThreads(min(4L, .threads))
+
+    rxWithPreserveSeed({
+      for (.s in 1:30) {
+        set.seed(.s)
+        .f <- suppressMessages(rxSolve(rx, e, sigma = lotri(err ~ 1), nStud = 4))
+        # records that left the loop before the i > 10 escape resampled to a
+        # positive value
+        expect_true(all(.f$c[.f$i <= 10] > 0))
+        gc()
+      }
+    })
+  })
+
   test_that("simeta", {
     rx <- rxode2({
       wt <- 70 * exp(eta.wt)


### PR DESCRIPTION
The package no longer builds on Windows because RcppParallel 6.x dropped the TBB library on Windows.

See https://cran.r-project.org/web/checks/check_results_rxode2.html

As a result packages that depend on rxode2  also fail to load:

https://cran.r-project.org/web/checks/check_results_nlmixr2.html

This PR is the solution is that Claude came up with, and it works but maybe there is something better?

cc @kevinushey