### PR TITLE
feat: safeLog=2 treats a negative log argument as a domain error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # rxode2 5.1.7 (development version)
 
+## New features
+
+- `rxSolve(safeLog=2)` floors `log(0)` at `log(.Machine$double.eps)` the way
+  `safeLog=TRUE` does, but treats a **negative** argument as a domain error and
+  returns `NaN`.  `safeLog=TRUE` (the default) and `safeLog=FALSE` are
+  unchanged.  This is for a hand-written likelihood taking `log()` of a
+  parameter that must stay positive: under `safeLog=TRUE` an invalid negative
+  value returns a large finite number, which `-log(sigma)` turns into a reward
+  of roughly `+36` per observation instead of a rejection.
+
 ## Bug fixes
 
 ### Installation / linking

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -274,7 +274,7 @@
 #'   negative and your base is zero, this will return the `machine
 #'   epsilon^(negative power)`.  By default this is turned on.
 #'
-#' @param safeLog Use safe log.  When enabled if your value that you are taking log() of is negative or zero, this will return `log(machine epsilon)`.  By default this is turned on.
+#' @param safeLog Use safe log.  When enabled (`TRUE`, the default) if your value that you are taking log() of is negative or zero, this will return `log(machine epsilon)`.  With `FALSE` both return the usual `NaN`/`-Inf`.  With `2` only zero is floored to `log(machine epsilon)`; a *negative* argument is treated as a domain error and returns `NaN`.  Use `2` when a hand-written likelihood takes `log()` of a parameter that must stay positive, so an invalid value propagates as `NaN` instead of a large finite number the optimizer could mistake for a good fit.
 #'
 #' @param sumType Sum type to use for `sum()` in
 #'     rxode2 code blocks.
@@ -1433,7 +1433,7 @@ rxSolve <- function(object, params = NULL, events = NULL, inits = NULL,
       checkmate::assertLogical(safeZero, len=1, any.missing=FALSE)
     }
     safeZero <- as.integer(safeZero)
-    if (!checkmate::testIntegerish(safeLog, lower=0, upper=1,
+    if (!checkmate::testIntegerish(safeLog, lower=0, upper=2,
                                    len=1, any.missing=FALSE)) {
       checkmate::assertLogical(safeLog, len=1, any.missing=FALSE)
     }

--- a/inst/include/rxode2_model_shared.h
+++ b/inst/include/rxode2_model_shared.h
@@ -37,7 +37,14 @@ static inline void _rxPrintf(const char *fmt, ...) {
 #define ODE0_Rprintf if ((_solveData->subjects[_cSub]).dadt_counter == 0) _rxPrintf
 #define LHS_Rprintf _rxPrintf
 static inline double _safe_log_(double a, rx_solve *rx) {
-  if (rx->safeLog) {
+  if (rx->safeLog == 2) {
+    // Zero is a benign numerical touch (a prediction landing exactly on 0), so it keeps
+    // the floor.  A NEGATIVE argument is a domain error: it must propagate as NaN rather
+    // than the large finite log(DBL_EPSILON), which a likelihood written as -log(sigma)
+    // otherwise reads as a +36 reward for an invalid sigma.
+    if (a < 0) return R_NaN;
+    return (a == 0) ? log(DBL_EPSILON) : log(a);
+  } else if (rx->safeLog) {
     return (a <= 0) ? log(DBL_EPSILON) : log(a);
   } else {
     return log(a);

--- a/man/rxSolve.Rd
+++ b/man/rxSolve.Rd
@@ -1225,7 +1225,7 @@ vector based on each state.}
 \item{safeZero}{Use safe zero divide. By default
 this is turned on but you may turn it off if you wish.}
 
-\item{safeLog}{Use safe log.  When enabled if your value that you are taking log() of is negative or zero, this will return \verb{log(machine epsilon)}.  By default this is turned on.}
+\item{safeLog}{Use safe log.  When enabled (\code{TRUE}, the default) if your value that you are taking log() of is negative or zero, this will return \verb{log(machine epsilon)}.  With \code{FALSE} both return the usual \code{NaN}/\code{-Inf}.  With \code{2} only zero is floored to \verb{log(machine epsilon)}; a \emph{negative} argument is treated as a domain error and returns \code{NaN}.  Use \code{2} when a hand-written likelihood takes \code{log()} of a parameter that must stay positive, so an invalid value propagates as \code{NaN} instead of a large finite number the optimizer could mistake for a good fit.}
 
 \item{safePow}{Use safe powers.  When enabled if your power is
 negative and your base is zero, this will return the \verb{machine epsilon^(negative power)}.  By default this is turned on.}

--- a/tests/testthat/test-safeZero.R
+++ b/tests/testthat/test-safeZero.R
@@ -31,3 +31,35 @@ test_that("safeZero solving", {
   expect_false(is.finite(safe$rPow))
 
 })
+
+test_that("safeLog=2 floors zero but rejects a negative argument", {
+
+  m <- rxode2({
+    negLog = log(-1)
+    zeroLog = log(0)
+  })
+
+  et <- et(1)
+
+  # safeLog=2: zero is a benign numerical touch and keeps the floor; a NEGATIVE
+  # argument is a domain error, so it must come back NaN rather than the large finite
+  # log(.Machine$double.eps) that safeLog=TRUE gives.  Written for a hand-written
+  # likelihood taking log() of a parameter that has to stay positive -- there the
+  # floored value reads as a large REWARD for an invalid parameter.
+  s2 <- rxSolve(m, et, safeLog=2L)
+  expect_true(is.nan(s2$negLog))
+  expect_equal(s2$zeroLog, log(.Machine$double.eps))
+
+  # the other two modes are unchanged (guarding the contract the block above pins)
+  s1 <- rxSolve(m, et, safeLog=TRUE)
+  expect_false(is.nan(s1$negLog))
+  expect_equal(s1$negLog, log(.Machine$double.eps))
+  expect_equal(s1$zeroLog, log(.Machine$double.eps))
+
+  s0 <- rxSolve(m, et, safeLog=FALSE)
+  expect_true(is.nan(s0$negLog))
+  expect_true(s0$zeroLog == -Inf)
+
+  # out-of-range values are still rejected
+  expect_error(rxSolve(m, et, safeLog=3L))
+})


### PR DESCRIPTION
Adds a third `rxSolve(safeLog=)` mode. `safeLog=0`/`FALSE` and `safeLog=1`/`TRUE` are **unchanged**; `safeLog=2` keeps the floor at exactly zero but returns `NaN` for a negative argument.

Needed by nlmixr2/nlmixr2est#850 (nlmixr2est PR to follow).

## Why

`safeLog=TRUE` returns `log(DBL_EPSILON)` for **any** argument `<= 0`. For zero that is deliberate and useful -- a solve landing exactly on 0 is a benign numerical touch -- and `tests/testthat/test-safeZero.R` pins it, using `log(-1)` as the test case. That contract is untouched here.

But it is actively harmful for a **negative** argument in a hand-written likelihood. A model written as

```r
ll(y) ~ -0.5*log(2*pi) - log(sigma) - 0.5*((DV - f)/sigma)^2
```

evaluates `-log(sigma)` at `sigma < 0` as **+36.04** (`= -log(DBL_EPSILON)`), while the squared term is even in `sigma`. So an invalid negative `sigma` is not merely tolerated -- it is **rewarded by about +36 per observation**. Downstream that reads as a spectacularly good fit rather than a rejected step.

Measured downstream: a 2-endpoint PK/PD fit under `est="npag"` reported a log-likelihood of **+2364 to +2831** where the data bounds it at **-155**, with the residual SD at **-0.83 to -1.93**.

## Why a new mode rather than changing `safeLog=TRUE`

`test-safeZero.R:22` asserts `expect_false(is.nan(safe$nanLog))` for `log(-1)` under `safeLog=TRUE`. The current behaviour is intentional and tested, so changing it would invert a documented contract and carry revdep risk. `safeLog=FALSE` already exists for callers who want plain `NaN`, but it also drops the zero floor, which is the part worth keeping.

`rx->safeLog` is already an `int` (`rxode2parseStruct.h:407`) and already validated as integerish, so this is additive:

- `inst/include/rxode2_model_shared.h` -- a `safeLog == 2` branch in `_safe_log_`
- `R/rxsolve.R` -- validation bound `upper=1` -> `upper=2`, plus docs
- no struct change, no serialization change (`rxSerialize.cpp` already I32)

## Verification

`test-safeZero.R` green: the **pre-existing** 12 assertions (including the `log(-1)` contract) unchanged, plus 8 new ones covering all three modes and rejecting an out-of-range `safeLog=3`.

Reviewed with a second-opinion model, which confirmed the branch leaves modes 0/1 bit-identical, that `R_NaN` is the right constant and reachable in that header's include chain, and that the plumbing (control index, serialization, `rxControl` round-trip) needs no other change. Its one finding -- `man/rxSolve.Rd` not regenerated -- is fixed.

## Note on the asymmetry

`x = -1e-300` gives `NaN` while `x = 0` gives `-36.04`. That is deliberate: zero is a benign numerical touch, a negative argument is a domain error.