### PR TITLE
fix(ui): keep the label when an ini() comment contains a '#'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,14 @@
   restored SAEM fit failing with "The following parameter(s) are required for
   solving: eta.v, eta.cl".
 
+- A trailing `#` comment on an `ini({})` line keeps its `label()` when the
+  comment itself contains a `#`, including the common `## comment` form.  The
+  code portion of the line was matched greedily, so on a line with two `#` it
+  ran on to the last one and left the first sitting in the generated code, where
+  it commented out the `label()` that had just been appended.  The label was
+  dropped silently -- the model still parsed and built, it simply lost the label
+  (#1205).
+
 ## Bug fixes
 
 ### Delay differential equations

--- a/R/ui.R
+++ b/R/ui.R
@@ -12,7 +12,13 @@
   .regOther1 <- rex::rex(any_spaces, "}", any_spaces, ")", any_spaces)
   .regOther2 <- rex::rex(any_spaces, "model", any_spaces, "(", any_spaces, "{", any_spaces)
   .regCommentOnBlankLine <- "^ *#+ *(.*) *$"
-  .regLabel <- "^( *[^\n\"]+) *#+ *(.*) *$"
+  # `#` is excluded from the code group so it stops at the FIRST `#`.  POSIX ERE
+  # is leftmost-longest, so a greedy `[^\n"]+` ran on to the LAST `#` and left
+  # the earlier one in the emitted code, where it commented out the label() just
+  # appended -- `x <- 1 ## Lbl` and `x <- 1 # a # b` lost their label entirely.
+  # Outside a string R code cannot contain `#`, and strings are already excluded
+  # by the `"` in the same bracket.
+  .regLabel <- "^( *[^\n\"#]+) *#+ *(.*) *$"
   .ret <- vapply(src,
                  function(line) {
                    if (regexpr(.regIni, line, perl=TRUE) != -1) {

--- a/tests/testthat/test-ui.R
+++ b/tests/testthat/test-ui.R
@@ -89,6 +89,37 @@ rxTest({
 
   })
 
+  test_that("a comment containing '#' keeps its label (rxode2 issue 1205)", {
+
+    .mkSrc <- function(comment) {
+      c("function() {", "  ini({",
+        paste0("    tka <- 0.45 ", comment),
+        "    add.sd <- 0.7", "  })", "  model({",
+        "    ka <- exp(tka)", "    linCmt() ~ add(add.sd)", "  })", "}")
+    }
+    .labelOf <- function(comment) {
+      suppressMessages(.res <- .rxReplaceCommentWithLabel(.mkSrc(comment)))
+      .lbl <- .res[grepl("^ *label\\(", .res)]
+      if (length(.lbl) != 1L) return(NA_character_)
+      parse(text = .lbl)[[1]][[2]]
+    }
+
+    # The code group used to run on to the LAST `#`, leaving the first one in the
+    # emitted code where it commented out the label() -- so these silently lost
+    # their label while still parsing as a valid model.
+    expect_equal(.labelOf("## Log Ka"), "Log Ka")
+    expect_equal(.labelOf("### Log Ka"), "Log Ka")
+    expect_equal(.labelOf("# rate # per hour"), "rate # per hour")
+    expect_equal(.labelOf("# Patient #2 only"), "Patient #2 only")
+
+    # unchanged for the single-`#` forms
+    expect_equal(.labelOf("# Log Ka"), "Log Ka")
+    expect_equal(.labelOf("#Log Ka"), "Log Ka")
+
+    # a `#` in a comment that also carries a quote needs the escaping fix from
+    # #1198 as well, so that combination is asserted there rather than here.
+  })
+
   test_that("meta information parsing", {
 
     one.cmt <- function() {


### PR DESCRIPTION
An `ini({})` comment containing a `#` -- including the common `## comment` form -- silently lost its `label()`.

`.rxReplaceCommentWithLabel()` matched the code portion of the line with a greedy `[^\n"]+`, which matches `#`. POSIX ERE is leftmost-longest, so on a line carrying two `#` the group ran on to the **last** one and left the earlier `#` sitting in the generated code -- where it commented out the `label()` that had just been appended.

```
tka <- 0.45 ## Log Ka          ->  tka <- 0.45 #; label("Log Ka")          # label dropped
tka <- 0.45 # rate # per hour  ->  tka <- 0.45 # rate ; label("per hour")  # label dropped
```

It failed silently: the model parsed and built normally, the label was simply gone. And because the promotion only runs when the model is parsed with source refs kept, the same model behaved differently under `keep.source` -- the same asymmetry as #1195.

Exclude `#` from the code group so it stops at the first one. Outside a string literal R code cannot contain `#`, and string literals are already excluded by the `"` already in that bracket, so nothing that previously matched stops matching.

| comment | before | after |
|---|---|---|
| `# Log Ka` | `label("Log Ka")` | unchanged |
| `#Log Ka` | `label("Log Ka")` | unchanged |
| `## Log Ka` | *label dropped* | `label("Log Ka")` |
| `### Log Ka` | *label dropped* | `label("Log Ka")` |
| `# rate # per hour` | *label dropped* | `label("rate # per hour")` |
| `# Patient #2 only` | *label dropped* | `label("Patient #2 only")` |

Adds a test enumerating those, plus a NEWS entry.

Found while reviewing #1198, which fixes a different escaping defect in the same function. The two are independent: this one is not a regression from #1198, and #1198 is not a regression from this. A comment carrying **both** a `#` and a `"` needs both fixes, so that combined case is asserted in #1198 rather than here.

Fixes #1205
