### PR TITLE
Expose the event-sensitivity shape and setIndCmt() in the C API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # rxode2 5.1.6
 
+## New features
+
+- Added the event ("jump") sensitivity shape to rxode2's linked
+  function-pointer API, so a downstream package can install a model's shape
+  from C++ without an R round trip: `rxode2EventSensLoadFull()` (all six dims,
+  where the older `rxode2EventSensLoad()` omitted `nParam3`/`useCalcJac`),
+  `rxode2EventSensGetDims()`/`rxode2EventSensSetDims()`,
+  `rxode2EventSensSetActive()`, `rxode2EventSensDeactivate()`, and
+  `rxode2EventSensShapeSize()`/`rxode2EventSensShapeSave()`/
+  `rxode2EventSensShapeRestore()`, which snapshot and reinstall a whole shape
+  (dims plus the model's dosing-derivative function pointers) through a
+  caller-owned opaque buffer.  This lets several peer models with different
+  shapes be solved through one shared solve pool, installing each batch's
+  shape and restoring the previous one afterwards.
+
+- Added `setIndCmt()` to the function-pointer API, the writer counterpart of
+  `getIndCmt()`, so a downstream package can re-base the per-observation `CMT`
+  covariate without reaching into `op->cmtCov`/`ind->cov_ptr` by field.
+
 ## Bug fixes
 
 ### Dependencies
@@ -9,6 +28,14 @@
   itself from that version on, rather than a length-one list wrapping it.
 
 ### Installation / linking
+
+- Fixed two wrong names in rxode2's function-pointer table: slot 8 was labeled
+  `getSolvingOptionsInd` (it is `getSolvingOptions`) and slot 9
+  `rxode2getUpdateInis` (it is `getSolvingOptionsInd`), left over from an export
+  that was removed.  The table is read positionally, so this was cosmetic, but
+  it made the slots impossible to audit by name.  The table is now also checked
+  at build time for unset slots, which would otherwise hand a downstream package
+  a `NULL` function pointer that only crashes when called.
 
 - Fixed the Windows build against `RcppParallel` 6.2.0, which no longer ships
   the TBB library there (6.0.0 still built).  `configure` already dropped the

--- a/R/eventSens.R
+++ b/R/eventSens.R
@@ -935,9 +935,7 @@
 .rxSetEventSensDims <- function(object) {
   .info <- tryCatch(object$eventSensInfo, error = function(e) NULL)
   if (is.null(.info) || identical(.info$mode, "fd")) {
-    .Call(`_rxode2_setEventSensUseCalcJac`, 0L)
-    .Call(`_rxode2_setEventSensNParam3`, 0L)
-    return(invisible(.Call(`_rxode2_setEventSensDims`, 0L, 0L, 0L, 0L)))
+    return(invisible(.Call(`_rxode2_eventSensDeactivate`)))
   }
   .nState <- .info$map$nState
   .nParam <- length(.info$map$sensParams)
@@ -945,10 +943,45 @@
   .nParam2 <- if (is.null(.info$map$map2)) 0L else length(unique(.info$map$map2$q))
   ## number of third-order (calcSens3) parameters; 0 when no Phase H1 path
   .nParam3 <- if (is.null(.info$map$map3)) 0L else length(unique(.info$map$map3$r))
-  .Call(`_rxode2_setEventSensUseCalcJac`, as.integer(.rxEventSensUseCalcJac(object)))
-  .Call(`_rxode2_setEventSensNParam3`, as.integer(.nParam3))
-  invisible(.Call(`_rxode2_setEventSensDims`, 1L,
-                  as.integer(.nState), as.integer(.nParam), as.integer(.nParam2)))
+  invisible(.Call(`_rxode2_eventSensSetDims`, 1L,
+                  as.integer(.nState), as.integer(.nParam), as.integer(.nParam2),
+                  as.integer(.nParam3),
+                  as.integer(.rxEventSensUseCalcJac(object))))
+}
+
+#' Read the installed event-sensitivity runtime dims
+#'
+#' Mirrors the C API's `rxode2EventSensGetDims()`; mostly for tests and for
+#' checking what a solve or [rxEventSensLoadModel()] installed.
+#'
+#' @return named integer vector: `active`, `nState`, `nParam`, `nParam2`,
+#'   `nParam3`, `useCalcJac`.
+#' @noRd
+.rxGetEventSensDims <- function() {
+  .Call(`_rxode2_eventSensGetDims`)
+}
+
+#' Save / restore the installed event-sensitivity shape
+#'
+#' R view of the C API's `rxode2EventSensShapeSave()` /
+#' `rxode2EventSensShapeRestore()`: the whole shape, dims plus the model's
+#' dosing-derivative function pointers, so a caller can bracket a batch of
+#' solves that install a different model's shape.  The raw vector holds live
+#' function pointers -- valid only in the session that produced it, never
+#' serialize it.
+#'
+#' @param buf A raw vector from `.rxEventSensShapeSave()`.
+#' @return `.rxEventSensShapeSave()` a raw vector; `.rxEventSensShapeRestore()`
+#'   invisibly `NULL`.
+#' @noRd
+.rxEventSensShapeSave <- function() {
+  .Call(`_rxode2_eventSensShapeSave`)
+}
+
+#' @rdname dot-rxEventSensShapeSave
+#' @noRd
+.rxEventSensShapeRestore <- function(buf) {
+  invisible(.Call(`_rxode2_eventSensShapeRestore`, buf))
 }
 
 #' Point the rxode2 event-sensitivity globals at a jump-sensitivity model
@@ -958,7 +991,9 @@
 #' rxode2's event ("jump") sensitivity function pointers and runtime dims to
 #' `model` and turns the jumps on.  The jump blocks are bounds-guarded, so
 #' smaller models solved afterwards skip the injection safely.  Pair with
-#' `rxEventSensDeactivate()` after the run.
+#' `rxEventSensDeactivate()` after the run.  The C API entry points behind this
+#' (`rxode2EventSensLoadFull()` and the shape save/restore) are in rxode2's
+#' function-pointer table, for callers that need the swap from C++.
 #'
 #' @param model A built jump-sensitivity model (carrying `eventSensInfo`).
 #' @return invisibly `TRUE` when the jumps were activated, `FALSE` otherwise
@@ -973,10 +1008,9 @@ rxEventSensLoadModel <- function(model) {
   .nParam <- length(.info$map$sensParams)
   .nParam2 <- if (is.null(.info$map$map2)) 0L else length(unique(.info$map$map2$q))
   .nParam3 <- if (is.null(.info$map$map3)) 0L else length(unique(.info$map$map3$r))
-  .Call(`_rxode2_eventSensLoad`, .trans, 1L, as.integer(.nState),
-        as.integer(.nParam), as.integer(.nParam2))
-  .Call(`_rxode2_setEventSensUseCalcJac`, as.integer(.rxEventSensUseCalcJac(model)))
-  .Call(`_rxode2_setEventSensNParam3`, as.integer(.nParam3))
+  .Call(`_rxode2_eventSensLoadFull`, .trans, 1L, as.integer(.nState),
+        as.integer(.nParam), as.integer(.nParam2), as.integer(.nParam3),
+        as.integer(.rxEventSensUseCalcJac(model)))
   invisible(TRUE)
 }
 
@@ -989,9 +1023,7 @@ rxEventSensLoadModel <- function(model) {
 #' @export
 #' @keywords internal
 rxEventSensDeactivate <- function() {
-  .Call(`_rxode2_setEventSensUseCalcJac`, 0L)
-  .Call(`_rxode2_setEventSensNParam3`, 0L)
-  invisible(.Call(`_rxode2_setEventSensDims`, 0L, 0L, 0L, 0L))
+  invisible(.Call(`_rxode2_eventSensDeactivate`))
 }
 
 #' Assemble the event-sensitivity information for a built model

--- a/inst/include/rxode2.h
+++ b/inst/include/rxode2.h
@@ -111,6 +111,20 @@ rx_solve *getRxSolve_(void);
 void rxSetSolveAtolRtol(double atol, double rtol);
 void rxGetSolveAtolRtol(double *atol, double *rtol);
 int getIndCmt(rx_solving_options* op, rx_solving_options_ind* ind, int kk);
+void setIndCmt(rx_solving_options* op, rx_solving_options_ind* ind, int kk, int cmt);
+// Event ("jump") sensitivity shape (src/par_solve.cpp); see the block comment
+// there for how a downstream package swaps shapes around a batch of solves.
+int rxode2EventSensShapeSize(void);
+void rxode2EventSensShapeSave(void *buf);
+void rxode2EventSensShapeRestore(const void *buf);
+void rxode2EventSensLoadFull(SEXP trans, int active, int nState, int nParam,
+                             int nParam2, int nParam3, int useCalcJac);
+void rxode2EventSensGetDims(int *active, int *nState, int *nParam, int *nParam2,
+                            int *nParam3, int *useCalcJac);
+void rxode2EventSensSetDims(int active, int nState, int nParam, int nParam2,
+                            int nParam3, int useCalcJac);
+void rxode2EventSensSetActive(int active);
+void rxode2EventSensDeactivate(void);
 #endif
 rx_solve *getRxSolve2_(void);
 rx_solve *getRxSolve(SEXP ptr);

--- a/inst/include/rxode2.h
+++ b/inst/include/rxode2.h
@@ -116,7 +116,7 @@ void setIndCmt(rx_solving_options* op, rx_solving_options_ind* ind, int kk, int 
 // there for how a downstream package swaps shapes around a batch of solves.
 int rxode2EventSensShapeSize(void);
 void rxode2EventSensShapeSave(void *buf);
-void rxode2EventSensShapeRestore(const void *buf);
+int rxode2EventSensShapeRestore(const void *buf);
 void rxode2EventSensLoadFull(SEXP trans, int active, int nState, int nParam,
                              int nParam2, int nParam3, int useCalcJac);
 void rxode2EventSensGetDims(int *active, int *nState, int *nParam, int *nParam2,

--- a/inst/include/rxode2.h
+++ b/inst/include/rxode2.h
@@ -115,8 +115,8 @@ void setIndCmt(rx_solving_options* op, rx_solving_options_ind* ind, int kk, int 
 // Event ("jump") sensitivity shape (src/par_solve.cpp); see the block comment
 // there for how a downstream package swaps shapes around a batch of solves.
 int rxode2EventSensShapeSize(void);
-void rxode2EventSensShapeSave(void *buf);
-int rxode2EventSensShapeRestore(const void *buf);
+int rxode2EventSensShapeSave(void *buf, int bufSize);
+int rxode2EventSensShapeRestore(const void *buf, int bufSize);
 void rxode2EventSensLoadFull(SEXP trans, int active, int nState, int nParam,
                              int nParam2, int nParam3, int useCalcJac);
 void rxode2EventSensGetDims(int *active, int *nState, int *nParam, int *nParam2,

--- a/inst/include/rxode2ptr.h
+++ b/inst/include/rxode2ptr.h
@@ -56,22 +56,27 @@ extern "C" {
   // `trans`, or a previously saved buffer), solve, then restore:
   //
   //   std::vector<char> saved(rxode2EventSensShapeSize());
-  //   rxode2EventSensShapeSave(saved.data());
-  //   rxode2EventSensShapeRestore(peerShape.data());   // ... solve the batch
-  //   rxode2EventSensShapeRestore(saved.data());
+  //   rxode2EventSensShapeSave(saved.data(), saved.size());
+  //   rxode2EventSensShapeRestore(peer.data(), peer.size());  // solve the batch
+  //   rxode2EventSensShapeRestore(saved.data(), saved.size());
   //
-  // The buffer layout is opaque and may change between rxode2 versions, so a
-  // buffer must not outlive the process that produced it; a buffer rxode2 does
-  // not recognize is rejected (restore returns 0 and changes nothing) rather
-  // than installed.  These globals are read inside the OpenMP solve loops, so
-  // install and restore only at batch boundaries, never from a parallel region.
+  // Both take the buffer's capacity and refuse to touch a buffer that is too
+  // small, so a mis-sized allocation fails cleanly instead of running off its
+  // end.  The layout is opaque and may change between rxode2 versions: a buffer
+  // rxode2 does not recognize is rejected rather than installed, and a buffer
+  // must never be serialized or reused across sessions.  A saved shape also
+  // holds pointers INTO the model's shared library, so unloading that model
+  // (rxUnload()) invalidates it -- re-install with rxode2EventSensLoadFull()
+  // rather than restoring a shape saved before the unload.  These globals are
+  // read inside the OpenMP solve loops, so install and restore only at batch
+  // boundaries, never from a parallel region or while a solve is running.
+  // Neither calls Rf_error, so a C++ caller is not longjmp'd past its
+  // destructors; both return 1 on success and 0 if the buffer was rejected.
   typedef int (*rxode2EventSensShapeSize_t)(void);
   extern rxode2EventSensShapeSize_t rxode2EventSensShapeSize;
-  typedef void (*rxode2EventSensShapeSave_t)(void *buf);
+  typedef int (*rxode2EventSensShapeSave_t)(void *buf, int bufSize);
   extern rxode2EventSensShapeSave_t rxode2EventSensShapeSave;
-  // Returns 1 on success, 0 if the buffer was rejected.  Never calls Rf_error,
-  // so a C++ caller is not longjmp'd past its destructors.
-  typedef int (*rxode2EventSensShapeRestore_t)(const void *buf);
+  typedef int (*rxode2EventSensShapeRestore_t)(const void *buf, int bufSize);
   extern rxode2EventSensShapeRestore_t rxode2EventSensShapeRestore;
   // Install a model's shape from its `trans` vector (all six dims).
   typedef void (*rxode2EventSensLoadFull_t)(SEXP trans, int active, int nState, int nParam, int nParam2, int nParam3, int useCalcJac);

--- a/inst/include/rxode2ptr.h
+++ b/inst/include/rxode2ptr.h
@@ -42,6 +42,45 @@ extern "C" {
   extern rxUnifEng_t rxUnifEng;
   typedef int (*getIndCmt_t)(rx_solving_options* op, rx_solving_options_ind* ind, int kk);
   extern getIndCmt_t getIndCmt;
+  // Writer for the CMT covariate (inverse of getIndCmt); lets a downstream
+  // package re-base the CMT column without touching op->cmtCov / ind->cov_ptr.
+  typedef void (*setIndCmt_t)(rx_solving_options* op, rx_solving_options_ind* ind, int kk, int cmt);
+  extern setIndCmt_t setIndCmt;
+
+  // Event ("jump") sensitivity shape.  A shape is one model's six dims
+  // (active/nState/nParam/nParam2/nParam3/useCalcJac) plus its dosing-derivative
+  // function pointers; rxode2 holds exactly one installed at a time.  To solve
+  // peer models with different shapes through a shared solve pool, save the
+  // installed shape into a caller-owned buffer of rxode2EventSensShapeSize()
+  // bytes, install the batch's shape (rxode2EventSensLoadFull() from the model's
+  // `trans`, or a previously saved buffer), solve, then restore:
+  //
+  //   std::vector<char> saved(rxode2EventSensShapeSize());
+  //   rxode2EventSensShapeSave(saved.data());
+  //   rxode2EventSensShapeRestore(peerShape.data());   // ... solve the batch
+  //   rxode2EventSensShapeRestore(saved.data());
+  //
+  // The buffer layout is opaque and may change between rxode2 versions, so a
+  // buffer must not outlive the process that produced it.
+  typedef int (*rxode2EventSensShapeSize_t)(void);
+  extern rxode2EventSensShapeSize_t rxode2EventSensShapeSize;
+  typedef void (*rxode2EventSensShapeSave_t)(void *buf);
+  extern rxode2EventSensShapeSave_t rxode2EventSensShapeSave;
+  typedef void (*rxode2EventSensShapeRestore_t)(const void *buf);
+  extern rxode2EventSensShapeRestore_t rxode2EventSensShapeRestore;
+  // Install a model's shape from its `trans` vector (all six dims).
+  typedef void (*rxode2EventSensLoadFull_t)(SEXP trans, int active, int nState, int nParam, int nParam2, int nParam3, int useCalcJac);
+  extern rxode2EventSensLoadFull_t rxode2EventSensLoadFull;
+  // Read / write the dims only (any getter pointer may be NULL to skip it).
+  typedef void (*rxode2EventSensGetDims_t)(int *active, int *nState, int *nParam, int *nParam2, int *nParam3, int *useCalcJac);
+  extern rxode2EventSensGetDims_t rxode2EventSensGetDims;
+  typedef void (*rxode2EventSensSetDims_t)(int active, int nState, int nParam, int nParam2, int nParam3, int useCalcJac);
+  extern rxode2EventSensSetDims_t rxode2EventSensSetDims;
+  // Toggle the active flag only / turn the jumps off and zero the dims.
+  typedef void (*rxode2EventSensSetActive_t)(int active);
+  extern rxode2EventSensSetActive_t rxode2EventSensSetActive;
+  typedef void (*rxode2EventSensDeactivate_t)(void);
+  extern rxode2EventSensDeactivate_t rxode2EventSensDeactivate;
 
   // Per-individual ODE solve buffer-pointer swap (nlmixr2est impmap gradient):
   // save the originals, install private larger buffers for a higher-state
@@ -350,8 +389,6 @@ extern "C" {
       setSeedEng1 = (setSeedEng1_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 71));
       seedEng = (seedEng_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 72));
       rxNormEng = (rxNormEng_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 73));
-      rxUnifEng = (rxUnifEng_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 81));
-      getIndCmt = (getIndCmt_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 82));
       setIndSolvePtr = (setIndSolvePtr_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 74));
       getIndSolveSave = (getIndSolveSave_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 75));
       setIndSolveSave = (setIndSolveSave_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 76));
@@ -359,6 +396,17 @@ extern "C" {
       setIndSolveLast = (setIndSolveLast_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 78));
       getIndSolveLast2 = (getIndSolveLast2_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 79));
       setIndSolveLast2 = (setIndSolveLast2_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 80));
+      rxUnifEng = (rxUnifEng_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 81));
+      getIndCmt = (getIndCmt_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 82));
+      setIndCmt = (setIndCmt_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 83));
+      rxode2EventSensShapeSize = (rxode2EventSensShapeSize_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 84));
+      rxode2EventSensShapeSave = (rxode2EventSensShapeSave_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 85));
+      rxode2EventSensShapeRestore = (rxode2EventSensShapeRestore_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 86));
+      rxode2EventSensLoadFull = (rxode2EventSensLoadFull_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 87));
+      rxode2EventSensGetDims = (rxode2EventSensGetDims_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 88));
+      rxode2EventSensSetDims = (rxode2EventSensSetDims_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 89));
+      rxode2EventSensSetActive = (rxode2EventSensSetActive_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 90));
+      rxode2EventSensDeactivate = (rxode2EventSensDeactivate_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 91));
     }
     return R_NilValue;
   }
@@ -447,6 +495,15 @@ extern "C" {
   setIndSolveLast_t setIndSolveLast = NULL;             \
   getIndSolveLast2_t getIndSolveLast2 = NULL;           \
   setIndSolveLast2_t setIndSolveLast2 = NULL;           \
+  setIndCmt_t setIndCmt = NULL;                         \
+  rxode2EventSensShapeSize_t rxode2EventSensShapeSize = NULL;       \
+  rxode2EventSensShapeSave_t rxode2EventSensShapeSave = NULL;       \
+  rxode2EventSensShapeRestore_t rxode2EventSensShapeRestore = NULL; \
+  rxode2EventSensLoadFull_t rxode2EventSensLoadFull = NULL;         \
+  rxode2EventSensGetDims_t rxode2EventSensGetDims = NULL;           \
+  rxode2EventSensSetDims_t rxode2EventSensSetDims = NULL;           \
+  rxode2EventSensSetActive_t rxode2EventSensSetActive = NULL;       \
+  rxode2EventSensDeactivate_t rxode2EventSensDeactivate = NULL;     \
   SEXP iniRxodePtrs(SEXP ptr) {                         \
     return iniRxodePtrs0(ptr);                          \
   }                                                     \

--- a/inst/include/rxode2ptr.h
+++ b/inst/include/rxode2ptr.h
@@ -61,12 +61,17 @@ extern "C" {
   //   rxode2EventSensShapeRestore(saved.data());
   //
   // The buffer layout is opaque and may change between rxode2 versions, so a
-  // buffer must not outlive the process that produced it.
+  // buffer must not outlive the process that produced it; a buffer rxode2 does
+  // not recognize is rejected (restore returns 0 and changes nothing) rather
+  // than installed.  These globals are read inside the OpenMP solve loops, so
+  // install and restore only at batch boundaries, never from a parallel region.
   typedef int (*rxode2EventSensShapeSize_t)(void);
   extern rxode2EventSensShapeSize_t rxode2EventSensShapeSize;
   typedef void (*rxode2EventSensShapeSave_t)(void *buf);
   extern rxode2EventSensShapeSave_t rxode2EventSensShapeSave;
-  typedef void (*rxode2EventSensShapeRestore_t)(const void *buf);
+  // Returns 1 on success, 0 if the buffer was rejected.  Never calls Rf_error,
+  // so a C++ caller is not longjmp'd past its destructors.
+  typedef int (*rxode2EventSensShapeRestore_t)(const void *buf);
   extern rxode2EventSensShapeRestore_t rxode2EventSensShapeRestore;
   // Install a model's shape from its `trans` vector (all six dims).
   typedef void (*rxode2EventSensLoadFull_t)(SEXP trans, int active, int nState, int nParam, int nParam2, int nParam3, int useCalcJac);

--- a/man/rxEventSensLoadModel.Rd
+++ b/man/rxEventSensLoadModel.Rd
@@ -19,6 +19,8 @@ model through a direct C++ \code{ind_solve()} loop, bypassing \code{rxSolve()}: 
 rxode2's event ("jump") sensitivity function pointers and runtime dims to
 \code{model} and turns the jumps on.  The jump blocks are bounds-guarded, so
 smaller models solved afterwards skip the injection safely.  Pair with
-\code{rxEventSensDeactivate()} after the run.
+\code{rxEventSensDeactivate()} after the run.  The C API entry points behind this
+(\code{rxode2EventSensLoadFull()} and the shape save/restore) are in rxode2's
+function-pointer table, for callers that need the swap from C++.
 }
 \keyword{internal}

--- a/src/init.c
+++ b/src/init.c
@@ -50,8 +50,13 @@ SEXP _rxode2_setEventSensDims(SEXP active, SEXP nState, SEXP nParam, SEXP nParam
 SEXP _rxode2_setEventSensUseCalcJac(SEXP useCalcJac);
 SEXP _rxode2_setEventSensNParam3(SEXP nParam3);
 void rxode2EventSensLoad(SEXP trans, int active, int nState, int nParam, int nParam2);
-void rxode2EventSensSetActive(int active);
 SEXP _rxode2_eventSensLoad(SEXP trans, SEXP active, SEXP nState, SEXP nParam, SEXP nParam2);
+SEXP _rxode2_eventSensLoadFull(SEXP trans, SEXP active, SEXP nState, SEXP nParam, SEXP nParam2, SEXP nParam3, SEXP useCalcJac);
+SEXP _rxode2_eventSensSetDims(SEXP active, SEXP nState, SEXP nParam, SEXP nParam2, SEXP nParam3, SEXP useCalcJac);
+SEXP _rxode2_eventSensGetDims(void);
+SEXP _rxode2_eventSensDeactivate(void);
+SEXP _rxode2_eventSensShapeSave(void);
+SEXP _rxode2_eventSensShapeRestore(SEXP buf);
 SEXP _rxode2_parseModel(SEXP type);
 SEXP _rxode2_isLinCmt(void);
 SEXP _rxode2_RcppExport_registerCCallable(void);
@@ -522,8 +527,17 @@ SEXP _rxode2_rxode2Ptr(void) {
   SEXP rxode2setIndSolveLast = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setIndSolveLast, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2getIndSolveLast2 = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&getIndSolveLast2, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2setIndSolveLast2 = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setIndSolveLast2, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2setIndCmt = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setIndCmt, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2EventSensShapeSizePtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxode2EventSensShapeSize, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2EventSensShapeSavePtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxode2EventSensShapeSave, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2EventSensShapeRestorePtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxode2EventSensShapeRestore, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2EventSensLoadFullPtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxode2EventSensLoadFull, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2EventSensGetDimsPtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxode2EventSensGetDims, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2EventSensSetDimsPtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxode2EventSensSetDims, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2EventSensSetActivePtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxode2EventSensSetActive, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2EventSensDeactivatePtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxode2EventSensDeactivate, R_NilValue, R_NilValue)); pro++;
 
-#define nVec 83
+#define nVec 92
   SEXP ret = PROTECT(Rf_allocVector(VECSXP, nVec)); pro++;
   SET_VECTOR_ELT(ret, 0, rxode2rxRmvnSEXP);
   SET_VECTOR_ELT(ret, 1, rxode2rxParProgress);
@@ -608,6 +622,15 @@ SEXP _rxode2_rxode2Ptr(void) {
   SET_VECTOR_ELT(ret, 80, rxode2setIndSolveLast2);
   SET_VECTOR_ELT(ret, 81, rxode2rxUnifEng);
   SET_VECTOR_ELT(ret, 82, rxode2getIndCmt);
+  SET_VECTOR_ELT(ret, 83, rxode2setIndCmt);
+  SET_VECTOR_ELT(ret, 84, rxode2EventSensShapeSizePtr);
+  SET_VECTOR_ELT(ret, 85, rxode2EventSensShapeSavePtr);
+  SET_VECTOR_ELT(ret, 86, rxode2EventSensShapeRestorePtr);
+  SET_VECTOR_ELT(ret, 87, rxode2EventSensLoadFullPtr);
+  SET_VECTOR_ELT(ret, 88, rxode2EventSensGetDimsPtr);
+  SET_VECTOR_ELT(ret, 89, rxode2EventSensSetDimsPtr);
+  SET_VECTOR_ELT(ret, 90, rxode2EventSensSetActivePtr);
+  SET_VECTOR_ELT(ret, 91, rxode2EventSensDeactivatePtr);
 
 
   SEXP retN = PROTECT(Rf_allocVector(STRSXP, nVec)); pro++;
@@ -619,8 +642,8 @@ SEXP _rxode2_rxode2Ptr(void) {
   SET_STRING_ELT(retN, 5, Rf_mkChar("rxode2isRstudio"));
   SET_STRING_ELT(retN, 6, Rf_mkChar("rxode2iniSubjectE"));
   SET_STRING_ELT(retN, 7, Rf_mkChar("rxode2sortIds"));
-  SET_STRING_ELT(retN, 8, Rf_mkChar("getSolvingOptionsInd"));
-  SET_STRING_ELT(retN, 9, Rf_mkChar("rxode2getUpdateInis"));
+  SET_STRING_ELT(retN, 8, Rf_mkChar("rxode2getSolvingOptions"));
+  SET_STRING_ELT(retN, 9, Rf_mkChar("rxode2getSolvingOptionsInd"));
   SET_STRING_ELT(retN, 10, Rf_mkChar("rxode2_rxode2_rxModelVars_"));
   SET_STRING_ELT(retN, 11, Rf_mkChar("rxode2_par_solve"));
   SET_STRING_ELT(retN, 12, Rf_mkChar("rxode2rxGetId"));
@@ -694,6 +717,26 @@ SEXP _rxode2_rxode2Ptr(void) {
   SET_STRING_ELT(retN, 80, Rf_mkChar("rxode2setIndSolveLast2"));
   SET_STRING_ELT(retN, 81, Rf_mkChar("rxode2rxUnifEng"));
   SET_STRING_ELT(retN, 82, Rf_mkChar("rxode2getIndCmt"));
+  SET_STRING_ELT(retN, 83, Rf_mkChar("rxode2setIndCmt"));
+  SET_STRING_ELT(retN, 84, Rf_mkChar("rxode2EventSensShapeSize"));
+  SET_STRING_ELT(retN, 85, Rf_mkChar("rxode2EventSensShapeSave"));
+  SET_STRING_ELT(retN, 86, Rf_mkChar("rxode2EventSensShapeRestore"));
+  SET_STRING_ELT(retN, 87, Rf_mkChar("rxode2EventSensLoadFull"));
+  SET_STRING_ELT(retN, 88, Rf_mkChar("rxode2EventSensGetDims"));
+  SET_STRING_ELT(retN, 89, Rf_mkChar("rxode2EventSensSetDims"));
+  SET_STRING_ELT(retN, 90, Rf_mkChar("rxode2EventSensSetActive"));
+  SET_STRING_ELT(retN, 91, Rf_mkChar("rxode2EventSensDeactivate"));
+
+  // Every slot must be filled: the table is read positionally by
+  // iniRxodePtrs0() (inst/include/rxode2ptr.h), so a slot left at R_NilValue by
+  // a missed SET_VECTOR_ELT hands the downstream package a NULL function pointer
+  // that only crashes when it is finally called.  Fail here instead.
+  for (int i = 0; i < nVec; ++i) {
+    if (VECTOR_ELT(ret, i) == R_NilValue) {
+      UNPROTECT(pro);
+      (Rf_error)("rxode2 function-pointer table slot %d is unset (internal error)", i);
+    }
+  }
 
 #undef nVec
 
@@ -802,6 +845,12 @@ void R_init_rxode2(DllInfo *info){
     {"_rxode2_setEventSensUseCalcJac", (DL_FUNC) &_rxode2_setEventSensUseCalcJac, 1},
     {"_rxode2_setEventSensNParam3", (DL_FUNC) &_rxode2_setEventSensNParam3, 1},
     {"_rxode2_eventSensLoad", (DL_FUNC) &_rxode2_eventSensLoad, 5},
+    {"_rxode2_eventSensLoadFull", (DL_FUNC) &_rxode2_eventSensLoadFull, 7},
+    {"_rxode2_eventSensSetDims", (DL_FUNC) &_rxode2_eventSensSetDims, 6},
+    {"_rxode2_eventSensGetDims", (DL_FUNC) &_rxode2_eventSensGetDims, 0},
+    {"_rxode2_eventSensDeactivate", (DL_FUNC) &_rxode2_eventSensDeactivate, 0},
+    {"_rxode2_eventSensShapeSave", (DL_FUNC) &_rxode2_eventSensShapeSave, 0},
+    {"_rxode2_eventSensShapeRestore", (DL_FUNC) &_rxode2_eventSensShapeRestore, 1},
     {"_rxode2_codeLoaded", (DL_FUNC) &_rxode2_codeLoaded, 0},
     {"_rxode2_parseModel", (DL_FUNC) &_rxode2_parseModel, 1},
     {"_rxode2_isLinCmt", (DL_FUNC) &_rxode2_isLinCmt, 0},

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -710,6 +710,217 @@ extern "C" SEXP _rxode2_eventSensLoad(SEXP trans, SEXP active, SEXP nState,
   return R_NilValue;
 }
 
+////////////////////////////////////////////////////////////////////////
+// Event-sensitivity shape: function-pointer-table API (issue #1169)
+//
+// A "shape" is everything that describes one model's event ("jump")
+// sensitivities: the six dims above plus the model's dosing-derivative function
+// pointers.  Downstream packages (nlmixr2est's FOCEi) solve several peer models
+// -- pred, inner, augmented outer -- through ONE shared solve pool, each with a
+// different shape, so a swap has to install the batch's shape and restore the
+// previous one afterwards.  These entry points make that a self-contained C++
+// batch boundary with no R round trip (which is not usable there: installing
+// from R can repoint rxode2's global model pointer while the pool solve is
+// live).  The shape is saved into a caller-owned opaque buffer rather than a
+// published struct, so its layout stays rxode2's business.
+////////////////////////////////////////////////////////////////////////
+
+typedef struct rxEsShape {
+  int active;
+  int nState;
+  int nParam;
+  int nParam2;
+  int nParam3;
+  int useCalcJac;
+  t_dydt dydtEs;
+  t_DUR durEsFn;
+  t_dLag dLagEs;
+  t_dLag d2LagEs;
+  t_dLag dLagJacEs;
+  t_dLag dLagQEs;
+  t_dF dF;
+  t_dF d2FEs;
+  t_dF d3FEs;
+  t_dF dFQEs;
+  t_dRate dRateEs;
+  t_dRate d2RateEs;
+  t_dDur dDurEs;
+  t_dDur d2DurEs;
+  t_dDur dDurQEs;
+} rxEsShape;
+
+// Bytes a caller must allocate for one saved shape.
+extern "C" int rxode2EventSensShapeSize(void) {
+  return (int) sizeof(rxEsShape);
+}
+
+// Snapshot the installed shape into `buf` (>= rxode2EventSensShapeSize() bytes).
+// memcpy'd, so `buf` needs no particular alignment.
+extern "C" void rxode2EventSensShapeSave(void *buf) {
+  if (buf == NULL) return;
+  rxEsShape s;
+  s.active = _rxEsActive;
+  s.nState = _rxEsNState;
+  s.nParam = _rxEsNParam;
+  s.nParam2 = _rxEsNParam2;
+  s.nParam3 = _rxEsNParam3;
+  s.useCalcJac = _rxEsUseCalcJac;
+  s.dydtEs = dydtEs;
+  s.durEsFn = durEsFn;
+  s.dLagEs = dLagEs;
+  s.d2LagEs = d2LagEs;
+  s.dLagJacEs = dLagJacEs;
+  s.dLagQEs = dLagQEs;
+  s.dF = dF;
+  s.d2FEs = d2FEs;
+  s.d3FEs = d3FEs;
+  s.dFQEs = dFQEs;
+  s.dRateEs = dRateEs;
+  s.d2RateEs = d2RateEs;
+  s.dDurEs = dDurEs;
+  s.d2DurEs = d2DurEs;
+  s.dDurQEs = dDurQEs;
+  memcpy(buf, &s, sizeof(rxEsShape));
+}
+
+// Reinstall a shape previously written by rxode2EventSensShapeSave().
+extern "C" void rxode2EventSensShapeRestore(const void *buf) {
+  if (buf == NULL) return;
+  rxEsShape s;
+  memcpy(&s, buf, sizeof(rxEsShape));
+  _rxEsActive = s.active;
+  _rxEsNState = s.nState;
+  _rxEsNParam = s.nParam;
+  _rxEsNParam2 = s.nParam2;
+  _rxEsNParam3 = s.nParam3;
+  _rxEsUseCalcJac = s.useCalcJac;
+  dydtEs = s.dydtEs;
+  durEsFn = s.durEsFn;
+  dLagEs = s.dLagEs;
+  d2LagEs = s.d2LagEs;
+  dLagJacEs = s.dLagJacEs;
+  dLagQEs = s.dLagQEs;
+  dF = s.dF;
+  d2FEs = s.d2FEs;
+  d3FEs = s.d3FEs;
+  dFQEs = s.dFQEs;
+  dRateEs = s.dRateEs;
+  d2RateEs = s.d2RateEs;
+  dDurEs = s.dDurEs;
+  d2DurEs = s.d2DurEs;
+  dDurQEs = s.dDurQEs;
+}
+
+// rxode2EventSensLoad plus the two dims that setter predates (nParam3,
+// useCalcJac); the C equivalent of R's rxEventSensLoadModel().
+extern "C" void rxode2EventSensLoadFull(SEXP trans, int active, int nState,
+                                        int nParam, int nParam2, int nParam3,
+                                        int useCalcJac) {
+  rxode2EventSensLoad(trans, active, nState, nParam, nParam2);
+  _rxEsNParam3 = nParam3;
+  _rxEsUseCalcJac = useCalcJac;
+}
+
+// Read the installed dims (any pointer may be NULL to skip it).  Pair with
+// rxode2EventSensSetDims() when only the dims change between peers -- use the
+// shape save/restore when the models differ, since the dosing-derivative
+// function pointers differ with them.
+extern "C" void rxode2EventSensGetDims(int *active, int *nState, int *nParam,
+                                       int *nParam2, int *nParam3,
+                                       int *useCalcJac) {
+  if (active != NULL) *active = _rxEsActive;
+  if (nState != NULL) *nState = _rxEsNState;
+  if (nParam != NULL) *nParam = _rxEsNParam;
+  if (nParam2 != NULL) *nParam2 = _rxEsNParam2;
+  if (nParam3 != NULL) *nParam3 = _rxEsNParam3;
+  if (useCalcJac != NULL) *useCalcJac = _rxEsUseCalcJac;
+}
+
+// Set all six dims at once, leaving the function pointers alone.
+extern "C" void rxode2EventSensSetDims(int active, int nState, int nParam,
+                                       int nParam2, int nParam3,
+                                       int useCalcJac) {
+  _rxEsActive = active;
+  _rxEsNState = nState;
+  _rxEsNParam = nParam;
+  _rxEsNParam2 = nParam2;
+  _rxEsNParam3 = nParam3;
+  _rxEsUseCalcJac = useCalcJac;
+}
+
+// Turn the jump injection off and zero the dims (C equivalent of R's
+// rxEventSensDeactivate()).  Function pointers are preserved, so a later
+// rxode2EventSensSetDims() can turn the same model back on.
+extern "C" void rxode2EventSensDeactivate(void) {
+  _rxEsActive = 0;
+  _rxEsNState = 0;
+  _rxEsNParam = 0;
+  _rxEsNParam2 = 0;
+  _rxEsNParam3 = 0;
+  _rxEsUseCalcJac = 0;
+}
+
+// R .Call wrappers around the entry points above, so the R side
+// (rxEventSensLoadModel() / rxEventSensDeactivate() / .rxSetEventSensDims())
+// and the C API drive the same code.
+extern "C" SEXP _rxode2_eventSensLoadFull(SEXP trans, SEXP active, SEXP nState,
+                                          SEXP nParam, SEXP nParam2,
+                                          SEXP nParam3, SEXP useCalcJac) {
+  rxode2EventSensLoadFull(trans, INTEGER(active)[0], INTEGER(nState)[0],
+                          INTEGER(nParam)[0], INTEGER(nParam2)[0],
+                          INTEGER(nParam3)[0], INTEGER(useCalcJac)[0]);
+  return R_NilValue;
+}
+
+extern "C" SEXP _rxode2_eventSensSetDims(SEXP active, SEXP nState, SEXP nParam,
+                                         SEXP nParam2, SEXP nParam3,
+                                         SEXP useCalcJac) {
+  rxode2EventSensSetDims(INTEGER(active)[0], INTEGER(nState)[0],
+                         INTEGER(nParam)[0], INTEGER(nParam2)[0],
+                         INTEGER(nParam3)[0], INTEGER(useCalcJac)[0]);
+  return R_NilValue;
+}
+
+extern "C" SEXP _rxode2_eventSensGetDims(void) {
+  rxProtect rx_protect;
+  SEXP ret = rx_protect.protect(Rf_allocVector(INTSXP, 6));
+  SEXP nm = rx_protect.protect(Rf_allocVector(STRSXP, 6));
+  rxode2EventSensGetDims(INTEGER(ret), INTEGER(ret) + 1, INTEGER(ret) + 2,
+                         INTEGER(ret) + 3, INTEGER(ret) + 4, INTEGER(ret) + 5);
+  SET_STRING_ELT(nm, 0, Rf_mkChar("active"));
+  SET_STRING_ELT(nm, 1, Rf_mkChar("nState"));
+  SET_STRING_ELT(nm, 2, Rf_mkChar("nParam"));
+  SET_STRING_ELT(nm, 3, Rf_mkChar("nParam2"));
+  SET_STRING_ELT(nm, 4, Rf_mkChar("nParam3"));
+  SET_STRING_ELT(nm, 5, Rf_mkChar("useCalcJac"));
+  Rf_setAttrib(ret, R_NamesSymbol, nm);
+  return ret;
+}
+
+extern "C" SEXP _rxode2_eventSensDeactivate(void) {
+  rxode2EventSensDeactivate();
+  return R_NilValue;
+}
+
+// Shape save/restore as an R raw vector.  The bytes are an internal snapshot
+// (they hold live function pointers), so they are valid only within the session
+// that produced them -- never serialize one.
+extern "C" SEXP _rxode2_eventSensShapeSave(void) {
+  rxProtect rx_protect;
+  SEXP ret = rx_protect.protect(Rf_allocVector(RAWSXP, rxode2EventSensShapeSize()));
+  rxode2EventSensShapeSave(RAW(ret));
+  return ret;
+}
+
+extern "C" SEXP _rxode2_eventSensShapeRestore(SEXP buf) {
+  if (TYPEOF(buf) != RAWSXP || Rf_xlength(buf) != rxode2EventSensShapeSize()) {
+    (Rf_error)("[eventSensShapeRestore]: expected a raw vector of %d bytes",
+               rxode2EventSensShapeSize());
+  }
+  rxode2EventSensShapeRestore(RAW(buf));
+  return R_NilValue;
+}
+
 t_update_inis update_inis = NULL;
 
 t_dydt_lsoda_dum dydt_lsoda_dum = NULL;

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -723,9 +723,21 @@ extern "C" SEXP _rxode2_eventSensLoad(SEXP trans, SEXP active, SEXP nState,
 // from R can repoint rxode2's global model pointer while the pool solve is
 // live).  The shape is saved into a caller-owned opaque buffer rather than a
 // published struct, so its layout stays rxode2's business.
+//
+// The shape globals are read (not written) inside the OpenMP solve loops, so
+// install and restore only at batch boundaries -- never from inside a parallel
+// region, and never while another thread is solving.
 ////////////////////////////////////////////////////////////////////////
 
+// Stamped into every saved buffer and checked on restore, so a buffer that did
+// not come from rxode2EventSensShapeSave() -- a corrupted one, or one saved by a
+// different rxode2 build whose layout has moved -- is rejected instead of
+// installed as live function pointers.  Bump when the struct below changes.
+#define RX_ES_SHAPE_MAGIC 0x72455331  /* "rES1" */
+
 typedef struct rxEsShape {
+  unsigned int magic;
+  int size;
   int active;
   int nState;
   int nParam;
@@ -759,6 +771,8 @@ extern "C" int rxode2EventSensShapeSize(void) {
 extern "C" void rxode2EventSensShapeSave(void *buf) {
   if (buf == NULL) return;
   rxEsShape s;
+  s.magic = RX_ES_SHAPE_MAGIC;
+  s.size = (int) sizeof(rxEsShape);
   s.active = _rxEsActive;
   s.nState = _rxEsNState;
   s.nParam = _rxEsNParam;
@@ -783,11 +797,19 @@ extern "C" void rxode2EventSensShapeSave(void *buf) {
   memcpy(buf, &s, sizeof(rxEsShape));
 }
 
-// Reinstall a shape previously written by rxode2EventSensShapeSave().
-extern "C" void rxode2EventSensShapeRestore(const void *buf) {
-  if (buf == NULL) return;
+// Reinstall a shape previously written by rxode2EventSensShapeSave().  Rejects
+// a buffer that does not carry this build's stamp rather than installing
+// whatever bytes it holds as function pointers.  Returns 1 on success and 0 if
+// the buffer was rejected (leaving the installed shape untouched); it never
+// calls Rf_error, so a C++ caller holding the buffer in a local container is
+// not longjmp'd past its destructor.
+extern "C" int rxode2EventSensShapeRestore(const void *buf) {
+  if (buf == NULL) return 0;
   rxEsShape s;
   memcpy(&s, buf, sizeof(rxEsShape));
+  if (s.magic != RX_ES_SHAPE_MAGIC || s.size != (int) sizeof(rxEsShape)) {
+    return 0;
+  }
   _rxEsActive = s.active;
   _rxEsNState = s.nState;
   _rxEsNParam = s.nParam;
@@ -809,6 +831,7 @@ extern "C" void rxode2EventSensShapeRestore(const void *buf) {
   dDurEs = s.dDurEs;
   d2DurEs = s.d2DurEs;
   dDurQEs = s.dDurQEs;
+  return 1;
 }
 
 // rxode2EventSensLoad plus the two dims that setter predates (nParam3,
@@ -917,7 +940,9 @@ extern "C" SEXP _rxode2_eventSensShapeRestore(SEXP buf) {
     (Rf_error)("[eventSensShapeRestore]: expected a raw vector of %d bytes",
                rxode2EventSensShapeSize());
   }
-  rxode2EventSensShapeRestore(RAW(buf));
+  if (!rxode2EventSensShapeRestore(RAW(buf))) {
+    (Rf_error)("[eventSensShapeRestore]: not an event-sensitivity shape saved by this rxode2 build");
+  }
   return R_NilValue;
 }
 

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -766,10 +766,12 @@ extern "C" int rxode2EventSensShapeSize(void) {
   return (int) sizeof(rxEsShape);
 }
 
-// Snapshot the installed shape into `buf` (>= rxode2EventSensShapeSize() bytes).
-// memcpy'd, so `buf` needs no particular alignment.
-extern "C" void rxode2EventSensShapeSave(void *buf) {
-  if (buf == NULL) return;
+// Snapshot the installed shape into `buf`, whose capacity is `bufSize` bytes.
+// Returns 1 on success, 0 if `buf` is NULL or too small (nothing is written --
+// the callee cannot otherwise tell, and a short buffer would be a silent
+// out-of-bounds write).  memcpy'd, so `buf` needs no particular alignment.
+extern "C" int rxode2EventSensShapeSave(void *buf, int bufSize) {
+  if (buf == NULL || bufSize < (int) sizeof(rxEsShape)) return 0;
   rxEsShape s;
   s.magic = RX_ES_SHAPE_MAGIC;
   s.size = (int) sizeof(rxEsShape);
@@ -795,6 +797,7 @@ extern "C" void rxode2EventSensShapeSave(void *buf) {
   s.d2DurEs = d2DurEs;
   s.dDurQEs = dDurQEs;
   memcpy(buf, &s, sizeof(rxEsShape));
+  return 1;
 }
 
 // Reinstall a shape previously written by rxode2EventSensShapeSave().  Rejects
@@ -803,8 +806,8 @@ extern "C" void rxode2EventSensShapeSave(void *buf) {
 // the buffer was rejected (leaving the installed shape untouched); it never
 // calls Rf_error, so a C++ caller holding the buffer in a local container is
 // not longjmp'd past its destructor.
-extern "C" int rxode2EventSensShapeRestore(const void *buf) {
-  if (buf == NULL) return 0;
+extern "C" int rxode2EventSensShapeRestore(const void *buf, int bufSize) {
+  if (buf == NULL || bufSize < (int) sizeof(rxEsShape)) return 0;
   rxEsShape s;
   memcpy(&s, buf, sizeof(rxEsShape));
   if (s.magic != RX_ES_SHAPE_MAGIC || s.size != (int) sizeof(rxEsShape)) {
@@ -930,8 +933,9 @@ extern "C" SEXP _rxode2_eventSensDeactivate(void) {
 // that produced them -- never serialize one.
 extern "C" SEXP _rxode2_eventSensShapeSave(void) {
   rxProtect rx_protect;
-  SEXP ret = rx_protect.protect(Rf_allocVector(RAWSXP, rxode2EventSensShapeSize()));
-  rxode2EventSensShapeSave(RAW(ret));
+  int n = rxode2EventSensShapeSize();
+  SEXP ret = rx_protect.protect(Rf_allocVector(RAWSXP, n));
+  rxode2EventSensShapeSave(RAW(ret), n);
   return ret;
 }
 
@@ -940,7 +944,7 @@ extern "C" SEXP _rxode2_eventSensShapeRestore(SEXP buf) {
     (Rf_error)("[eventSensShapeRestore]: expected a raw vector of %d bytes",
                rxode2EventSensShapeSize());
   }
-  if (!rxode2EventSensShapeRestore(RAW(buf))) {
+  if (!rxode2EventSensShapeRestore(RAW(buf), (int) Rf_xlength(buf))) {
     (Rf_error)("[eventSensShapeRestore]: not an event-sensitivity shape saved by this rxode2 build");
   }
   return R_NilValue;

--- a/src/rx2api.c
+++ b/src/rx2api.c
@@ -274,6 +274,19 @@ int getIndCmt(rx_solving_options* op, rx_solving_options_ind* ind, int kk) {
   return (int) v;
 }
 
+// Inverse of getIndCmt(): write the CMT covariate at row kk.  Lets a downstream
+// package re-base the CMT column (e.g. nlmixr2est's shared FOCEi solve pool,
+// whose peer models carry different sensitivity-compartment counts and so
+// different _CMT offsets) without reaching into op->cmtCov / ind->cov_ptr.  A
+// no-op for a model with no CMT covariate (single endpoint).
+void setIndCmt(rx_solving_options* op, rx_solving_options_ind* ind, int kk, int cmt) {
+  if (op == NULL || op->cmtCov < 0) return;
+  if (kk < 0 || kk >= ind->n_all_times) {
+    (Rf_error)("[setIndCmt]: kk (%d) should be between [0, %d)", kk, ind->n_all_times);
+  }
+  ind->cov_ptr[(size_t)ind->n_all_times * (size_t)op->cmtCov + (size_t)kk] = (double) cmt;
+}
+
 ////////////////////////////////////////////////////////////////////////
 // Solving options (rx->op)
 ////////////////////////////////////////////////////////////////////////

--- a/src/rx2api.c
+++ b/src/rx2api.c
@@ -265,7 +265,7 @@ int getIndIdx(rx_solving_options_ind* ind) {
 // covariate (a single-endpoint model) or the value is missing.  CMT values are the
 // data's compartment numbers (distinct, not necessarily sequential).
 int getIndCmt(rx_solving_options* op, rx_solving_options_ind* ind, int kk) {
-  if (op == NULL || op->cmtCov < 0) return 1;
+  if (op == NULL || op->cmtCov < 0 || ind == NULL || ind->cov_ptr == NULL) return 1;
   if (kk < 0 || kk >= ind->n_all_times) {
     Rf_error("[getIndCmt]: kk (%d) should be between [0, %d)", kk, ind->n_all_times);
   }
@@ -278,9 +278,10 @@ int getIndCmt(rx_solving_options* op, rx_solving_options_ind* ind, int kk) {
 // package re-base the CMT column (e.g. nlmixr2est's shared FOCEi solve pool,
 // whose peer models carry different sensitivity-compartment counts and so
 // different _CMT offsets) without reaching into op->cmtCov / ind->cov_ptr.  A
-// no-op for a model with no CMT covariate (single endpoint).
+// no-op for a model with no CMT covariate (single endpoint) or an individual
+// with no covariate array.
 void setIndCmt(rx_solving_options* op, rx_solving_options_ind* ind, int kk, int cmt) {
-  if (op == NULL || op->cmtCov < 0) return;
+  if (op == NULL || op->cmtCov < 0 || ind == NULL || ind->cov_ptr == NULL) return;
   if (kk < 0 || kk >= ind->n_all_times) {
     (Rf_error)("[setIndCmt]: kk (%d) should be between [0, %d)", kk, ind->n_all_times);
   }

--- a/tests/testthat/test-event-sensitivities-api.R
+++ b/tests/testthat/test-event-sensitivities-api.R
@@ -1,0 +1,96 @@
+rxTest({
+  # C API for the event ("jump") sensitivity shape (issue #1169) and the CMT
+  # covariate writer (issue #1172).  These entry points exist so a downstream
+  # package (nlmixr2est's FOCEi) can swap between peer models inside one shared
+  # solve pool from C++.  Here they are driven through their .Call wrappers,
+  # which call exactly the same C functions the pointer table exports.
+
+  .mod1 <- "
+    ka <- exp(tka + eta_ka)
+    cl <- exp(tcl)
+    v  <- exp(tv)
+    alag(depot) <- exp(tlag + eta_lag)
+    f(depot)    <- expit(tf)
+    d/dt(depot)   <- -ka * depot
+    d/dt(central) <-  ka * depot - cl / v * central
+    cp <- central / v
+  "
+
+  test_that("the rxode2 function-pointer table is complete and named", {
+    p <- .rxode2ptrs()
+    expect_false(any(vapply(p, is.null, logical(1))))
+    expect_true(all(nzchar(names(p))))
+    expect_false(anyDuplicated(names(p)) > 0L)
+    # the entry points added for issues #1169 / #1172
+    expect_true(all(c("rxode2setIndCmt", "rxode2EventSensShapeSize",
+                      "rxode2EventSensShapeSave", "rxode2EventSensShapeRestore",
+                      "rxode2EventSensLoadFull", "rxode2EventSensGetDims",
+                      "rxode2EventSensSetDims", "rxode2EventSensSetActive",
+                      "rxode2EventSensDeactivate") %in% names(p)))
+  })
+
+  test_that("event-sensitivity dims round trip and deactivate to zero", {
+    on.exit(rxEventSensDeactivate(), add = TRUE)
+    .Call(`_rxode2_eventSensSetDims`, 1L, 3L, 4L, 5L, 6L, 1L)
+    expect_equal(.rxGetEventSensDims(),
+                 c(active = 1L, nState = 3L, nParam = 4L, nParam2 = 5L,
+                   nParam3 = 6L, useCalcJac = 1L))
+    rxEventSensDeactivate()
+    expect_equal(.rxGetEventSensDims(),
+                 c(active = 0L, nState = 0L, nParam = 0L, nParam2 = 0L,
+                   nParam3 = 0L, useCalcJac = 0L))
+  })
+
+  test_that("rxEventSensLoadModel installs all six dims", {
+    on.exit(rxEventSensDeactivate(), add = TRUE)
+    m <- rxode2(.mod1, calcSens = c("eta_ka", "eta_lag"), eventSens = "jump")
+    expect_true(rxEventSensLoadModel(m))
+    d <- .rxGetEventSensDims()
+    expect_equal(unname(d[["active"]]), 1L)
+    expect_equal(unname(d[["nState"]]), 2L)   # depot + central
+    expect_equal(unname(d[["nParam"]]), 2L)   # eta_ka + eta_lag
+    # an fd model must not activate the jumps
+    mfd <- rxode2(.mod1, calcSens = c("eta_ka", "eta_lag"), eventSens = "fd")
+    expect_false(rxEventSensLoadModel(mfd))
+  })
+
+  test_that("shape save/restore round trips the whole shape, not just the dims", {
+    on.exit(rxEventSensDeactivate(), add = TRUE)
+    m <- rxode2(.mod1, calcSens = c("eta_ka", "eta_lag"), eventSens = "jump")
+    rxEventSensLoadModel(m)
+    saved <- .rxEventSensShapeSave()
+    expect_true(is.raw(saved))
+    expect_gt(length(saved), 0L)
+
+    # clobber the shape the way a peer model's install would
+    rxEventSensDeactivate()
+    .Call(`_rxode2_eventSensSetDims`, 1L, 99L, 99L, 99L, 99L, 1L)
+    expect_equal(unname(.rxGetEventSensDims()[["nState"]]), 99L)
+
+    .rxEventSensShapeRestore(saved)
+    expect_equal(.rxGetEventSensDims(),
+                 c(active = 1L, nState = 2L, nParam = 2L, nParam2 = 0L,
+                   nParam3 = 0L, useCalcJac = 0L))
+
+    expect_error(.rxEventSensShapeRestore(as.raw(1:4)))
+  })
+
+  test_that("a solve is unchanged by a save / clobber / restore bracket", {
+    # The strong check: the function pointers, not only the dims, come back --
+    # a restored shape must reproduce the reference sensitivities exactly.
+    on.exit(rxEventSensDeactivate(), add = TRUE)
+    ev <- et(amt = 100, cmt = "depot") |> et(c(1, 4, 8, 12, 24))
+    p <- c(tka = 0.45, tcl = 1, tv = 3.45, tlag = -0.7, tf = 1,
+           eta_ka = 0, eta_lag = 0)
+    m <- rxode2(.mod1, calcSens = c("eta_ka", "eta_lag"), eventSens = "jump")
+    ref <- as.data.frame(rxSolve(m, ev, params = p, atol = 1e-10, rtol = 1e-10))
+
+    rxEventSensLoadModel(m)
+    saved <- .rxEventSensShapeSave()
+    rxEventSensDeactivate()
+    .rxEventSensShapeRestore(saved)
+
+    got <- as.data.frame(rxSolve(m, ev, params = p, atol = 1e-10, rtol = 1e-10))
+    expect_equal(got, ref)
+  })
+})

--- a/tests/testthat/test-event-sensitivities-api.R
+++ b/tests/testthat/test-event-sensitivities-api.R
@@ -87,6 +87,24 @@ rxTest({
     expect_false(rxEventSensLoadModel(mfd))
   })
 
+  test_that("toggling active preserves the rest of the shape", {
+    # rxode2EventSensSetActive() is the cheap gate: it must flip `active` and
+    # leave the dims (and the function pointers) in place, unlike Deactivate().
+    on.exit(rxEventSensDeactivate(), add = TRUE)
+    m <- rxode2(.mod1, calcSens = c("eta_ka", "eta_lag"), eventSens = "jump")
+    rxEventSensLoadModel(m)
+    before <- .rxGetEventSensDims()
+    saved <- .rxEventSensShapeSave()
+    .Call(`_rxode2_eventSensSetDims`, 0L, before[["nState"]], before[["nParam"]],
+          before[["nParam2"]], before[["nParam3"]], before[["useCalcJac"]])
+    off <- .rxGetEventSensDims()
+    expect_equal(unname(off[["active"]]), 0L)
+    expect_equal(off[-1L], before[-1L])   # only `active` moved
+    # and the pointers were untouched: restoring the saved shape is a no-op here
+    .rxEventSensShapeRestore(saved)
+    expect_equal(.rxGetEventSensDims(), before)
+  })
+
   test_that("rxEventSensLoadModel carries nParam2 for a second-order model", {
     on.exit(rxEventSensDeactivate(), add = TRUE)
     m <- rxode2(.mod2, calcSens = c("trate", "tlag"),

--- a/tests/testthat/test-event-sensitivities-api.R
+++ b/tests/testthat/test-event-sensitivities-api.R
@@ -16,6 +16,17 @@ rxTest({
     cp <- central / v
   "
 
+  # depot with a modeled alag() AND rate(), plus second-order sensitivities, so
+  # the shape carries dLagEs/dRateEs/d2LagEs/d2RateEs and a nonzero nParam2 --
+  # a first-order alag/F model alone would not notice a dropped rate pointer.
+  .mod2 <- "
+    ka <- exp(tka); cl <- exp(tcl); v <- exp(tv)
+    alag(depot) <- exp(tlag)
+    rate(depot) <- exp(trate)
+    d/dt(depot)   = -ka * depot
+    d/dt(central) =  ka * depot - cl / v * central
+  "
+
   test_that("the rxode2 function-pointer table is complete and named", {
     p <- .rxode2ptrs()
     expect_false(any(vapply(p, is.null, logical(1))))
@@ -27,6 +38,28 @@ rxTest({
                       "rxode2EventSensLoadFull", "rxode2EventSensGetDims",
                       "rxode2EventSensSetDims", "rxode2EventSensSetActive",
                       "rxode2EventSensDeactivate") %in% names(p)))
+  })
+
+  test_that("every table slot lands where iniRxodePtrs0() reads it", {
+    # The table is positional: src/init.c fills slot N and iniRxodePtrs0() in
+    # rxode2ptr.h reads slot N into a specific function pointer.  If the two ever
+    # disagree a downstream package silently gets the wrong function, which no
+    # other test would catch.  Check every slot's name against the variable
+    # rxode2ptr.h assigns it to (names carry an inconsistent rxode2/rx prefix,
+    # so compare on the normalized stem).
+    h <- system.file("include", "rxode2ptr.h", package = "rxode2")
+    skip_if(!nzchar(h) || !file.exists(h))
+    lines <- grep("R_ExternalPtrAddrFn\\(VECTOR_ELT\\(p, [0-9]+\\)\\)",
+                  readLines(h), value = TRUE)
+    idx <- as.integer(sub(".*VECTOR_ELT\\(p, ([0-9]+)\\).*", "\\1", lines))
+    var <- trimws(sub("^\\s*([A-Za-z0-9_]+)\\s*=.*", "\\1", lines))
+    p <- .rxode2ptrs()
+    # every slot is read exactly once, and none is out of range
+    expect_equal(sort(idx), seq_along(p) - 1L)
+    .stem <- function(x) {
+      sub("^rx", "", tolower(gsub("[^A-Za-z0-9]", "", gsub("rxode2", "", x))))
+    }
+    expect_equal(.stem(var), .stem(names(p)[idx + 1L]))
   })
 
   test_that("event-sensitivity dims round trip and deactivate to zero", {
@@ -54,6 +87,28 @@ rxTest({
     expect_false(rxEventSensLoadModel(mfd))
   })
 
+  test_that("rxEventSensLoadModel carries nParam2 for a second-order model", {
+    on.exit(rxEventSensDeactivate(), add = TRUE)
+    m <- rxode2(.mod2, calcSens = c("trate", "tlag"),
+                calcSens2 = c("trate", "tlag"), eventSens = "jump")
+    expect_true(rxEventSensLoadModel(m))
+    d <- .rxGetEventSensDims()
+    expect_equal(unname(d[["nParam"]]), 2L)
+    expect_gt(d[["nParam2"]], 0L)   # would be 0 if the dim were dropped
+  })
+
+  test_that("eventSensLoadFull carries nParam3 and useCalcJac", {
+    # rxode2EventSensLoad() (the older entry point) takes only four dims; the
+    # regression this guards is LoadFull silently dropping the two added ones.
+    on.exit(rxEventSensDeactivate(), add = TRUE)
+    m <- rxode2(.mod1, calcSens = c("eta_ka", "eta_lag"), eventSens = "jump")
+    .Call(`_rxode2_eventSensLoadFull`, rxModelVars(m)$trans,
+          1L, 2L, 3L, 4L, 5L, 1L)
+    expect_equal(.rxGetEventSensDims(),
+                 c(active = 1L, nState = 2L, nParam = 3L, nParam2 = 4L,
+                   nParam3 = 5L, useCalcJac = 1L))
+  })
+
   test_that("shape save/restore round trips the whole shape, not just the dims", {
     on.exit(rxEventSensDeactivate(), add = TRUE)
     m <- rxode2(.mod1, calcSens = c("eta_ka", "eta_lag"), eventSens = "jump")
@@ -72,7 +127,38 @@ rxTest({
                  c(active = 1L, nState = 2L, nParam = 2L, nParam2 = 0L,
                    nParam3 = 0L, useCalcJac = 0L))
 
+    # a wrong-sized buffer, and a same-sized one that rxode2 did not stamp, are
+    # both rejected rather than installed as live function pointers
     expect_error(.rxEventSensShapeRestore(as.raw(1:4)))
+    expect_error(.rxEventSensShapeRestore(raw(length(saved))))
+    corrupt <- saved
+    corrupt[1:4] <- as.raw(c(0, 0, 0, 0))
+    expect_error(.rxEventSensShapeRestore(corrupt))
+    # the rejected restores left the installed shape alone
+    expect_equal(.rxGetEventSensDims(),
+                 c(active = 1L, nState = 2L, nParam = 2L, nParam2 = 0L,
+                   nParam3 = 0L, useCalcJac = 0L))
+  })
+
+  test_that("save/restore preserves modeled rate() and second-order pointers", {
+    # The .mod1 round trip below only exercises alag()/f().  This one carries
+    # rate() and calcSens2 as well, so dropping dRateEs/d2RateEs/d2LagEs from the
+    # saved shape would change the sensitivities instead of passing silently.
+    on.exit(rxEventSensDeactivate(), add = TRUE)
+    ev <- et(amt = 100, cmt = "depot") |> et(c(1, 4, 8, 12, 24))
+    p <- c(tka = 0.45, tcl = 1, tv = 3.45, tlag = -0.7, trate = 3)
+    m <- rxode2(.mod2, calcSens = c("trate", "tlag"),
+                calcSens2 = c("trate", "tlag"), eventSens = "jump")
+    ref <- as.data.frame(rxSolve(m, ev, params = p, atol = 1e-10, rtol = 1e-10))
+    expect_true(any(grepl("rx__sens_", names(ref))))
+
+    rxEventSensLoadModel(m)
+    saved <- .rxEventSensShapeSave()
+    rxEventSensDeactivate()
+    .rxEventSensShapeRestore(saved)
+
+    got <- as.data.frame(rxSolve(m, ev, params = p, atol = 1e-10, rtol = 1e-10))
+    expect_equal(got, ref)
   })
 
   test_that("a solve is unchanged by a save / clobber / restore bracket", {


### PR DESCRIPTION
Closes #1169. Closes #1172.

## Event-sensitivity shape (#1169)

The jump-sensitivity runtime state lives in rxode2 process globals, so it
describes exactly one model at a time. nlmixr2est's FOCEi solves several peer
models -- `rxPred`, `rxInner`, the augmented outer-gradient model -- through
**one** shared solve pool, each with a different shape, and had no legal way to
swap between them: the C entry points existed but only under
`R_RegisterCCallable` (unpinned ABI), and installing from R crashes a live pool
solve.

Added to the function-pointer table:

| entry point | purpose |
|---|---|
| `rxode2EventSensLoadFull()` | install a model's shape from its `trans`, **including** `nParam3`/`useCalcJac`, which the older `rxode2EventSensLoad()` omitted |
| `rxode2EventSensGetDims()` / `SetDims()` | read / write all six dims |
| `rxode2EventSensSetActive()` / `Deactivate()` | cheap gate / full reset |
| `rxode2EventSensShapeSize()` / `ShapeSave()` / `ShapeRestore()` | snapshot and reinstall a **whole** shape |

The shape save/restore is the part that makes the swap correct: the peers are
different compiled libraries, so their dosing-derivative function pointers
differ along with the dims. A dims-only getter/setter would restore an
incomplete shape. It goes through a caller-owned opaque buffer, so the layout
stays rxode2's business:

```cpp
std::vector<char> saved(rxode2EventSensShapeSize());
rxode2EventSensShapeSave(saved.data(), saved.size());
rxode2EventSensShapeRestore(peer.data(), peer.size());   // solve the batch
rxode2EventSensShapeRestore(saved.data(), saved.size()); // restore
```

Buffers carry a magic + size stamp, both calls take the buffer capacity and
refuse one that is too small or unrecognized, and neither calls `Rf_error` -- so
a C++ caller is not longjmp'd past its destructors.

## `setIndCmt()` (#1172)

Writer counterpart of `getIndCmt()`, so a caller can re-base the
per-observation CMT covariate without ABI-linking to `op->cmtCov` and
`ind->cov_ptr`. Both now also null-guard `ind`/`ind->cov_ptr`.

## Table hygiene

Two slot names had drifted -- slot 8 was labeled `getSolvingOptionsInd` (it is
`getSolvingOptions`) and slot 9 named a `getUpdateInis` export that no longer
exists. The table is read positionally, so this was cosmetic, but it made the
slots impossible to audit by name. Added a build-time check that no slot is
left unset (an unset slot hands a downstream package a `NULL` function pointer
that only crashes when finally called) and a test that every slot lands where
`iniRxodePtrs0()` reads it.

The R side (`rxEventSensLoadModel()` / `rxEventSensDeactivate()` /
`.rxSetEventSensDims()`) now drives the same C functions instead of duplicating
the logic across three separate setters.

## Verification

- `devtools::test(filter='event-sensitivities')`: **216 pass, 0 fail** (185
  pre-existing + 31 new).
- Built a mock downstream consumer against `inst/include/rxode2ptr.h` in both C
  and C++, loaded it, and drove every new entry point through the live pointer
  table: dims set/read back correctly, save/restore round trips, and undersized
  buffers are refused rather than overrun. This is what confirms the slot
  indices in `src/init.c` and `iniRxodePtrs0()` agree.
- Reviewed independently by Antigravity (Gemini) and Copilot (GPT); their
  confirmed findings are fixed in the follow-up commits, and the two I rejected
  are recorded with reasoning in those commit messages.

Note the new API is additive -- slots are appended, so older consumers read the
lower indices and ignore the rest. Changing `inst/include/*.h` requires a clean
rebuild (`rm -f src/*.o && R CMD INSTALL .`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)