### PR TITLE
fix(eventSens): translate THETA[n]/ETA[n] in every emitted C line (#1196)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -152,6 +152,16 @@
   restored SAEM fit failing with "The following parameter(s) are required for
   solving: eta.v, eta.cl".
 
+- Event ("jump") sensitivities now compile when a dosing modifier (`dur()`,
+  `f()`, `alag()`, ...) depends on more than one estimated parameter.  Each such
+  parameter contributes its own assignment line to the same generated buffer,
+  but the rewrite of nlmixr2's indexed `THETA[n]`/`ETA[n]` to the codegen locals
+  `_THETA_n_`/`_ETA_n_` only collected the indices used by the *first* line, so
+  an index appearing only in a later line survived as raw symengine array syntax
+  and the model failed with "'ETA' undeclared".  This hit any model with, say, a
+  food-effect duration built from two etas, whether or not the parameters were
+  mu-referenced (#1196).
+
 ### Delay differential equations
 
 - `rxOptExpr()` no longer fails on a `past(state, tau)` whose delay duration is

--- a/R/eventSens.R
+++ b/R/eventSens.R
@@ -787,18 +787,16 @@
        durQ = .buildQ(map$durCmt, "dur", .q2All))
 }
 
-#' Generate the C assignment lines for the dLag / dF functions
+#' Rewrite indexed nlmixr2 parameters into their codegen locals
 #'
-#' Produces the body assignment lines writing each dosing-parameter total
-#' derivative into a flat per-subject scratch buffer indexed
-#' `(cmt0 * nSensParam + paramIdx)`.  The lines are inserted into the generated
-#' C verbatim; the only rewrite needed is nlmixr2's indexed
-#' `THETA[n]`/`ETA[n]` parameters, which `.rxEventSensCExpr()` maps to the
-#' codegen locals `_THETA_n_`/`_ETA_n_`.
+#' Maps nlmixr2's indexed `THETA[n]`/`ETA[n]` to the codegen locals
+#' `_THETA_n_`/`_ETA_n_`, or to the plain `THETA_n_`/`ETA_n_` when the model
+#' declares that name itself.
 #'
-#' @param info An `.rxEventSensInfo()` result (mode + map + derivs).
-#' @return list with `nSensParam`, `paramIdx` (named 0-based), and character
-#'   vectors `lag` and `f` of C assignment lines; `NULL` if `info` is `NULL`.
+#' @param expr Character vector of C expressions, one per assignment line.
+#' @param plainParams Parameter names the model declares plainly (no leading
+#'   underscore).
+#' @return `expr` with every indexed parameter rewritten.
 #' @noRd
 .rxEventSensCExpr <- function(expr, plainParams = character(0)) {
   # THETA[n]/ETA[n] map to the codegen locals _THETA_n_/_ETA_n_ unless the
@@ -818,6 +816,19 @@
   .rw(.rw(expr, "THETA"), "ETA")     # THETA before ETA (ETA[ nests inside THETA[)
 }
 
+#' Generate the C assignment lines for the dLag / dF functions
+#'
+#' Produces the body assignment lines writing each dosing-parameter total
+#' derivative into a flat per-subject scratch buffer indexed
+#' `(cmt0 * nSensParam + paramIdx)`.  The lines are inserted into the generated
+#' C verbatim; the only rewrite needed is nlmixr2's indexed
+#' `THETA[n]`/`ETA[n]` parameters, which `.rxEventSensCExpr()` maps to the
+#' codegen locals `_THETA_n_`/`_ETA_n_`.
+#'
+#' @param info An `.rxEventSensInfo()` result (mode + map + derivs).
+#' @return list with `nSensParam`, `paramIdx` (named 0-based), and character
+#'   vectors `lag` and `f` of C assignment lines; `NULL` if `info` is `NULL`.
+#' @noRd
 .rxEventSensCLines <- function(info) {
   if (is.null(info)) return(NULL)
   .pp <- info$params                     # declared param names (plain THETA_n_ vs indexed)

--- a/R/eventSens.R
+++ b/R/eventSens.R
@@ -804,7 +804,9 @@
   # THETA[n]/ETA[n] map to the codegen locals _THETA_n_/_ETA_n_ unless the
   # model declares the plain name THETA_n_ itself (then use it, no leading _).
   .rw <- function(expr, kind) {
-    .toks <- unique(regmatches(expr, gregexpr(paste0(kind, "\\[[0-9]+\\]"), expr))[[1]])
+    # expr is a vector of assignment lines; collect tokens from every element
+    # (not just the first) or indices unique to later lines leak into the C.
+    .toks <- unique(unlist(regmatches(expr, gregexpr(paste0(kind, "\\[[0-9]+\\]"), expr))))
     for (.tok in .toks) {
       .n <- sub(paste0(kind, "\\[([0-9]+)\\]"), "\\1", .tok)
       .plain <- paste0(kind, "_", .n, "_")

--- a/tests/testthat/test-event-sensitivities.R
+++ b/tests/testthat/test-event-sensitivities.R
@@ -1437,6 +1437,27 @@ rxTest({
       expect_true(grepl("_ETA_5_", .c, fixed = TRUE))
       expect_true(grepl("_THETA_5_", .c, fixed = TRUE))
     }
+    # and the line that used to be left untranslated carries the right value:
+    # with FOOD=0 the duration is exp(ETA[5]+THETA[5]), so the jump sensitivity
+    # wrt ETA[5] must match finite differences (and wrt ETA[4] must be zero).
+    .m <- rxode2(.code("dur"), eventSens = "jump")
+    p <- c("THETA[4]" = 0.3, "THETA[5]" = 0.5, "ETA[4]" = 0.1, "ETA[5]" = 0.2,
+           FOOD = 0)
+    ev <- et(amt = 100, rate = -2, cmt = "depot") |> et(seq(0.25, 12, length.out = 20))
+    .sl <- function(pp) rxSolve(.m, pp, ev, atol = 1e-12, rtol = 1e-12)
+    s <- .sl(p)
+    h <- 1e-5
+    pp <- pm <- p
+    pp[["ETA[5]"]] <- p[["ETA[5]"]] + h
+    pm[["ETA[5]"]] <- p[["ETA[5]"]] - h
+    sp <- .sl(pp)
+    sm <- .sl(pm)
+    for (st in c("depot", "central")) {
+      fd <- (sp[[st]] - sm[[st]]) / (2 * h)
+      expect_equal(s[[sprintf("rx__sens_%s_BY_ETA_5___", st)]], fd, tolerance = 1e-5)
+      expect_gt(max(abs(fd)), 1)
+    }
+    expect_equal(max(abs(s[["rx__sens_central_BY_ETA_4___"]])), 0)
   })
 
   test_that("eventSens mode is folded into the model cache key", {

--- a/tests/testthat/test-event-sensitivities.R
+++ b/tests/testthat/test-event-sensitivities.R
@@ -354,6 +354,23 @@ rxTest({
     expect_true("params" %in% names(m$eventSensInfo))
   })
 
+  test_that(".rxEventSensCExpr translates every element of a vector (#1196)", {
+    # expr is one entry per emitted assignment line; indices appearing only in a
+    # later line must be translated too, otherwise raw ETA[n]/THETA[n] leaks into
+    # the generated C and the model does not compile.
+    expect_equal(.rxEventSensCExpr(c("exp(ETA[4]+THETA[4])*(FOOD!=0)",
+                                     "exp(ETA[5]+THETA[5])*(FOOD==0)")),
+                 c("exp(_ETA_4_+_THETA_4_)*(FOOD!=0)",
+                   "exp(_ETA_5_+_THETA_5_)*(FOOD==0)"))
+    # plainParams still applies element-wise across the whole vector
+    expect_equal(.rxEventSensCExpr(c("THETA[1]", "ETA[3]"),
+                                   plainParams = c("THETA_1_", "ETA_3_")),
+                 c("THETA_1_", "ETA_3_"))
+    # zero-length and no-token inputs are unchanged
+    expect_equal(.rxEventSensCExpr(character(0)), character(0))
+    expect_equal(.rxEventSensCExpr(c("1", "cl/v")), c("1", "cl/v"))
+  })
+
   test_that("eventSens='jump' model with state-dependent F compiles and solves", {
     # Exercises the full lines channel: R-generated dLag/dF assignment lines are
     # pushed to codegen, spliced into the function bodies (with the state-coupling
@@ -1390,6 +1407,36 @@ rxTest({
     .F <- 1 / (1 + exp(-(0.2 + 0.9)))
     expect_equal(max(s[["rx__sens_depot_BY_ETA_3___"]]), 100 * .F * (1 - .F),
                  tolerance = 1e-2)
+  })
+
+  test_that("multi-eta dosing modifier emits fully translated C (#1196)", {
+    # A dur()/f() built from two distinct etas emits two assignment lines into the
+    # same event-sensitivity buffer.  Only the first line's indices used to be
+    # rewritten, so the second kept raw ETA[n]/THETA[n] and the model failed to
+    # compile with "'ETA' undeclared".
+    .code <- function(mod) {
+      paste(
+        "param(THETA[4],THETA[5],ETA[4],ETA[5],FOOD);",
+        "cmt(depot);",
+        "cmt(central);",
+        sprintf("%s(depot)=exp(ETA[4]+THETA[4])*(FOOD!=0)+exp(ETA[5]+THETA[5])*(FOOD==0);", mod),
+        "d/dt(depot)=-depot;",
+        "d/dt(central)=depot-central;",
+        "d/dt(rx__sens_depot_BY_ETA_4___)=-rx__sens_depot_BY_ETA_4___;",
+        "d/dt(rx__sens_central_BY_ETA_4___)=rx__sens_depot_BY_ETA_4___-rx__sens_central_BY_ETA_4___;",
+        "d/dt(rx__sens_depot_BY_ETA_5___)=-rx__sens_depot_BY_ETA_5___;",
+        "d/dt(rx__sens_central_BY_ETA_5___)=rx__sens_depot_BY_ETA_5___-rx__sens_central_BY_ETA_5___;",
+        sep = "\n")
+    }
+    for (.mod in c("dur", "f", "alag")) {
+      .m <- rxode2(.code(.mod), eventSens = "jump")
+      .c <- paste(readLines(rxC(.m)), collapse = "\n")
+      # no raw symengine array syntax survives into the generated C
+      expect_false(grepl("ETA\\[", .c))
+      expect_false(grepl("THETA\\[", .c))
+      expect_true(grepl("_ETA_5_", .c, fixed = TRUE))
+      expect_true(grepl("_THETA_5_", .c, fixed = TRUE))
+    }
   })
 
   test_that("eventSens mode is folded into the model cache key", {


### PR DESCRIPTION
Fixes #1196.

## The bug

`.rxEventSensCExpr()` (`R/eventSens.R`) rewrites nlmixr2's indexed
`THETA[n]`/`ETA[n]` parameters into the codegen locals `_THETA_n_`/`_ETA_n_`.
Its `expr` argument is a character **vector** -- one entry per emitted C
assignment line -- but the token collection subset the `gregexpr()` match list
with `[[1]]`, so only the indices used by the *first* element were gathered.

A dosing modifier (`dur()`, `f()`, `alag()`, ...) that depends on two or more
estimated parameters emits one assignment line per parameter into the same
buffer, so any index appearing only in a later line survived as raw symengine
array syntax and the generated C did not compile:

```c
_dDurSave[0] = exp(_ETA_4_+_THETA_4_)*(FOOD!=0);   // OK
_dDurSave[1] = exp(ETA[5]+THETA[5])*(FOOD==0);     // 'ETA' undeclared
```

This is what the food-effect model in nlmixr2/nlmixr2#408 hit ("error building
model"); the reporter was sent down an Rtools rabbit hole, but it reproduces on
a perfectly good Linux toolchain.

## The fix

Collect the tokens across every element:

```r
.toks <- unique(unlist(regmatches(expr, gregexpr(paste0(kind, "\\[[0-9]+\\]"), expr))))
```

All five `.rxEventSensCLines()` helpers pass a vector through this one function,
so the single change covers the 1st-, 2nd-, and 3rd-order buffers as well.

## Tests

`tests/testthat/test-event-sensitivities.R`:

- a unit test on `.rxEventSensCExpr()` with a length-2 input (plus `plainParams`,
  zero-length, and no-token inputs);
- `dur()`/`f()`/`alag()` models whose modifier is built from two etas: the
  generated C must contain no bare `ETA[`/`THETA[`, and must reference
  `_ETA_5_`/`_THETA_5_`;
- a finite-difference check that the line which used to be left untranslated
  carries the *right* value -- with `FOOD=0` the duration is
  `exp(ETA[5]+THETA[5])`, so the jump sensitivity wrt `ETA[5]` matches central
  differences (and wrt `ETA[4]` is zero).

All three fail on `main` (the models do not compile).

Also moves a misplaced `@noRd` roxygen block: it documented
`.rxEventSensCLines()` but sat above `.rxEventSensCExpr()`, which now has its
own.

## Verification

- `testthat::test_local(filter='sens')`: 365 pass, 0 fail
- `testthat::test_local(filter='focei|jump|codegen|lincmt')`: 6326 pass, 0 fail
- `testthat::test_local(filter='event-sensitivities|adjoint|dde')`: 3142 pass, 0 fail
- Two independent Antigravity (Gemini) review rounds over the diff: no findings.
