### PR TITLE
getIndCmt(): report a missing CMT as NA_INTEGER

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,16 @@
 
 ## Bug fixes
 
+### C API
+
+- `getIndCmt()` now returns `NA_INTEGER` when a row's CMT covariate is missing,
+  instead of `1`.  Returning `1` made a missing compartment indistinguishable
+  from compartment 1, so a caller walking the CMT column silently treated NA
+  rows as real observations in compartment 1.  A model with no CMT covariate at
+  all still returns `1`, which is correct -- every observation in a
+  single-endpoint model *is* compartment 1.  Callers wanting the old lenient
+  behaviour map `NA_INTEGER` to `1` themselves.
+
 ### Dependencies
 
 - The suggested `xgxr` is now required to be `>= 1.1.6`.  Its

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,18 +18,12 @@
 - Added `setIndCmt()` to the function-pointer API, the writer counterpart of
   `getIndCmt()`, so a downstream package can re-base the per-observation `CMT`
   covariate without reaching into `op->cmtCov`/`ind->cov_ptr` by field.
+  `getIndCmt()` reports a missing `CMT` as `NA_INTEGER`, distinct from the `1`
+  it returns for a model with no `CMT` covariate at all (where every observation
+  really is compartment 1), so a caller re-basing the column can leave missing
+  rows alone.
 
 ## Bug fixes
-
-### C API
-
-- `getIndCmt()` now returns `NA_INTEGER` when a row's CMT covariate is missing,
-  instead of `1`.  Returning `1` made a missing compartment indistinguishable
-  from compartment 1, so a caller walking the CMT column silently treated NA
-  rows as real observations in compartment 1.  A model with no CMT covariate at
-  all still returns `1`, which is correct -- every observation in a
-  single-endpoint model *is* compartment 1.  Callers wanting the old lenient
-  behaviour map `NA_INTEGER` to `1` themselves.
 
 ### Dependencies
 

--- a/inst/include/rxode2ptr.h
+++ b/inst/include/rxode2ptr.h
@@ -40,6 +40,10 @@ extern "C" {
   extern rxNormEng_t rxNormEng;
   typedef double (*rxUnifEng_t)(double low, double hi);
   extern rxUnifEng_t rxUnifEng;
+  // Per-observation CMT.  Returns 1 when the model has no CMT covariate (every
+  // observation is compartment 1) but NA_INTEGER when the covariate is present and
+  // this row's value is missing -- so "no compartment recorded" is distinguishable
+  // from "compartment 1".  For the old lenient behaviour, map NA_INTEGER to 1.
   typedef int (*getIndCmt_t)(rx_solving_options* op, rx_solving_options_ind* ind, int kk);
   extern getIndCmt_t getIndCmt;
   // Writer for the CMT covariate (inverse of getIndCmt); lets a downstream

--- a/src/rx2api.c
+++ b/src/rx2api.c
@@ -261,16 +261,24 @@ int getIndIdx(rx_solving_options_ind* ind) {
 
 // Per-observation endpoint (compartment) from the CMT time-varying covariate.  The
 // covariate index is cached in op->cmtCov at setup (getIndCmt does no name lookup).
-// Returns the raw CMT value at observation row kk, or 1 when the model has no CMT
-// covariate (a single-endpoint model) or the value is missing.  CMT values are the
-// data's compartment numbers (distinct, not necessarily sequential).
+// CMT values are the data's compartment numbers (distinct, not necessarily
+// sequential).  Two distinct answers, deliberately NOT the same value:
+//
+//   * the model has NO CMT covariate (a single-endpoint model), or the individual
+//     has no covariate array -> 1, because every observation IS compartment 1;
+//   * the covariate is present but this row's value is MISSING -> NA_INTEGER, so a
+//     caller can tell "no compartment recorded here" from "compartment 1".
+//
+// Returning 1 for a missing value made the two indistinguishable, which silently
+// mis-classifies an NA row as a real compartment.  A caller that wants the old
+// lenient behaviour writes `cmt = getIndCmt(...); if (cmt == NA_INTEGER) cmt = 1;`.
 int getIndCmt(rx_solving_options* op, rx_solving_options_ind* ind, int kk) {
   if (op == NULL || op->cmtCov < 0 || ind == NULL || ind->cov_ptr == NULL) return 1;
   if (kk < 0 || kk >= ind->n_all_times) {
     Rf_error("[getIndCmt]: kk (%d) should be between [0, %d)", kk, ind->n_all_times);
   }
   double v = ind->cov_ptr[(size_t)ind->n_all_times * (size_t)op->cmtCov + (size_t)kk];
-  if (ISNA(v)) return 1;
+  if (ISNA(v) || ISNAN(v)) return NA_INTEGER;
   return (int) v;
 }
 


### PR DESCRIPTION
Follow-up to #1175, which added `setIndCmt()` so nlmixr2est could stop reaching
into `op->cmtCov`/`ind->cov_ptr` by field.  Moving to the accessor pair surfaced
that the *reader* loses information the writer preserves.

`getIndCmt()` answers `1` in two different situations:

* the model has **no CMT covariate** -- correct, every observation in a
  single-endpoint model *is* compartment 1;
* the covariate is present but **this row's value is missing** -- which conflates
  "no compartment recorded" with "compartment 1".

A caller walking the CMT column cannot distinguish them, so an NA row reads as a
real observation in compartment 1.

## Change

```c
if (ISNA(v) || ISNAN(v)) return NA_INTEGER;
```

`1` still means "this model has no CMT covariate" (a NULL `op`/`ind` is
unchanged).  `NaN` is guarded too -- it previously reached the `(int)` cast.
A caller wanting the lenient behaviour writes
`cmt = getIndCmt(...); if (cmt == NA_INTEGER) cmt = 1;`.

**Not flagged as a bug fix:** 5.1.6 is unreleased, so this is not a change to
behaviour anyone could have depended on -- it is part of the same C-API work.
The NEWS entry sits with the `setIndCmt()` feature bullet.

## Why it matters

nlmixr2est is the only consumer of this accessor today, and both call sites care:

* its shared FOCEi solve pool re-bases the CMT column between peer models (which
  carry different sensitivity-compartment counts, hence different `_CMT` offsets)
  and must leave NA rows alone.  With the old return it could only manage that
  *indirectly* -- relying on compartment 1 always being physical so the
  `|cmt| > nPhys` test skips NA-as-1.  That is an inference, not a check.
* `npBuildObsEndpoint()` matches the value against the endpoint list and falls
  back to endpoint 0, so `NA_INTEGER` lands exactly where an NA row already did.

## Verification

`getIndCmt()` has no R entry point, so there is no R-level test to add; the
accessors are exercised the way #1175 verified them, through a downstream
consumer compiled against `inst/include/rxode2ptr.h`.  nlmixr2est's CMT-rebase
path now skips NA rows explicitly rather than inferring them.

Header documentation included.