### PR TITLE
fix(indLin): evaluate the indLin() forcing at the current states (#1183)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,15 @@
   `RcppParallel` 6.2.0 restored the TBB library on Windows rather than
   dropping it.)
 
+### Matrix exponential / inductive linearization
+
+- An `indLin(<state>) <- <expr>` forcing that references a compartment is now
+  evaluated at that compartment's current value.  The generated forcing
+  function took no state vector, so the compartment kept its `NA_REAL`
+  declaration and any state-dependent forcing (e.g. Michaelis-Menten
+  elimination, `indLin(central) <- -vmax*central/(km+central)`) solved to `NA`
+  under `method="indLin"`.  A forcing that references no state is unchanged.
+
 ## Bug fixes
 
 - `rxCompile()` now re-parses the model it is handed whenever the parser's

--- a/inst/include/rxode2parseStruct.h
+++ b/inst/include/rxode2parseStruct.h
@@ -52,7 +52,7 @@ typedef void (*t_dDur)(int _cSub, double t, double *y, double *_dDurSave);
 typedef void (*t_calc_mtime)(int cSub, double *mtime, double *y);
 
 typedef void (*t_ME)(int _cSub, double _t, double t, double *_mat, const double *__zzStateVar__);
-typedef void (*t_IndF)(int _cSub, double _t, double t, double *_mat);
+typedef void (*t_IndF)(int _cSub, double _t, double t, double *_mat, const double *__zzStateVar__);
 
 typedef double (*t_getTime)(int idx, rx_solving_options_ind *ind);
 typedef int (*t_locateTimeIndex)(double obs_time,  rx_solving_options_ind *ind);

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -394,7 +394,7 @@ void codegen(char *model, int show_ode, const char *prefix, const char *libname,
       sAppend(&sbOut, "// Matrix Exponential (%d)\nvoid %sME(int _cSub, double _t, double __t, double *_mat, const double *__zzStateVar__){\n  int _itwhile = 0;\n  (void)_itwhile;\n  double t = __t + _solveData->subjects[_cSub].curShift;\n  (void)t;\n  rx_solving_options_ind *_ind = &(_solveData->subjects[_cSub]);\n  _setThreadInd(_cSub);\n  _ind->_rxFlag=9;\n",
               tb.matn, prefix);
     } else if (show_ode == ode_indLinVec) {
-      sAppend(&sbOut, "// Inductive linearization Matf\nvoid %sIndF(int _cSub, double _t, double __t, double *_matf){\n int _itwhile = 0;\n  (void)_itwhile;\n  double t = __t + _solveData->subjects[_cSub].curShift;\n  (void)t;\n  rx_solving_options_ind *_ind = &(_solveData->subjects[_cSub]);\n  _setThreadInd(_cSub);\n  _ind->_rxFlag=10;\n", prefix);
+      sAppend(&sbOut, "// Inductive linearization Matf\nvoid %sIndF(int _cSub, double _t, double __t, double *_matf, const double *__zzStateVar__){\n int _itwhile = 0;\n  (void)_itwhile;\n  double t = __t + _solveData->subjects[_cSub].curShift;\n  (void)t;\n  rx_solving_options_ind *_ind = &(_solveData->subjects[_cSub]);\n  _setThreadInd(_cSub);\n  _ind->_rxFlag=10;\n", prefix);
     } else if (ode_is_es_dcode(show_ode)) {
       // Event ("jump") sensitivities: total derivative of the modeled
       // alag / F / rate / dur wrt each first-order sensitivity parameter,
@@ -504,7 +504,7 @@ void codegen(char *model, int show_ode, const char *prefix, const char *libname,
         sAppendN(&sbOut, "  _update_par_ptr(__t, _cSub, _solveData, _idx);\n", 49);
       }
       prnt_vars(print_populateParameters, 1, "", "\n",show_ode);                   /* pass system pars */
-      if (show_ode != ode_indLinVec && show_ode != ode_past){
+      if (show_ode != ode_past){
         // past() history is a function of t and parameters only (no states); its
         // __zzStateVar__ is NULL, so state-var population is skipped for ode_past.
         for (i=0; i<tb.de.n; i++) {                   /* name state vars */

--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -384,7 +384,9 @@ extern "C" int indLin(int cSub, rx_solving_options *op, rx_solving_options_ind *
       break;
     }
     case 2: {
-      IndF(cSub, tcov, _subTf, u.memptr());
+      // Evaluate the forcing at the interval-start state, the same vector
+      // `meOnly()` hands to `ME` below (it is `meOnly()` that advances `yp_`).
+      IndF(cSub, tcov, _subTf, u.memptr(), yp_);
       _ret = meOnly(cSub, yp_, yp_, _subTp, _subTf, tcov, u.memptr(), on_, ME, op, ind);
       break;
     }

--- a/tests/testthat/test-mexp-nonmem.R
+++ b/tests/testthat/test-mexp-nonmem.R
@@ -590,6 +590,44 @@ rxTest({
                       grepl("central", .jac)))
   })
 
+  test_that("an indLin() forcing that references a state is evaluated at that state", {
+    # rxode2#1183: IndF() took no state vector and codegen skipped the
+    # __zzStateVar__ population loop for ode_indLinVec, so the state locals kept
+    # their NA_REAL declaration and a Michaelis-Menten forcing solved to NA.
+    mexp <- suppressMessages(rxode2({
+      matExp()
+      cmt(depot)
+      cmt(central)
+      k_depot_central <- 1
+      vmax <- 10
+      km <- 5
+      indLin(central) <- -vmax * central / (km + central)
+      cp <- central / 20
+    }))
+    ode <- suppressMessages(rxode2({
+      vmax <- 10
+      km <- 5
+      d/dt(depot) <- -1 * depot
+      d/dt(central) <- 1 * depot - vmax * central / (km + central)
+      cp <- central / 20
+    }))
+    e <- et(amt = 100, cmt = "depot") %>% et(seq(0, 20, by = 0.5))
+    ref <- rxSolve(ode, e, atol = 1e-10, rtol = 1e-10)
+
+    fine <- rxSolve(mexp, e, method = "indLin", hmax = 0.001)
+    expect_false(any(is.na(fine$central)))
+    expect_equal(fine$central, ref$central, tolerance = 1e-3)
+    expect_gt(max(abs(ref$central)), 1)
+
+    # The forcing is relinearized once per hmax substep, so it is first order in
+    # hmax; refining hmax must measurably reduce the error.
+    dCoarse <- max(abs(rxSolve(mexp, e, method = "indLin", hmax = 0.5)$central -
+                         ref$central))
+    dFine <- max(abs(rxSolve(mexp, e, method = "indLin", hmax = 0.05)$central -
+                       ref$central))
+    expect_lt(dFine, dCoarse / 2)
+  })
+
   test_that("rxSensMatExp() calcSens2/calcSens3 match the generic ODE path (linear)", {
     ode_code <- "
       d/dt(depot) = -ka * depot

--- a/tests/testthat/test-mexp-nonmem.R
+++ b/tests/testthat/test-mexp-nonmem.R
@@ -626,6 +626,26 @@ rxTest({
     dFine <- max(abs(rxSolve(mexp, e, method = "indLin", hmax = 0.05)$central -
                        ref$central))
     expect_lt(dFine, dCoarse / 2)
+
+    # Same forcing through the braced rxode2({...}) front end rather than a
+    # string.  One compartment, so no k_from_to micro constant is needed.
+    mexpBraced <- suppressMessages(rxode2({
+      matExp()
+      cmt(central)
+      vmax <- 10
+      km <- 5
+      indLin(central) <- -vmax * central / (km + central)
+    }))
+    odeMm <- suppressMessages(rxode2({
+      vmax <- 10
+      km <- 5
+      d/dt(central) <- -vmax * central / (km + central)
+    }))
+    eb <- et(amt = 100, cmt = "central") |> et(seq(0, 20, by = 0.5))
+    refMm <- rxSolve(odeMm, eb, atol = 1e-10, rtol = 1e-10)
+    fineBraced <- rxSolve(mexpBraced, eb, method = "indLin", hmax = 0.001)
+    expect_false(any(is.na(fineBraced$central)))
+    expect_equal(fineBraced$central, refMm$central, tolerance = 1e-3)
   })
 
   test_that("rxSensMatExp() calcSens2/calcSens3 match the generic ODE path (linear)", {

--- a/tests/testthat/test-mexp-nonmem.R
+++ b/tests/testthat/test-mexp-nonmem.R
@@ -591,19 +591,19 @@ rxTest({
   })
 
   test_that("an indLin() forcing that references a state is evaluated at that state", {
-    # rxode2#1183: IndF() took no state vector and codegen skipped the
-    # __zzStateVar__ population loop for ode_indLinVec, so the state locals kept
-    # their NA_REAL declaration and a Michaelis-Menten forcing solved to NA.
-    mexp <- suppressMessages(rxode2({
-      matExp()
-      cmt(depot)
-      cmt(central)
-      k_depot_central <- 1
-      vmax <- 10
-      km <- 5
-      indLin(central) <- -vmax * central / (km + central)
-      cp <- central / 20
-    }))
+    # rxode2#1183: the forcing function took no state vector and codegen skipped
+    # the __zzStateVar__ population loop for ode_indLinVec, so the state locals
+    # kept their NA_REAL declaration and a Michaelis-Menten forcing solved to NA.
+    # The matExp model is a string so the micro-constant name stays out of R.
+    mexp <- suppressMessages(rxode2(paste("matExp()",
+                                          "cmt(depot)",
+                                          "cmt(central)",
+                                          "k_depot_central = 1",
+                                          "vmax = 10",
+                                          "km = 5",
+                                          "indLin(central) <- -vmax*central/(km+central)",
+                                          "cp = central/20",
+                                          sep = "\n")))
     ode <- suppressMessages(rxode2({
       vmax <- 10
       km <- 5
@@ -611,7 +611,7 @@ rxTest({
       d/dt(central) <- 1 * depot - vmax * central / (km + central)
       cp <- central / 20
     }))
-    e <- et(amt = 100, cmt = "depot") %>% et(seq(0, 20, by = 0.5))
+    e <- et(amt = 100, cmt = "depot") |> et(seq(0, 20, by = 0.5))
     ref <- rxSolve(ode, e, atol = 1e-10, rtol = 1e-10)
 
     fine <- rxSolve(mexp, e, method = "indLin", hmax = 0.001)


### PR DESCRIPTION
Fixes #1183.

`indLin(<state>) <- <expr>` supplies the nonlinear forcing `f` in `dy/dt = f(t,y) + A.y`, but the generated `IndF()` took no state vector and codegen skipped the `__zzStateVar__` population loop for `ode_indLinVec`. The state locals kept their `NA_REAL` declaration, so any forcing referencing a compartment (e.g. Michaelis-Menten elimination) solved to `NA` under `method="indLin"`.

### Correction to the issue text

The states were *not* read from uninitialized memory. `printDoubleDeclaration()` (`src/codegen.h:358`) emits `double <name> = NA_REAL;`, and `prnt_vars(print_double, lhs=0, ...)` skips nothing. So the behavior was a deterministic NaN forcing, not UB -- confirmed against installed 5.1.7, where `rxSolve(mexp, e, method="indLin")$central` came back all `NA`. The regression test is therefore a plain "not NA, and matches the ODE" check rather than the repeated-solve UB detector the issue proposed.

### Changes

- `inst/include/rxode2parseStruct.h:55` -- `t_IndF` gains `const double *__zzStateVar__`, mirroring `t_ME` on the line above.
- `src/codegen.c:397` -- emit the matching signature.
- `src/codegen.c:507` -- drop `ode_indLinVec` from the guard (keeping `ode_past`, whose `__zzStateVar__` is NULL by design) so the state locals are actually populated. This is the substantive half; the new argument is inert without it. Also covers the legacy `$MATF` path (`src/parseIndLin.h`), which shares the gate.
- `src/expm.cpp:387` -- pass the interval-start state `yp_`, the same buffer `meOnly()` hands to `ME`.

Every other `t_IndF` reference names the type by its typedef, so nothing else needed an edit.

### Verification

- Generated `IndF` now contains `central = __zzStateVar__[__DDT1__]*((double)(_ON[__DDT1__]));` ahead of the forcing.
- Michaelis-Menten forcing vs. the equivalent `d/dt()` model: no NAs, max abs error 0.0044 at `hmax=0.001` against a peak of 69.7. Error falls 3.75 -> 0.25 -> 0.02 as `hmax` refines, i.e. still first order in `hmax` (that is what #1185 addresses).
- `devtools::test()`: **FAIL 0 | PASS 79433** (32 warnings, 4 skips, all pre-existing).
- Cache invalidation needs no manual bump: both edited files are inside the content digest `configure` turns into `rxode2.md5`, and the digest was verified to move (`0ef602f2...` unfixed vs `546084ed...` fixed). Same as commit `e352215292`, which gave `t_LAG` a state argument and touched no version or md5 seed.
- Not a downstream ABI concern: neither `IndF` nor `t_IndF` is referenced by nlmixr2est, babelmixr2, nonmem2rx or monolix2rx, and neither appears in the `inst/include/rxode2ptr.h` pointer table, so the append-only rule is not engaged.

Scoped to #1183 only. #1184 (`wIndLin`) and #1185 (restore the fixed-point iteration) are untouched; #1185 is now unblocked.