### PR TITLE
fix: raise an R condition, not a signal, when an Imports: package is missing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,16 @@
   `RcppParallel` 6.2.0 restored the TBB library on Windows rather than
   dropping it.)
 
+- A missing `Imports:` package no longer crashes the R process.  Every compiled
+  model resolves `rxode2ll`'s symbols with `R_GetCCallable()` from its
+  `R_init()`, which errors out of `R_init()` and leaves the model's globals
+  `NULL`; R keeps the dll loaded regardless, so the half-initialized model was
+  accepted and the first solve segfaulted.  `rxode2` now stops with a message
+  naming the missing package before loading a model dll.  Separately, a
+  file-scope `loadNamespace("cli")` ran inside `dlopen()`, where the R error
+  raised when `cli` was absent became an unhandled C++ exception and aborted
+  `library(rxode2)` itself; the `cli` namespace is now loaded on first use.
+
 ## Bug fixes
 
 - `rxCompile()` now re-parses the model it is handed whenever the parser's

--- a/R/utils.R
+++ b/R/utils.R
@@ -945,10 +945,21 @@ is.latex <- function() {
 
 
 .nsToLoad <- function() {
-  vapply(rxode2parseGetPackagesToLoad(),
-         function(pkg) {
-           requireNamespace(pkg, quietly = TRUE)
-         }, logical(1))
+  .pkgs <- rxode2parseGetPackagesToLoad()
+  .ok <- vapply(.pkgs,
+                function(pkg) {
+                  requireNamespace(pkg, quietly = TRUE)
+                }, logical(1))
+  # Must be an error: every compiled rxode2 model resolves these packages'
+  # symbols with R_GetCCallable() from its R_init(), which errors out of R_init
+  # and leaves the model's globals NULL.  R keeps the dll loaded anyway, so the
+  # half-initialized model is accepted and the first solve segfaults.
+  if (!all(.ok)) {
+    stop("rxode2 models require package(s) that are not installed: ",
+         paste0("'", .pkgs[!.ok], "'", collapse = ", "),
+         call. = FALSE)
+  }
+  .ok
 }
 
 #' Check if a language object matches a template language object

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -463,16 +463,29 @@ Function loadNamespace("loadNamespace", R_BaseNamespace);
 
 Function requireNamespace("requireNamespace", R_BaseNamespace);
 
-Environment cliNS = loadNamespace("cli");
-Function cliAlert0 = as<Function>(cliNS["cli_alert_info"]);
+// Loaded on first use, not at file scope: a file-scope initializer runs inside
+// dlopen(), where an R error (as when 'cli' is not installed) becomes an
+// Rcpp::LongjumpException with no handler and calls std::terminate, aborting R
+// during library(rxode2).  Same shape as loadCheckmate() in checkmate.cpp.
+Environment cliNS;
+bool loadedCliNs = false;
+
+static void loadCli() {
+  if (!loadedCliNs) {
+    cliNS = loadNamespace("cli");
+    loadedCliNs = true;
+  }
+}
 
 extern "C" void cliAlert(const char *format, ...) {
   va_list args;
   char buffer[256];
   va_start(args, format);
   vsnprintf(buffer, 256, format, args);
-  cliAlert0(wrap(buffer));
   va_end (args);
+  loadCli();
+  Function cliAlert0 = as<Function>(cliNS["cli_alert_info"]);
+  cliAlert0(wrap(buffer));
 }
 
 extern "C" SEXP _rxode2_rxRmvn0(SEXP A_SEXP, SEXP muSEXP, SEXP sigmaSEXP,

--- a/tests/testthat/test-missing-package.R
+++ b/tests/testthat/test-missing-package.R
@@ -1,0 +1,100 @@
+# A missing DESCRIPTION Imports: package must produce an R condition, never a
+# signal.  These run in a child Rscript because a SIGSEGV/SIGABRT would kill the
+# testthat process itself, so the assertion is on the child's exit status.
+#
+# The two regressions guarded here:
+#   rxode2ll missing -> SIGSEGV (139) on the first solve of any compiled model.
+#     Every generated model resolves rxode2ll's symbols with R_GetCCallable()
+#     from its R_init(); that errors out of R_init leaving the model's globals
+#     NULL, but R keeps the dll loaded, so the half-initialized model is
+#     accepted and the first solve calls through NULL.
+#   cli missing -> SIGABRT (134) inside library(rxode2), from a file-scope
+#     loadNamespace("cli") running in dlopen() where the R error becomes an
+#     Rcpp::LongjumpException with no handler.
+
+rxTest({
+
+  .allVisiblePackages <- function() {
+    .out <- character(0)
+    for (.l in setdiff(.libPaths(), .Library)) {
+      .d <- list.dirs(.l, recursive = FALSE)
+      .d <- .d[file.exists(file.path(.d, "Meta", "package.rds"))]
+      .nm <- basename(.d)
+      .new <- !(.nm %in% names(.out))
+      .out <- c(.out, stats::setNames(.d[.new], .nm[.new]))
+    }
+    .out
+  }
+
+  # Library of symlinks to every installed package except `drop`.  Read-only
+  # with respect to the real libraries.
+  .shadowLib <- function(drop, dir) {
+    .lib <- file.path(dir, paste0("lib-no-", drop))
+    dir.create(.lib, recursive = TRUE, showWarnings = FALSE)
+    .src <- .allVisiblePackages()
+    .src <- .src[names(.src) != drop]
+    if (!all(file.symlink(unname(.src), file.path(.lib, names(.src))))) {
+      return(NULL)
+    }
+    .lib
+  }
+
+  .runWithout <- function(drop, code, dir) {
+    .lib <- .shadowLib(drop, dir)
+    if (is.null(.lib)) return(NULL)
+    .f <- file.path(dir, paste0("child-", drop, ".R"))
+    writeLines(c('.libPaths(Sys.getenv("RX_LIB"), include.site = FALSE)', code), .f)
+    .log <- file.path(dir, paste0("child-", drop, ".log"))
+    .status <- suppressWarnings(system2(
+      file.path(R.home("bin"), "Rscript"), c("--vanilla", shQuote(.f)),
+      env = c(paste0("R_LIBS=", .lib), paste0("R_LIBS_USER=", .lib),
+              paste0("R_LIBS_SITE=", file.path(dir, "no-site")),
+              paste0("RX_LIB=", .lib), "NOT_CRAN=true"),
+      stdout = .log, stderr = .log))
+    list(status = .status, log = paste(readLines(.log, warn = FALSE), collapse = "\n"))
+  }
+
+  # Only meaningful against a real installed rxode2 (a load_all() tree cannot be
+  # library()'d from a child process).
+  .installed <- tryCatch(file.exists(file.path(find.package("rxode2"), "Meta", "package.rds")),
+                         error = function(e) FALSE)
+
+  for (.pkg in c("rxode2ll", "cli")) {
+    local({
+      pkg <- .pkg
+      test_that(paste0("a missing '", pkg, "' gives an R condition, not a signal"), {
+        skip_on_cran()
+        skip_on_os("windows")
+        skip_if_not(.installed, "needs an installed (not load_all) rxode2")
+        skip_if_not(pkg %in% names(.allVisiblePackages()),
+                    paste0("'", pkg, "' is not installed, nothing to hide"))
+        dir <- tempfile("rxMissing"); dir.create(dir)
+        on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+        res <- .runWithout(pkg, c(
+          'ok <- tryCatch({ suppressMessages(library(rxode2)); TRUE },',
+          '               error = function(e) { cat("CAUGHT:", conditionMessage(e), "\n"); FALSE })',
+          'if (ok) {',
+          '  tryCatch({',
+          '    m <- rxode2::rxode2("d/dt(x) <- -0.5*x;")',
+          '    ev <- rxode2::et(rxode2::et(0:3), amt = 1, cmt = "x")',
+          '    print(as.data.frame(rxode2::rxSolve(m, ev, cores = 1L))$x[2])',
+          '  }, error = function(e) cat("CAUGHT:", conditionMessage(e), "\n"))',
+          '}',
+          'cat("REACHED-END\n")'), dir)
+        skip_if(is.null(res), "symlinks unsupported here")
+        # The regression: exit 139 (SIGSEGV) for rxode2ll, 134 (SIGABRT) for cli.
+        expect_lt(res$status, 128L)
+        expect_false(grepl("caught segfault", res$log, fixed = TRUE))
+        expect_false(grepl("terminate called", res$log, fixed = TRUE))
+        expect_match(res$log, "REACHED-END", fixed = TRUE)
+        # Whatever happens, the child has to finish under R's control: either it
+        # completes the workload, or it raises a condition naming what is gone.
+        # (A package only reached lazily need not be wanted by this workload at
+        # all, so an uneventful run is a pass.)
+        if (grepl("CAUGHT:", res$log, fixed = TRUE)) {
+          expect_match(res$log, pkg, fixed = TRUE)
+        }
+      })
+    })
+  }
+})


### PR DESCRIPTION
Fixes #1204

Fixes two independent ways a missing `DESCRIPTION` `Imports:` package crashes the
R process instead of erroring: `rxode2ll` missing gives SIGSEGV (139) on the
first solve of *any* compiled model, and `cli` missing gives SIGABRT (134) inside
`library(rxode2)` itself. Neither is catchable -- `tryCatch()` and testthat die
with the process.

## `rxode2ll` -> SIGSEGV

Every generated model resolves the whole parse table with `R_GetCCallable()` from
its `R_init()`, including the `rxode2ll` rows (`src/codegen.c:247`). That errors
out of `R_init` before the model's globals are assigned, leaving them NULL -- but
R keeps the dll in its loaded table, so the retry in `R/rxode2.R:2107` looks like
it succeeded, the half-initialised model is accepted, and the first solve calls
through NULL.

`.nsToLoad()` already ran at exactly the right checkpoint (`dynLoad()` calls it
immediately before `dyn.load`) but threw its `requireNamespace()` results away.
It now stops and names the missing package.

## `cli` -> SIGABRT

A file-scope `Environment cliNS = loadNamespace("cli")` runs as a dynamic
initialiser inside `dlopen()`, where the R error becomes an
`Rcpp::LongjumpException` with no handler and reaches `std::terminate`. Now
loaded on first use -- the same shape `checkmate.cpp` already uses for
`loadCheckmate()`/`qtest()`.

## Test

`tests/testthat/test-missing-package.R` runs the workload in a child `Rscript`
against a symlink library with one package hidden, and asserts the child exits
under R's control rather than on a signal. A subprocess is required because a
SIGSEGV/SIGABRT would kill the testthat process itself. It builds its library
from symlinks and never writes to a real one.

Verified **red on `main`** (6 failures: `139 >= 128` + `caught segfault` for
`rxode2ll`, `134 >= 128` + `terminate called` for `cli`) and green with this
change.

The test asserts "an R condition, never a signal" rather than requiring an error,
because a package reached only lazily need not be wanted by a given workload at
all -- an uneventful run is a legitimate pass.

## Verification

- `test-missing-package.R`: 9 pass on this branch, red on `main`.
- Sweep of `test-par-solve.R`, `test-lincmt-solve.R` (1569), `test-omega-chol.R`
  (435), `test-ui-simulation.R`, `test-solver-basic.R`, `test-sim-zeros.R`,
  `test-reset.R`, `test-et.R`, `test-deSolve-events.R`,
  `test-multisim-shared-event-oob.R`, `test-nopred-ui.R`: no change versus `main`.
  `test-et.R` has 10 failures identically before and after (pre-existing).

**One limitation, stated plainly:** I could not construct a call that reaches
`cliAlert()` -- the R layer strips zero `thetaMat`/`omega`/`sigma` before the C
code tests `_globals.zeroOmega` etc., which is presumably why no test covers
those messages. So the `cli` change is verified by the crash disappearing and by
matching the already-exercised `checkmate.cpp` idiom, not by exercising the alert
itself. Worth a maintainer eye.

## Not included

Emitting the `llik*()` lookups only for functions a model actually uses -- that
would remove the `rxode2ll` dependency for plain ODE models entirely, but it is a
codegen change with a wider blast radius and belongs in its own PR.