### PR TITLE
feat(indLin): sensitivities of the indLin() forcing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -398,6 +398,16 @@
   compartment is a parse error for a sensitivity model as well now.  Third-order
   sensitivities do not yet get a forcing contribution.
 
+- `eventSens="jump"` gets the right event-time (`alag`) jump sensitivity on a
+  `matExp()` model that has an `indLin()` forcing.  The `replace()`/`multiply()`
+  jump rows need the right-hand side at the pre-event state, which was taken
+  from the model Jacobian dotted with the state -- correct only while the whole
+  right-hand side is the rate matrix times the state.  With a forcing it is
+  short by the forcing's own contribution, which on a Michaelis-Menten model put
+  those sensitivities about 3.6% out.  It now comes from the rate matrix and the
+  forcing function directly.  This also affects hand-written `indLin()` models,
+  not only the ones `rxSensMatExp()` generates.
+
 - `rxSolve(indLinRichardson=)` Richardson-extrapolates each `method="indLin"`
   relinearization step, raising it from second to third order: the step is run
   once whole and twice at half length, and since a second-order step has a

--- a/NEWS.md
+++ b/NEWS.md
@@ -385,6 +385,19 @@
   multi-state product yields a state-free rate constant; both are kept so
   existing code keeps working.
 
+- `rxSensMatExp()` (`rxToIndLin(calcSens=)`) splits the system the same way.  It
+  used to take its rate matrix from the full Jacobian, so for a nonlinear model
+  every rate constant read a compartment and the propagated primal was `A(X).X`
+  rather than `f(X)`.  The nonlinear part now rides in an `indLin()` forcing, and
+  each sensitivity compartment gets its own forcing
+  `d(f)/dp + (df/dy).S^p`, at first and second order.  A state-free input term
+  (`d/dt(x) = k0 - ke*x`), which the Jacobian never saw, is carried too instead
+  of being dropped.  Michaelis-Menten forward sensitivities now match the
+  ordinary ODE `calcSens` path, and since the rate matrix is constant the
+  matrix exponential is cached across substeps.  A rate constant that reads a
+  compartment is a parse error for a sensitivity model as well now.  Third-order
+  sensitivities do not yet get a forcing contribution.
+
 - `rxSolve(indLinRichardson=)` Richardson-extrapolates each `method="indLin"`
   relinearization step, raising it from second to third order: the step is run
   once whole and twice at half length, and since a second-order step has a
@@ -419,10 +432,8 @@
   when the rate matrix is constant over the step, so a `k_from_to` that reads a
   state breaks the method's central assumption; the error names the constant and
   the compartment it reaches and points at `indLin()`, which is where a
-  state-dependent term belongs and where the solver can iterate it.  Models
-  built by `rxSensMatExp()` are exempt for now: their sensitivity blocks are
-  built out of rate constants throughout, and rewriting that generator is
-  separate work.
+  state-dependent term belongs and where the solver can iterate it.  This
+  applies to sensitivity models built by `rxSensMatExp()` as well.
 
 - `method="indLin"` chooses its own relinearization step for models with a
   state-dependent `indLin()` forcing, instead of subdividing each interval

--- a/R/indLin.R
+++ b/R/indLin.R
@@ -279,16 +279,22 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
 
 #' Differentiate and expand a matrix exponential model with forward sensitivities
 #'
+#' The system is split the way [indLin()] splits it: a rate matrix that is
+#' constant in the states, expressed as `k_from_to` micro-constants, plus an
+#' `indLin()` forcing carrying everything else.  Each sensitivity compartment
+#' gets the same rate matrix, the `(dA/dp).X` cross terms as non-depleting
+#' transfers, and its own forcing `d(f)/dp + (df/dy).S^p`.
+#'
 #' @param model rxode2 model, text, or function
 #' @param calcSens A character vector of parameter names for which sensitivities should be calculated.
 #' @param calcSens2 character vector (or `NULL`) requesting second-order
 #'   sensitivities `rx__sens_<x>_BY_<p>_BY_<q>__` (`p` over `calcSens`, `q` over
 #'   `calcSens2`; every `calcSens2` element must also be in `calcSens`).
-#'   Expressed as `k_from_to` micro-constant transfers like the first-order
-#'   ones.  Ignored for `linCmt()` states (those use Stan forward-AD).
+#'   Ignored for `linCmt()` states (those use Stan forward-AD).
 #' @param calcSens3 character vector (or `NULL`) requesting third-order
 #'   sensitivities `rx__sens_<x>_BY_<p>_BY_<q>_BY_<r>__` (`r` over `calcSens3`).
 #'   Requires `calcSens2`; every `calcSens3` element must also be in `calcSens2`.
+#'   The forcing contribution is not generated at third order.
 #' @param doConst Replace constants with values; By default this is `FALSE`.
 #' @param env A pre-loaded symengine environment (from `.rxLoadPrune()`) to
 #'   reuse instead of reloading `model`; when `NULL` it is built internally.
@@ -339,18 +345,23 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
     stop("No state variables (compartments) found in the model.", call. = FALSE)
   }
 
-  # 2. Build the system Jacobian A[i, j] = d(d/dt X_i)/d X_j directly from the
-  #    materialized derivatives.  For linear models A is constant; for nonlinear
-  #    models (e.g. Michaelis-Menten) the entries are state-dependent expressions.
+  # 2. Split the system the way indLin() does: dX/dt = A.X + F(X), with A
+  #    CONSTANT IN THE STATES.  That is the premise of the matrix exponential
+  #    (rxode2#1186); anything that cannot leave a state-free coefficient is the
+  #    nonlinear residual and belongs in the indLin() forcing, where the solver
+  #    iterates it.  The Jacobian is still needed -- for the df()/dy() block and
+  #    for the forcing -- but it is no longer what the rate constants come from.
   .zero <- symengine::S("0")
   .isZero <- function(.e) {
     .z <- rxFromSE(.e)
     .z == "0" || .z == "0.0" || .z == "-0"
   }
+  # `.zero +` coerces a plain numeric (how a constant `d/dt(depot) <- 0` is
+  # stored) to a Basic, which symengine::D() and the arithmetic below require.
   .rhs <- lapply(.states, function(.s) {
     .v <- paste0("rx__d_dt_", .s, "__")
     if (exists(.v, envir = .env, inherits = FALSE)) {
-      base::get(.v, envir = .env, inherits = FALSE)
+      .zero + base::get(.v, envir = .env, inherits = FALSE)
     } else {
       .zero
     }
@@ -358,12 +369,49 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
   names(.rhs) <- .states
   .stateSym <- lapply(.states, function(.s) symengine::S(.s))
   names(.stateSym) <- .states
-  .A <- lapply(.states, function(.i) {
+  # Full Jacobian, for the df()/dy() block only.
+  .jac <- lapply(.states, function(.i) {
     .row <- lapply(.states, function(.j) symengine::D(.rhs[[.i]], .stateSym[[.j]]))
     names(.row) <- .states
     .row
   })
+  names(.jac) <- .states
+  # The rate matrix, from the same term-wise routing indLin() uses.  rxIndLin_()
+  # generates R code that reads the locals `.env` and `.states`, so both have to
+  # be in scope here.  `.states` drops `output` and any linCmt() compartment, so
+  # the routing treats those as parameters -- correct, since neither has matExp
+  # dynamics of its own (linCmt sensitivities come from Stan forward-AD).
+  .aTxt <- eval(parse(text = rxIndLin_(.states)))[.states, .states, drop = FALSE]
+  # eval-in-env rather than symengine::S(): S() re-parses, and symengine's
+  # parser rejects an ordinary rxode2 name such as `eta.Cl` (same reason as
+  # indLin():57-62).  A coefficient is state free, so it cannot carry the
+  # C-level helpers (Rx_pow_di() and friends) the forcing text can.
+  .A <- lapply(.states, function(.i) {
+    .row <- lapply(.states, function(.j) {
+      .t <- .aTxt[.i, .j]
+      if (.t == "0") .zero else .zero + eval(parse(text = .t), envir = .env)
+    })
+    names(.row) <- .states
+    .row
+  })
   names(.A) <- .states
+  # The forcing, as the residual the rate matrix does not reproduce.  Taken
+  # symbolically rather than from rxIndLin_()'s `_rxF` column, which is text
+  # that has been through rxFromSE() and so can carry C-level helpers such as
+  # Rx_pow_di() that do not exist in the symengine environment -- the hazard
+  # indLin():105-113 documents.  The split is term wise, so the residual is the
+  # same expression; symengine cancels the A.X part outright.  This is also
+  # what carries a state-free input term (`d/dt(x) = k0 - ke*x`), which the
+  # Jacobian never saw.
+  .force <- lapply(.states, function(.i) {
+    .f <- .rhs[[.i]]
+    for (.j in .states) {
+      .aij <- .A[[.i]][[.j]]
+      if (!.isZero(.aij)) .f <- .f - .aij * .stateSym[[.j]]
+    }
+    .f
+  })
+  names(.force) <- .states
   # elimination from compartment j: -(A[j,j] + sum_{i != j} A[i,j])
   .elimOf <- function(.j) {
     .e <- -.A[[.j]][[.j]]
@@ -411,26 +459,54 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
     for (.i in .states) {
       if (.i == .j) next
       .aij <- .A[[.i]][[.j]]
-      if (!.isZero(.aij)) {
-        .code <- c(.code, paste0("k_", .j, "_", .i, " = ", rxFromSE(.aij)))
+      if (.isZero(.aij)) next
+      .kname <- paste0("k_", .j, "_", .i)
+      .val <- rxFromSE(.aij)
+      # A matExp()-form input can carry the rate as a model parameter, in which
+      # case the coefficient IS the micro-constant name; declare it rather than
+      # assigning it to itself (same case indLin():51-56 handles).
+      if (.val == .kname || .val == paste0("k.", .j, ".", .i)) {
+        .code <- c(.code, paste0("param(", .val, ")"))
+      } else {
+        .code <- c(.code, paste0(.kname, " = ", .val))
       }
     }
     .elim <- .elimOf(.j)
     if (!.isZero(.elim)) {
-      .code <- c(.code, paste0("k_", .j, "_output = ", rxFromSE(.elim)))
+      .knameOut <- paste0("k_", .j, "_output")
+      .elimVal <- rxFromSE(.elim)
+      if (.elimVal == .knameOut || .elimVal == paste0("k.", .j, ".output")) {
+        .code <- c(.code, paste0("param(", .elimVal, ")"))
+      } else {
+        .code <- c(.code, paste0(.knameOut, " = ", .elimVal))
+      }
     }
   }
 
-  # 4b. Explicit Jacobian (df/dy) lines from `.A`.  matExp()/indLin() models
-  # have a no-op dydt(), so the event-sensitivity Jacobian column would be
-  # zero; these df()/dy() lines populate calc_jac with the known Jacobian,
-  # which handle_evid reads instead for these models.  Emitted unconditionally
-  # (any eventSens="jump" solve needs it).
+  # 4a. The primal forcing.  Everything the rate matrix cannot represent goes
+  # here, so the states themselves are right for a nonlinear model -- A.X is
+  # not f(X).  An indLin() line in the input model was dropped by the preserve
+  # loop below and is re-derived here.
+  for (.i in .states) {
+    .fi <- .force[[.i]]
+    if (!.isZero(.fi)) {
+      .code <- c(.code, paste0("indLin(", .i, ") <- ", rxFromSE(.fi)))
+    }
+  }
+
+  # 4b. Explicit Jacobian (df/dy) lines from the FULL Jacobian (A + dF/dX).
+  # matExp()/indLin() models have a no-op dydt(), so the event-sensitivity
+  # Jacobian column would be zero; these df()/dy() lines populate calc_jac with
+  # the known Jacobian, which handle_evid reads instead for these models.
+  # Emitted unconditionally (any eventSens="jump" solve needs it), and only for
+  # the physical block -- _esJacColF() (rxode2parseHandleEvid.h) sizes its
+  # calc_jac buffer by the physical state count, so rows for the sensitivity
+  # compartments would write past it.
   for (.i in .states) {
     for (.j in .states) {
-      .aij <- .A[[.i]][[.j]]
-      if (!.isZero(.aij)) {
-        .code <- c(.code, paste0("df(", .i, ")/dy(", .j, ") = ", rxFromSE(.aij)))
+      .jij <- .jac[[.i]][[.j]]
+      if (!.isZero(.jij)) {
+        .code <- c(.code, paste0("df(", .i, ")/dy(", .j, ") = ", rxFromSE(.jij)))
       }
     }
   }
@@ -461,6 +537,17 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
         if (!.isZero(.dAdp)) {
           .code <- c(.code, paste0("k_", .j, "_", .S(.i), "_nd = ", rxFromSE(.dAdp)))
         }
+      }
+    }
+    # 5bf. Forcing: the part of the system that is not in A contributes
+    #     d(F_i)/dp + sum_j (d(F_i)/dX_j) S^p_j to the sensitivity compartment,
+    #     which is exactly .rxIndLinTotalD() (rxode2#1187).
+    for (.i in .states) {
+      .fi <- .force[[.i]]
+      if (.isZero(.fi)) next
+      .g <- .rxIndLinTotalD(.fi, .p, .states)
+      if (!.isZero(.g)) {
+        .code <- c(.code, paste0("indLin(", .S(.i), ") <- ", rxFromSE(.g)))
       }
     }
   }
@@ -512,6 +599,19 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
           }
         }
         .code <- c(.code, .acc$emit())
+        # forcing: the first-order forcing differentiated once more.  The second
+        # pass chains through the states (-> S^q) and through the
+        # rx__sens_*_BY_<p>__ symbols the first pass introduced (-> _BY_p_BY_q),
+        # which is the naming .S2() emits.  No accumulator is needed: a forcing
+        # is keyed by one target compartment, so p == q still gives one line.
+        for (.i in .states) {
+          .fi <- .force[[.i]]
+          if (.isZero(.fi)) next
+          .g2 <- .rxIndLinChainD(.fi, c(.p, .q), .states)
+          if (!.isZero(.g2)) {
+            .code <- c(.code, paste0("indLin(", .S2(.i), ") <- ", rxFromSE(.g2)))
+          }
+        }
       }
     }
   }
@@ -528,6 +628,11 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
   #   from S^q_j:       totalD_r(dAdp_ij)
   #   from S^r_j:       totalD_q(dAdp_ij)
   #   from X_j:         totalD_r(totalD_q(dAdp_ij))
+  # The forcing contribution -- .rxIndLinChainD(.force[[i]], c(p, q, r),
+  # .states), emitted as indLin(S^{pqr}_i) the way the first and second order
+  # blocks above do -- is NOT emitted here.  Third order has never carried one,
+  # so this is not a regression, but for a nonlinear model it is incomplete
+  # (rxode2#1187 follow-up).
   if (!is.null(calcSens3)) {
     for (.p in calcSens) {
       .pSym <- symengine::S(.p)

--- a/R/indLin.R
+++ b/R/indLin.R
@@ -188,9 +188,16 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
 #'   of one built by a previous call to this function).
 #' @param byVar Parameter name to differentiate wrt.
 #' @param states Physical state names.
+#' @param statesSe The symengine name of each of `states`, in the same order.
+#' @param byVarSe The symengine name of `byVar`.
+#'
+#'   Both are required rather than defaulted from `rxToSE()`: `rxToSE()` parses,
+#'   and parsing stops working once symengine `Basic` arithmetic has been done in
+#'   the same session (`user function '[[' requires 0 arguments`).  The caller
+#'   has to map every name before it touches a Basic.
 #' @return symengine expression for the total derivative.
 #' @noRd
-.rxIndLinTotalD <- function(expr, byVar, states) {
+.rxIndLinTotalD <- function(expr, byVar, states, statesSe, byVarSe) {
   .isZero <- function(.e) {
     .z <- rxFromSE(.e)
     .z == "0" || .z == "0.0" || .z == "-0"
@@ -203,22 +210,28 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
   .add <- function(.term) {
     if (is.null(.tot)) .tot <<- .term else .tot <<- .tot + .term
   }
-  if (byVar %in% .vars) {
-    .add(symengine::D(expr, symengine::S(byVar)))
+  # Symbol(), not S(): S() re-parses, so it rejects a dotted rxode2 name
+  # (`eta.cl`) and reads a compartment called `I`, `E` or `Catalan` as the
+  # matching mathematical constant, which D() then refuses to differentiate by.
+  # The names differentiated by are symengine-side (rxToSE()); the names built
+  # INTO a sensitivity compartment are model-side, since that is what cmt()
+  # declared.
+  if (byVarSe %in% .vars) {
+    .add(symengine::D(expr, symengine::Symbol(byVarSe)))
   }
-  for (.l in states) {
-    if (!(.l %in% .vars)) next
-    .dl <- symengine::D(expr, symengine::S(.l))
+  for (.i in seq_along(states)) {
+    if (!(statesSe[[.i]] %in% .vars)) next
+    .dl <- symengine::D(expr, symengine::Symbol(statesSe[[.i]]))
     if (!.isZero(.dl)) {
-      .add(.dl * symengine::S(paste0("rx__sens_", .l, "_BY_", byVar, "__")))
+      .add(.dl * symengine::Symbol(paste0("rx__sens_", states[[.i]], "_BY_", byVar, "__")))
     }
   }
   for (.s in .vars) {
     if (!startsWith(.s, "rx__sens_") || !endsWith(.s, "__")) next
-    .ds <- symengine::D(expr, symengine::S(.s))
+    .ds <- symengine::D(expr, symengine::Symbol(.s))
     if (.isZero(.ds)) next
     .target <- paste0(substring(.s, 1L, nchar(.s) - 2L), "_BY_", byVar, "__")
-    .add(.ds * symengine::S(.target))
+    .add(.ds * symengine::Symbol(.target))
   }
   if (is.null(.tot)) symengine::S("0") else .tot
 }
@@ -228,11 +241,15 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
 #' @param base Starting symengine expression (a Jacobian entry).
 #' @param byVars Character vector of variables to differentiate by, in order.
 #' @param states Physical state names.
+#' @param statesSe The symengine name of each of `states`, in the same order.
+#' @param byVarsSe The symengine name of each of `byVars`, in the same order.
 #' @return symengine expression for the repeated total derivative.
 #' @noRd
-.rxIndLinChainD <- function(base, byVars, states) {
+.rxIndLinChainD <- function(base, byVars, states, statesSe, byVarsSe) {
   .e <- base
-  for (.v in byVars) .e <- .rxIndLinTotalD(.e, .v, states)
+  for (.i in seq_along(byVars)) {
+    .e <- .rxIndLinTotalD(.e, byVars[[.i]], states, statesSe, byVarsSe[[.i]])
+  }
   .e
 }
 
@@ -345,6 +362,20 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
     stop("No state variables (compartments) found in the model.", call. = FALSE)
   }
 
+  # 1b. Map every model name to the symengine name it is bound under, BEFORE
+  # touching a single Basic.  rxToSE() parses, and parsing stops working once
+  # symengine arithmetic has been done ("user function '[[' requires 0
+  # arguments"), so this cannot be deferred into the loops below.  The mapping
+  # matters because a compartment may legitimately be called `I`, `E` or
+  # `Catalan`, which symengine reads as the matching mathematical constant
+  # rather than a symbol (`.rxSEreserved`, R/symengine.R:524).
+  # The anonymous wrapper is required: rxToSE() resolves its argument with
+  # substitute(), so handing it to vapply() as a bare FUN passes it the literal
+  # `X[[i]]` expression and it reports `user function '[[' requires 0 arguments`.
+  .toSe <- function(.n) rxToSE(.n)
+  .statesSe <- vapply(.states, .toSe, character(1), USE.NAMES = FALSE)
+  .parSe <- vapply(unique(c(calcSens, calcSens2, calcSens3)), .toSe, character(1))
+
   # 2. Split the system the way indLin() does: dX/dt = A.X + F(X), with A
   #    CONSTANT IN THE STATES.  That is the premise of the matrix exponential
   #    (rxode2#1186); anything that cannot leave a state-free coefficient is the
@@ -367,7 +398,9 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
     }
   })
   names(.rhs) <- .states
-  .stateSym <- lapply(.states, function(.s) symengine::S(.s))
+  # Symbol(), not S(): S() re-parses, so it turns the mapped-away reserved
+  # names back into constants and cannot read a dotted rxode2 name at all.
+  .stateSym <- lapply(.statesSe, symengine::Symbol)
   names(.stateSym) <- .states
   # Full Jacobian, for the df()/dy() block only.
   .jac <- lapply(.states, function(.i) {
@@ -513,7 +546,8 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
 
   # 5. Sensitivity blocks for each parameter.
   for (.p in calcSens) {
-    .pSym <- symengine::S(.p)
+    .pSe <- .parSe[[.p]]
+    .pSym <- symengine::Symbol(.pSe)
     .S <- function(.s) paste0("rx__sens_", .s, "_BY_", .p, "__")
     # 5a. Diagonal block: sensitivity states obey the same dynamics as the
     #     originals (reuse the original micro-constants).
@@ -545,7 +579,7 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
     for (.i in .states) {
       .fi <- .force[[.i]]
       if (.isZero(.fi)) next
-      .g <- .rxIndLinTotalD(.fi, .p, .states)
+      .g <- .rxIndLinTotalD(.fi, .p, .states, .statesSe, .pSe)
       if (!.isZero(.g)) {
         .code <- c(.code, paste0("indLin(", .S(.i), ") <- ", rxFromSE(.g)))
       }
@@ -564,9 +598,11 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
   # symbols, which fails when a coefficient depends on the state it multiplies).
   if (!is.null(calcSens2)) {
     for (.p in calcSens) {
-      .pSym <- symengine::S(.p)
+      .pSe <- .parSe[[.p]]
+      .pSym <- symengine::Symbol(.pSe)
       .S1p <- function(.s) paste0("rx__sens_", .s, "_BY_", .p, "__")
       for (.q in calcSens2) {
+        .qSe <- .parSe[[.q]]
         .S1q <- function(.s) paste0("rx__sens_", .s, "_BY_", .q, "__")
         .S2 <- function(.s) paste0("rx__sens_", .s, "_BY_", .p, "_BY_", .q, "__")
         # homogeneous block: S^{pq} obeys the same dynamics as X / S^p (reuse).
@@ -588,13 +624,13 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
         .acc <- .rxIndLinNdAccumulator()
         for (.i in .states) {
           for (.k in .states) {
-            .c2a <- .rxIndLinTotalD(.A[[.i]][[.k]], .q, .states) # from S^p_k
+            .c2a <- .rxIndLinTotalD(.A[[.i]][[.k]], .q, .states, .statesSe, .qSe) # from S^p_k
             .acc$add(.S1p(.k), .S2(.i), .c2a)
           }
           for (.j in .states) {
             .dAdp <- symengine::D(.A[[.i]][[.j]], .pSym)
             .acc$add(.S1q(.j), .S2(.i), .dAdp) # from S^q_j
-            .c2c <- .rxIndLinTotalD(.dAdp, .q, .states) # from X_j
+            .c2c <- .rxIndLinTotalD(.dAdp, .q, .states, .statesSe, .qSe) # from X_j
             .acc$add(.j, .S2(.i), .c2c)
           }
         }
@@ -607,7 +643,7 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
         for (.i in .states) {
           .fi <- .force[[.i]]
           if (.isZero(.fi)) next
-          .g2 <- .rxIndLinChainD(.fi, c(.p, .q), .states)
+          .g2 <- .rxIndLinChainD(.fi, c(.p, .q), .states, .statesSe, c(.pSe, .qSe))
           if (!.isZero(.g2)) {
             .code <- c(.code, paste0("indLin(", .S2(.i), ") <- ", rxFromSE(.g2)))
           }
@@ -631,16 +667,24 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
   # The forcing contribution -- .rxIndLinChainD(.force[[i]], c(p, q, r),
   # .states), emitted as indLin(S^{pqr}_i) the way the first and second order
   # blocks above do -- is NOT emitted here.  Third order has never carried one,
-  # so this is not a regression, but for a nonlinear model it is incomplete
-  # (rxode2#1187 follow-up).
+  # so this is not a regression, but now that the orders around it do, a
+  # nonlinear model would be silently short a term; say so rather than let it
+  # pass (rxode2#1187 follow-up).
   if (!is.null(calcSens3)) {
+    if (any(vapply(.states, function(.i) !.isZero(.force[[.i]]), logical(1)))) {
+      warning("third-order sensitivities omit the indLin() forcing contribution, so they are incomplete for this nonlinear model; first and second order carry it",
+              call. = FALSE)
+    }
     for (.p in calcSens) {
-      .pSym <- symengine::S(.p)
+      .pSe <- .parSe[[.p]]
+      .pSym <- symengine::Symbol(.pSe)
       .S1p <- function(.s) paste0("rx__sens_", .s, "_BY_", .p, "__")
       for (.q in calcSens2) {
+        .qSe <- .parSe[[.q]]
         .S1q <- function(.s) paste0("rx__sens_", .s, "_BY_", .q, "__")
         .S2pq <- function(.s) paste0("rx__sens_", .s, "_BY_", .p, "_BY_", .q, "__")
         for (.r in calcSens3) {
+          .rSe <- .parSe[[.r]]
           .S1r <- function(.s) paste0("rx__sens_", .s, "_BY_", .r, "__")
           .S2pr <- function(.s) paste0("rx__sens_", .s, "_BY_", .p, "_BY_", .r, "__")
           .S2qr <- function(.s) paste0("rx__sens_", .s, "_BY_", .q, "_BY_", .r, "__")
@@ -665,16 +709,16 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
           for (.i in .states) {
             for (.k in .states) {
               .Aik <- .A[[.i]][[.k]]
-              .acc$add(.S2pq(.k), .S3(.i), .rxIndLinTotalD(.Aik, .r, .states)) # from S^{pq}_k
-              .acc$add(.S2pr(.k), .S3(.i), .rxIndLinTotalD(.Aik, .q, .states)) # from S^{pr}_k
-              .acc$add(.S1p(.k), .S3(.i), .rxIndLinChainD(.Aik, c(.q, .r), .states)) # from S^p_k
+              .acc$add(.S2pq(.k), .S3(.i), .rxIndLinTotalD(.Aik, .r, .states, .statesSe, .rSe)) # from S^{pq}_k
+              .acc$add(.S2pr(.k), .S3(.i), .rxIndLinTotalD(.Aik, .q, .states, .statesSe, .qSe)) # from S^{pr}_k
+              .acc$add(.S1p(.k), .S3(.i), .rxIndLinChainD(.Aik, c(.q, .r), .states, .statesSe, c(.qSe, .rSe))) # from S^p_k
             }
             for (.j in .states) {
               .dAdp <- symengine::D(.A[[.i]][[.j]], .pSym)
               .acc$add(.S2qr(.j), .S3(.i), .dAdp) # from S^{qr}_j
-              .acc$add(.S1q(.j), .S3(.i), .rxIndLinTotalD(.dAdp, .r, .states)) # from S^q_j
-              .acc$add(.S1r(.j), .S3(.i), .rxIndLinTotalD(.dAdp, .q, .states)) # from S^r_j
-              .acc$add(.j, .S3(.i), .rxIndLinChainD(.dAdp, c(.q, .r), .states)) # from X_j
+              .acc$add(.S1q(.j), .S3(.i), .rxIndLinTotalD(.dAdp, .r, .states, .statesSe, .rSe)) # from S^q_j
+              .acc$add(.S1r(.j), .S3(.i), .rxIndLinTotalD(.dAdp, .q, .states, .statesSe, .qSe)) # from S^r_j
+              .acc$add(.j, .S3(.i), .rxIndLinChainD(.dAdp, c(.q, .r), .states, .statesSe, c(.qSe, .rSe))) # from X_j
             }
           }
           .code <- c(.code, .acc$emit())

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -261,7 +261,8 @@
 #'     symbolic one when the model carries it and falls back to finite
 #'     differences otherwise -- which is what happens above
 #'     `getOption("rxode2.indLinJacMaxStates")` states, where the symbolic
-#'     emission is skipped to bound the symengine work at model build.
+#'     emission is skipped to bound the symengine work at model build, and on a
+#'     sensitivity model, whose `df()/dy()` lines cover the physical states only.
 #'
 #' @param indLinPhiM  the maximum size for the Krylov basis
 #'

--- a/inst/include/rxode2parseHandleEvid.h
+++ b/inst/include/rxode2parseHandleEvid.h
@@ -551,10 +551,10 @@ static inline void _esMoveDeferredToPending(rx_solving_options_ind *ind, double 
 // rows in the paper's replace/additive/multiplicative tables.  Source
 // depends on model type (see _rxEsUseCalcJac, set from mv$indLin):
 //   - matExp()/indLin() models: dydt() is a no-op stub (matrix-exponential
-//     primal solve, not RHS evaluation), so both come from calc_jac -- the
-//     column directly, and f_cmt from the identity dX/dt = A*X (exact for
-//     the reconstructed matExp system) via row `cmt` of the Jacobian dotted
-//     with the current state.
+//     primal solve, not RHS evaluation), so the column comes from calc_jac,
+//     and f_cmt from ME() and IndF() -- the rate matrix dotted with the
+//     current state plus the forcing.  NOT from the Jacobian row: that is
+//     f_cmt only while the whole right-hand side is A.X.
 //   - ordinary ODE models: calc_jac is normally an empty stub (only
 //     populated by explicit user-written df/dy lines) but dydt is fully
 //     functional, so the column comes from a central difference of dydt and
@@ -562,8 +562,10 @@ static inline void _esMoveDeferredToPending(rx_solving_options_ind *ind, double 
 //     computed for it (accurate to O(eps^2), avoids a third dydt call).
 // `_esJcol` (size >= ns) and `*_esFc` are left untouched if neither source
 // is available (caller must pre-zero/guard on the relevant function pointer).
+// Pass `_esFc = NULL` when the caller's jump row has no f_cmt term.
 static inline void _esJacColF(int id, double xout, double *yp, int cmt, int ns,
-                              int neq, double *_esJcol, double *_esFc) {
+                              int neq, double *_esJcol, double *_esFc,
+                              rx_solving_options_ind *ind) {
   int _esNj[2]; _esNj[0] = neq; _esNj[1] = id;
   if (_rxEsUseCalcJac) {
     double *_esPD = (double*) calloc((size_t)ns * ns, sizeof(double));
@@ -574,8 +576,42 @@ static inline void _esJacColF(int id, double xout, double *yp, int cmt, int ns,
         _esJcol[_k] = _esPD[_k * ns + cmt];
         _f += _esPD[cmt * ns + _k] * yp[_k];
       }
-      *_esFc = _f;
+      if (_esFc != NULL) *_esFc = _f;
       free(_esPD);
+    }
+    // The Jacobian row dotted with the state is f_cmt only for a model whose
+    // whole right-hand side is A.X.  Once part of it lives in an indLin()
+    // forcing -- which is where rxode2#1186/#1187 put every nonlinear term --
+    // J is A + dF/dX, so that dot product both misses F(X) and double counts
+    // (dF/dX).X.  Take the two pieces from the functions the solver already
+    // has: ME() is the rate matrix (column major, A[i][j] = _mat[j*neq + i])
+    // and IndF() is the forcing, seeded with the infusion rate, which is part
+    // of the true right-hand side at this instant too.
+    //
+    // Only the replace/multiply dtau rows need f_cmt; the additive-bolus rows
+    // pass NULL and skip the two extra evaluations.
+    if (_esFc != NULL) {
+      rx_solve *_esRx = (ind != NULL && ind->rx) ? ind->rx : &rx_global;
+      t_ME _esME = _esRx->fns.me;
+      t_IndF _esIndF = _esRx->fns.indf;
+      if (_esME != NULL) {
+        double *_esA = (double*) calloc((size_t)neq * neq, sizeof(double));
+        if (_esA != NULL) {
+          _esME(id, xout, xout, _esA, yp);
+          double _fa = 0.0;
+          for (int _j = 0; _j < neq; _j++) _fa += _esA[_j * neq + cmt] * yp[_j];
+          *_esFc = _fa;
+          free(_esA);
+          if (_esIndF != NULL) {
+            double *_esFv = (double*) calloc((size_t)neq, sizeof(double));
+            if (_esFv != NULL) {
+              _esIndF(id, xout, xout, _esFv, yp);
+              *_esFc += _esFv[cmt];
+              free(_esFv);
+            }
+          }
+        }
+      }
     }
   } else if (dydtEs != NULL) {
     double *_esF0 = (double*) calloc((size_t)neq, sizeof(double));
@@ -591,7 +627,7 @@ static inline void _esJacColF(int id, double xout, double *yp, int cmt, int ns,
       for (int _k = 0; _k < ns; _k++) {
         _esJcol[_k] = (_esF1[_k] - _esF0[_k]) * _esInv;
       }
-      *_esFc = 0.5 * (_esF0[cmt] + _esF1[cmt]);
+      if (_esFc != NULL) *_esFc = 0.5 * (_esF0[cmt] + _esF1[cmt]);
     }
     if (_esF0 != NULL) free(_esF0);
     if (_esF1 != NULL) free(_esF1);
@@ -1580,7 +1616,7 @@ static inline int handle_evid(int evid, int neq,
           if (_esDLagB != NULL && _esJcol != NULL) {
             dLagEs(id, xout, yp, _esDLagB);
             double _esFc = 0.0;
-            _esJacColF(id, xout, yp, cmt, _ns, neq, _esJcol, &_esFc);
+            _esJacColF(id, xout, yp, cmt, _ns, neq, _esJcol, &_esFc, ind);
             double _esX1 = yp[cmt];
             double _esXi = getAmt(ind, id, cmt, getDoseIndex(ind, ind->idx), xout, yp);
             for (int _p = 0; _p < _np; _p++) {
@@ -1657,7 +1693,7 @@ static inline int handle_evid(int evid, int neq,
             if (_esDLagB != NULL && _esJcol != NULL) {
               dLagEs(id, xout, yp, _esDLagB);
               double _esFc = 0.0;
-              _esJacColF(id, xout, yp, cmt, _ns, neq, _esJcol, &_esFc);
+              _esJacColF(id, xout, yp, cmt, _ns, neq, _esJcol, &_esFc, ind);
               double _esOneMAlpha = 1.0 - _esAlpha;
               for (int _p = 0; _p < _np; _p++) {
                 double _esDLagP = _esDLagB[cmt * _np + _p];
@@ -1832,8 +1868,8 @@ static inline int handle_evid(int evid, int neq,
             double *_esJcol = (double*) calloc((size_t)_ns, sizeof(double));
             if (_esDLagB != NULL && _esJcol != NULL) {
               dLagEs(id, xout, yp, _esDLagB);
-              double _esFc; // unused here (additive-bolus dtau row has no f_c term)
-              _esJacColF(id, xout, yp, cmt, _ns, neq, _esJcol, &_esFc);
+              // NULL: the additive-bolus dtau row has no f_c term
+              _esJacColF(id, xout, yp, cmt, _ns, neq, _esJcol, NULL, ind);
               for (int _p = 0; _p < _np; _p++) {
                 double _esDLagP = _esDLagB[cmt * _np + _p];
                 if (_esDLagP != 0.0) {
@@ -1927,8 +1963,7 @@ static inline int handle_evid(int evid, int neq,
             if (_esDLagB2 != NULL && _esJcol2 != NULL && _esD2LagB != NULL &&
                 _esDFQB != NULL && _esJacQB != NULL && _esDLagQB != NULL) {
               dLagEs(id, xout, yp, _esDLagB2);
-              double _esFc2;
-              _esJacColF(id, xout, yp, cmt, _ns, neq, _esJcol2, &_esFc2);
+              _esJacColF(id, xout, yp, cmt, _ns, neq, _esJcol2, NULL, ind);
               d2LagEs(id, xout, yp, _esD2LagB);
               if (dFQEs != NULL) dFQEs(id, xout, yp, _esDFQB);
               dLagJacEs(id, xout, yp, _esJacQB);

--- a/inst/include/rxode2parseHandleEvid.h
+++ b/inst/include/rxode2parseHandleEvid.h
@@ -563,74 +563,90 @@ static inline void _esMoveDeferredToPending(rx_solving_options_ind *ind, double 
 // `_esJcol` (size >= ns) and `*_esFc` are left untouched if neither source
 // is available (caller must pre-zero/guard on the relevant function pointer).
 // Pass `_esFc = NULL` when the caller's jump row has no f_cmt term.
+// matExp()/indLin(): the column straight out of calc_jac, and the Jacobian row
+// dotted with the state as a provisional f_cmt (the right answer whenever the
+// model has no forcing; _esJacColMeF() replaces it when it does).
+static inline void _esJacColCalcJac(int *_esNj, double xout, double *yp, int cmt,
+                                    int ns, double *_esJcol, double *_esFc) {
+  double *_esPD = (double*) calloc((size_t)ns * ns, sizeof(double));
+  if (_esPD == NULL) return;
+  calc_jac(_esNj, xout, yp, _esPD, (unsigned int) ns);
+  double _f = 0.0;
+  for (int _k = 0; _k < ns; _k++) {
+    _esJcol[_k] = _esPD[_k * ns + cmt];
+    _f += _esPD[cmt * ns + _k] * yp[_k];
+  }
+  if (_esFc != NULL) *_esFc = _f;
+  free(_esPD);
+}
+
+// f_cmt for a matExp()/indLin() model, from the rate matrix and the forcing.
+//
+// The Jacobian row dotted with the state is f_cmt only for a model whose whole
+// right-hand side is A.X.  Once part of it lives in an indLin() forcing --
+// which is where rxode2#1186/#1187 put every nonlinear term -- J is A + dF/dX,
+// so that dot product both misses F(X) and double counts (dF/dX).X.  ME() is
+// the rate matrix (column major, A[i][j] = _mat[j*neq + i]) and IndF() is the
+// forcing, seeded with the infusion rate, which is part of the true right-hand
+// side at this instant too.  Leaves `*_esFc` alone if ME() is unavailable.
+static inline void _esJacColMeF(int id, double xout, double *yp, int cmt,
+                                int neq, double *_esFc,
+                                rx_solving_options_ind *ind) {
+  rx_solve *_esRx = (ind != NULL && ind->rx) ? ind->rx : &rx_global;
+  t_ME _esME = _esRx->fns.me;
+  if (_esME == NULL) return;
+  double *_esA = (double*) calloc((size_t)neq * neq, sizeof(double));
+  if (_esA == NULL) return;
+  _esME(id, xout, xout, _esA, yp);
+  double _fa = 0.0;
+  for (int _j = 0; _j < neq; _j++) _fa += _esA[_j * neq + cmt] * yp[_j];
+  free(_esA);
+  t_IndF _esIndF = _esRx->fns.indf;
+  if (_esIndF != NULL) {
+    double *_esFv = (double*) calloc((size_t)neq, sizeof(double));
+    if (_esFv != NULL) {
+      _esIndF(id, xout, xout, _esFv, yp);
+      _fa += _esFv[cmt];
+      free(_esFv);
+    }
+  }
+  *_esFc = _fa;
+}
+
+// Ordinary ODE: central difference of dydt about yp[cmt], which yields f_cmt as
+// the average of the two evaluations already made (O(eps^2), no third call).
+static inline void _esJacColFd(int *_esNj, double xout, double *yp, int cmt,
+                               int ns, int neq, double *_esJcol, double *_esFc) {
+  double *_esF0 = (double*) calloc((size_t)neq, sizeof(double));
+  double *_esF1 = (double*) calloc((size_t)neq, sizeof(double));
+  if (_esF0 != NULL && _esF1 != NULL) {
+    double _esXc = yp[cmt];
+    double _esAx = _esXc < 0 ? -_esXc : _esXc;
+    double _esEps = 6e-6 * (_esAx > 1.0 ? _esAx : 1.0);
+    yp[cmt] = _esXc + _esEps; dydtEs(_esNj, xout, yp, _esF1);
+    yp[cmt] = _esXc - _esEps; dydtEs(_esNj, xout, yp, _esF0);
+    yp[cmt] = _esXc; // restore pre-event state
+    double _esInv = 1.0 / (2.0 * _esEps);
+    for (int _k = 0; _k < ns; _k++) {
+      _esJcol[_k] = (_esF1[_k] - _esF0[_k]) * _esInv;
+    }
+    if (_esFc != NULL) *_esFc = 0.5 * (_esF0[cmt] + _esF1[cmt]);
+  }
+  if (_esF0 != NULL) free(_esF0);
+  if (_esF1 != NULL) free(_esF1);
+}
+
 static inline void _esJacColF(int id, double xout, double *yp, int cmt, int ns,
                               int neq, double *_esJcol, double *_esFc,
                               rx_solving_options_ind *ind) {
   int _esNj[2]; _esNj[0] = neq; _esNj[1] = id;
   if (_rxEsUseCalcJac) {
-    double *_esPD = (double*) calloc((size_t)ns * ns, sizeof(double));
-    if (_esPD != NULL) {
-      calc_jac(_esNj, xout, yp, _esPD, (unsigned int) ns);
-      double _f = 0.0;
-      for (int _k = 0; _k < ns; _k++) {
-        _esJcol[_k] = _esPD[_k * ns + cmt];
-        _f += _esPD[cmt * ns + _k] * yp[_k];
-      }
-      if (_esFc != NULL) *_esFc = _f;
-      free(_esPD);
-    }
-    // The Jacobian row dotted with the state is f_cmt only for a model whose
-    // whole right-hand side is A.X.  Once part of it lives in an indLin()
-    // forcing -- which is where rxode2#1186/#1187 put every nonlinear term --
-    // J is A + dF/dX, so that dot product both misses F(X) and double counts
-    // (dF/dX).X.  Take the two pieces from the functions the solver already
-    // has: ME() is the rate matrix (column major, A[i][j] = _mat[j*neq + i])
-    // and IndF() is the forcing, seeded with the infusion rate, which is part
-    // of the true right-hand side at this instant too.
-    //
+    _esJacColCalcJac(_esNj, xout, yp, cmt, ns, _esJcol, _esFc);
     // Only the replace/multiply dtau rows need f_cmt; the additive-bolus rows
     // pass NULL and skip the two extra evaluations.
-    if (_esFc != NULL) {
-      rx_solve *_esRx = (ind != NULL && ind->rx) ? ind->rx : &rx_global;
-      t_ME _esME = _esRx->fns.me;
-      t_IndF _esIndF = _esRx->fns.indf;
-      if (_esME != NULL) {
-        double *_esA = (double*) calloc((size_t)neq * neq, sizeof(double));
-        if (_esA != NULL) {
-          _esME(id, xout, xout, _esA, yp);
-          double _fa = 0.0;
-          for (int _j = 0; _j < neq; _j++) _fa += _esA[_j * neq + cmt] * yp[_j];
-          *_esFc = _fa;
-          free(_esA);
-          if (_esIndF != NULL) {
-            double *_esFv = (double*) calloc((size_t)neq, sizeof(double));
-            if (_esFv != NULL) {
-              _esIndF(id, xout, xout, _esFv, yp);
-              *_esFc += _esFv[cmt];
-              free(_esFv);
-            }
-          }
-        }
-      }
-    }
+    if (_esFc != NULL) _esJacColMeF(id, xout, yp, cmt, neq, _esFc, ind);
   } else if (dydtEs != NULL) {
-    double *_esF0 = (double*) calloc((size_t)neq, sizeof(double));
-    double *_esF1 = (double*) calloc((size_t)neq, sizeof(double));
-    if (_esF0 != NULL && _esF1 != NULL) {
-      double _esXc = yp[cmt];
-      double _esAx = _esXc < 0 ? -_esXc : _esXc;
-      double _esEps = 6e-6 * (_esAx > 1.0 ? _esAx : 1.0);
-      yp[cmt] = _esXc + _esEps; dydtEs(_esNj, xout, yp, _esF1);
-      yp[cmt] = _esXc - _esEps; dydtEs(_esNj, xout, yp, _esF0);
-      yp[cmt] = _esXc; // restore pre-event state
-      double _esInv = 1.0 / (2.0 * _esEps);
-      for (int _k = 0; _k < ns; _k++) {
-        _esJcol[_k] = (_esF1[_k] - _esF0[_k]) * _esInv;
-      }
-      if (_esFc != NULL) *_esFc = 0.5 * (_esF0[cmt] + _esF1[cmt]);
-    }
-    if (_esF0 != NULL) free(_esF0);
-    if (_esF1 != NULL) free(_esF1);
+    _esJacColFd(_esNj, xout, yp, cmt, ns, neq, _esJcol, _esFc);
   }
 }
 

--- a/man/rxSensMatExp.Rd
+++ b/man/rxSensMatExp.Rd
@@ -21,12 +21,12 @@ rxSensMatExp(
 \item{calcSens2}{character vector (or \code{NULL}) requesting second-order
 sensitivities \verb{rx__sens_<x>_BY_<p>_BY_<q>__} (\code{p} over \code{calcSens}, \code{q} over
 \code{calcSens2}; every \code{calcSens2} element must also be in \code{calcSens}).
-Expressed as \code{k_from_to} micro-constant transfers like the first-order
-ones.  Ignored for \code{linCmt()} states (those use Stan forward-AD).}
+Ignored for \code{linCmt()} states (those use Stan forward-AD).}
 
 \item{calcSens3}{character vector (or \code{NULL}) requesting third-order
 sensitivities \verb{rx__sens_<x>_BY_<p>_BY_<q>_BY_<r>__} (\code{r} over \code{calcSens3}).
-Requires \code{calcSens2}; every \code{calcSens3} element must also be in \code{calcSens2}.}
+Requires \code{calcSens2}; every \code{calcSens3} element must also be in \code{calcSens2}.
+The forcing contribution is not generated at third order.}
 
 \item{doConst}{Replace constants with values; By default this is \code{FALSE}.}
 
@@ -37,7 +37,11 @@ reuse instead of reloading \code{model}; when \code{NULL} it is built internally
 A character string representing the matrix exponential sensitivity-expanded model code
 }
 \description{
-Differentiate and expand a matrix exponential model with forward sensitivities
+The system is split the way \code{\link[=indLin]{indLin()}} splits it: a rate matrix that is
+constant in the states, expressed as \code{k_from_to} micro-constants, plus an
+\code{indLin()} forcing carrying everything else.  Each sensitivity compartment
+gets the same rate matrix, the \verb{(dA/dp).X} cross terms as non-depleting
+transfers, and its own forcing \verb{d(f)/dp + (df/dy).S^p}.
 }
 \author{
 Matthew L. Fidler

--- a/man/rxSolve.Rd
+++ b/man/rxSolve.Rd
@@ -1658,7 +1658,8 @@ extra forcing evaluations; \code{"fd"} central-differences the forcing, at
 symbolic one when the model carries it and falls back to finite
 differences otherwise -- which is what happens above
 \code{getOption("rxode2.indLinJacMaxStates")} states, where the symbolic
-emission is skipped to bound the symengine work at model build.}
+emission is skipped to bound the symengine work at model build, and on a
+sensitivity model, whose \code{df()/dy()} lines cover the physical states only.}
 
 \item{envir}{is the environment to look for R user functions
 (defaults to parent environment)}

--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -173,9 +173,10 @@ static inline void matrixExp(arma::mat& H, arma::mat& out, double t, int type,
 // about what has been invalidated.  That is why this is content-addressed and
 // not a validity flag: the old `ind->cacheME` flag was cleared on some
 // covariate paths and not others, and reviving it would be a staleness bug.
-// Content addressing needs no such bookkeeping -- a state-dependent rate matrix
-// (rxSensMatExp models) simply never hits, and an infusion starting or stopping
-// changes the augmented dimension, which is a key mismatch.
+// Content addressing needs no such bookkeeping -- a rate matrix that moves
+// between substeps (one reading `t` or a time-varying covariate) simply never
+// hits, and an infusion starting or stopping changes the augmented dimension,
+// which is a key mismatch.
 //
 // `memcmp`, not elementwise ==: conservative on signed zero, correct on NaN bit
 // patterns, and it does not invite anyone to relax it into a tolerance later.
@@ -1431,8 +1432,8 @@ static int indLinIterate(int cSub, rx_solving_options *op, rx_solving_options_in
 // without which every tolerance would silently be twice as tight as asked --
 // and their average is the trapezoidal rule, which is one order better.  The
 // same cancellation holds when it is the matrix rather than the forcing that is
-// frozen (a sensitivity model built by rxSensMatExp(), where `A` still reads the
-// states); only the derivative being expanded changes.
+// frozen (a rate constant reading `t` or a time-varying covariate); only the
+// derivative being expanded changes.
 // The two exponential Rosenbrock schemes, wrapped so the substep dispatcher
 // stays a dispatcher.  Both own the same scratch, neither iterates, and both
 // report an overflow the same way -- `-2` with ratio 2, asking the driver for a

--- a/src/genModelVars.h
+++ b/src/genModelVars.h
@@ -491,18 +491,13 @@ static inline int indLinDepSource(int j, int *dep) {
 // compartment it reaches, and point at indLin() -- which is where a
 // state-dependent term belongs and where the solver can iterate it.
 //
-// A sensitivity model is exempt for now.  rxSensMatExp() builds its whole
-// sensitivity system out of rate constants -- including the primal ones, which
-// the sensitivity blocks then reference BY NAME -- so for a nonlinear model
-// every one of them is state dependent.  Rewriting that generator to route the
-// nonlinear parts into forcings is a job of its own (rxode2#1186 follow-up);
-// until then those models keep the first-order propagation they have always
-// had, which is no worse than before.
+// Sensitivity models are held to the same rule.  rxSensMatExp() takes its rate
+// matrix from the same term-wise split the plain conversion uses, so every rate
+// constant it emits -- primal, homogeneous, non-depleting cross term, at every
+// order -- is state free, and the nonlinear part rides in the indLin() forcing
+// (rxode2#1187).
 static inline void assertNoStateDependentMicro(void) {
   if (!tb.isMexp || tb.de.n <= 0 || NV <= 0) return;
-  for (int d = 0; d < tb.de.n; ++d) {
-    if (!strncmp(tb.de.line[d], "rx__sens_", 9)) return;
-  }
   int *dep  = (int*)R_alloc(NV, sizeof(int));
   int *fdep = (int*)R_alloc(tb.de.n, sizeof(int));
   indLinReplay(dep, fdep);

--- a/src/parseCmtProperties.h
+++ b/src/parseCmtProperties.h
@@ -119,8 +119,16 @@ static inline int handleCmtPropertyIndLin(nodeInfo ni, char *name, char *v) {
     if (tb.lho[tb.ix] == 0) {
       tb.lho[tb.ix] = tb.lhi++;
     }
-    sAppend(&sb, "%s = ", lhsVar);
-    sAppend(&sbDt, "%s = ", lhsVar);
+    // doDot2(), not a plain sAppend(): the compartment name can carry a `.`
+    // (`rx__sens_central_BY_eta.cl__`, from a sensitivity wrt a dotted
+    // parameter), and everything else that names this variable -- its
+    // declaration, its `_PL[]` read, and codegen's `_matf[] +=` line -- writes
+    // it through doDot() as `_DoT_`.  Emitting the raw name here left the
+    // assignment referring to an undeclared identifier, which C then read as a
+    // struct member access.
+    doDot2(&sb, &sbDt, lhsVar);
+    sAppendN(&sb, " = ", 3);
+    sAppendN(&sbDt, " = ", 3);
     sAppend(&sbt, "indLin(%s)=", v);
     aType(TASSIGN);
     // The forcing's right-hand side is parsed next; record the symbols it

--- a/src/parseCmtProperties.h
+++ b/src/parseCmtProperties.h
@@ -109,16 +109,19 @@ static inline int handleCmtPropertyIndLin(nodeInfo ni, char *name, char *v) {
   if (nodeHas(indLin_prop)){
     sb.o=0;sbDt.o=0; sbt.o=0;
     tb.hasIndLinProp = 1;
-    // A growable buffer, not a fixed one: `v` is a compartment name, and
+    // Sized from `v`, not a fixed buffer: `v` is a compartment name, and
     // rxSensMatExp() names a second-order sensitivity compartment
     // `rx__sens_<state>_BY_<p>_BY_<q>__`, which passes 150 bytes with ordinary
-    // parameter names.  snprintf() truncated silently, so two distinct
-    // compartments could share one C symbol -- one forcing overwriting the
-    // other in a model that still compiled.  Same pattern parseDfdy.h uses for
-    // its synthetic names.
-    sClear(&_gbuf);
-    sAppend(&_gbuf, "rx_indLin_%s", v);
-    char *lhsVar = _gbuf.s;
+    // parameter names.  snprintf() into a fixed buffer truncated silently, so
+    // two distinct compartments could share one C symbol -- one forcing
+    // overwriting the other in a model that still compiled.
+    //
+    // A copy rather than a pointer into `_gbuf`: `new_or_ith()` below writes
+    // `_gbuf` on its interpolation-clash path, which would realloc it out from
+    // under the name that is about to be registered.
+    size_t lhsN = strlen(v) + 11;
+    char *lhsVar = R_alloc(lhsN, sizeof(char));
+    snprintf(lhsVar, lhsN, "rx_indLin_%s", v);
     if (new_or_ith(lhsVar)) {
       addSymbolStr(lhsVar);
       new_or_ith(lhsVar);

--- a/src/parseCmtProperties.h
+++ b/src/parseCmtProperties.h
@@ -109,8 +109,16 @@ static inline int handleCmtPropertyIndLin(nodeInfo ni, char *name, char *v) {
   if (nodeHas(indLin_prop)){
     sb.o=0;sbDt.o=0; sbt.o=0;
     tb.hasIndLinProp = 1;
-    char lhsVar[150];
-    snprintf(lhsVar, sizeof(lhsVar), "rx_indLin_%s", v);
+    // A growable buffer, not a fixed one: `v` is a compartment name, and
+    // rxSensMatExp() names a second-order sensitivity compartment
+    // `rx__sens_<state>_BY_<p>_BY_<q>__`, which passes 150 bytes with ordinary
+    // parameter names.  snprintf() truncated silently, so two distinct
+    // compartments could share one C symbol -- one forcing overwriting the
+    // other in a model that still compiled.  Same pattern parseDfdy.h uses for
+    // its synthetic names.
+    sClear(&_gbuf);
+    sAppend(&_gbuf, "rx_indLin_%s", v);
+    char *lhsVar = _gbuf.s;
     if (new_or_ith(lhsVar)) {
       addSymbolStr(lhsVar);
       new_or_ith(lhsVar);

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -6146,14 +6146,20 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
     op->indLinRichardson=asInt(rxControl[Rxc_indLinRichardson], "indLinRichardson");
     op->indLinIteration=asInt(rxControl[Rxc_indLinIteration], "indLinIteration");
     op->indLinJac=asInt(rxControl[Rxc_indLinJac], "indLinJac");
-    // "auto" cannot take the symbolic forcing Jacobian on a sensitivity model.
+    // The symbolic forcing Jacobian is not available on a sensitivity model.
     // indLinForcingJacSym() wants calc_jac over the WHOLE system, but
     // rxSensMatExp() emits df()/dy() rows for the physical block only -- it has
     // to, because _esJacColF() (rxode2parseHandleEvid.h) calls calc_jac with a
     // buffer sized by the physical state count.  `calc_jac - A` would therefore
-    // hand back -A for every sensitivity row.  Difference the forcing instead;
-    // that is right for every row, and only the newton/exprb schemes ever ask.
-    if (op->indLinJac == 0 &&
+    // hand back -A for every sensitivity row, which newton merely converges
+    // slowly through but exprb/exprb32 use directly and get a wrong answer from.
+    // Difference the forcing instead; that is right for every row, and only the
+    // newton/exprb schemes ever ask for one.
+    //
+    // An explicit "symbolic" is downgraded too, not just "auto": the same thing
+    // indLinUseSymJac() already does when the model carries no df()/dy() at all
+    // ("cannot force what is not there").
+    if (op->indLinJac != 2 &&
         Rf_length(as<SEXP>(rxSolveDat->mv[RxMv_sens])) > 0) {
       op->indLinJac = 2;
     }

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -6146,7 +6146,7 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
     op->indLinRichardson=asInt(rxControl[Rxc_indLinRichardson], "indLinRichardson");
     op->indLinIteration=asInt(rxControl[Rxc_indLinIteration], "indLinIteration");
     op->indLinJac=asInt(rxControl[Rxc_indLinJac], "indLinJac");
-    // The symbolic forcing Jacobian is not available on a sensitivity model.
+    // The symbolic forcing Jacobian cannot be trusted on a sensitivity model.
     // indLinForcingJacSym() wants calc_jac over the WHOLE system, but
     // rxSensMatExp() emits df()/dy() rows for the physical block only -- it has
     // to, because _esJacColF() (rxode2parseHandleEvid.h) calls calc_jac with a
@@ -6159,6 +6159,14 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
     // An explicit "symbolic" is downgraded too, not just "auto": the same thing
     // indLinUseSymJac() already does when the model carries no df()/dy() at all
     // ("cannot force what is not there").
+    //
+    // Deliberately blunt.  An ODE model built with calcSens= and then converted
+    // by method="indLin"'s auto-conversion has df()/dy() for every compartment,
+    // sensitivity ones included, so its symbolic Jacobian would have been fine;
+    // it loses nothing but the 2n forcing evaluations, and only under the
+    // schemes that ask for a Jacobian at all.  Whether calc_jac spans the system
+    // is a property of which generator wrote the model, which is not something
+    // modelVars records -- so err toward the source that is right either way.
     if (op->indLinJac != 2 &&
         Rf_length(as<SEXP>(rxSolveDat->mv[RxMv_sens])) > 0) {
       op->indLinJac = 2;

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -6146,6 +6146,17 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
     op->indLinRichardson=asInt(rxControl[Rxc_indLinRichardson], "indLinRichardson");
     op->indLinIteration=asInt(rxControl[Rxc_indLinIteration], "indLinIteration");
     op->indLinJac=asInt(rxControl[Rxc_indLinJac], "indLinJac");
+    // "auto" cannot take the symbolic forcing Jacobian on a sensitivity model.
+    // indLinForcingJacSym() wants calc_jac over the WHOLE system, but
+    // rxSensMatExp() emits df()/dy() rows for the physical block only -- it has
+    // to, because _esJacColF() (rxode2parseHandleEvid.h) calls calc_jac with a
+    // buffer sized by the physical state count.  `calc_jac - A` would therefore
+    // hand back -A for every sensitivity row.  Difference the forcing instead;
+    // that is right for every row, and only the newton/exprb schemes ever ask.
+    if (op->indLinJac == 0 &&
+        Rf_length(as<SEXP>(rxSolveDat->mv[RxMv_sens])) > 0) {
+      op->indLinJac = 2;
+    }
     List indLin = rxSolveDat->mv[RxMv_indLin];
     op->doIndLin=0;
     if (indLin.size() == 4){

--- a/tests/testthat/test-ind-lin.R
+++ b/tests/testthat/test-ind-lin.R
@@ -753,8 +753,12 @@ d/dt(blood)     = a*intestine - b*blood
     expect_no_error(suppressMessages(rxode2(rxSensMatExp(.mm, calcSens = c("ka", "vmax")))))
     expect_no_error(suppressMessages(rxode2(rxSensMatExp(
       .mm, calcSens = c("ka", "vmax"), calcSens2 = "vmax"))))
-    expect_no_error(suppressMessages(rxode2(rxSensMatExp(
-      .mm, calcSens = c("ka", "vmax"), calcSens2 = "vmax", calcSens3 = "vmax"))))
+    # third order warns that it is short the forcing term, but still emits a
+    # model whose rate constants are state free
+    expect_warning(.s3 <- rxSensMatExp(.mm, calcSens = c("ka", "vmax"),
+                                       calcSens2 = "vmax", calcSens3 = "vmax"),
+                   "third-order")
+    expect_no_error(suppressMessages(rxode2(.s3)))
   })
 
   test_that("a non-converging inductive linearization is reported", {

--- a/tests/testthat/test-ind-lin.R
+++ b/tests/testthat/test-ind-lin.R
@@ -759,6 +759,16 @@ d/dt(blood)     = a*intestine - b*blood
                                        calcSens2 = "vmax", calcSens3 = "vmax"),
                    "third-order")
     expect_no_error(suppressMessages(rxode2(.s3)))
+
+    # and the exemption really is gone: a hand-written sensitivity model with a
+    # state-reading rate constant is rejected like any other matExp() model
+    expect_error(
+      suppressMessages(rxode2(paste(
+        "matExp()", "cmt(central)", "cmt(rx__sens_central_BY_ka__)",
+        "k_central_output = 0.1",
+        "k_rx__sens_central_BY_ka___output = 1/(1 + rx__sens_central_BY_ka__)",
+        sep = "\n"))),
+      "syntax error")
   })
 
   test_that("a non-converging inductive linearization is reported", {

--- a/tests/testthat/test-ind-lin.R
+++ b/tests/testthat/test-ind-lin.R
@@ -745,6 +745,16 @@ d/dt(blood)     = a*intestine - b*blood
                     "d/dt(depot) = -ka*depot\nd/dt(central) = ka*depot - cl/v*central\n")) {
       expect_no_error(suppressMessages(rxode2(rxToIndLin(.code))))
     }
+
+    # nor with sensitivities: rxSensMatExp() routes the nonlinear part into the
+    # forcing too, so its rate constants are state free at every order
+    # (rxode2#1187).
+    .mm <- "d/dt(depot) = -ka*depot\nd/dt(central) = ka*depot - vmax*central/(km+central)\n"
+    expect_no_error(suppressMessages(rxode2(rxSensMatExp(.mm, calcSens = c("ka", "vmax")))))
+    expect_no_error(suppressMessages(rxode2(rxSensMatExp(
+      .mm, calcSens = c("ka", "vmax"), calcSens2 = "vmax"))))
+    expect_no_error(suppressMessages(rxode2(rxSensMatExp(
+      .mm, calcSens = c("ka", "vmax"), calcSens2 = "vmax", calcSens3 = "vmax"))))
   })
 
   test_that("a non-converging inductive linearization is reported", {
@@ -1207,11 +1217,12 @@ d/dt(blood)     = a*intestine - b*blood
     }
   })
 
-  test_that("a state-dependent rate matrix never reuses an exponential", {
-    # rxSensMatExp() builds its sensitivity blocks out of rate constants that
-    # read the primal states, so the operand differs on every pass.  Content
-    # addressing needs no exemption for that -- it simply never hits -- and the
-    # reuse counter proves it.
+  test_that("a nonlinear sensitivity model still reuses its exponential", {
+    # rxSensMatExp() used to build its sensitivity blocks out of rate constants
+    # that read the primal states, so the operand differed on every pass and the
+    # content-addressed cache never hit.  Since rxode2#1187 the nonlinear part
+    # rides in the indLin() forcing and the rate matrix is constant, so the
+    # exponential is reused as heavily as a plain linear model's.
     .sens <- suppressMessages(rxode2(rxSensMatExp(
       "d/dt(depot) = -ka*depot\nd/dt(central) = ka*depot - Vm*central/(Km + central)\n",
       calcSens = c("ka", "Vm"))))
@@ -1220,10 +1231,6 @@ d/dt(blood)     = a*intestine - b*blood
       suppressMessages(rxSolve(.sens, .e, method = "indLin",
                                params = c(ka = 0.5, Vm = 10, Km = 5)))
     })
-    # Incidental hits are possible and are correct by construction -- two
-    # substeps can produce the same operand bitwise.  The claim is that reuse
-    # cannot CARRY such a model, and the contrast with a state-free rate matrix
-    # on the same machinery is what shows it.
     expect_gt(sum(.a$counts$dadt), 0)
     .sensReuse <- sum(.a$counts$jac) / (sum(.a$counts$jac) + sum(.a$counts$dadt))
     .lin <- suppressMessages(rxode2(paste("matExp()", "cmt(central)",
@@ -1232,7 +1239,7 @@ d/dt(blood)     = a*intestine - b*blood
                                      et(seq(0, 10, by = 1)),
                                    method = "indLin", hmax = 0.25))
     .linReuse <- sum(.l$counts$jac) / (sum(.l$counts$jac) + sum(.l$counts$dadt))
-    expect_lt(.sensReuse, 0.2)
+    expect_gt(.sensReuse, 0.9)
     expect_gt(.linReuse, 0.9)
   })
 

--- a/tests/testthat/test-mexp-nonmem.R
+++ b/tests/testthat/test-mexp-nonmem.R
@@ -384,6 +384,25 @@ rxTest({
     expect_gt(max(nchar(.sym)), 150L)
   })
 
+  test_that("rxSensMatExp() splits a state dependency hidden behind an lhs", {
+    # The split reads the symengine right-hand side, which has every lhs
+    # substituted into it, not the source text.  So a nonlinearity reached
+    # through an intermediate still lands in the forcing rather than becoming a
+    # state-reading rate constant.
+    .code <- rxSensMatExp("my_rate = vmax/(km + central)\nd/dt(central) = -my_rate*central\n",
+                          calcSens = "vmax")
+    .lines <- strsplit(.code, "\n")[[1L]]
+    expect_true(any(grepl("^indLin\\(central\\) <- ", .lines)))
+    expect_length(grep("^k_", .lines), 0L)
+    expect_no_error(suppressMessages(rxode2(.code)))
+
+    # ... and an lhs whose name merely starts with `k_` is inlined the same way,
+    # so dropping its line does not turn it into a required parameter.
+    .m <- suppressMessages(rxode2(rxSensMatExp(
+      "k_el = CL/V\nd/dt(central) = -k_el*central\n", calcSens = "CL")))
+    expect_equal(sort(rxModelVars(.m)$params), c("CL", "V"))
+  })
+
   test_that("rxSensMatExp() says third-order omits the forcing", {
     .mm <- "d/dt(depot) = -ka*depot\nd/dt(central) = ka*depot - Vm*central/(Km + central)\n"
     expect_warning(rxSensMatExp(.mm, calcSens = c("ka", "Vm"),

--- a/tests/testthat/test-mexp-nonmem.R
+++ b/tests/testthat/test-mexp-nonmem.R
@@ -359,6 +359,27 @@ rxTest({
                  .o[["rx__sens_central_BY_eta.cl__"]], tolerance = 1e-4)
   })
 
+  test_that("a long indLin() compartment name gets its own C symbol", {
+    # The forcing's LHS symbol is `rx_indLin_<cmt>`, and a second-order
+    # sensitivity compartment name passes 150 bytes with ordinary parameter
+    # names.  A fixed buffer truncated it silently, so two compartments shared
+    # one symbol and one forcing overwrote the other in a model that still
+    # compiled.
+    .st <- "centralCompartmentConcentrationStateVariable"
+    .p1 <- "etaBetweenSubjectVariabilityParameterNumberOne"
+    .p2 <- "etaBetweenSubjectVariabilityParameterNumberTwo"
+    .code <- rxSensMatExp(
+      sprintf("d/dt(%s) = -%s*%s - %s*%s/(km + %s)\n", .st, .p1, .st, .p2, .st, .st),
+      calcSens = c(.p1, .p2), calcSens2 = c(.p1, .p2))
+    .lines <- grep("^indLin\\(", strsplit(.code, "\n")[[1L]], value = TRUE)
+    expect_gt(length(.lines), 1L)
+    .m <- suppressMessages(rxode2(.code))
+    .c <- paste(summary(rxC(.m)), collapse = "\n")
+    .sym <- unique(regmatches(.c, gregexpr("rx_indLin_[A-Za-z0-9_]+", .c))[[1L]])
+    expect_equal(length(.sym), length(.lines))
+    expect_gt(max(nchar(.sym)), 150L)
+  })
+
   test_that("rxSensMatExp() says third-order omits the forcing", {
     .mm <- "d/dt(depot) = -ka*depot\nd/dt(central) = ka*depot - Vm*central/(Km + central)\n"
     expect_warning(rxSensMatExp(.mm, calcSens = c("ka", "Vm"),

--- a/tests/testthat/test-mexp-nonmem.R
+++ b/tests/testthat/test-mexp-nonmem.R
@@ -235,15 +235,126 @@ rxTest({
       d/dt(central) = ka * depot - Vm * central / (Km + central)
     "
     mexp_sens_mm <- rxSensMatExp(ode_code_mm, calcSens = c("ka", "Vm", "Km"))
+    # The nonlinear part rides in the indLin() forcing -- on the primal and on
+    # every sensitivity compartment it reaches -- so no rate constant reads a
+    # compartment (rxode2#1186, #1187).
+    .lines <- strsplit(mexp_sens_mm, "\n")[[1L]]
+    expect_true(any(grepl("^indLin\\(central\\) <- ", .lines)))
+    expect_true(any(grepl("^indLin\\(rx__sens_central_BY_Vm__\\) <- ", .lines)))
+    expect_true(any(grepl("^indLin\\(rx__sens_central_BY_Km__\\) <- ", .lines)))
+    .k <- grep("^k_", .lines, value = TRUE)
+    .rhsVars <- unique(unlist(lapply(.k, function(.l) {
+      all.vars(parse(text = sub("^[^=]*=", "", .l)))
+    })))
+    expect_false(any(c("depot", "central") %in% .rhsVars))
+
     mod_mexp_mm <- rxode2(mexp_sens_mm)
-    res_mexp_mm <- rxSolve(mod_mexp_mm, et, method = "indLin", params = c(ka = 0.5, Vm = 10, Km = 5))
-    
-    # Verify the sensitivity columns are present and contain numeric values
-    expect_true(all(c("rx__sens_depot_BY_ka__", "rx__sens_central_BY_ka__",
-                      "rx__sens_central_BY_Vm__", "rx__sens_central_BY_Km__") %in% colnames(res_mexp_mm)))
-    expect_true(is.numeric(res_mexp_mm$rx__sens_central_BY_ka__))
-    expect_true(is.numeric(res_mexp_mm$rx__sens_central_BY_Vm__))
-    expect_true(is.numeric(res_mexp_mm$rx__sens_central_BY_Km__))
+    # A forcing that reads a state puts the model on the iterating solver path.
+    expect_true(rxModelVars(mod_mexp_mm)$indLin$fullIndLin)
+
+    mod_ode_mm <- rxode2(ode_code_mm, calcSens = c("ka", "Vm", "Km"))
+    pars_mm <- c(ka = 0.5, Vm = 10, Km = 5)
+    res_mexp_mm <- rxSolve(mod_mexp_mm, et, method = "indLin", params = pars_mm)
+    res_ode_mm <- rxSolve(mod_ode_mm, et, params = pars_mm, atol = 1e-12, rtol = 1e-12)
+
+    expect_equal(res_mexp_mm$central, res_ode_mm$central, tolerance = 1e-4)
+    expect_equal(res_mexp_mm$rx__sens_depot_BY_ka__,
+                 res_ode_mm$rx__sens_depot_BY_ka__, tolerance = 1e-4)
+    expect_equal(res_mexp_mm$rx__sens_central_BY_ka__,
+                 res_ode_mm$rx__sens_central_BY_ka__, tolerance = 1e-4)
+    expect_equal(res_mexp_mm$rx__sens_central_BY_Vm__,
+                 res_ode_mm$rx__sens_central_BY_Vm__, tolerance = 1e-4)
+    expect_equal(res_mexp_mm$rx__sens_central_BY_Km__,
+                 res_ode_mm$rx__sens_central_BY_Km__, tolerance = 1e-4)
+
+    # The forcing Jacobian only gets formed under the schemes that need one, so
+    # solve under each of them as well (rxSensMatExp() emits df()/dy() for the
+    # physical block only, which is why "auto" differences the forcing here).
+    for (.sch in c("newton", "exprb", "exprb32")) {
+      .r <- rxSolve(mod_mexp_mm, et, method = "indLin", params = pars_mm,
+                    indLinIteration = .sch)
+      expect_equal(.r$central, res_ode_mm$central, tolerance = 1e-4)
+      expect_equal(.r$rx__sens_central_BY_Vm__,
+                   res_ode_mm$rx__sens_central_BY_Vm__, tolerance = 1e-4)
+    }
+  })
+
+  test_that("rxSensMatExp() carries a state-free input term into the forcing", {
+    # `k0` is invisible to the Jacobian, so the old Jacobian-derived rate matrix
+    # dropped it outright; it is part of the forcing residual now.
+    ode_code <- "d/dt(x) = k0 - ke*x"
+    .code <- rxSensMatExp(ode_code, calcSens = c("ke", "k0"))
+    expect_true(any(grepl("^indLin\\(x\\) <- k0$", strsplit(.code, "\n")[[1L]])))
+    expect_true(any(grepl("^indLin\\(rx__sens_x_BY_k0__\\) <- 1$",
+                          strsplit(.code, "\n")[[1L]])))
+
+    .et <- eventTable() |> add.sampling(seq(0, 10, by = 1))
+    .p <- c(k0 = 3, ke = 0.4)
+    .m <- rxSolve(rxode2(.code), .et, method = "indLin", params = .p)
+    .o <- rxSolve(rxode2(ode_code, calcSens = c("ke", "k0")), .et, params = .p,
+                  atol = 1e-12, rtol = 1e-12)
+    expect_equal(.m$x, .o$x, tolerance = 1e-4)
+    expect_equal(.m$rx__sens_x_BY_ke__, .o$rx__sens_x_BY_ke__, tolerance = 1e-4)
+    expect_equal(.m$rx__sens_x_BY_k0__, .o$rx__sens_x_BY_k0__, tolerance = 1e-4)
+  })
+
+  test_that("rxSensMatExp() keeps an already-matExp() model's indLin() forcing", {
+    # The preserve loop drops any indLin() line in the input, so the forcing has
+    # to be re-derived rather than passed through.  It used to be re-expressed
+    # as a state-dependent rate constant instead, which propagated A(X).X in
+    # place of f(X).
+    mexp_code <- paste("matExp()", "cmt(depot)", "cmt(central)",
+                       "k_depot_central = ka",
+                       "indLin(central) <- -Vm*central/(Km + central)",
+                       sep = "\n")
+    ode_code <- "
+      d/dt(depot) = -ka*depot
+      d/dt(central) = ka*depot - Vm*central/(Km + central)
+    "
+    .code <- rxSensMatExp(mexp_code, calcSens = c("ka", "Vm", "Km"))
+    .lines <- strsplit(.code, "\n")[[1L]]
+    expect_true(any(grepl("^indLin\\(central\\) <- ", .lines)))
+    expect_true(any(grepl("^indLin\\(rx__sens_central_BY_Vm__\\) <- ", .lines)))
+
+    .et <- eventTable() |>
+      add.dosing(dose = 100, nbr.doses = 1, start.time = 0) |>
+      add.sampling(seq(0, 10, by = 1))
+    .p <- c(ka = 0.5, Vm = 10, Km = 5)
+    .m <- rxSolve(rxode2(.code), .et, method = "indLin", params = .p)
+    .o <- rxSolve(rxode2(ode_code, calcSens = c("ka", "Vm", "Km")), .et,
+                  params = .p, atol = 1e-12, rtol = 1e-12)
+    expect_equal(.m$central, .o$central, tolerance = 1e-4)
+    expect_equal(.m$rx__sens_central_BY_ka__,
+                 .o$rx__sens_central_BY_ka__, tolerance = 1e-4)
+    expect_equal(.m$rx__sens_central_BY_Vm__,
+                 .o$rx__sens_central_BY_Vm__, tolerance = 1e-4)
+    expect_equal(.m$rx__sens_central_BY_Km__,
+                 .o$rx__sens_central_BY_Km__, tolerance = 1e-4)
+  })
+
+  test_that("rxSensMatExp() second-order forcing matches the ODE calcSens2 path", {
+    ode_code <- "
+      d/dt(depot) = -ka*depot
+      d/dt(central) = ka*depot - Vm*central/(Km + central)
+    "
+    .code <- rxSensMatExp(ode_code, calcSens = c("ka", "Vm", "Km"),
+                          calcSens2 = c("Vm", "Km"))
+    expect_true(any(grepl("^indLin\\(rx__sens_central_BY_Vm_BY_Vm__\\) <- ",
+                          strsplit(.code, "\n")[[1L]])))
+
+    .et <- eventTable() |>
+      add.dosing(dose = 100, nbr.doses = 1, start.time = 0) |>
+      add.sampling(seq(0, 10, by = 1))
+    .p <- c(ka = 0.5, Vm = 10, Km = 5)
+    .m <- rxSolve(rxode2(.code), .et, method = "indLin", params = .p)
+    .o <- rxSolve(rxode2(ode_code, calcSens = c("ka", "Vm", "Km"),
+                         calcSens2 = c("Vm", "Km")), .et, params = .p,
+                  atol = 1e-12, rtol = 1e-12)
+    for (.cn in c("rx__sens_central_BY_ka_BY_Vm__", "rx__sens_central_BY_Vm_BY_Vm__",
+                  "rx__sens_central_BY_Km_BY_Vm__", "rx__sens_central_BY_ka_BY_Km__",
+                  "rx__sens_central_BY_Vm_BY_Km__", "rx__sens_central_BY_Km_BY_Km__")) {
+      expect_equal(.m[[.cn]], .o[[.cn]], tolerance = 1e-4)
+    }
   })
 
   test_that("matExp symengine env can build jacobians and sensitivities", {

--- a/tests/testthat/test-mexp-nonmem.R
+++ b/tests/testthat/test-mexp-nonmem.R
@@ -403,6 +403,34 @@ rxTest({
     expect_equal(sort(rxModelVars(.m)$params), c("CL", "V"))
   })
 
+  test_that("event-time jumps are right when the nonlinearity is in the forcing", {
+    # The replace/multiply dtau rows need f_cmt, the right-hand side at the
+    # pre-event state.  For a matExp() model that used to come from the
+    # Jacobian row dotted with the state, which is f_cmt only while the whole
+    # right-hand side is A.X -- with a Michaelis-Menten forcing it is short by
+    # a factor Km/(Km + central), and these sensitivities came out ~3.6% off.
+    .ode <- "alag(central) <- tlag*exp(eta_lag)\nd/dt(central) = -Vm*central/(Km + central)\n"
+    .mx <- rxode2(rxSensMatExp(.ode, calcSens = "eta_lag"), eventSens = "jump")
+    .od <- rxode2(.ode, calcSens = "eta_lag", eventSens = "jump")
+    .p <- c(tlag = 1.5, eta_lag = 0.1, Vm = 8, Km = 4)
+    # et() reads `evid`/`amt` with NSE, so bind plain scalars rather than
+    # indexing into a list inside the call
+    for (.i in 1:2) {
+      .evid <- c(5L, 6L)[.i]
+      .amt <- c(50, 2)[.i]
+      .e <- et(amt = 100, cmt = "central") |>
+        et(time = 3, amt = .amt, cmt = "central", evid = .evid) |>
+        et(seq(0, 10, by = 0.7))
+      .a <- rxSolve(.mx, .e, method = "indLin", params = .p)
+      .b <- rxSolve(.od, .e, params = .p, atol = 1e-12, rtol = 1e-12)
+      expect_equal(.a$central, .b$central, tolerance = 1e-4)
+      # non-trivial: a wrong f_cmt shows up here, not in the states
+      expect_gt(max(abs(.b$rx__sens_central_BY_eta_lag__)), 1)
+      expect_equal(.a$rx__sens_central_BY_eta_lag__,
+                   .b$rx__sens_central_BY_eta_lag__, tolerance = 1e-4)
+    }
+  })
+
   test_that("rxSensMatExp() says third-order omits the forcing", {
     .mm <- "d/dt(depot) = -ka*depot\nd/dt(central) = ka*depot - Vm*central/(Km + central)\n"
     expect_warning(rxSensMatExp(.mm, calcSens = c("ka", "Vm"),

--- a/tests/testthat/test-mexp-nonmem.R
+++ b/tests/testthat/test-mexp-nonmem.R
@@ -332,6 +332,44 @@ rxTest({
                  .o$rx__sens_central_BY_Km__, tolerance = 1e-4)
   })
 
+  test_that("rxSensMatExp() handles reserved and dotted names in a forcing", {
+    # `I`, `E` and `Catalan` are symengine constants, so a compartment with one
+    # of those names has to be differentiated by its rx_SymPy_Res_* symbol; a
+    # dotted parameter (`eta.cl`) cannot be re-parsed by symengine at all and
+    # gives a sensitivity compartment whose name carries a `.`.
+    .ie <- "d/dt(I) = -ka*I\nd/dt(E) = ka*I - kout*E/(km + E)\n"
+    .code <- rxSensMatExp(.ie, calcSens = c("ka", "kout"))
+    expect_true(any(grepl("^indLin\\(rx__sens_E_BY_kout__\\) <- ",
+                          strsplit(.code, "\n")[[1L]])))
+    expect_no_error(suppressMessages(rxode2(.code)))
+
+    .dot <- "cl <- exp(tcl + eta.cl)\nd/dt(central) = -cl/v*central - vm*central/(km + central)\n"
+    .codeDot <- rxSensMatExp(.dot, calcSens = "eta.cl")
+    expect_true(any(grepl("^indLin\\(rx__sens_central_BY_eta.cl__\\) <- ",
+                          strsplit(.codeDot, "\n")[[1L]])))
+    .et <- eventTable() |>
+      add.dosing(dose = 100, nbr.doses = 1, start.time = 0) |>
+      add.sampling(seq(0, 10, by = 1))
+    .p <- c(tcl = log(4), eta.cl = 0.1, v = 70, vm = 5, km = 1)
+    .m <- rxSolve(rxode2(.codeDot), .et, method = "indLin", params = .p)
+    .o <- rxSolve(rxode2(.dot, calcSens = "eta.cl"), .et, params = .p,
+                  atol = 1e-12, rtol = 1e-12)
+    expect_equal(.m$central, .o$central, tolerance = 1e-4)
+    expect_equal(.m[["rx__sens_central_BY_eta.cl__"]],
+                 .o[["rx__sens_central_BY_eta.cl__"]], tolerance = 1e-4)
+  })
+
+  test_that("rxSensMatExp() says third-order omits the forcing", {
+    .mm <- "d/dt(depot) = -ka*depot\nd/dt(central) = ka*depot - Vm*central/(Km + central)\n"
+    expect_warning(rxSensMatExp(.mm, calcSens = c("ka", "Vm"),
+                                calcSens2 = "Vm", calcSens3 = "Vm"),
+                   "third-order")
+    # a linear model has no forcing to omit, so it stays quiet
+    .lin <- "d/dt(depot) = -ka*depot\nd/dt(central) = ka*depot - cl/v*central\n"
+    expect_no_warning(rxSensMatExp(.lin, calcSens = c("ka", "cl"),
+                                   calcSens2 = "cl", calcSens3 = "cl"))
+  })
+
   test_that("rxSensMatExp() second-order forcing matches the ODE calcSens2 path", {
     ode_code <- "
       d/dt(depot) = -ka*depot

--- a/tests/testthat/test-mexp-nonmem.R
+++ b/tests/testthat/test-mexp-nonmem.R
@@ -268,14 +268,18 @@ rxTest({
                  res_ode_mm$rx__sens_central_BY_Km__, tolerance = 1e-4)
 
     # The forcing Jacobian only gets formed under the schemes that need one, so
-    # solve under each of them as well (rxSensMatExp() emits df()/dy() for the
-    # physical block only, which is why "auto" differences the forcing here).
+    # solve under each of them as well.  rxSensMatExp() emits df()/dy() for the
+    # physical block only, so `calc_jac - A` would be -A on every sensitivity
+    # row; an explicit indLinJac="symbolic" has to fall back to differencing the
+    # forcing just as "auto" does, or exprb/exprb32 integrate the wrong Jacobian.
     for (.sch in c("newton", "exprb", "exprb32")) {
-      .r <- rxSolve(mod_mexp_mm, et, method = "indLin", params = pars_mm,
-                    indLinIteration = .sch)
-      expect_equal(.r$central, res_ode_mm$central, tolerance = 1e-4)
-      expect_equal(.r$rx__sens_central_BY_Vm__,
-                   res_ode_mm$rx__sens_central_BY_Vm__, tolerance = 1e-4)
+      for (.jac in c("auto", "symbolic", "fd")) {
+        .r <- rxSolve(mod_mexp_mm, et, method = "indLin", params = pars_mm,
+                      indLinIteration = .sch, indLinJac = .jac)
+        expect_equal(.r$central, res_ode_mm$central, tolerance = 1e-4)
+        expect_equal(.r$rx__sens_central_BY_Vm__,
+                     res_ode_mm$rx__sens_central_BY_Vm__, tolerance = 1e-4)
+      }
     }
   })
 


### PR DESCRIPTION
Closes #1187.

## What this is

#1186 fixed the ODE -> `matExp()` converter so the rate matrix stays constant in
the states: any term that cannot leave a state-free coefficient goes to the
`indLin()` forcing, where the solver can iterate it. `rxSensMatExp()` -- the
`calcSens` arm of the same converter -- was left behind. It still built `A` from
the full Jacobian and emitted every entry as a rate constant, so for a nonlinear
model the rate constants read compartments, the propagated primal was `A(X).X`
rather than `f(X)`, and `assertNoStateDependentMicro()` had to skip every
`rx__sens_*` model to let any of it compile. The comment on that exemption named
this work as the follow-up.

The system is now split the same way, and with `A` state free what the
sensitivity compartments were missing is exactly `d/dp f + (df/dy).S^p` -- which
is what `.rxIndLinTotalD()` already computed for the second-order cross terms.
First order emits it directly; second order applies it twice through
`.rxIndLinChainD()`.

## Accuracy

Michaelis-Menten depot/central against the ordinary ODE `calcSens` path
(`atol = rtol = 1e-12`), relative:

| column | 1st order | 2nd order |
|---|---|---|
| `central` | 6.5e-09 | -- |
| `rx__sens_central_BY_ka__` | 6.9e-09 | 2.0e-08 |
| `rx__sens_central_BY_Vm__` | 3.0e-09 | 4.9e-08 |
| `rx__sens_central_BY_Km__` | 1.5e-08 | 4.4e-08 |

Holds under every `indLinIteration` scheme and every `indLinJac` source. These
models also reach the iterating solver path now (`fullIndLin` is `TRUE`), and
because the rate matrix no longer moves, the matrix exponential is reused across
substeps -- cache hit rate on the MM sensitivity model goes from under 0.2 to
0.94.

## Also fixed

Found while validating, each with a regression test:

- **A state-free input term was silently dropped.** `d/dt(x) = k0 - ke*x` is
  invisible to the Jacobian, so `k0` never reached the generated model. It is
  part of the forcing residual now.
- **Reserved and dotted names.** `symengine::S()` read a compartment named `I`,
  `E` or `Catalan` as the matching mathematical constant, and could not parse a
  dotted rxode2 name such as `eta.cl` at all. Names are mapped through
  `rxToSE()` and built with `symengine::Symbol()`, before the first `Basic`
  arithmetic -- `rxToSE()` itself stops working after that.
- **A long `indLin()` compartment name lost its C symbol.** The forcing's
  left-hand side was built with `snprintf` into a fixed 150-byte buffer, which a
  second-order sensitivity compartment name passes with ordinary parameter
  names. It truncated silently, so distinct compartments shared one symbol and
  one forcing overwrote the other in a model that still compiled -- seven
  forcings produced five symbols.
- **A dotted compartment name was not `doDot()`-ed** on the `indLin()`
  assignment while its declaration and reads were, leaving C to parse the `.` as
  a member access. Reachable before this PR by any `indLin()` on a dotted name.
- **`eventSens="jump"` event-time sensitivities.** The replace/multiply dtau rows
  take `f_cmt` from the Jacobian row dotted with the state, which is `f_cmt` only
  while the whole right-hand side is `A.X`. With a forcing that is short by the
  forcing's contribution: on MM with a modeled `alag`, replace was 11.95 out on a
  sensitivity of 331 and multiply 587 out on 15802, both ~3.6%. Now 7e-7 and
  1.4e-6, sourced from `ME()` and `IndF()`. Hand-written `indLin()` models had
  the same wrong `f_cmt` before this PR.
- **`indLinJac`** no longer offers the symbolic forcing Jacobian to a sensitivity
  model. `rxSensMatExp()` emits `df()/dy()` for the physical block only -- it has
  to, since `_esJacColF()` sizes its `calc_jac` buffer by the physical state
  count -- so `calc_jac - A` returned `-A` for every sensitivity row, which
  `exprb`/`exprb32` integrate directly.
- **The `assertNoStateDependentMicro()` exemption is removed.** Every rate
  constant the generator emits is state free at every order now, so a
  state-reading `k_` in a sensitivity model is the same parse error it is
  everywhere else.

## Not in scope

Third-order sensitivities still get no forcing contribution. That was never
there, but now that the orders around it have one, it warns -- and only when the
model actually has a forcing to omit, so linear models stay quiet. Emitting it is
the same one-line `.rxIndLinChainD()` call the second-order block uses; it was
left out because it needs its own validation.

`indLin(model, calcSens=)` still does not forward `calcSens2`/`calcSens3` to
`rxSensMatExp()`, so higher orders are only reachable by calling it directly.
Pre-existing.

## Testing

Full suite: `FAIL 2 | WARN 35 | SKIP 9 | PASS 37573`, against `FAIL 2 | ... |
PASS 37539` on the merge base. The two failures are identical before and after:
`test-oom.R:243` and `:270` fail with `unused argument: 'indLinStepSearch',
'indLinMaxIter', 'indLinRichardson', 'indLinIteration', 'indLinJac'` in a mirai
daemon, because the daemons load the installed rxode2 rather than the
`load_all()` tree and its `rxControl()` predates #1213's controls. They should
pass in CI, which tests an installed package.

Reviewed independently by Gemini 3.1 Pro over three rounds; every confirmed
finding is fixed and the rejected ones are pinned as regression tests.
