### PR TITLE
fix(indLin): serialize the indLin() convergence set; third-order forcing sensitivities

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -184,6 +184,11 @@
 
 ### Matrix exponential / inductive linearization
 
+- `rxSensMatExp(calcSens3=)` now carries the `indLin()` forcing at third order,
+  as `calcSens` and `calcSens2` already did.  Only the rate-matrix cross terms
+  were generated, so third-order sensitivities of a nonlinear model were short
+  every term the forcing contributes; the warning that said so is gone.
+
 - The `Al-Mohy` matrix exponential evaluated the wrong Pade numerator below
   degree 13.  The coefficients depend on the degree, and the routine read a
   fixed table -- the degree-13 row -- and truncated it, which is not the

--- a/NEWS.md
+++ b/NEWS.md
@@ -488,6 +488,22 @@
   `t` back to first order: on a Michaelis-Menten model with an `exp(-t)` input
   the error at `atol=rtol=1e-9` falls from 4.6e-03 to 1.1e-07.
 
+### Serialization
+
+- A saved solver state now round-trips the `indLin()` convergence set
+  (`op->indLin`, from `rxModelVars()$indLin$wIndLin`).  Only its length was
+  written, so restoring a state for a model with an `indLin()` forcing left the
+  set itself empty and the relinearization iteration indexed a null pointer.
+
+- A saved solver state now round-trips the initial-condition and scale vectors
+  it claims to.  Their lengths were taken from the distance to the next pointer
+  in the `gsolve` slab rather than from the vectors themselves, so they spanned
+  the intervening `lhs` and tolerance blocks and no state could be restored at
+  all: `rxLoadState()` failed with a size mismatch for every model.  The two
+  lengths now travel with the state, which is what the format version is bumped
+  to 3 for; a state written by an earlier version is rejected with a message
+  asking for it to be re-saved.
+
 ### Installation / linking
 
 - On Windows, `STAN_THREADS` and the TBB link are kept when building against

--- a/R/indLin.R
+++ b/R/indLin.R
@@ -311,7 +311,6 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
 #' @param calcSens3 character vector (or `NULL`) requesting third-order
 #'   sensitivities `rx__sens_<x>_BY_<p>_BY_<q>_BY_<r>__` (`r` over `calcSens3`).
 #'   Requires `calcSens2`; every `calcSens3` element must also be in `calcSens2`.
-#'   The forcing contribution is not generated at third order.
 #' @param doConst Replace constants with values; By default this is `FALSE`.
 #' @param env A pre-loaded symengine environment (from `.rxLoadPrune()`) to
 #'   reuse instead of reloading `model`; when `NULL` it is built internally.
@@ -664,17 +663,8 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
   #   from S^q_j:       totalD_r(dAdp_ij)
   #   from S^r_j:       totalD_q(dAdp_ij)
   #   from X_j:         totalD_r(totalD_q(dAdp_ij))
-  # The forcing contribution -- .rxIndLinChainD(.force[[i]], c(p, q, r),
-  # .states), emitted as indLin(S^{pqr}_i) the way the first and second order
-  # blocks above do -- is NOT emitted here.  Third order has never carried one,
-  # so this is not a regression, but now that the orders around it do, a
-  # nonlinear model would be silently short a term; say so rather than let it
-  # pass (rxode2#1187 follow-up).
+  # The forcing is chained one variable further as well (rxode2#1188).
   if (!is.null(calcSens3)) {
-    if (any(vapply(.states, function(.i) !.isZero(.force[[.i]]), logical(1)))) {
-      warning("third-order sensitivities omit the indLin() forcing contribution, so they are incomplete for this nonlinear model; first and second order carry it",
-              call. = FALSE)
-    }
     for (.p in calcSens) {
       .pSe <- .parSe[[.p]]
       .pSym <- symengine::Symbol(.pSe)
@@ -722,6 +712,22 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
             }
           }
           .code <- c(.code, .acc$emit())
+          # forcing: the second-order forcing differentiated once more.  The
+          # third pass chains through the states (-> S^r) and through the
+          # rx__sens_*_BY_<p>__ / _BY_<p>_BY_<q>__ symbols the earlier passes
+          # introduced (-> _BY_p_BY_q_BY_r), which is what .S3() emits.  Every
+          # name it can reach is declared: calcSens3 is a subset of calcSens2,
+          # which is a subset of calcSens.  No accumulator, for the same reason
+          # as second order -- a forcing is keyed by one target compartment.
+          for (.i in .states) {
+            .fi <- .force[[.i]]
+            if (.isZero(.fi)) next
+            .g3 <- .rxIndLinChainD(.fi, c(.p, .q, .r), .states, .statesSe,
+                                   c(.pSe, .qSe, .rSe))
+            if (!.isZero(.g3)) {
+              .code <- c(.code, paste0("indLin(", .S3(.i), ") <- ", rxFromSE(.g3)))
+            }
+          }
         }
       }
     }

--- a/man/rxSensMatExp.Rd
+++ b/man/rxSensMatExp.Rd
@@ -25,8 +25,7 @@ Ignored for \code{linCmt()} states (those use Stan forward-AD).}
 
 \item{calcSens3}{character vector (or \code{NULL}) requesting third-order
 sensitivities \verb{rx__sens_<x>_BY_<p>_BY_<q>_BY_<r>__} (\code{r} over \code{calcSens3}).
-Requires \code{calcSens2}; every \code{calcSens3} element must also be in \code{calcSens2}.
-The forcing contribution is not generated at third order.}
+Requires \code{calcSens2}; every \code{calcSens3} element must also be in \code{calcSens2}.}
 
 \item{doConst}{Replace constants with values; By default this is \code{FALSE}.}
 

--- a/src/rxSerialize.cpp
+++ b/src/rxSerialize.cpp
@@ -20,7 +20,8 @@ extern "C" void rxOptionsIniEnsure(int mx, int cores);
 extern rx_globals _globals;
 
 static const char rxSerializeMagic[8] = {'R','X','O','D','E','2','S','Z'};
-static const uint32_t rxSerializeFormatVer = 2u;
+static const uint32_t rxSerializeFormatVer = 3u;
+// Format 3 appended the op->indLin convergence set at the end of the stream.
 
 // ---------------------------------------------------------------------------
 // Low-level write helpers -- all abort via Rf_error on failure
@@ -233,6 +234,17 @@ SEXP rxSaveState_() {
   }
   sWriteI32(f, state_size_saved, "state_size");
 
+  // n4 (initsC.size()) and n6 (scaleC.size()) drive the gsolve layout and are
+  // not recoverable from any scalar field, so they travel with it: ginits is
+  // followed by glhs and gscale by gatol2.
+  int32_t n4_saved = op->neq, n6_saved = op->neq;
+  if (_globals.ginits && _globals.glhs && _globals.glhs >= _globals.ginits)
+    n4_saved = (int32_t)(_globals.glhs - _globals.ginits);
+  if (_globals.gscale && _globals.gatol2 && _globals.gatol2 >= _globals.gscale)
+    n6_saved = (int32_t)(_globals.gatol2 - _globals.gscale);
+  sWriteI32(f, n4_saved, "n4");
+  sWriteI32(f, n6_saved, "n6");
+
   // gLin (linH values): linB * 7 * nsub * nsim doubles
   sWriteDoubleBlob(f, _globals.gLin,
                    (uint64_t)((int64_t)rx->linB * 7 * rx->nsub * rx->nsim),
@@ -243,22 +255,9 @@ SEXP rxSaveState_() {
                    (uint64_t)((int64_t)rx->nMtime * rx->nsub * rx->nsim),
                    "gmtime");
 
-  // ginits: n4 = initsC.size() -- stored in op->neq when pure ODE; use pointer arithmetic
-  // ginits pointer in gsolve: gsolve + n0 + nlin + 3*nsave + n2
-  // Easiest: compute size as scaleC offset - ginits
-  // But we don't have scaleC.size() directly. Use _globals.gscale - _globals.ginits.
-  {
-    uint64_t n4 = 0, n6 = 0;
-    if (_globals.ginits && _globals.gscale && _globals.gscale > _globals.ginits)
-      n4 = (uint64_t)(_globals.gscale - _globals.ginits);
-    sWriteDoubleBlob(f, _globals.ginits, n4, "ginits");
-
-    // gscale: n6 = scaleC.size()
-    // gscale is followed by gIndSim in the slab; use gIndSim - gscale
-    if (_globals.gscale && _globals.gIndSim && _globals.gIndSim > _globals.gscale)
-      n6 = (uint64_t)(_globals.gIndSim - _globals.gscale);
-    sWriteDoubleBlob(f, _globals.gscale, n6, "gscale");
-  }
+  // ginits (n4 doubles) and gscale (n6 doubles) -- the sizes written just above
+  sWriteDoubleBlob(f, _globals.ginits, (uint64_t)(n4_saved > 0 ? n4_saved : 0), "ginits");
+  sWriteDoubleBlob(f, _globals.gscale, (uint64_t)(n6_saved > 0 ? n6_saved : 0), "gscale");
 
   // gIndSim: n7 = nIndSim * nsub * nsim doubles
   sWriteDoubleBlob(f, _globals.gIndSim,
@@ -446,6 +445,15 @@ SEXP rxSaveState_() {
     sWriteDoubleBlob(f, ind->linH, (uint64_t)(rx->linB ? 7 : 0), "linH");
   }
 
+  // -- Section 9: op->indLin convergence set (format 3+) --------------------
+  // op->indLinN is written as a scalar above, but the set itself lives in
+  // _globals.gindLin and is rebuilt from mv$indLin[[4]] on an ordinary setup;
+  // a restored doIndLin 3/4 solve has no such setup, so it round-trips here.
+  {
+    uint64_t iln = (op->indLin != NULL && op->indLinN > 0) ? (uint64_t)op->indLinN : 0u;
+    sWriteIntBlob(f, op->indLin, iln, "indLin");
+  }
+
   RawVector ret(vec.size());
   std::copy(vec.begin(), vec.end(), ret.begin());
   return ret;
@@ -621,9 +629,15 @@ SEXP rxRestoreState_(SEXP rawSexp) {
   }
   uint32_t fmt = sReadU32(f, "format_ver");
   if (fmt > rxSerializeFormatVer) {
-    
+
     (Rf_error)("rxRestoreState: file format version %u > supported %u",
                fmt, rxSerializeFormatVer);
+  }
+  if (fmt < 3u) {
+    // Format 3 carries the gsolve layout sizes (n4/n6) that format 2 left the
+    // reader to guess wrongly, so a format 2 file could never be restored.
+    (Rf_error)("rxRestoreState: file format version %u is no longer supported; "
+               "re-save the state with this version of rxode2", fmt);
   }
 
   uint32_t vlen = sReadU32(f, "pkg_ver_len");
@@ -763,6 +777,8 @@ SEXP rxRestoreState_(SEXP rawSexp) {
 
   // -- Section 6: gsolve meaningful subsections ------------------------------
   int32_t state_size_saved = sReadI32(f, "state_size");
+  int32_t n4_saved = sReadI32(f, "n4");
+  int32_t n6_saved = sReadI32(f, "n6");
 
   // Allocate gsolve using rxFillMemLayout with saved dimensions
   rx_mem_layout _mem;
@@ -772,8 +788,7 @@ SEXP rxRestoreState_(SEXP rawSexp) {
     rx->linB, op->nLlik, rx->nIndSim, (int)rx->nsub,
     (int64_t)rx->nall, rx->maxAllTimes,
     op->numLinSens, op->numLin,
-    (int64_t)op->neq,  // n4_actual: use neq as proxy (actual restored below)
-    (int64_t)op->neq,  // n6_actual: use neq as proxy
+    (int64_t)n4_saved, (int64_t)n6_saved,
     &_mem);
 
   if (_globals.gsolve != NULL) free(_globals.gsolve);
@@ -974,10 +989,12 @@ SEXP rxRestoreState_(SEXP rawSexp) {
 
   // gParPos, gParPos2 (gsvar, govar covered by gParPos2)
   {
-    uint64_t expected_gpp = (rx->npars > 0 && _globals.gParPos) ? (uint64_t)rx->npars : 0u;
+    // gParPos was written only when the saving solve had one, so take the
+    // file's count rather than predicting it from the (already freed) pointer.
+    uint64_t n_gpp;
     int *buf;
 
-    buf = sReadIntBlobExpected(f, expected_gpp, "gParPos");
+    buf = sReadIntBlob(f, &n_gpp, "gParPos");
     if (_globals.gParPos != NULL) free(_globals.gParPos);
     _globals.gParPos = buf;
     
@@ -1153,6 +1170,29 @@ SEXP rxRestoreState_(SEXP rawSexp) {
     ind->jac_counter  = _globals.jac_counter  + si;
     ind->BadDose      = _globals.gBadDose + (int64_t)neq * si;
     ind->rc           = _globals.grc + si;
+  }
+
+  // -- Section 10: op->indLin convergence set --------------------------------
+  {
+    uint64_t expected = (uint64_t)(op->indLinN > 0 ? op->indLinN : 0);
+    uint64_t n;
+    int *buf = sReadIntBlob(f, &n, "indLin");
+    if (n != expected) {
+      if (buf) free(buf);
+      (Rf_error)("rxRestoreState: indLin size mismatch (file: %llu, expected: %llu)",
+                 (unsigned long long)n, (unsigned long long)expected);
+    }
+    // gindLin is an R_Calloc allocation (rxSolveFreeC R_Free()s it), so copy
+    // the malloc'd blob into R's allocator rather than handing it over.
+    if (_globals.gindLin != NULL) R_Free(_globals.gindLin);
+    if (n > 0) {
+      _globals.gindLin = R_Calloc((int)n, int);
+      memcpy(_globals.gindLin, buf, (size_t)n * sizeof(int));
+      op->indLin = _globals.gindLin;
+    } else {
+      op->indLin = NULL;
+    }
+    if (buf) free(buf);
   }
 
   _globals.alloc = true;

--- a/src/rxSerialize.cpp
+++ b/src/rxSerialize.cpp
@@ -45,10 +45,14 @@ static void sWriteI32(std::vector<uint8_t> *f, int32_t v, const char *what) {
 }
 
 // Write a size-prefixed blob: uint64_t count then count elements of width w.
+// A NULL pointer is an absent array, so it writes a count of zero -- writing the
+// asked-for count with no payload behind it would leave every later field in the
+// stream shifted and read as garbage.
 static void sWriteBlob(std::vector<uint8_t> *f, const void *data, uint64_t count, size_t w,
                        const char *what) {
+  if (data == NULL) count = 0;
   sWriteU64(f, count, what);
-  if (count > 0 && data != NULL)
+  if (count > 0)
     sWrite(f, data, count * w, what);
 }
 
@@ -237,7 +241,9 @@ SEXP rxSaveState_() {
   // n4 (initsC.size()) and n6 (scaleC.size()) drive the gsolve layout and are
   // not recoverable from any scalar field, so they travel with it: ginits is
   // followed by glhs and gscale by gatol2.
-  int32_t n4_saved = op->neq, n6_saved = op->neq;
+  // Zero when the slab is not allocated: the blobs below would then be absent,
+  // and a layout claiming a length nothing was written for cannot be restored.
+  int32_t n4_saved = 0, n6_saved = 0;
   if (_globals.ginits && _globals.glhs && _globals.glhs >= _globals.ginits)
     n4_saved = (int32_t)(_globals.glhs - _globals.ginits);
   if (_globals.gscale && _globals.gatol2 && _globals.gatol2 >= _globals.gscale)

--- a/src/rxSerialize.cpp
+++ b/src/rxSerialize.cpp
@@ -21,7 +21,8 @@ extern rx_globals _globals;
 
 static const char rxSerializeMagic[8] = {'R','X','O','D','E','2','S','Z'};
 static const uint32_t rxSerializeFormatVer = 3u;
-// Format 3 appended the op->indLin convergence set at the end of the stream.
+// Format 3 added the gsolve layout sizes n4/n6 after state_size, and appended
+// the op->indLin convergence set at the end of the stream.
 
 // ---------------------------------------------------------------------------
 // Low-level write helpers -- all abort via Rf_error on failure

--- a/src/rxSerialize.cpp
+++ b/src/rxSerialize.cpp
@@ -785,6 +785,12 @@ SEXP rxRestoreState_(SEXP rawSexp) {
   int32_t state_size_saved = sReadI32(f, "state_size");
   int32_t n4_saved = sReadI32(f, "n4");
   int32_t n6_saved = sReadI32(f, "n6");
+  // These size the gsolve slab and then bound the blob reads into it; a
+  // negative one from a corrupt file becomes a huge unsigned bound, so the
+  // reads would no longer be bounded at all.
+  if (state_size_saved < 0 || n4_saved < 0 || n6_saved < 0) {
+    (Rf_error)("rxRestoreState: corrupt state (negative layout size)");
+  }
 
   // Allocate gsolve using rxFillMemLayout with saved dimensions
   rx_mem_layout _mem;
@@ -1181,24 +1187,22 @@ SEXP rxRestoreState_(SEXP rawSexp) {
   // -- Section 10: op->indLin convergence set --------------------------------
   {
     uint64_t expected = (uint64_t)(op->indLinN > 0 ? op->indLinN : 0);
-    uint64_t n;
-    int *buf = sReadIntBlob(f, &n, "indLin");
+    uint64_t n = sReadU64(f, "indLin");
     if (n != expected) {
-      if (buf) free(buf);
       (Rf_error)("rxRestoreState: indLin size mismatch (file: %llu, expected: %llu)",
                  (unsigned long long)n, (unsigned long long)expected);
     }
-    // gindLin is an R_Calloc allocation (rxSolveFreeC R_Free()s it), so copy
-    // the malloc'd blob into R's allocator rather than handing it over.
+    // gindLin is an R_Calloc allocation (rxSolveFreeC R_Free()s it), so read
+    // straight into R's allocator -- a malloc'd staging buffer would leak if
+    // R_Calloc() raised on the way past it.
     if (_globals.gindLin != NULL) R_Free(_globals.gindLin);
     if (n > 0) {
       _globals.gindLin = R_Calloc((int)n, int);
-      memcpy(_globals.gindLin, buf, (size_t)n * sizeof(int));
       op->indLin = _globals.gindLin;
+      sRead(f, _globals.gindLin, (size_t)n * sizeof(int), "indLin");
     } else {
       op->indLin = NULL;
     }
-    if (buf) free(buf);
   }
 
   _globals.alloc = true;

--- a/tests/testthat/test-ind-lin.R
+++ b/tests/testthat/test-ind-lin.R
@@ -753,11 +753,10 @@ d/dt(blood)     = a*intestine - b*blood
     expect_no_error(suppressMessages(rxode2(rxSensMatExp(.mm, calcSens = c("ka", "vmax")))))
     expect_no_error(suppressMessages(rxode2(rxSensMatExp(
       .mm, calcSens = c("ka", "vmax"), calcSens2 = "vmax"))))
-    # third order warns that it is short the forcing term, but still emits a
-    # model whose rate constants are state free
-    expect_warning(.s3 <- rxSensMatExp(.mm, calcSens = c("ka", "vmax"),
-                                       calcSens2 = "vmax", calcSens3 = "vmax"),
-                   "third-order")
+    # third order carries the forcing too, and its rate constants stay state
+    # free (rxode2#1188)
+    expect_no_warning(.s3 <- rxSensMatExp(.mm, calcSens = c("ka", "vmax"),
+                                          calcSens2 = "vmax", calcSens3 = "vmax"))
     expect_no_error(suppressMessages(rxode2(.s3)))
 
     # and the exemption really is gone: a hand-written sensitivity model with a

--- a/tests/testthat/test-mexp-nonmem.R
+++ b/tests/testthat/test-mexp-nonmem.R
@@ -431,15 +431,20 @@ rxTest({
     }
   })
 
-  test_that("rxSensMatExp() says third-order omits the forcing", {
+  test_that("rxSensMatExp() emits a third-order forcing", {
     .mm <- "d/dt(depot) = -ka*depot\nd/dt(central) = ka*depot - Vm*central/(Km + central)\n"
-    expect_warning(rxSensMatExp(.mm, calcSens = c("ka", "Vm"),
-                                calcSens2 = "Vm", calcSens3 = "Vm"),
-                   "third-order")
-    # a linear model has no forcing to omit, so it stays quiet
+    .lines <- strsplit(rxSensMatExp(.mm, calcSens = c("ka", "Vm"),
+                                    calcSens2 = "Vm", calcSens3 = "Vm"), "\n")[[1L]]
+    expect_true(any(grepl("^indLin\\(rx__sens_central_BY_Vm_BY_Vm_BY_Vm__\\) <- ",
+                          .lines)))
+    expect_true(any(grepl("^indLin\\(rx__sens_central_BY_ka_BY_Vm_BY_Vm__\\) <- ",
+                          .lines)))
+    # a linear model has no forcing at any order
     .lin <- "d/dt(depot) = -ka*depot\nd/dt(central) = ka*depot - cl/v*central\n"
-    expect_no_warning(rxSensMatExp(.lin, calcSens = c("ka", "cl"),
-                                   calcSens2 = "cl", calcSens3 = "cl"))
+    expect_false(any(grepl("^indLin\\(",
+                           strsplit(rxSensMatExp(.lin, calcSens = c("ka", "cl"),
+                                                 calcSens2 = "cl", calcSens3 = "cl"),
+                                    "\n")[[1L]])))
   })
 
   test_that("rxSensMatExp() second-order forcing matches the ODE calcSens2 path", {
@@ -465,6 +470,75 @@ rxTest({
                   "rx__sens_central_BY_Vm_BY_Km__", "rx__sens_central_BY_Km_BY_Km__")) {
       expect_equal(.m[[.cn]], .o[[.cn]], tolerance = 1e-4)
     }
+  })
+
+  test_that("rxSensMatExp() third-order forcing matches the ODE calcSens3 path", {
+    ode_code <- "
+      d/dt(depot) = -ka*depot
+      d/dt(central) = ka*depot - Vm*central/(Km + central)
+    "
+    .cs <- c("ka", "Vm", "Km")
+    .m <- suppressMessages(rxode2(rxSensMatExp(ode_code, calcSens = .cs,
+                                               calcSens2 = c("Vm", "Km"),
+                                               calcSens3 = "Vm")))
+    .o <- suppressMessages(rxode2(ode_code, calcSens = .cs,
+                                  calcSens2 = c("Vm", "Km"), calcSens3 = "Vm"))
+    .et <- eventTable() |>
+      add.dosing(dose = 100, nbr.doses = 1, start.time = 0) |>
+      add.sampling(seq(0, 10, by = 1))
+    .p <- c(ka = 0.5, Vm = 10, Km = 5)
+    .rm <- rxSolve(.m, .et, method = "indLin", params = .p, atol = 1e-12, rtol = 1e-12)
+    .ro <- rxSolve(.o, .et, params = .p, atol = 1e-12, rtol = 1e-12)
+    for (.cn in c("rx__sens_central_BY_ka_BY_Vm_BY_Vm__",
+                  "rx__sens_central_BY_Vm_BY_Vm_BY_Vm__",
+                  "rx__sens_central_BY_Km_BY_Vm_BY_Vm__",
+                  "rx__sens_central_BY_ka_BY_Km_BY_Vm__",
+                  "rx__sens_central_BY_Vm_BY_Km_BY_Vm__",
+                  "rx__sens_central_BY_Km_BY_Km_BY_Vm__")) {
+      # non-trivial: without the forcing these are not merely inaccurate, they
+      # are a different quantity
+      expect_gt(max(abs(.ro[[.cn]])), 0.01)
+      expect_equal(.rm[[.cn]], .ro[[.cn]], tolerance = 1e-4)
+    }
+
+    # ... and against finite differences of the second-order sensitivities,
+    # which is the reference that does not share the ODE path's own machinery
+    .h <- 1e-3
+    .pu <- .p; .pu[["Vm"]] <- .p[["Vm"]] + .h
+    .pd <- .p; .pd[["Vm"]] <- .p[["Vm"]] - .h
+    .ru <- rxSolve(.m, .et, method = "indLin", params = .pu, atol = 1e-12, rtol = 1e-12)
+    .rd <- rxSolve(.m, .et, method = "indLin", params = .pd, atol = 1e-12, rtol = 1e-12)
+    for (.nm in c("Vm_BY_Vm", "Km_BY_Vm", "ka_BY_Vm")) {
+      expect_equal(.rm[[paste0("rx__sens_central_BY_", .nm, "_BY_Vm__")]],
+                   (.ru[[paste0("rx__sens_central_BY_", .nm, "__")]] -
+                      .rd[[paste0("rx__sens_central_BY_", .nm, "__")]]) / (2 * .h),
+                   tolerance = 1e-4)
+    }
+  })
+
+  test_that("rxSensMatExp() third-order forcing handles a fully repeated parameter", {
+    # p == q == r: every differentiation path lands on the same compartment, so
+    # the chained forcing must still be one line per target and the cross terms
+    # must sum rather than collide.
+    ode_code <- "
+      d/dt(central) = -Vm*central/(Km + central)
+    "
+    .code <- rxSensMatExp(ode_code, calcSens = "Vm", calcSens2 = "Vm", calcSens3 = "Vm")
+    .lines <- strsplit(.code, "\n")[[1L]]
+    expect_equal(sum(grepl("^indLin\\(rx__sens_central_BY_Vm_BY_Vm_BY_Vm__\\) <- ",
+                           .lines)), 1L)
+    .m <- suppressMessages(rxode2(.code))
+    .o <- suppressMessages(rxode2(ode_code, calcSens = "Vm", calcSens2 = "Vm",
+                                  calcSens3 = "Vm"))
+    .et <- eventTable() |>
+      add.dosing(dose = 100, nbr.doses = 1, start.time = 0, cmt = "central") |>
+      add.sampling(seq(0, 10, by = 1))
+    .p <- c(Vm = 10, Km = 5)
+    .rm <- rxSolve(.m, .et, method = "indLin", params = .p, atol = 1e-12, rtol = 1e-12)
+    .ro <- rxSolve(.o, .et, params = .p, atol = 1e-12, rtol = 1e-12)
+    expect_gt(max(abs(.ro$rx__sens_central_BY_Vm_BY_Vm_BY_Vm__)), 0.01)
+    expect_equal(.rm$rx__sens_central_BY_Vm_BY_Vm_BY_Vm__,
+                 .ro$rx__sens_central_BY_Vm_BY_Vm_BY_Vm__, tolerance = 1e-4)
   })
 
   test_that("matExp symengine env can build jacobians and sensitivities", {

--- a/tests/testthat/test-serialize.R
+++ b/tests/testthat/test-serialize.R
@@ -258,5 +258,57 @@ rxTest({
         as.data.frame(groupedDoseOnlyKeepExpanded)[, c("id", "time", "cp", "grp")]
       )
     })
+
+    # The C-state restore path (rxLoadState()/rxSolveFromRaw_()) rebuilds the
+    # solver from the binary alone, without the setup that normally fills
+    # op->indLin and the gsolve layout (rxode2#1189).
+    cStateSolve <- function(object, bundle, control = rxControl(),
+                            params = NULL) {
+      .rxRestoreStateBundle(bundle)
+      rxSolveFromRaw_(object, bundle$cState, bundle$solveState, control,
+                      NULL, NULL, params, NULL, NULL)
+    }
+
+    cStateFile <- tempfile(fileext = ".rxbin")
+    rxSolve(mod, theta, ev, serializeFile = cStateFile)
+    cStateBundle <- .rxReadStateBundle(cStateFile)
+
+    test_that("rxLoadState() restores the saved C state", {
+      expect_true(rxLoadState(cStateFile))
+    })
+
+    test_that("C-state replay reproduces the direct solve", {
+      cStateRep <- cStateSolve(mod, cStateBundle, params = theta)
+      expect_equal(as.data.frame(cStateRep), as.data.frame(ref))
+      expect_equal(cStateRep$params, ref$params)
+    })
+
+    # indLin() forcing: op->indLin is the convergence set the Picard iteration
+    # indexes with, and it is built from mv$indLin[[4]] only on a full setup.
+    indLinMod <- suppressMessages(rxode2({
+      ka <- 1
+      Vc <- 1
+      Vmax <- 0.00734
+      Km <- 0.3672
+      Cp <- center / Vc
+      d / dt(depot) <- -ka * depot
+      d / dt(center) <- ka * depot - Vmax / (Km + Cp) * Cp
+    }, indLin = TRUE))
+    indLinEv <- et(amt = 100) |> et(seq(0, 24, by = 1))
+    indLinRef <- rxSolve(indLinMod, indLinEv, method = "indLin")
+    indLinFile <- tempfile(fileext = ".rxbin")
+    rxSolve(indLinMod, indLinEv, method = "indLin", serializeFile = indLinFile)
+
+    test_that("indLin() replay from a serialization file matches direct solve", {
+      expect_equal(as.data.frame(rxSolve(indLinMod, indLinFile)),
+                   as.data.frame(indLinRef))
+    })
+
+    test_that("indLin() C-state replay keeps the convergence set", {
+      expect_equal(
+        as.data.frame(cStateSolve(indLinMod, .rxReadStateBundle(indLinFile),
+                                  rxControl(method = "indLin"))),
+        as.data.frame(indLinRef))
+    })
   })
 })


### PR DESCRIPTION
Closes #1189. Closes #1188.

## #1189 -- serialize `wIndLin`

`op->indLin` -- the states the inductive-linearization iteration checks for
convergence -- was rebuilt from `mv$indLin[[4]]` only on a full solve setup.
Only the scalar `indLinN` was written to the state file, so a restored
`doIndLin` 3/4 solve came back with a null pointer and a non-zero count; the
Picard iteration indexed it and segfaulted. It round-trips as an int blob at
the end of the stream now.

Getting there turned up that **the C-state restore path could not restore
anything at all**. `ginits` and `gscale` were sized by the distance to the
next pointer in the `gsolve` slab, which spans the intervening `lhs` and
tolerance blocks, so `rxLoadState()` failed with

```
rxRestoreState: buffer overflow protection, ginits size mismatch (file: 13, expected: 2)
```

for every model, `indLin()` or not. The layout sizes `n4`/`n6` now travel with
`state_size` and feed `rxFillMemLayout()` directly, and `gParPos` takes its
count from the file rather than predicting it from an already-freed pointer.

Format version 3. This is the one place the issue's "do not insert mid-list"
rule is bent: `n4`/`n6` sit next to `state_size` because they have to be known
before the slab is allocated, and there is no format 2 reader to keep
compatible -- a format 2 file could never be restored, so it is rejected with
a message asking for a re-save.

Two more, from the Antigravity review:

- `sWriteBlob()` wrote the caller's count and then, for a NULL pointer, no
  payload behind it, leaving every later field in the stream read shifted.
  A NULL array now writes a count of zero, so the strict readers report a
  missing array instead of silently mis-reading the rest of the state.
- A negative `n4`/`n6`/`state_size` from a corrupt file became a huge unsigned
  bound, so the reads that use it as their ceiling were no longer bounded.

## #1188 -- second- and third-order sensitivities of the forcing

Second order already carried the forcing; third order generated only the
rate-matrix cross terms and warned that it was short the rest. It is chained
one variable further with `.rxIndLinChainD()` now, the same way second order
does. Every sensitivity symbol the third pass can reach is already declared,
because `calcSens3` is a subset of `calcSens2` is a subset of `calcSens`.

## Tests

- `test-serialize.R`: `rxLoadState()` round-trip; C-state replay
  (`rxSolveFromRaw_`) reproduces the direct solve; the same for an `indLin()`
  forcing model, which segfaults without the `op->indLin` blob (verified by
  disabling just that read).
- `test-mexp-nonmem.R`: third-order forcing against the generic ODE
  `calcSens3` path and against finite differences of the second-order
  sensitivities, plus a fully repeated parameter (`p == q == r`).

Reviewed with Antigravity (`gemini-3.1-pro-high`) until it returned no
findings.

## Test run

Full suite: 37618 pass, 2 fail. Both failures are in `test-oom.R` and are
pre-existing: the mirai daemons load the *installed* rxode2, whose `rxControl()`
predates the `indLinStepSearch`/`indLinMaxIter`/`indLinRichardson`/
`indLinIteration`/`indLinJac` arguments already on `main`. Nothing in this diff
touches `rxControl()` or the OOM path.
