### PR TITLE
fix: rxCompile() must generate code for the model it is given

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # rxode2 5.1.7
 
+## Bug fixes
+
+- `rxCompile()` now re-parses the model it is handed whenever the parser's
+  current model is a different one.  Code generation reads the parser's global
+  model state, and the old guard only checked whether *some* model was loaded,
+  so a re-compile requested while an unrelated model was parsed wrote that other
+  model's C under this model's name and handed back its model variables.
+  Building a model with `rxode2()` never hit this (it parses, then compiles
+  immediately), but re-loading one whose `.so` is gone did -- as when a saved
+  fit is restored in a new session, since its DLL lived in the original
+  session's `tempdir()`.  Such a fit came back solving a different model, e.g. a
+  restored SAEM fit failing with "The following parameter(s) are required for
+  solving: eta.v, eta.cl".
+
 # rxode2 5.1.6
 
 ## New features

--- a/R/rxode2.R
+++ b/R/rxode2.R
@@ -1960,8 +1960,37 @@ rxCompile.rxModelVars <- function(model, # Model
         .j <- 0
         .i <- 0
         .trans <- c(.mv$trans, .mv$md5)
-        ## Load model into memory if needed
-        if (.Call(`_rxode2_codeLoaded`) == 0L) .rxModelVarsCharacter(setNames(.mv$model, NULL))
+        ## Load model into memory if needed.
+        ##
+        ## `_rxode2_codegen` below emits C from the parser's GLOBAL
+        ## `.rxModelVarsLast`, not from `model` -- so the parsed state has to be
+        ## THIS model.  Testing `codeLoaded() == 0L` alone is not enough: it only
+        ## asks whether *some* model is loaded.  Whenever the loaded model is a
+        ## DIFFERENT one, the C written out is that other model's while the
+        ## artifact keeps this model's md5-derived name, and the returned
+        ## `modVars` (read back from the DLL) describe the wrong model entirely.
+        ##
+        ## `rxode2()` never hits this, because it parses and then immediately
+        ## compiles.  A RE-compile does: an existing model object whose .so is
+        ## gone (a saved fit restored in a new session -- its DLL lived in the
+        ## original session's tempdir) reaches here via rxDynLoad() ->
+        ## `$compile()` long after some other model was parsed.  Measured on a
+        ## restored SAEM fit: the mu-referenced prediction model `param(tcl,tv)`
+        ## came back as the fit's base model `param(tcl,eta.cl,tv,eta.v)`, so
+        ## every later solve failed with "parameter(s) are required for solving:
+        ## eta.v, eta.cl".
+        ##
+        ## Re-parse unless the loaded model is provably this one.  Only the model
+        ## SYNTAX (`normModel`) is parsed: the sibling `indLin` slot holds
+        ## generated matrix-exponential C, and it is restored from `.indLinInfo`
+        ## / `.rxMECode` a few lines below anyway.
+        .lastMd5 <- .rxModelVarsLast$md5["parsed_md5"]
+        if (.Call(`_rxode2_codeLoaded`) == 0L ||
+              length(.lastMd5) != 1L || anyNA(.lastMd5) ||
+              !identical(as.character(.lastMd5),
+                         as.character(.mv$md5["parsed_md5"]))) {
+          .rxModelVarsCharacter(setNames(rxNorm(.mv), NULL))
+        }
         .prefix2 <- .rxModelVarsCCache[[3]]
         ## SEXP pMd5, SEXP timeId, SEXP fixInis
         .newMod <- FALSE

--- a/tests/testthat/test-recompile-model.R
+++ b/tests/testthat/test-recompile-model.R
@@ -1,0 +1,42 @@
+rxTest({
+  # `_rxode2_codegen` emits C from the parser's global `.rxModelVarsLast`, so
+  # rxCompile() has to make sure the parsed model is the one it was handed.
+  # It used to re-parse only when NO model was loaded, which meant a recompile
+  # requested while some other model was the parsed one wrote that other model's
+  # C under this model's name -- and handed back its model variables.
+  #
+  # rxode2() itself never shows this (it parses, then compiles immediately); a
+  # re-compile does, e.g. a saved fit restored in a new session, whose .so lived
+  # in the original session's tempdir, so rxDynLoad() has to rebuild it.
+
+  test_that("rxCompile() compiles the model it is given, not the last parsed one", {
+    .mod <- rxode2("d/dt(recompileA) = -kRecompileA * recompileA")
+    .mv <- rxModelVars(.mod)
+
+    ## make an unrelated model the parser's current one
+    rxode2:::.rxModelVarsCharacter(
+      "d/dt(recompileB) = -kRecompileB * recompileB - kRecompileB2 * recompileB")
+
+    .dll <- rxCompile(.mv, force = TRUE)
+
+    expect_equal(.dll$modVars$params, .mv$params)
+    expect_equal(.dll$modVars$state, .mv$state)
+  })
+
+  test_that("a model whose dll is gone reloads as itself", {
+    .mod <- rxode2("d/dt(reloadA) = -kReloadA * reloadA")
+    .params <- rxModelVars(.mod)$params
+
+    ## drop the built artifact the way a new session would find it: gone
+    .dll <- rxDll(.mod)
+    rxUnload(.mod)
+    unlink(.dll)
+
+    ## and leave an unrelated model as the parsed one
+    rxode2:::.rxModelVarsCharacter(
+      "d/dt(reloadB) = -kReloadB * reloadB - kReloadB2 * reloadB")
+
+    rxLoad(.mod)
+    expect_equal(rxModelVars(.mod)$params, .params)
+  })
+})


### PR DESCRIPTION
## Problem

`_rxode2_codegen` emits C from the parser's **global** `.rxModelVarsLast`, not from the model variables passed to `rxCompile()`. The guard before it only asked whether *some* model was loaded:

```r
if (.Call(`_rxode2_codeLoaded`) == 0L) .rxModelVarsCharacter(setNames(.mv$model, NULL))
```

So whenever a *different* model happens to be the parsed one, the C written out is that other model's, while the artifact keeps this model's md5-derived name — and the `modVars` read back from the DLL describe the wrong model entirely.

`rxode2()` never hits this: it parses, then compiles immediately. A **re-compile** does. An existing model object whose `.so` is gone reaches `rxCompile()` via `rxDynLoad()` → `$compile()` long after some other model was parsed — which is exactly what happens to a saved fit restored in a new session, since its DLL lived in the original session's `tempdir()`.

Measured on a restored SAEM fit (nlmixr2's `broom` article, which loads a cached fit):

```
requested mv params:  tcl, tv
.rxModelVarsLast:     tcl, eta.cl, tv, eta.v     <- what got compiled
```

and every solve after that failed with

```
The following parameter(s) are required for solving: eta.v, eta.cl
```

## Fix

Re-parse unless the loaded model is provably this one (`parsed_md5` comparison). Only the model *syntax* (`normModel`) is parsed — the sibling `indLin` slot holds generated matrix-exponential C and is restored from `.indLinInfo`/`.rxMECode` a few lines below anyway.

In the ordinary `rxode2()` path the md5s match, so nothing re-parses and behavior is unchanged.

## Tests

New `tests/testthat/test-recompile-model.R`, covering both the direct `rxCompile()` call and the `rxLoad()`-after-the-`.so`-is-gone path. Verified the tests fail against the old guard (emulated by neutering the re-parse) — model A came back reporting model B's parameters — and pass with the fix.

Downstream check: nlmixr2's `broom` article, which failed to build on `setOfv(fit.s, "gauss3_1.6")`, now renders, and the full nlmixr2 article precompute (10 cached articles) renders with 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)