### PR TITLE
fix(parser): make the ifelse(cond, stmt, stmt) statement form compile anywhere in a model (#1211)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -117,6 +117,16 @@
 
 ### Compilation
 
+- The statement form of `ifelse()` -- `ifelse(cond, stmt, stmt)`, where each
+  branch is a statement rather than a value -- now compiles anywhere in a model.
+  Its handler appended `if (` to the code buffers without first clearing the
+  preceding statement's text, so the generated C ran the two together
+  (`kin=3if (t<2) {`) and only a model whose *first* statement was an `ifelse()`
+  compiled.  The construct now emits and normalizes exactly like the equivalent
+  `if (...) {...} else {...}`, so it round-trips through `rxNorm()` and
+  translates for symengine derivatives (sensitivities, FOCEi) the same way
+  (#1211).
+
 - `rxCompile()` now re-parses the model it is handed whenever the parser's
   current model is a different one.  Code generation reads the parser's global
   model state, and the old guard only checked whether *some* model was loaded,

--- a/src/parseLogical.h
+++ b/src/parseLogical.h
@@ -87,13 +87,18 @@ static inline int handleIfElse(nodeInfo ni, char *name, int i) {
     if (i == 0){
       return 1;
     } else if (i == 1){
+      // reset the buffers; they still hold the preceding statement's text
+      // (each statement handler is what clears them)
+      sb.o=0;sbDt.o=0; sbt.o=0;
       aAppendN("if (", 4);
       sAppendN(&sbt, "if (", 4);
       return 1;
     } else if (i == 3){
       aType(TLOGIC);
       aAppendN(") {", 3);
-      sAppendN(&sbt,") {", 3);
+      // normalized text uses the same spelling as 'if (...){' so rxNorm() is a
+      // fixed point when the statement is re-parsed
+      sAppendN(&sbt,"){", 2);
       addLine(&sbPm, "%s\n", sb.s);
       addLine(&sbPmDt, "%s\n", sbDt.s);
       sAppend(&sbNrm, "%s\n", sbt.s);
@@ -104,7 +109,7 @@ static inline int handleIfElse(nodeInfo ni, char *name, int i) {
       sb.o=0;sbDt.o=0; sbt.o=0;
       aType(TLOGIC);
       aAppendN("}\nelse {", 8);
-      sAppendN(&sbt,"}\nelse {", 1);
+      sAppendN(&sbt,"}\nelse {", 8);
       addLine(&sbPm, "%s\n", sb.s);
       addLine(&sbPmDt, "%s\n", sbDt.s);
       sAppend(&sbNrm, "%s\n", sbt.s);

--- a/tests/testthat/test-rxode-issue-1211.R
+++ b/tests/testthat/test-rxode-issue-1211.R
@@ -1,7 +1,8 @@
 rxTest({
-  # rxode2#1211: the statement form ifelse(cond, stmt, stmt) appended "if (" to
-  # whatever the previous statement had left in the code buffers, so it only
-  # compiled when it was the first statement of the model.
+  # rxode2#1211: the statement form of ifelse -- where each branch is a
+  # statement rather than a value -- appended the opening brace to whatever the
+  # previous statement had left in the code buffers, so it only compiled when it
+  # was the first statement of the model.
 
   test_that("ifelse() statement form compiles after a preceding assignment", {
     m <- rxode2("
@@ -27,12 +28,14 @@ d/dt(c2) <- b
 
   test_that("ifelse() statement form normalizes to a re-parsable fixed point", {
     .norm <- function(txt) rxNorm(rxode2(txt))
-    for (txt in c(
+    .models <- c(
       "kin = 3\nifelse(t<2, b <- 1, b <- 2)\nd/dt(a) <- -a + b",
       "q=1\nifelse(t<2, ifelse(t<1, b <- 1, b <- 2), b <- 3)\nd/dt(a) <- -a+b",
       "q=1\nif (q>0) {\n ifelse(t<2, b <- 1, b <- 2)\n}\nd/dt(a) <- -a+b",
       "q=1\nifelse(t<2, d/dt(a) <- -a, d/dt(a) <- -2*a)\n",
-      "q=1\nifelse(t<2, b <- 1, b <- 2)\nifelse(t<3, c2 <- 1, c2 <- 2)\nd/dt(a) <- -a+b+c2")) {
+      "q=1\nifelse(t<2, b <- 1, b <- 2)\nifelse(t<3, c2 <- 1, c2 <- 2)\nd/dt(a) <- -a+b+c2"
+    )
+    for (txt in .models) {
       .n1 <- .norm(txt)
       expect_equal(.norm(.n1), .n1)
     }
@@ -50,7 +53,7 @@ if (t<2) { b <- 1 } else { b <- 2 }
 d/dt(c2) <- b
 ")
     expect_equal(rxNorm(.ie), rxNorm(.if))
-    .ev <- et(seq(0, 5, by = 0.5)) %>% et(amt = 10, cmt = 1)
+    .ev <- et(seq(0, 5, by = 0.5)) |> et(amt = 10, cmt = 1)
     expect_equal(rxSolve(.ie, .ev, returnType = "data.frame"),
                  rxSolve(.if, .ev, returnType = "data.frame"))
   })
@@ -66,7 +69,7 @@ d/dt(a) <- -a + q
     expect_equal(rxNorm(m),
                  paste0("q=1;\nwhile (q>0){\nif (q<0.4){\nbreak;\n}\nelse {\n",
                         "q=q-0.25;\n}\n}\nd/dt(a)=-a+q;\n"))
-    .s <- rxSolve(m, et(0:3) %>% et(amt = 10, cmt = 1), returnType = "data.frame")
+    .s <- rxSolve(m, et(0:3) |> et(amt = 10, cmt = 1), returnType = "data.frame")
     expect_equal(unique(.s$q), 0.25)
   })
 

--- a/tests/testthat/test-rxode-issue-1211.R
+++ b/tests/testthat/test-rxode-issue-1211.R
@@ -1,0 +1,82 @@
+rxTest({
+  # rxode2#1211: the statement form ifelse(cond, stmt, stmt) appended "if (" to
+  # whatever the previous statement had left in the code buffers, so it only
+  # compiled when it was the first statement of the model.
+
+  test_that("ifelse() statement form compiles after a preceding assignment", {
+    m <- rxode2("
+kin = 3
+ifelse(t<2, b <- 1, b <- 2)
+d/dt(a) <- -a + b*kin
+")
+    expect_s3_class(m, "rxode2")
+    expect_equal(rxNorm(m),
+                 "kin=3;\nif (t<2){\nb=1;\n}\nelse {\nb=2;\n}\nd/dt(a)=-a+b*kin;\n")
+  })
+
+  test_that("ifelse() statement form compiles after a d/dt()", {
+    m <- rxode2("
+d/dt(a) <- -a
+ifelse(t<2, b <- 1, b <- 2)
+d/dt(c2) <- b
+")
+    expect_s3_class(m, "rxode2")
+    expect_equal(rxNorm(m),
+                 "d/dt(a)=-a;\nif (t<2){\nb=1;\n}\nelse {\nb=2;\n}\nd/dt(c2)=b;\n")
+  })
+
+  test_that("ifelse() statement form normalizes to a re-parsable fixed point", {
+    .norm <- function(txt) rxNorm(rxode2(txt))
+    for (txt in c(
+      "kin = 3\nifelse(t<2, b <- 1, b <- 2)\nd/dt(a) <- -a + b",
+      "q=1\nifelse(t<2, ifelse(t<1, b <- 1, b <- 2), b <- 3)\nd/dt(a) <- -a+b",
+      "q=1\nif (q>0) {\n ifelse(t<2, b <- 1, b <- 2)\n}\nd/dt(a) <- -a+b",
+      "q=1\nifelse(t<2, d/dt(a) <- -a, d/dt(a) <- -2*a)\n",
+      "q=1\nifelse(t<2, b <- 1, b <- 2)\nifelse(t<3, c2 <- 1, c2 <- 2)\nd/dt(a) <- -a+b+c2")) {
+      .n1 <- .norm(txt)
+      expect_equal(.norm(.n1), .n1)
+    }
+  })
+
+  test_that("ifelse() statement form is equivalent to the if/else statement", {
+    .ie <- rxode2("
+d/dt(a) <- -a
+ifelse(t<2, b <- 1, b <- 2)
+d/dt(c2) <- b
+")
+    .if <- rxode2("
+d/dt(a) <- -a
+if (t<2) { b <- 1 } else { b <- 2 }
+d/dt(c2) <- b
+")
+    expect_equal(rxNorm(.ie), rxNorm(.if))
+    .ev <- et(seq(0, 5, by = 0.5)) %>% et(amt = 10, cmt = 1)
+    expect_equal(rxSolve(.ie, .ev, returnType = "data.frame"),
+                 rxSolve(.if, .ev, returnType = "data.frame"))
+  })
+
+  test_that("ifelse() statement form works in symengine derivatives", {
+    .mod <- function(cond) {
+      sprintf(paste0("ka <- exp(tka)\ncl <- exp(tcl)\nv <- exp(tv)\n%s\n",
+                     "d/dt(depot) <- -ka*depot\n",
+                     "d/dt(center) <- ka*depot - cl/v*center*fac\ncp <- center/v"),
+              cond)
+    }
+    .ie <- .mod("ifelse(t < 2, fac <- 1, fac <- 2)")
+    .if <- .mod("if (t < 2) { fac <- 1 } else { fac <- 2 }")
+    expect_equal(rxPrune(rxode2(.ie)), rxPrune(rxode2(.if)))
+    .sie <- suppressMessages(rxode2(.ie, calcSens = c("tka", "tcl", "tv")))
+    .sif <- suppressMessages(rxode2(.if, calcSens = c("tka", "tcl", "tv")))
+    expect_equal(rxNorm(.sie), rxNorm(.sif))
+    expect_true(any(grepl("rx__sens_center_BY_tcl__", rxState(.sie), fixed = TRUE)))
+  })
+
+  test_that("the ifelse() expression form is unaffected", {
+    m <- rxode2("
+q = 1
+b <- ifelse(t<2, 1, 2)
+d/dt(a) <- -a + b*q
+")
+    expect_equal(rxNorm(m), "q=1;\nb=ifelse(t<2,1,2);\nd/dt(a)=-a+b*q;\n")
+  })
+})

--- a/tests/testthat/test-rxode-issue-1211.R
+++ b/tests/testthat/test-rxode-issue-1211.R
@@ -55,6 +55,21 @@ d/dt(c2) <- b
                  rxSolve(.if, .ev, returnType = "data.frame"))
   })
 
+  test_that("ifelse() statement form carries break inside a while()", {
+    m <- rxode2("
+q = 1
+while (q > 0) {
+  ifelse(q < 0.4, break, q <- q - 0.25)
+}
+d/dt(a) <- -a + q
+")
+    expect_equal(rxNorm(m),
+                 paste0("q=1;\nwhile (q>0){\nif (q<0.4){\nbreak;\n}\nelse {\n",
+                        "q=q-0.25;\n}\n}\nd/dt(a)=-a+q;\n"))
+    .s <- rxSolve(m, et(0:3) %>% et(amt = 10, cmt = 1), returnType = "data.frame")
+    expect_equal(unique(.s$q), 0.25)
+  })
+
   test_that("ifelse() statement form works in symengine derivatives", {
     .mod <- function(cond) {
       sprintf(paste0("ka <- exp(tka)\ncl <- exp(tcl)\nv <- exp(tv)\n%s\n",


### PR DESCRIPTION
Fixes #1211.

## Status

Fixed, tested, and reviewed by two independent outside models (both clean -- see
below). The construct now behaves identically to the equivalent
`if (...) {...} else {...}` in every path I could find: generated C, `rxNorm()`
text, `rxPrune()`/symengine translation, generated sensitivity model, and solved
output.

## The bug

`ifelse(cond, stmt, stmt)` -- the *statement* form in the grammar
(`inst/tran.g:49-50`), where each branch is a statement rather than a value --
generated uncompilable C whenever any statement preceded it:

```r
rxode2("
kin = 3
ifelse(t<2, b <- 1, b <- 2)
d/dt(a) <- -a + b
")
#> Error building the model: see rxode2::rxLastCompile()
#>   kin=3if (t<2) {
#>        ^~~ invalid suffix "if" on integer constant
```

`handleIfElse()` (`src/parseLogical.h`) appended `if (` to `sb`/`sbDt`/`sbt` at
child `i == 1` without first clearing them, and each statement handler is what
resets those buffers -- so the `if (` ran onto the previous statement's text. It
only compiled when the `ifelse()` was the model's *first* statement, which is
why a minimal test never caught it.

## The fix

`src/parseLogical.h`, the `ifelse_statement` branch of `handleIfElse()`:

1. **The reported bug.** Add the `sb.o = 0; sbDt.o = 0; sbt.o = 0;` reset at
   `i == 1` -- exactly what `handleLogicalIfOrWhile()` opens with for the
   ordinary `if`/`while`.

2. **`sAppendN(&sbt, "}\nelse {", 1)` -> `..., 8)`.** `sAppendN()`
   (`inst/include/sbuf.c:70`) `snprintf`s the whole string but advances the
   buffer offset by exactly `n`, so with `n = 1` only the `}` stuck and the
   `else {` was overwritten by whatever was appended next. `rxNorm()` emitted a
   bare `}` where the `else` belonged, and the normalized text did not re-parse.

3. **`") {"` -> `"){"` in the normalized text only** (the C emission is
   unchanged). `selection_statement` spells it `){`, so with this the two forms
   normalize byte-identically and `rxNorm()` output is a fixed point under
   re-parse.

Points 2 and 3 are what make the construct work in the **symengine derivative
path**, which was raised as a condition for supporting this syntax: `rxPrune()`
and `rxS()` consume `rxNorm()` output, so once the statement form normalizes to
a plain `if/else` they see exactly the text the `if/else` model produces. The
generated sensitivity model is identical for both spellings --
`rxode2(model, calcSens = c("tka","tcl","tv"))` on

```r
ifelse(t < 2, fac <- 1, fac <- 2)          # vs
if (t < 2) { fac <- 1 } else { fac <- 2 }
```

produces the same `rxNorm()`, with the conditional correctly flattened into
`(1*(1-(1-(t<2)))*(t<2)+2*(1-(t<2)))` inside each
`d/dt(rx__sens_<state>_BY_<param>__)`. (`rxS()` on an *unpruned* conditional
model still fails with `user function 'if' requires 0 arguments`; that is
pre-existing and identical for plain `if/else`.)

The `ifelse()` **expression** form (`b <- ifelse(t<2, 1, 2)`) is a separate
grammar rule and is untouched.

## Tests

New `tests/testthat/test-rxode-issue-1211.R` (17 assertions):

- compiles after a preceding assignment, and after a `d/dt()`
- `rxNorm()` is a re-parsable fixed point for: nested `ifelse`, `ifelse` inside
  an `if` block, `d/dt()` in both branches, two `ifelse` statements in a row
- normalized text and solved output equal the `if/else` model exactly
- `break` inside an `ifelse` branch inside a `while()` loop
- `rxPrune()` and the generated `calcSens` model equal the `if/else` model's
- the `ifelse()` expression form is unaffected

## Reviews

Both run over the branch diff with the full tree available, and asked
specifically about (a) cases the tests miss and (b) whether the handler is now
genuinely equivalent to `selection_statement`, since `selection_statement`'s
handlers also call `ENDLINE` (`tb.ixL=-1; tb.didEq=0; tb.NEnd=NV;`) at each
flush point and `ifelse_statement` never does.

**Antigravity (gemini-3.1-pro-high): no findings.** On the `ENDLINE` question it
concluded the omission cannot diverge: a `logical_or_expression` condition
cannot contain an assignment, so `tb.ixL`/`tb.didEq` are still at their reset
values from the preceding statement's own `ENDLINE`, and the branch statements
call `ENDLINE` themselves. For `tb.NEnd`, the new-assignment test in
`parseCmtProperties.h` is `tb.ix+1 == NV && tb.NEnd != NV` -- for an existing
variable the first conjunct is already false, and for a new one `NV` has
incremented again, so both spellings land the same way.

**Copilot (gpt-5.4): no findings.** Same conclusion on `ENDLINE`, reached
independently, and it verified every `sAppendN`/`aAppendN` length in the touched
function (`"if ("`=4, `"){"`=2, `"}\nelse {"`=8, `"}"`=1). It probed
`while (...) { ifelse(t<1, break, a <- 1) }` and a doubly-nested `ifelse` with
`d/dt()` in every branch without finding a divergence.

Both independently named `while`/`break` inside an `ifelse` branch as the one
case the tests did not cover, so a test for it was added in the second commit.

## Note

The `tb.nCond` block-nesting accounting in #1184 already handles
`ifelse_statement`, so `wIndLin` will be right for these models once they
compile. Nothing in that PR depends on this one.
