### PR TITLE
fix: resolve rxode2ll llik symbols only in models that call one

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,11 @@
   raised when `cli` was absent became an unhandled C++ exception and aborted
   `library(rxode2)` itself; the `cli` namespace is now loaded on first use.
 
+- Generated models only resolve `rxode2ll`'s `llik*()` symbols when the model
+  actually calls one, instead of resolving all of them in every model.  A model
+  with no `llik*()` no longer depends on `rxode2ll` at all, and skips that many
+  `R_GetCCallable()` lookups when it loads.
+
 ## Bug fixes
 
 - `rxCompile()` now re-parses the model it is handed whenever the parser's

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,16 @@
   `RcppParallel` 6.2.0 restored the TBB library on Windows rather than
   dropping it.)
 
+- A missing `Imports:` package no longer crashes the R process.  Every compiled
+  model resolves `rxode2ll`'s symbols with `R_GetCCallable()` from its
+  `R_init()`, which errors out of `R_init()` and leaves the model's globals
+  `NULL`; R keeps the dll loaded regardless, so the half-initialized model was
+  accepted and the first solve segfaulted.  `rxode2` now stops with a message
+  naming the missing package before loading a model dll.  Separately, a
+  file-scope `loadNamespace("cli")` ran inside `dlopen()`, where the R error
+  raised when `cli` was absent became an unhandled C++ exception and aborted
+  `library(rxode2)` itself; the `cli` namespace is now loaded on first use.
+
 ## Bug fixes
 
 - `rxCompile()` now re-parses the model it is handed whenever the parser's

--- a/R/utils.R
+++ b/R/utils.R
@@ -945,10 +945,21 @@ is.latex <- function() {
 
 
 .nsToLoad <- function() {
-  vapply(rxode2parseGetPackagesToLoad(),
-         function(pkg) {
-           requireNamespace(pkg, quietly = TRUE)
-         }, logical(1))
+  .pkgs <- rxode2parseGetPackagesToLoad()
+  .ok <- vapply(.pkgs,
+                function(pkg) {
+                  requireNamespace(pkg, quietly = TRUE)
+                }, logical(1))
+  # Must be an error: every compiled rxode2 model resolves these packages'
+  # symbols with R_GetCCallable() from its R_init(), which errors out of R_init
+  # and leaves the model's globals NULL.  R keeps the dll loaded anyway, so the
+  # half-initialized model is accepted and the first solve segfaults.
+  if (!all(.ok)) {
+    stop("rxode2 models require package(s) that are not installed: ",
+         paste0("'", .pkgs[!.ok], "'", collapse = ", "),
+         call. = FALSE)
+  }
+  .ok
 }
 
 #' Check if a language object matches a template language object

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -246,6 +246,18 @@ void codegen(char *model, int show_ode, const char *prefix, const char *libname,
       sAppendN(&sbOut,"#include \"extraC.h\"\n", 20);
       writeBody1();
       for (int i = Rf_length(_rxode2parse_functionName); i--;) {
+        // rxode2ll supplies only llik*() functions, and those are reachable
+        // solely when the model calls one -- which is exactly what tb.nLlik
+        // counts.  Looking them up unconditionally made a plain ODE model
+        // depend on rxode2ll for no reason, and the lookup is not a soft
+        // failure: R_GetCCallable() errors, which longjmps out of the model's
+        // R_init() before its globals are assigned while R keeps the dll in its
+        // loaded table.
+        if (tb.nLlik == 0 &&
+            !strcmp(R_CHAR(STRING_ELT(_rxode2parse_functionPackageName, i)),
+                    "rxode2ll")) {
+          continue;
+        }
         sAppend(&sbOut,"  %s = (%s) R_GetCCallable(\"%s\", \"%s\");\n",
                 R_CHAR(STRING_ELT(_rxode2parse_functionName, i)),
                 R_CHAR(STRING_ELT(_rxode2parse_functionType, i)),

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -463,16 +463,29 @@ Function loadNamespace("loadNamespace", R_BaseNamespace);
 
 Function requireNamespace("requireNamespace", R_BaseNamespace);
 
-Environment cliNS = loadNamespace("cli");
-Function cliAlert0 = as<Function>(cliNS["cli_alert_info"]);
+// Loaded on first use, not at file scope: a file-scope initializer runs inside
+// dlopen(), where an R error (as when 'cli' is not installed) becomes an
+// Rcpp::LongjumpException with no handler and calls std::terminate, aborting R
+// during library(rxode2).  Same shape as loadCheckmate() in checkmate.cpp.
+Environment cliNS;
+bool loadedCliNs = false;
+
+static void loadCli() {
+  if (!loadedCliNs) {
+    cliNS = loadNamespace("cli");
+    loadedCliNs = true;
+  }
+}
 
 extern "C" void cliAlert(const char *format, ...) {
   va_list args;
   char buffer[256];
   va_start(args, format);
   vsnprintf(buffer, 256, format, args);
-  cliAlert0(wrap(buffer));
   va_end (args);
+  loadCli();
+  Function cliAlert0 = as<Function>(cliNS["cli_alert_info"]);
+  cliAlert0(wrap(buffer));
 }
 
 extern "C" SEXP _rxode2_rxRmvn0(SEXP A_SEXP, SEXP muSEXP, SEXP sigmaSEXP,

--- a/tests/testthat/test-llik.R
+++ b/tests/testthat/test-llik.R
@@ -1065,4 +1065,25 @@ rxTest({
     expect_error(rxSolve(modelX, et, cores=2), NA)
 
   })
+
+  test_that("rxode2ll lookups are generated only for models that use llik()", {
+    # Emitting them for every model made a plain ODE depend on rxode2ll:
+    # R_GetCCallable() errors out of the generated model's R_init() before its
+    # globals are assigned, and R keeps the dll loaded anyway, so the first
+    # solve of a half-initialized model segfaulted.
+    .llRefs <- function(m) {
+      .c <- paste(readLines(as.character(rxC(m)), warn = FALSE), collapse = "\n")
+      lengths(regmatches(.c, gregexpr("rxode2ll", .c)))
+    }
+    .nLlFuns <- sum(rxode2parseGetTranslation()$package == "rxode2ll")
+    expect_gt(.nLlFuns, 0L)
+
+    .plain <- rxode2("d/dt(x) <- -0.5*x;")
+    expect_equal(setNames(rxModelVars(.plain)$flags["nLlik"], NULL), 0L)
+    expect_equal(.llRefs(.plain), 0L)
+
+    .withLlik <- rxode2("ll <- llikNorm(0, 1, 2); d/dt(x) <- -0.5*x;")
+    expect_equal(setNames(rxModelVars(.withLlik)$flags["nLlik"], NULL), 1L)
+    expect_equal(.llRefs(.withLlik), .nLlFuns)
+  })
 })

--- a/tests/testthat/test-missing-package.R
+++ b/tests/testthat/test-missing-package.R
@@ -1,0 +1,100 @@
+# A missing DESCRIPTION Imports: package must produce an R condition, never a
+# signal.  These run in a child Rscript because a SIGSEGV/SIGABRT would kill the
+# testthat process itself, so the assertion is on the child's exit status.
+#
+# The two regressions guarded here:
+#   rxode2ll missing -> SIGSEGV (139) on the first solve of any compiled model.
+#     Every generated model resolves rxode2ll's symbols with R_GetCCallable()
+#     from its R_init(); that errors out of R_init leaving the model's globals
+#     NULL, but R keeps the dll loaded, so the half-initialized model is
+#     accepted and the first solve calls through NULL.
+#   cli missing -> SIGABRT (134) inside library(rxode2), from a file-scope
+#     loadNamespace("cli") running in dlopen() where the R error becomes an
+#     Rcpp::LongjumpException with no handler.
+
+rxTest({
+
+  .allVisiblePackages <- function() {
+    .out <- character(0)
+    for (.l in setdiff(.libPaths(), .Library)) {
+      .d <- list.dirs(.l, recursive = FALSE)
+      .d <- .d[file.exists(file.path(.d, "Meta", "package.rds"))]
+      .nm <- basename(.d)
+      .new <- !(.nm %in% names(.out))
+      .out <- c(.out, stats::setNames(.d[.new], .nm[.new]))
+    }
+    .out
+  }
+
+  # Library of symlinks to every installed package except `drop`.  Read-only
+  # with respect to the real libraries.
+  .shadowLib <- function(drop, dir) {
+    .lib <- file.path(dir, paste0("lib-no-", drop))
+    dir.create(.lib, recursive = TRUE, showWarnings = FALSE)
+    .src <- .allVisiblePackages()
+    .src <- .src[names(.src) != drop]
+    if (!all(file.symlink(unname(.src), file.path(.lib, names(.src))))) {
+      return(NULL)
+    }
+    .lib
+  }
+
+  .runWithout <- function(drop, code, dir) {
+    .lib <- .shadowLib(drop, dir)
+    if (is.null(.lib)) return(NULL)
+    .f <- file.path(dir, paste0("child-", drop, ".R"))
+    writeLines(c('.libPaths(Sys.getenv("RX_LIB"), include.site = FALSE)', code), .f)
+    .log <- file.path(dir, paste0("child-", drop, ".log"))
+    .status <- suppressWarnings(system2(
+      file.path(R.home("bin"), "Rscript"), c("--vanilla", shQuote(.f)),
+      env = c(paste0("R_LIBS=", .lib), paste0("R_LIBS_USER=", .lib),
+              paste0("R_LIBS_SITE=", file.path(dir, "no-site")),
+              paste0("RX_LIB=", .lib), "NOT_CRAN=true"),
+      stdout = .log, stderr = .log))
+    list(status = .status, log = paste(readLines(.log, warn = FALSE), collapse = "\n"))
+  }
+
+  # Only meaningful against a real installed rxode2 (a load_all() tree cannot be
+  # library()'d from a child process).
+  .installed <- tryCatch(file.exists(file.path(find.package("rxode2"), "Meta", "package.rds")),
+                         error = function(e) FALSE)
+
+  for (.pkg in c("rxode2ll", "cli")) {
+    local({
+      pkg <- .pkg
+      test_that(paste0("a missing '", pkg, "' gives an R condition, not a signal"), {
+        skip_on_cran()
+        skip_on_os("windows")
+        skip_if_not(.installed, "needs an installed (not load_all) rxode2")
+        skip_if_not(pkg %in% names(.allVisiblePackages()),
+                    paste0("'", pkg, "' is not installed, nothing to hide"))
+        dir <- tempfile("rxMissing"); dir.create(dir)
+        on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+        res <- .runWithout(pkg, c(
+          'ok <- tryCatch({ suppressMessages(library(rxode2)); TRUE },',
+          '               error = function(e) { cat("CAUGHT:", conditionMessage(e), "\n"); FALSE })',
+          'if (ok) {',
+          '  tryCatch({',
+          '    m <- rxode2::rxode2("d/dt(x) <- -0.5*x;")',
+          '    ev <- rxode2::et(rxode2::et(0:3), amt = 1, cmt = "x")',
+          '    print(as.data.frame(rxode2::rxSolve(m, ev, cores = 1L))$x[2])',
+          '  }, error = function(e) cat("CAUGHT:", conditionMessage(e), "\n"))',
+          '}',
+          'cat("REACHED-END\n")'), dir)
+        skip_if(is.null(res), "symlinks unsupported here")
+        # The regression: exit 139 (SIGSEGV) for rxode2ll, 134 (SIGABRT) for cli.
+        expect_lt(res$status, 128L)
+        expect_false(grepl("caught segfault", res$log, fixed = TRUE))
+        expect_false(grepl("terminate called", res$log, fixed = TRUE))
+        expect_match(res$log, "REACHED-END", fixed = TRUE)
+        # Whatever happens, the child has to finish under R's control: either it
+        # completes the workload, or it raises a condition naming what is gone.
+        # (A package only reached lazily need not be wanted by this workload at
+        # all, so an uneventful run is a pass.)
+        if (grepl("CAUGHT:", res$log, fixed = TRUE)) {
+          expect_match(res$log, pkg, fixed = TRUE)
+        }
+      })
+    })
+  }
+})


### PR DESCRIPTION
@mattfidler, this is likely low importance based on our discussion in the other issue about missing packages.

Follow-up to the missing-`Imports:` crash PR, which that PR deliberately left out.
Stacked on `fix/missing-imports-crash`; base this on that branch.

## What was happening

Every generated model resolved the **entire** parse table with `R_GetCCallable()`
from its `R_init()` (`src/codegen.c:237`), including all 39 of rxode2ll's
`llik*()` rows, whether or not the model used any of them. So a plain ODE with no
`llik*()` call anywhere still depended on rxode2ll -- and not softly:
`R_GetCCallable` calls `Rf_error()`, which longjmps out of `R_init` before the
model's globals are assigned, while R keeps the dll in its loaded table.

## The change

rxode2ll contributes only `llik*()` functions, and the parser already records
whether a model calls one: `handleLlFunctions()` (`src/parseFuns.h:385`) sets
`tb.nLlik`, which is reset per parse (`src/tran.c:460`) and exported in the model
vars. So the guard is a single condition on an existing, already-trusted signal --
no new tracking:

```c
if (tb.nLlik == 0 &&
    !strcmp(R_CHAR(STRING_ELT(_rxode2parse_functionPackageName, i)), "rxode2ll")) {
  continue;
}
```

`handleLlFunctions()` runs inside the recognised-function branch of
`handleBadFunctions()`, so every `llik*`/`llikX*` call in the parsed model text
sets it -- including models rxode2 generates itself (error models, focei), since
those are re-parsed as text. `_rxode2parse_packages` is only `"rxode2"`, so these
lookups were the sole rxode2ll reference in generated code.

## Evidence

Generated C, counting `rxode2ll` references:

| model | before | after |
|---|---|---|
| `d/dt(x) <- -0.5*x;` | 39 | **0** |
| `ll <- llikNorm(0, 1, 2); d/dt(x) <- -0.5*x;` | 39 | 39 |

With rxode2ll genuinely absent and dropped from the `packagesToLoad` guard, a
plain ODE model:

- on `main`: `*** caught segfault ***`, **exit 139**
- with this change: `SOLVED: 0.6065312` (= e^-0.5, correct), **exit 0**

`llikNorm()` returns an identical value before and after (`-1.737086`).

## Tests

Added to `test-llik.R`, next to the existing `nLlik` flag test. It asserts the
plain model generates exactly zero rxode2ll references and the `llik` model
generates one per rxode2ll row -- the expected count is derived from
`rxode2parseGetTranslation()` rather than hard-coded, so it stays exact if the
table grows. **Red on `main`** (`Expected .llRefs(.plain) to equal 0L`).

Sweep, all green, 0 failures: `test-llik.R` (388), `test-lincmt-solve.R` (1569),
`test-omega-chol.R` (435), `test-par-solve.R` (357), `test-focei-variances.R`,
`test-ui-focei-ord.R`, `test-ui-pred-err.R`, `test-ui-simulation.R`,
`test-solver-basic.R`, `test-missing-package.R`, `test-sim-zeros.R`,
`test-reset.R`, `test-rm-dll.R`, `test-ind-alloc.R`, `test-dollar-names.R`.

## Scope, stated plainly

`.nsToLoad()` still requires rxode2ll for every model load, so **this does not by
itself change what a user sees when rxode2ll is missing** -- that remains the
clean error from the parent PR. What it changes is that the generated code no
longer references rxode2ll for non-llik models, which is what makes the guard
narrowable later, and it drops 39 symbol lookups from every non-llik model's load.

Making the guard itself model-aware would be the natural next step, but the model
vars that carry `nLlik` are only read *after* `dynLoad()`, so it needs a
restructure rather than a condition -- left alone here.