### PR TITLE
ci(coverage): do not discard the whole run over one truncated covr trace

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -36,6 +36,30 @@ jobs:
 
       - name: Test coverage
         run: |
+          ## A truncated covr trace file must not discard the whole run.
+          ## covr appends `reg.finalizer(ns, ... save_trace(...), onexit = TRUE)`
+          ## to the installed package's load script, so EVERY R process that
+          ## loads rxode2 writes a covr_trace_* into the merge directory on exit
+          ## -- including the helper subprocesses the test suite spawns.  One of
+          ## those dying mid-write leaves a partial file, and covr's
+          ## merge_coverage() readRDS()es each trace with no error handling, so a
+          ## single partial file aborts a multi-hour run and the upload below
+          ## never happens.  Drop the unreadable ones and say which, loudly.
+          .origMerge <- covr:::merge_coverage.character
+          .tolerantMerge <- function(x, ...) {
+            .ok <- vapply(x, function(f) {
+              !inherits(try(suppressWarnings(readRDS(f)), silent = TRUE), "try-error")
+            }, logical(1))
+            if (any(!.ok)) {
+              message(sprintf("covr: skipping %d of %d unreadable trace file(s): %s",
+                              sum(!.ok), length(x),
+                              paste(basename(x[!.ok]), collapse = ", ")))
+            }
+            if (!any(.ok)) stop("covr: every trace file was unreadable")
+            .origMerge(x[.ok])
+          }
+          assignInNamespace("merge_coverage.character", .tolerantMerge, "covr")
+
           cov <- covr::package_coverage(
             quiet = FALSE,
             clean = FALSE,


### PR DESCRIPTION
`test-coverage` has been red on `main` and on essentially every open PR branch. The test suite passes -- `[ FAIL 0 | WARN 31 | SKIP 58 | PASS 76505 ]` -- and then the run dies in covr's merge:

```
Error in readRDS(f) : error reading from connection
Calls: <Anonymous> ... merge_coverage.character -> lapply -> FUN -> as.list
```

Since the step exits non-zero, `codecov/codecov-action` is skipped and nothing is uploaded. Each run burns 2--5 hours first.

## Why

`covr:::add_hooks()` appends `reg.finalizer(ns, ... covr:::save_trace(...), onexit = TRUE)` to the installed package's load script, so **every** R process that loads rxode2 writes a `covr_trace_*` into the merge directory on exit -- including the helper subprocesses the test suite spawns. `merge_coverage.character()` is `lapply(x, function(f) as.list(readRDS(f)))` with no error handling, so one partial file aborts everything.

The `coverage-test-failures` artifacts from a PR run (31139091448) and a `main` run (31040944854) show the same thing both times: **25 traces, exactly 8 unreadable** -- valid gzip header, real data, stopping abruptly at an exact multiple of 4096.

Fingerprinting the readable traces shows what the 8 actually cost:

| trace | covered expressions |
|---|---|
| 1 file (testthat run, 26 MB) | 15972 -- **intact** |
| 6 files | 0 |
| 4 files | 41 (`.onAttach` only) |
| 6 files | ~525 (`rxForget`) |
| 8 files | *truncated* |

All the real coverage is in the one intact trace; the rest are near-empty helper processes.

## Change

Wrap `merge_coverage.character` so unreadable traces are skipped and named in the log, and error only if *every* trace is unreadable.

Verified against the actual artifact files: unpatched, `merge_coverage()` errors. Patched, it reports the 8 skips and returns a normal coverage object with **16027 of 20218** expressions covered.

This is a tolerance fix, not a root-cause fix -- it does not explain why those 8 subprocesses die mid-write, which is worth a separate look. But the job should not be red, and discarding a multi-hour run over a trace worth 0--525 expressions is the wrong trade.

Fixes #1207
