### PR TITLE
fix(evid_): fire model-pushed events at the record, on every method (#1214, #1152)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -85,6 +85,20 @@
 
 ### Solving
 
+- An event pushed by the model with `evid_()` (and the `bolus()`, `infuse()`,
+  `replace()`, `multiply()`, `reset()`, `phantom()` and `obs()` helpers) now
+  gives the same solution as the identical event written in the data, on every
+  solving method.  The ODE methods fired the model body from `dydt()` at the
+  start of the next integration interval: the time value was right, but the
+  event was inserted only after the solver had been asked to integrate past it,
+  so `liblsoda`, `dop853` and `cvode` applied the jump one observation late and
+  `lsoda` dropped it altogether.  `evid_()` now fires from a single shared point
+  at the record itself -- once per distinct record time, with the pushed event
+  landing in the slot immediately after that record -- so ODE, `linCmt()` and
+  `indLin()` models agree with each other and with the explicit event.  A model
+  that pushes an event but defines no `lhs` variable also compiled to an empty
+  `calc_lhs()` and never pushed anything; its body is now emitted.
+
 - `rxSolve()` no longer returns silently wrong, run-to-run varying results when
   a multi-row `params` data.frame (one parameter set per `id`) is combined with
   `omega = NA` or `sigma = NA`.  `c()` on a data.frame drops the data.frame

--- a/NEWS.md
+++ b/NEWS.md
@@ -104,6 +104,16 @@
   observation between two key events at once, which cannot honour an event the
   model decides on at one of those observations.
 
+- An adaptive dosing helper guarded by `t == <mtime>` no longer pushes its dose
+  twice when that `mtime()` names a time the event table already contains.  The
+  same model written as a function (`ini({})`/`model({})`) and as an
+  `rxode2({})` block disagreed, because `rxSolve()` defaults to
+  `useLinCmt=TRUE` for a function model: that one was auto-converted to a
+  `linCmt()` model, and the `linCmt()` driver fired `evid_()` from both its own
+  internal model evaluation and a second pass for the same-time observation.
+  Both forms now push once, and the doubled dose (silent except in the state at
+  the next time point) is gone.
+
 - `rxSolve()` no longer returns silently wrong, run-to-run varying results when
   a multi-row `params` data.frame (one parameter set per `id`) is combined with
   `omega = NA` or `sigma = NA`.  `c()` on a data.frame drops the data.frame

--- a/NEWS.md
+++ b/NEWS.md
@@ -102,7 +102,10 @@
   truncated by the dense `dop853` driver, and `dense=TRUE` is now dropped (with
   a warning) for a model that pushes: a dense segment integrates across every
   observation between two key events at once, which cannot honour an event the
-  model decides on at one of those observations.
+  model decides on at one of those observations.  A model that combines
+  `delay()` with a pushed event is now an error rather than silently returning
+  one of two wrong answers: `delay()` requires the dense output that a pushed
+  event rules out.
 
 - An adaptive dosing helper guarded by `t == <mtime>` no longer pushes its dose
   twice when that `mtime()` names a time the event table already contains.  The

--- a/NEWS.md
+++ b/NEWS.md
@@ -97,7 +97,12 @@
   landing in the slot immediately after that record -- so ODE, `linCmt()` and
   `indLin()` models agree with each other and with the explicit event.  A model
   that pushes an event but defines no `lhs` variable also compiled to an empty
-  `calc_lhs()` and never pushed anything; its body is now emitted.
+  `calc_lhs()` and never pushed anything; its body is now emitted.  A pushed
+  event that extends the timeline past its original last record is no longer
+  truncated by the dense `dop853` driver, and `dense=TRUE` is now dropped (with
+  a warning) for a model that pushes: a dense segment integrates across every
+  observation between two key events at once, which cannot honour an event the
+  model decides on at one of those observations.
 
 - `rxSolve()` no longer returns silently wrong, run-to-run varying results when
   a multi-row `params` data.frame (one parameter set per `id`) is combined with

--- a/R/evidPush.R
+++ b/R/evidPush.R
@@ -1,10 +1,13 @@
 #' Push a future dose or observation event from within an rxode2 model
 #'
 #' @description
-#' `evid_()` is a model-only function that schedules a future dosing or
-#' observation event during ODE solving.  It is evaluated at each output
-#' time point and inserts the requested event into the individual's event
-#' timeline for future processing.
+#' `evid_()` is a model-only function that schedules a current or future
+#' dosing or observation event during ODE solving.  The model body is run
+#' once per distinct record time, at the first record of that time, and the
+#' event is inserted immediately after it -- so an event pushed at the
+#' current time is applied before the solver advances, exactly like the same
+#' event written in the data.  The final record of the timeline does not
+#' push (it starts no integration interval).
 #'
 #' This function has no meaning outside an rxode2 model block and will
 #' throw an error if called directly from R.

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -2895,6 +2895,21 @@ rxSolve.default <- function(object, params = NULL, events = NULL, inits = NULL, 
   # output; a non-dense method requested explicitly is an error.
   .hasDelay <- isTRUE(rxModelVars(object)$flags[["hasDelay"]] == 1L)
   if (.hasDelay) {
+    # delay() and evid_() pull the solver in opposite directions and cannot both
+    # be honoured: delay() needs dense output (a non-dense method records no
+    # history and silently returns wrong lagged values), while a dense segment
+    # integrates across every observation between two key events at once and so
+    # cannot apply an event the model decides on at one of those observations
+    # (rxode2#1214).  Refuse rather than silently return one of the two wrong
+    # answers.
+    if (isTRUE(rxModelVars(object)$flags[["evid_"]] == 1L)) {
+      stop("a model cannot combine delay() with evid_() event pushing ",
+           "(bolus(), infuse(), replace(), multiply(), reset(), phantom(), obs()):
+",
+           "  delay() requires dense output, which cannot apply an event pushed ",
+           "at an observation",
+           call. = FALSE)
+    }
     # Validate any non-constant past(state, tau) <- expr history lines (state is
     # a delayed ODE state, tau matches a delay(), history references no states).
     .rxValidatePast(object)

--- a/inst/include/rxode2parseStruct.h
+++ b/inst/include/rxode2parseStruct.h
@@ -346,7 +346,7 @@ struct rx_solving_options_ind_s {
   int indOwnAllocN;     // allocated capacity for event arrays (>= n_all_times)
   int solveAllocN;      // allocated capacity for ind->solve in units of events (neq doubles each)
   int idoseOwnAllocN;   // allocated capacity for idose (>= ndoses)
-  int _atEventTime;     // set before each event-table interval; consumed once in dydt
+  int _atEventTime;     // set at an evid_() firing record; consumed once in calc_lhs
   int nPushedExtra;      // count of events pushed via evid_() for this individual this solve
   int    autoMethod;             /* 0 = using primary (non-stiff), 1 = using secondary (stiff) */
   int    autoCount;              /* positive = consecutive stiff detections; negative = nonstiff */

--- a/man/evid_.Rd
+++ b/man/evid_.Rd
@@ -62,10 +62,13 @@ returns \code{NULL} invisibly if called from R directly (after signaling
 an error).
 }
 \description{
-\code{evid_()} is a model-only function that schedules a future dosing or
-observation event during ODE solving.  It is evaluated at each output
-time point and inserts the requested event into the individual's event
-timeline for future processing.
+\code{evid_()} is a model-only function that schedules a current or future
+dosing or observation event during ODE solving.  The model body is run
+once per distinct record time, at the first record of that time, and the
+event is inserted immediately after it -- so an event pushed at the
+current time is applied before the solver advances, exactly like the same
+event written in the data.  The final record of the timeline does not
+push (it starts no integration interval).
 
 This function has no meaning outside an rxode2 model block and will
 throw an error if called directly from R.

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -467,7 +467,9 @@ void codegen(char *model, int show_ode, const char *prefix, const char *libname,
         (show_ode == ode_past && foundPast) ||
         ode_is_es_dcode(show_ode) ||
         (show_ode == ode_ini && foundF0) ||
-        (show_ode == ode_lhs && tb.li) ||
+        /* tb.evid_: calc_lhs() is the firing point for evid_() pushes, so it
+           needs its preamble even when the model defines no lhs variable */
+        (show_ode == ode_lhs && (tb.li || tb.evid_)) ||
         (show_ode == ode_mtime && nmtime) ||
         (show_ode == ode_mexp && (tb.matn || tb.isMexp)) ||
         (show_ode == ode_indLinVec && (tb.matnf || tb.isMexp))){
@@ -527,7 +529,7 @@ void codegen(char *model, int show_ode, const char *prefix, const char *libname,
         (foundPast && show_ode == ode_past) ||
         ode_is_es_dcode(show_ode) ||
         (foundF0 && show_ode == ode_ini) ||
-        (show_ode == ode_lhs && tb.li) ||
+        (show_ode == ode_lhs && (tb.li || tb.evid_)) ||
         (show_ode == ode_mtime && nmtime) ||
         (show_ode == ode_jac && found_jac == 1 && good_jac == 1) ||
         (show_ode != ode_mtime && show_ode != ode_lhs &&

--- a/src/iem.cpp
+++ b/src/iem.cpp
@@ -37,11 +37,6 @@ extern "C" void ind_iem_0(rx_solve *rx, rx_solving_options *op, int solveid, int
   int neqOde = op->neq - op->numLin - op->numLinSens;
   auto sys = make_rxode2_system_iem(ind, c_dydt, calc_jac, neq);
   state_type state(neqOde > 0 ? (size_t)neqOde : (size_t)1);
-  std::vector<double> tmp_f;
-  if (op->indOwnAlloc && neqOde > 0) {
-    tmp_f.resize((size_t)neqOde, 0.0);
-  }
-
   double *yp;
 
   for(i = 0; i < ind->n_all_times; i++) {
@@ -79,10 +74,6 @@ extern "C" void ind_iem_0(rx_solve *rx, rx_solving_options *op, int solveid, int
                             xp, ind->id, &i, ind->n_all_times, &istate, op, ind, u_inis, ctx)) {
             if (!localBadSolve && !isSameTime(ind->extraDoseNewXout, xp)) {
               preSolve(op, ind, xp, ind->extraDoseNewXout, yp);
-              if (op->indOwnAlloc && ind->_atEventTime && neqOde > 0) {
-                c_dydt(neq, xp, yp, tmp_f.data());
-              }
-
               if (neqOde > 0) {
                   double dt = (ind->autoHcur > 0.0) ? ind->autoHcur
                   : (op->HMIN > 0.0) ? op->HMIN : 1e-4;
@@ -125,10 +116,6 @@ extern "C" void ind_iem_0(rx_solve *rx, rx_solving_options *op, int solveid, int
               if (!isSameTime(xout, ind->extraDoseNewXout)) {
                 double _xp2 = ind->extraDoseNewXout;
                 preSolve(op, ind, _xp2, xout, yp);
-                if (op->indOwnAlloc && ind->_atEventTime && neqOde > 0) {
-                  c_dydt(neq, _xp2, yp, tmp_f.data());
-                }
-
                 if (neqOde > 0) {
                     double dt = (ind->autoHcur > 0.0) ? ind->autoHcur
                   : (op->HMIN > 0.0) ? op->HMIN : 1e-4;
@@ -162,10 +149,6 @@ extern "C" void ind_iem_0(rx_solve *rx, rx_solving_options *op, int solveid, int
         }
         if (!localBadSolve && !isSameTime(xout, xp)) {
           preSolve(op, ind, xp, xout, yp);
-          if (op->indOwnAlloc && ind->_atEventTime && neqOde > 0) {
-            c_dydt(neq, xp, yp, tmp_f.data());
-          }
-
           if (neqOde > 0) {
               double dt = (ind->autoHcur > 0.0) ? ind->autoHcur
                   : (op->HMIN > 0.0) ? op->HMIN : 1e-4;

--- a/src/ode_implicit_bridge.h
+++ b/src/ode_implicit_bridge.h
@@ -131,17 +131,6 @@ static inline void implicit_do_steps(rx_solving_options_ind *ind, rx_solving_opt
 
     int neqOde = neq[0] - op->numLin - op->numLinSens;
 
-    // For models with in-ODE adaptive dosing (indOwnAlloc), some implicit methods
-    // evaluate their first stage at t + c1*h (c1 > 0, e.g. SDIRK, Gauss, RadauIIA).
-    // When _atEventTime=1 is consumed at that offset time, evid_()/bolus()/etc. would
-    // push doses using the wrong t value.  Pre-evaluate dydt at the canonical start
-    // time xp so that dose pushing happens at the correct event time before the solver
-    // takes any stage that evaluates at xp + c1*h.
-    if (op->indOwnAlloc && ind->_atEventTime) {
-        std::vector<double> tmp_f((size_t)neqOde, 0.0);
-        c_dydt(neq, xp, yp, tmp_f.data());   // consumes _atEventTime; pushes doses at xp
-    }
-
     RxImplicit<OdeSolver> solver(c_dydt, c_jac, neq, neqOde, ind, yp, (long unsigned)op->mxstep);
     solver.set_quiet(true);
     solver.set_t(xp);

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -4030,8 +4030,11 @@ updateSolve(rx_solving_options_ind *ind, rx_solving_options *op, int *neq,
             double &xout,
             int &i, int &nx) {
   // Grow if needed before accessing getSolve(i) and optionally getSolve(i+1).
-  _growSolveIfNeeded(ind, op, i, (i + 1 != nx));
-  if (i+1 != nx) {
+  // Record whether the next slot was seeded here: callers pass ind->n_all_times
+  // itself as nx, so a push below would change nx under us.
+  bool _seededNext = (i + 1 != nx);
+  _growSolveIfNeeded(ind, op, i, _seededNext);
+  if (_seededNext) {
     std::copy(getSolve(i), getSolve(i) + rxEffNeq(ind, op), getSolve(i+1));
   }
   // This calc_lhs() is the single firing point for evid_() (bolus(), infuse(),
@@ -4051,7 +4054,7 @@ updateSolve(rx_solving_options_ind *ind, rx_solving_options *op, int *neq,
   calc_lhs(neq[1], xout, getSolve(i), ind->lhs);
   if (_fire) {
     _rxEvidSortStart = -1;
-    if (ind->n_all_times > _nBefore && i + 1 == nx) {
+    if (!_seededNext && ind->n_all_times > _nBefore) {
       // The copy above was skipped because i+1 was past the end of the
       // timeline; the push has since created that slot, so seed it here.
       _growSolveIfNeeded(ind, op, i, 1);

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -1319,6 +1319,16 @@ static inline void _rxSortIdoseSuffix(rx_solving_options_ind *ind, int startDose
        });
 }
 
+// ix position that _rxPushDose() re-sorts from, set by updateSolve() around the
+// calc_lhs() call that fires evid_(): the slot immediately after the record the
+// model body is being evaluated at.  A pushed event therefore lands after that
+// record and before every record still to be processed, so a dose pushed at the
+// current time is applied before the solver advances -- the same place the
+// identical event written in the data would sort.  -1 when no fire is in
+// progress (then the pre-existing ind->idx rule applies).  Thread-local because
+// a subject is solved start to finish on one thread.
+static thread_local int _rxEvidSortStart = -1;
+
 // Push a current/future event into the individual's own event arrays during ODE solving.
 // _curTime: current ODE model time (for past-time guard with solver tolerance).
 // Returns 1 on success, 0 if ignored (past time or unknown evid), -1 on alloc failure.
@@ -1477,8 +1487,13 @@ extern "C" int _rxPushDose(rx_solving_options_ind *_ind, double _curTime,
     _ind->whI = savedWhI; _ind->wh0 = savedWh0;
 
     // Re-sort ix from current event forward so new events land in the right slots
-    int sortStart = (_ind->idx >= 0 && _ind->idx < _ind->n_all_times)
-                    ? _ind->idx : 0;
+    int sortStart;
+    if (_rxEvidSortStart >= 0) {
+      sortStart = min2(_rxEvidSortStart, _ind->n_all_times);
+    } else {
+      sortStart = (_ind->idx >= 0 && _ind->idx < _ind->n_all_times)
+        ? _ind->idx : 0;
+    }
     reSortMainTimeline(_ind, sortStart);
 
     // Re-sort unprocessed idose suffix
@@ -3988,6 +4003,22 @@ static inline void _growSolveIfNeeded(rx_solving_options_ind *ind,
   }
 }
 
+// Should the model body be run (and evid_() fired) at record i?
+//
+// Once per DISTINCT record time, at the FIRST record of that time.  "First of
+// the time group" is what makes the rule self-limiting: an event the model
+// pushes at the current time is inserted after record i, so it is never the
+// first record of its time group and cannot re-trigger the same condition.
+// Anchoring on record i-1 keeps this stateless -- reSortMainTimeline() only
+// ever touches slots after the current record, so ix[i-1] is stable.
+static inline bool _rxFireEvid(rx_solving_options_ind *ind,
+                               rx_solving_options *op, int i) {
+  if (!op->indOwnAlloc) return false;
+  if (i == 0) return true;
+  return !isSameTime(ind->timeThread[ind->ix[i]],
+                     ind->timeThread[ind->ix[i-1]]);
+}
+
 static inline void
 updateSolve(rx_solving_options_ind *ind, rx_solving_options *op, int *neq,
             double &xout,
@@ -3997,7 +4028,30 @@ updateSolve(rx_solving_options_ind *ind, rx_solving_options *op, int *neq,
   if (i+1 != nx) {
     std::copy(getSolve(i), getSolve(i) + rxEffNeq(ind, op), getSolve(i+1));
   }
+  // This calc_lhs() is the single firing point for evid_() (bolus(), infuse(),
+  // replace(), multiply(), reset(), ...) on EVERY method.  It runs at the
+  // record's own time with the record's own events already applied, and pushes
+  // land in the slot right after it -- so the pushed event is applied before
+  // the solver advances, exactly as the same event written in the data would
+  // be.  The old ODE-only path fired from dydt() at the start of the next
+  // integration interval, which inserted the event only after the solver had
+  // already integrated past it.
+  bool _fire = _rxFireEvid(ind, op, i);
+  int _nBefore = ind->n_all_times;
+  if (_fire) {
+    _rxEvidSortStart = i + 1;
+    ind->_atEventTime = 1;
+  }
   calc_lhs(neq[1], xout, getSolve(i), ind->lhs);
+  if (_fire) {
+    _rxEvidSortStart = -1;
+    if (ind->n_all_times > _nBefore && i + 1 == nx) {
+      // The copy above was skipped because i+1 was past the end of the
+      // timeline; the push has since created that slot, so seed it here.
+      _growSolveIfNeeded(ind, op, i, 1);
+      std::copy(getSolve(i), getSolve(i) + rxEffNeq(ind, op), getSolve(i+1));
+    }
+  }
 }
 
 //================================================================================
@@ -4024,7 +4078,6 @@ extern "C" void ind_indLin0(rx_solve *rx, rx_solving_options *op, int solveid,
   nx = ind->n_all_times;
   rc= ind->rc;
   double xp = ind->all_times[0];
-  bool _skipEvid = false;
   ind->solvedIdx = 0;
   for (i=0; i<ind->n_all_times; i++) {
     ind->idx=i;
@@ -4140,36 +4193,8 @@ extern "C" void ind_indLin0(rx_solve *rx, rx_solving_options *op, int solveid,
           ind->mainSorted = 0;
         }
       }
-      // Fire evid_() through calc_lhs at observation records, the same way
-      // ind_linCmt0 does.  codegen emits evid_() into dydt and calc_lhs only
-      // (src/codegen.c TEVID), and a matExp()/indLin() model's dydt is a no-op
-      // stub -- so without this, doses pushed by the model at run time
-      // (bolus(), infuse(), replace(), multiply(), reset(), ...) never happen
-      // on this method.  Unlike linCmt there is no internal dydt call to have
-      // already consumed the flag, so calc_lhs is the only firing point.
-      // Observation AND model-time (mtime, evid 10-99) records: an ODE method
-      // fires evid_() from dydt continuously, so a guard like
-      // `t >= mt && t < mt + 0.5` triggers wherever the integrator steps.  With
-      // no dydt the model body is only seen at records, and an mtime record is
-      // usually the very record such a guard was written against.
-      ind->idx = i + 1;
-      int _evidHere = getEvid(ind, ind->ix[i]);
-      if (op->indOwnAlloc &&
-          (isObs(_evidHere) || (_evidHere >= 10 && _evidHere <= 99))) {
-        if (_skipEvid) {
-          _skipEvid = false;
-        } else {
-          ind->_atEventTime = 1;
-        }
-      }
-      // A push inside calc_lhs can insert events at this same time and displace
-      // the current observation to ix[i+1]; without this the displaced record
-      // fires evid_() a second time and the pushed dose is counted twice.
-      // linCmt needs the same guard, but detects the growth around its solve,
-      // because its linSolve calls dydt and so pushes there instead.
-      int _nBeforePush = ind->n_all_times;
+      // evid_() fires inside updateSolve(), shared by every method.
       updateSolve(ind, op, neq, xout, i, ind->n_all_times);
-      if (ind->n_all_times > _nBeforePush) _skipEvid = true;
       ind->slvr_counter[0]++; // doesn't need do be critical; one subject at a time.
       if (_mtime_requeued) i--;
     }
@@ -4446,14 +4471,6 @@ extern "C" void ind_liblsoda0(rx_solve *rx, rx_solving_options *op, struct lsoda
         }
         if (!localBadSolve && !isSameTime(xout, xp)) {
           preSolve(op, ind, xp, xout, yp);
-          if (ctx->state == 2) {
-            // liblsoda continuation mode does not call f at xp (it uses the cached
-            // derivative from the previous step).  Explicitly call f at xp so that
-            // any model side-effects that depend on _atEventTime (e.g. evid_() push
-            // doses) fire at the correct time, matching dop853 behaviour.
-            std::vector<double> _evid_tmpydot(neqOde);
-            (*ctx->function)(xp, yp, _evid_tmpydot.data(), ctx->data);
-          }
           lsoda(ctx, yp, &xp, xout);
           copyLinCmt(neq, ind, op, yp);
           postSolve(neq, &(ctx->state), rc, &i, yp, NULL, 0, false, ind, op, rx);
@@ -5174,11 +5191,6 @@ static void ind_lsode0(rx_solve *rx, rx_solving_options *op, int solveid,
           if (!localBadSolve && !isSameTime(ind->extraDoseNewXout, xp)) {
             preSolve(op, ind, xp, ind->extraDoseNewXout, yp);
             neq[0] = eff - op->numLin - op->numLinSens;
-            if (op->indOwnAlloc && ind->_atEventTime) {
-              // Pre-evaluate dydt at xp so in-model evid_() pushes at the correct
-              // time before lsode's Adams predictor evaluates at xp + H_prev.
-              { std::vector<double> _tmp_f_ls((size_t)neq[0]); dydt(neq, xp, yp, _tmp_f_ls.data()); }
-            }
             F77_CALL(dlsode)(rxode2_dlsode_F, neq, yp, &xp, &ind->extraDoseNewXout,
                              &itol, &(op->RTOL), &(op->ATOL), &itask, &istate, &iopt,
                              rwork, &lrw, iwork, &liw, rxode2_dlsode_JAC, &mf, &rpar, &ipar);
@@ -5202,11 +5214,7 @@ static void ind_lsode0(rx_solve *rx, rx_solving_options *op, int solveid,
               preSolve(op, ind, _xp_ls, xout, yp);
               neq[0] = eff - op->numLin - op->numLinSens;
               // istate is already 1 from the dose handler above (needed for restart
-              // after a dose event); also pre-evaluate to push any in-model doses
-              // at the canonical sub-interval start time.
-              if (op->indOwnAlloc && ind->_atEventTime) {
-                { std::vector<double> _tmp_f_ls((size_t)neq[0]); dydt(neq, _xp_ls, yp, _tmp_f_ls.data()); }
-              }
+              // after a dose event).
               F77_CALL(dlsode)(rxode2_dlsode_F, neq, yp, &ind->extraDoseNewXout, &xout,
                                &itol, &(op->RTOL), &(op->ATOL), &itask, &istate, &iopt,
                                rwork, &lrw, iwork, &liw, rxode2_dlsode_JAC, &mf, &rpar, &ipar);
@@ -5221,12 +5229,6 @@ static void ind_lsode0(rx_solve *rx, rx_solving_options *op, int solveid,
         if (!localBadSolve && !isSameTime(xout, xp)) {
           preSolve(op, ind, xp, xout, yp);
           neq[0] = eff - op->numLin - op->numLinSens;
-          if (op->indOwnAlloc && ind->_atEventTime) {
-            // Pre-evaluate dydt at xp so in-model evid_() pushes doses at the
-            // correct canonical start time before lsode's Adams predictor can
-            // evaluate at xp + H_prev.
-            { std::vector<double> _tmp_f_ls((size_t)neq[0]); dydt(neq, xp, yp, _tmp_f_ls.data()); }
-          }
           F77_CALL(dlsode)(rxode2_dlsode_F, neq, yp, &xp, &xout,
                            &itol, &(op->RTOL), &(op->ATOL), &itask, &istate, &iopt,
                            rwork, &lrw, iwork, &liw, rxode2_dlsode_JAC, &mf, &rpar, &ipar);
@@ -5617,7 +5619,6 @@ extern "C" void ind_linCmt0(rx_solve *rx, rx_solving_options *op, int solveid, i
   rc= ind->rc;
   double xp = ind->all_times[0];
   ind->solvedIdx = 0;
-  bool _skipEvid = false;
   for(i=0; i<nx; i++) {
     ind->idx=i;
     ind->linSS=0;
@@ -5645,7 +5646,6 @@ extern "C" void ind_linCmt0(rx_solve *rx, rx_solving_options *op, int solveid, i
     if (global_debug) {
       RSprintf("i=%d xp=%f xout=%f\n", i, xp, xout);
     }
-    bool _linSolveCalled = false;
     if (getEvid(ind, ind->ix[i]) != 3) {
       if (ind->err) {
         printErr(ind->err, ind->id);
@@ -5678,21 +5678,10 @@ extern "C" void ind_linCmt0(rx_solve *rx, rx_solving_options *op, int solveid, i
           }
         }
         if (!isSameTime(xout, xp)) {
-          // Keep ind->idx=i so _rxPushDose uses sortStart=i: pushed events at
-          // the same time as the current obs sort before it (doses before obs),
-          // which preserves the correct reset-before-dose-before-obs ordering.
-          // If a push displaced the current obs to ix[i+1], _skipEvid prevents
-          // evid_() from double-firing when the displaced obs is re-processed.
-          int _nBeforePush = ind->n_all_times;
           preSolve(op, ind, xp, xout, yp);
           linSolve(neq, ind, yp, &xp, xout);
           postSolve(neq, &idid, rc, &i, yp, err_msg, 4, true, ind, op, rx);
           xp = xout;
-          _linSolveCalled = true;
-          if (ind->n_all_times > _nBeforePush) {
-            _skipEvid = true;
-            nx = ind->n_all_times;
-          }
         }
       }
     }
@@ -5721,22 +5710,7 @@ extern "C" void ind_linCmt0(rx_solve *rx, rx_solving_options *op, int solveid, i
           ind->mainSorted = 0;
         }
       }
-      ind->idx = i + 1;
-      // Fire evid_() via calc_lhs only for same-time obs (when linSolve was
-      // not called).  For non-same-time obs, preSolve already set
-      // _atEventTime=1 and linSolve's internal dydt(xout) captured and
-      // cleared it, firing evid_() once at the observation time.  Setting
-      // _atEventTime=1 again here would cause calc_lhs to fire a second time,
-      // double-counting pushed doses.
-      // _skipEvid: set when a push displaced the current obs to ix[i+1]; consume
-      // the flag here to prevent the displaced obs from re-firing evid_().
-      if (op->indOwnAlloc && isObs(getEvid(ind, ind->ix[i])) && !_linSolveCalled) {
-        if (_skipEvid) {
-          _skipEvid = false;
-        } else {
-          ind->_atEventTime = 1;
-        }
-      }
+      // evid_() fires inside updateSolve(), shared by every method.
       updateSolve(ind, op, neq, xout, i, nx);
       // Refresh nx after updateSolve: evid_() inside calc_lhs may have pushed
       // new events into the timeline, growing ind->n_all_times.

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -1527,6 +1527,32 @@ extern "C" int _rxPushDose(rx_solving_options_ind *_ind, double _curTime,
   return anyPushed ? 1 : 0;
 }
 
+// Is the solver at the original sort-time of an mtime slot that has not fired?
+static inline int _rxMtimeTriggerPending(rx_solve *rx,
+                                         rx_solving_options_ind *ind,
+                                         double xout) {
+  for (int k = 0; k < rx->nMtime; k++) {
+    if (ind->mtime0[k] != R_NegInf && isSameTime(xout, ind->mtime0[k])) return 1;
+  }
+  return 0;
+}
+
+// Points every not-yet-processed record of mtime slot k at its re-evaluated
+// time.  Returns 1 if any record in ix[nextI..] moved.
+static inline int _rxRetimeMtimeSlot(rx_solving_options_ind *ind, int k,
+                                     int nextI) {
+  double *time = ind->timeThread;
+  int moved = 0;
+  for (int j = nextI; j < ind->n_all_times; j++) {
+    int raw = ind->ix[j];
+    if (getEvid(ind, raw) == k + 10) {
+      time[raw] = ind->mtime[k];
+      moved = 1;
+    }
+  }
+  return moved;
+}
+
 // Recomputes ind->mtime[k] with current state yp when the solver is exactly at
 // the original sort-time mtime0[k].  Only fires once per mtime slot (mtime0[k]
 // is set to R_NegInf after firing to prevent double re-evaluation).
@@ -1537,36 +1563,20 @@ static inline int recomputeMtimeIfNeeded(rx_solve *rx,
                                          double *yp, int nextI, double xout) {
   if (rx->nMtime == 0) return 0;
   int nm = rx->nMtime;
-  // Check whether we are at the original time of any pending mtime slot.
-  int needEval = 0;
-  for (int k = 0; k < nm; k++) {
-    if (ind->mtime0[k] != R_NegInf && isSameTime(xout, ind->mtime0[k])) {
-      needEval = 1;
-      break;
-    }
-  }
-  if (!needEval) return 0;
+  if (!_rxMtimeTriggerPending(rx, ind, xout)) return 0;
   // Evaluate all mtime slots with current state into a temporary buffer so we
   // can selectively apply only the slot(s) whose trigger time has arrived.
   double newMtime[90];
   for (int k = 0; k < nm; k++) newMtime[k] = ind->mtime[k];
   if (ind->fns && ind->fns->mtime) ind->fns->mtime(ind->id, newMtime, yp);
   int changed = 0;
-  double *time = ind->timeThread;
   for (int k = 0; k < nm; k++) {
     if (ind->mtime0[k] == R_NegInf) continue;          // already fired
     if (!isSameTime(xout, ind->mtime0[k])) continue;   // not yet at trigger time
     // Lock in the one-time re-evaluated value and update timeThread.
     if (newMtime[k] != ind->mtime[k]) {
       ind->mtime[k] = newMtime[k];
-      for (int j = nextI; j < ind->n_all_times; j++) {
-        int raw = ind->ix[j];
-        int evid = getEvid(ind, raw);
-        if (evid == k + 10) {
-          time[raw] = ind->mtime[k];
-          changed = 1;
-        }
-      }
+      if (_rxRetimeMtimeSlot(ind, k, nextI)) changed = 1;
     }
     ind->mtime0[k] = R_NegInf; // mark fired; no further re-evaluation
   }

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -1422,20 +1422,29 @@ extern "C" int _rxPushDose(rx_solving_options_ind *_ind, double _curTime,
       // dose, all_times, ii, evid: allocate newCap+1 so that the [idx+1]
       // "plus-one" macros (setDoseP1, getDoseP1, setAllTimesP1, getAllTimesP1,
       // getEvidP1) are always within bounds when idx == n_all_times-1.
+      // Each successful realloc is published on _ind straight away.  realloc()
+      // frees the old block when it moves one, so holding the new pointer in a
+      // local until every call has succeeded would leave _ind pointing at freed
+      // memory on a later failure -- and the driver loop keeps reading these
+      // arrays after the abort flag is set.
       double *a   = (double*)realloc(_ind->all_times,  newCap * sizeof(double));
+      if (a   != NULL) _ind->all_times  = a;
       double *d   = (double*)realloc(_ind->dose,       newCap * sizeof(double));
+      if (d   != NULL) _ind->dose       = d;
       double *i2  = (double*)realloc(_ind->ii,         newCap * sizeof(double));
+      if (i2  != NULL) _ind->ii         = i2;
       int    *ev2 = (int*)   realloc(_ind->evid,       newCap * sizeof(int));
+      if (ev2 != NULL) _ind->evid       = ev2;
       int    *ix  = (int*)   realloc(_ind->ix,         newCap * sizeof(int));
+      if (ix  != NULL) _ind->ix         = ix;
       double *tt  = (double*)realloc(_ind->timeThread, newCap * sizeof(double));
+      if (tt  != NULL) _ind->timeThread = tt;
       if (!a || !d || !i2 || !ev2 || !ix || !tt) {
         int bad = 1;
 #pragma omp atomic write
         op->badSolve = bad;
         return -1;
       }
-      _ind->all_times  = a;  _ind->dose = d;  _ind->ii = i2;
-      _ind->evid       = ev2; _ind->ix  = ix; _ind->timeThread = tt;
       _ind->indOwnAllocN = newCap;
       // Zero guard elements (solve slots are grown on next rxAllocInd call)
       memset(a + _ind->n_all_times, 0, (newCap - _ind->n_all_times) * sizeof(double));
@@ -4041,14 +4050,8 @@ static inline void
 updateSolve(rx_solving_options_ind *ind, rx_solving_options *op, int *neq,
             double &xout,
             int &i, int &nx) {
-  // Grow if needed before accessing getSolve(i) and optionally getSolve(i+1).
-  // Record whether the next slot was seeded here: callers pass ind->n_all_times
-  // itself as nx, so a push below would change nx under us.
-  bool _seededNext = (i + 1 != nx);
-  _growSolveIfNeeded(ind, op, i, _seededNext);
-  if (_seededNext) {
-    std::copy(getSolve(i), getSolve(i) + rxEffNeq(ind, op), getSolve(i+1));
-  }
+  (void)nx; // the timeline can grow below, so ind->n_all_times is the authority
+  _growSolveIfNeeded(ind, op, i, 0);
   // This calc_lhs() is the single firing point for evid_() (bolus(), infuse(),
   // replace(), multiply(), reset(), ...) on EVERY method.  It runs at the
   // record's own time with the record's own events already applied, and pushes
@@ -4059,20 +4062,19 @@ updateSolve(rx_solving_options_ind *ind, rx_solving_options *op, int *neq,
   // already integrated past it.
   bool _fire = _rxFireEvid(ind, op, i) && !_rxEvidMtimeRequeued;
   _rxEvidMtimeRequeued = false;
-  int _nBefore = ind->n_all_times;
   if (_fire) {
     _rxEvidSortStart = i + 1;
     ind->_atEventTime = 1;
   }
   calc_lhs(neq[1], xout, getSolve(i), ind->lhs);
-  if (_fire) {
-    _rxEvidSortStart = -1;
-    if (!_seededNext && ind->n_all_times > _nBefore) {
-      // The copy above was skipped because i+1 was past the end of the
-      // timeline; the push has since created that slot, so seed it here.
-      _growSolveIfNeeded(ind, op, i, 1);
-      std::copy(getSolve(i), getSolve(i) + rxEffNeq(ind, op), getSolve(i+1));
-    }
+  if (_fire) _rxEvidSortStart = -1;
+  // Carry this record's state forward into the next slot.  Done AFTER calc_lhs
+  // (which only reads getSolve(i) and writes ind->lhs) so that a slot the push
+  // above just created is seeded too, rather than left with whatever the
+  // reallocation happened to leave there.
+  if (i + 1 != ind->n_all_times) {
+    _growSolveIfNeeded(ind, op, i, 1);
+    std::copy(getSolve(i), getSolve(i) + rxEffNeq(ind, op), getSolve(i+1));
   }
 }
 

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -4011,9 +4011,15 @@ static inline void _growSolveIfNeeded(rx_solving_options_ind *ind,
 // first record of its time group and cannot re-trigger the same condition.
 // Anchoring on record i-1 keeps this stateless -- reSortMainTimeline() only
 // ever touches slots after the current record, so ix[i-1] is stable.
+// The last record of the timeline does not fire: it starts no integration
+// interval, which is also where the old dydt() firing point drew the line.
+// Keeping that boundary keeps an unconditional evid_() self-limiting -- a push
+// made at the final record could only ever extend the timeline, and the record
+// it appends would push again, without bound.
 static inline bool _rxFireEvid(rx_solving_options_ind *ind,
                                rx_solving_options *op, int i) {
   if (!op->indOwnAlloc) return false;
+  if (i + 1 >= ind->n_all_times) return false;
   if (i == 0) return true;
   return !isSameTime(ind->timeThread[ind->ix[i]],
                      ind->timeThread[ind->ix[i-1]]);

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -1336,7 +1336,12 @@ static thread_local int _rxEvidSortStart = -1;
 // once.  Without this a state-dependent mtime() that reschedules fires evid_()
 // twice at the same time -- once on the requeued pass and again on the record
 // that takes over slot i.
-static thread_local bool _rxEvidMtimeRequeued = false;
+//
+// Keyed on the subject and record it was set for so a value stranded by an
+// aborted solve cannot suppress an unrelated record's push later on the same
+// thread.
+static thread_local int _rxEvidRequeueId  = -1;
+static thread_local int _rxEvidRequeueIdx = -1;
 
 // Push a current/future event into the individual's own event arrays during ODE solving.
 // _curTime: current ODE model time (for past-time guard with solver tolerance).
@@ -1566,8 +1571,11 @@ static inline int recomputeMtimeIfNeeded(rx_solve *rx,
     ind->mtime0[k] = R_NegInf; // mark fired; no further re-evaluation
   }
   // Every driver responds to a change by re-sorting and re-running this slot;
-  // tell updateSolve() to sit this pass out (see _rxEvidMtimeRequeued).
-  if (changed) _rxEvidMtimeRequeued = true;
+  // tell updateSolve() to sit this pass out (see _rxEvidRequeueId).
+  if (changed) {
+    _rxEvidRequeueId  = ind->id;
+    _rxEvidRequeueIdx = nextI;
+  }
   return changed;
 }
 
@@ -4052,6 +4060,11 @@ updateSolve(rx_solving_options_ind *ind, rx_solving_options *op, int *neq,
             int &i, int &nx) {
   (void)nx; // the timeline can grow below, so ind->n_all_times is the authority
   _growSolveIfNeeded(ind, op, i, 0);
+  // Clear any sort-start stranded by an earlier call that did not return
+  // normally (an R-level error inside a user function can longjmp out of
+  // calc_lhs).  Safe to do unconditionally here: a push only ever happens
+  // inside the calc_lhs() below, which this function sets the value for.
+  _rxEvidSortStart = -1;
   // This calc_lhs() is the single firing point for evid_() (bolus(), infuse(),
   // replace(), multiply(), reset(), ...) on EVERY method.  It runs at the
   // record's own time with the record's own events already applied, and pushes
@@ -4060,8 +4073,10 @@ updateSolve(rx_solving_options_ind *ind, rx_solving_options *op, int *neq,
   // be.  The old ODE-only path fired from dydt() at the start of the next
   // integration interval, which inserted the event only after the solver had
   // already integrated past it.
-  bool _fire = _rxFireEvid(ind, op, i) && !_rxEvidMtimeRequeued;
-  _rxEvidMtimeRequeued = false;
+  bool _mtimeRequeued = (_rxEvidRequeueId == ind->id && _rxEvidRequeueIdx == i);
+  _rxEvidRequeueId = -1;
+  _rxEvidRequeueIdx = -1;
+  bool _fire = _rxFireEvid(ind, op, i) && !_mtimeRequeued;
   if (_fire) {
     _rxEvidSortStart = i + 1;
     ind->_atEventTime = 1;

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -1329,6 +1329,15 @@ static inline void _rxSortIdoseSuffix(rx_solving_options_ind *ind, int startDose
 // a subject is solved start to finish on one thread.
 static thread_local int _rxEvidSortStart = -1;
 
+// Set when recomputeMtimeIfNeeded() has just rescheduled a model time and the
+// driver is about to re-process this same slot (its `i--`).  The record sitting
+// in slot i is about to move somewhere later, so updateSolve() must not run the
+// model body for it; the settled pass over slot i does that instead, exactly
+// once.  Without this a state-dependent mtime() that reschedules fires evid_()
+// twice at the same time -- once on the requeued pass and again on the record
+// that takes over slot i.
+static thread_local bool _rxEvidMtimeRequeued = false;
+
 // Push a current/future event into the individual's own event arrays during ODE solving.
 // _curTime: current ODE model time (for past-time guard with solver tolerance).
 // Returns 1 on success, 0 if ignored (past time or unknown evid), -1 on alloc failure.
@@ -1547,6 +1556,9 @@ static inline int recomputeMtimeIfNeeded(rx_solve *rx,
     }
     ind->mtime0[k] = R_NegInf; // mark fired; no further re-evaluation
   }
+  // Every driver responds to a change by re-sorting and re-running this slot;
+  // tell updateSolve() to sit this pass out (see _rxEvidMtimeRequeued).
+  if (changed) _rxEvidMtimeRequeued = true;
   return changed;
 }
 
@@ -4045,7 +4057,8 @@ updateSolve(rx_solving_options_ind *ind, rx_solving_options *op, int *neq,
   // be.  The old ODE-only path fired from dydt() at the start of the next
   // integration interval, which inserted the event only after the solver had
   // already integrated past it.
-  bool _fire = _rxFireEvid(ind, op, i);
+  bool _fire = _rxFireEvid(ind, op, i) && !_rxEvidMtimeRequeued;
+  _rxEvidMtimeRequeued = false;
   int _nBefore = ind->n_all_times;
   if (_fire) {
     _rxEvidSortStart = i + 1;
@@ -5581,6 +5594,9 @@ extern "C" double ind_linCmt0H(rx_solve *rx, rx_solving_options *op, int solveid
       }
 
       updateSolve(ind, op, neq, xout, i, nx);
+      // Refresh the cached loop bound: evid_() inside calc_lhs may have pushed
+      // events past the original end of the timeline.
+      nx = ind->n_all_times;
 
       ind->slvr_counter[0]++; // doesn't need do be critical; one subject at a time.
       if (_mtime_requeued) i--;
@@ -6433,6 +6449,10 @@ extern "C" void ind_dop0_dense(rx_solve *rx, rx_solving_options *op, int solveid
         }
       }
       updateSolve(ind, op, neq, xout, i, ind->n_all_times);
+      // Refresh the cached loop bound: evid_() inside calc_lhs may have pushed
+      // events past the original end of the timeline, and this driver's `for`
+      // tests against nx rather than ind->n_all_times.
+      nx = ind->n_all_times;
       if (_mtime_requeued) i--;
     }
     last_key_i = i;

--- a/src/par_solve.h
+++ b/src/par_solve.h
@@ -424,7 +424,12 @@ static inline void preSolve(rx_solving_options *op, rx_solving_options_ind *ind,
     ind->tprior = xp + ind->curShift; // Set the time to the time to solve to.
     ind->tout   = xout + ind->curShift;
   }
-  ind->_atEventTime = 1;
+  // NOTE: ind->_atEventTime is deliberately NOT set here.  evid_() is fired
+  // once per record from updateSolve() (see par_solve.cpp) so that every
+  // method -- ODE, linCmt() and indLin() alike -- pushes the event at the
+  // record it was decided at.  Setting it here fired evid_() from dydt() at
+  // the START of the next integration interval, i.e. after the solver had
+  // already been asked to integrate past the pushed event's own time.
 }
 
 

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -5908,7 +5908,10 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
     // closed.  A model that pushes its own events cannot work that way: the
     // event it decides on at an observation has to be applied before the solver
     // moves past that observation (rxode2#1214).
-    if (op->useDense && op->indOwnAlloc) {
+    // Keyed on the PARSER flag, not op->indOwnAlloc: rxSolve.default() defaults
+    // indOwnAlloc to TRUE, so that would disable dense output for every model
+    // -- including the delay() models whose history needs it.
+    if (op->useDense && INTEGER(rxSolveDat->mv[RxMv_flags])[RxMvFlag_evid_]) {
       Rf_warning("dense output not yet supported for models that push events with evid_(); using standard output");
       op->useDense = 0;
     }

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -5903,6 +5903,15 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
       Rf_warning("dense output not yet supported for linCmt models; using standard dop853");
       op->useDense = 0;
     }
+    // A dense segment integrates across every observation between two key
+    // events at once, so an observation is only filled in once the segment has
+    // closed.  A model that pushes its own events cannot work that way: the
+    // event it decides on at an observation has to be applied before the solver
+    // moves past that observation (rxode2#1214).
+    if (op->useDense && op->indOwnAlloc) {
+      Rf_warning("dense output not yet supported for models that push events with evid_(); using standard output");
+      op->useDense = 0;
+    }
     op->stiff = method;
 
     if (method == 206 || method == 239 || method == 240 || method == 241 || method == 210 || method == 200 || method == 207 || method == 265 || method == 227 || method == 228 || method == 229 || method == 205 || method == 213 || method == 236 || method == 233 || method == 234 || method == 238 || method == 235 || method == 231 || method == 232 || method == 237 || method == 243 || method == 225 || method == 221 || method == 202 || method == 226 || method == 230 || method == 208 || method == 282 || method == 300 || method == 301 || method == 302 || method == 304 || method == 267 || method == 268 || method == 270 || method == 271 || method == 272 || method == 273 || method == 274 || method == 275 || method == 276 || method == 277 || method == 279 || method == 280 || method == 281 || method == 283 || method == 284 || method == 285 || method == 286 || method == 287 || method == 288 || method == 289 || method == 290 || method == 291 || method == 292 || method == 293 || method == 295 || method == 296 || method == 297 || method == 298) {

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -5911,6 +5911,17 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
     // Keyed on the PARSER flag, not op->indOwnAlloc: rxSolve.default() defaults
     // indOwnAlloc to TRUE, so that would disable dense output for every model
     // -- including the delay() models whose history needs it.
+    //
+    // delay() needs that dense output (a non-dense method records no history
+    // and silently returns wrong lagged values), so a model asking for both is
+    // asking for two incompatible things.  Refuse instead of dropping one of
+    // them.  rxSolve() refuses this earlier with a fuller message; this is the
+    // backstop for a caller that reaches solver setup another way.
+    if (op->hasDelay && INTEGER(rxSolveDat->mv[RxMv_flags])[RxMvFlag_evid_]) {
+      (Rf_error)("a model cannot combine delay() with evid_() event pushing: "
+                 "delay() requires dense output, which cannot apply an event "
+                 "pushed at an observation");
+    }
     if (op->useDense && INTEGER(rxSolveDat->mv[RxMv_flags])[RxMvFlag_evid_]) {
       Rf_warning("dense output not yet supported for models that push events with evid_(); using standard output");
       op->useDense = 0;

--- a/tests/testthat/test-evid-push.R
+++ b/tests/testthat/test-evid-push.R
@@ -343,6 +343,115 @@ rxTest({
     expect_equal(gotLinReset$cp, wantLinReset$cp, tolerance = 1e-5)
   })
 
+  # rxode2#1214: a linCmt() model has no dydt() of its own, so it took a
+  # different evid_() firing path than the ODE methods.  Every dosing modifier
+  # pushed onto a linCmt compartment must reproduce the identical event written
+  # in the data, at the pushed time itself.
+  .linPushObs <- seq(0, 24, by = 1)
+  .linPushE <- et(amt = 100, time = 0) |>
+    et(amt = 50, time = 18) |>
+    et(.linPushObs)
+  .linPushP <- c(ka = 0.5, cl = 1, v = 10)
+  .linPushRef <- rxode2({
+    cp <- linCmt(ka, cl, v)
+  })
+
+  .linPushCheck <- function(mod, eRef) {
+    got <- rxSolve(mod, .linPushP, .linPushE)
+    want <- rxSolve(.linPushRef, .linPushP, eRef)
+    gotPush <- got[got$time >= 13, ]
+    wantPush <- want[want$time >= 13, ]
+    expect_equal(sum(got$time == 12), 2)
+    expect_equal(gotPush$time, wantPush$time)
+    expect_equal(gotPush$cp, wantPush$cp, tolerance = 1e-5)
+  }
+
+  test_that("in-model bolus() push matches the same event in the data (linCmt)", {
+    .linPushCheck(
+      rxode2({
+        mtime(pushAt) <- 12
+        cp <- linCmt(ka, cl, v)
+        if (t >= pushAt && t < pushAt + 0.5 && depot > 0) {
+          bolus(50, depot, 0, 0, 0)
+        }
+      }),
+      et(amt = 100, time = 0) |>
+        et(time = 12, amt = 50, cmt = 1, evid = 1) |>
+        et(amt = 50, time = 18) |>
+        et(.linPushObs))
+  })
+
+  test_that("in-model replace() push matches the same event in the data (linCmt)", {
+    .linPushCheck(
+      rxode2({
+        mtime(pushAt) <- 12
+        cp <- linCmt(ka, cl, v)
+        if (t >= pushAt && t < pushAt + 0.5 && depot > 0) {
+          replace(25, depot)
+        }
+      }),
+      et(amt = 100, time = 0) |>
+        et(time = 12, amt = 25, cmt = 1, evid = 5) |>
+        et(amt = 50, time = 18) |>
+        et(.linPushObs))
+  })
+
+  test_that("in-model multiply() push matches the same event in the data (linCmt)", {
+    .linPushCheck(
+      rxode2({
+        mtime(pushAt) <- 12
+        cp <- linCmt(ka, cl, v)
+        if (t >= pushAt && t < pushAt + 0.5 && depot > 0) {
+          multiply(2, depot)
+        }
+      }),
+      et(amt = 100, time = 0) |>
+        et(time = 12, amt = 2, cmt = 1, evid = 6) |>
+        et(amt = 50, time = 18) |>
+        et(.linPushObs))
+  })
+
+  # indLin excluded: matExp()/indLin() cannot represent linCmt() states, so a
+  # mixed linCmt + ODE model does not build on it.  t54+sdirk43 excluded: it
+  # needs an analytical Jacobian, which cannot be generated for a mixed model,
+  # so it silently falls back to liblsoda.
+  for (meth in setdiff(.methods0, c("indLin", "t54+sdirk43"))) {
+    test_that(paste0("in-model replace() on a mixed linCmt + ODE model (",
+                     meth, ")"), {
+      obs <- seq(0, 24, by = 1)
+      e <- et(amt = 100, time = 0) |>
+        et(amt = 50, time = 18) |>
+        et(obs)
+      eRef <- et(amt = 100, time = 0) |>
+        et(time = 12, amt = 25, cmt = 1, evid = 5) |>
+        et(amt = 50, time = 18) |>
+        et(obs)
+
+      mod <- rxode2({
+        mtime(replaceAt) <- 12
+        cp <- linCmt(ka, cl, v)
+        d/dt(eff) <- ke0 * (cp - eff)
+        if (t >= replaceAt && t < replaceAt + 0.5 && depot > 0) {
+          replace(25, depot)
+        }
+      })
+      ref <- rxode2({
+        cp <- linCmt(ka, cl, v)
+        d/dt(eff) <- ke0 * (cp - eff)
+      })
+
+      p <- c(ka = 0.5, cl = 1, v = 10, ke0 = 0.3)
+      got <- rxSolve(mod, p, e, method = meth)
+      want <- rxSolve(ref, p, eRef, method = meth)
+      gotPush <- got[got$time >= 13, ]
+      wantPush <- want[want$time >= 13, ]
+
+      expect_equal(gotPush$time, wantPush$time)
+      expect_equal(gotPush$cp, wantPush$cp, tolerance = 1e-5)
+      expect_equal(gotPush$eff, wantPush$eff, tolerance = 1e-5)
+    })
+  }
+
   test_that("in-model replace() pushes a replacement event", {
     # rxode2#1214: the pushed replacement and the identical evid=5 event
     # written in the data (at the same time, t = 12) must agree on every method.

--- a/tests/testthat/test-evid-push.R
+++ b/tests/testthat/test-evid-push.R
@@ -688,6 +688,20 @@ rxTest({
       }), c(cl = 1, v = 10), et(amt = 100, time = 0) |> et(seq(0, 20, by = 1))),
       regexp = "delay\\(\\) with evid_\\(\\)")
 
+    # the refusal is also enforced in solver setup, so a caller that does not
+    # come through rxSolve.default() cannot slip past it
+    mod <- rxode2({
+      d/dt(central) <- -cl / v * central
+      d/dt(eff) <- delay(central, 1.0) - eff
+      if (t >= 5 && t < 5.1) {
+        bolus(100, central, 0, 0, 0)
+      }
+    })
+    expect_error(
+      mod$solve(c(cl = 1, v = 10),
+                et(amt = 100, time = 0) |> et(seq(0, 20, by = 1))),
+      regexp = "delay\\(\\) with evid_\\(\\)")
+
     # the same delay() model without a push still solves, and matches the
     # identical dose written in the data
     ref <- rxode2({

--- a/tests/testthat/test-evid-push.R
+++ b/tests/testthat/test-evid-push.R
@@ -257,13 +257,9 @@ rxTest({
     test_that(paste0("in-model reset() matches an evid=3 reset event (",
                      meth,
                      ")"), {
-                       # rxode2#1214: a pushed dose and the identical event
-                       # written in the data give different solutions on the ODE
-                       # methods, which also disagree with each other; these
-                       # expectations are built from an ODE reference and so
-                       # encode that.  indLin reproduces the explicit-event
-                       # (analytic) result instead, so it cannot match them.
-                       skip_if(meth == "indLin", "rxode2#1214")
+                       # rxode2#1214: the pushed reset and the identical
+                       # evid=3 event written in the data must give the same
+                       # solution on every method.
                        obs <- seq(0, 24, by = 1)
                        e <- et(amt = 100, time = 0) |>
                          et(amt = 50, time = 18) |>
@@ -296,7 +292,11 @@ rxTest({
                        wantReset <- want[want$time >= 13, ]
 
                        expect_equal(sum(got$time == 12), 2)
-                       expect_true(all(got$cp[got$time == 12] > 0))
+                       # The mtime() trigger record reports the state at the
+                       # moment the model decides to reset (pre-reset); the
+                       # observation at that same time reports post-reset.
+                       expect_true(got$cp[got$time == 12][1] > 0)
+                       expect_equal(got$cp[got$time == 12][2], 0)
                        expect_true(all(gotReset$cp[gotReset$time < 18] == 0))
                        expect_equal(gotReset$time, wantReset$time)
                        expect_equal(gotReset$depot, wantReset$depot, tolerance = 1e-5)
@@ -334,21 +334,24 @@ rxTest({
     wantLinReset <- wantLin[wantLin$time >= 13, ]
 
     expect_equal(sum(gotLin$time == 12), 2)
-    expect_true(all(gotLin$cp[gotLin$time == 12] == 0))
+    # Same ordering as the ODE methods: the mtime() trigger record is pre-reset,
+    # the observation at that time is post-reset.
+    expect_true(gotLin$cp[gotLin$time == 12][1] > 0)
+    expect_equal(gotLin$cp[gotLin$time == 12][2], 0)
     expect_true(all(gotLinReset$cp[gotLinReset$time < 18] == 0))
     expect_equal(gotLinReset$time, wantLinReset$time)
     expect_equal(gotLinReset$cp, wantLinReset$cp, tolerance = 1e-5)
   })
 
   test_that("in-model replace() pushes a replacement event", {
-    # rxode2#1214: see the note on the other pushed-event tests below.
-    skip_if("indLin" %in% .methods0, "rxode2#1214")
+    # rxode2#1214: the pushed replacement and the identical evid=5 event
+    # written in the data (at the same time, t = 12) must agree on every method.
     obs <- seq(0, 24, by = 1)
     e <- et(amt = 100, time = 0) |>
       et(amt = 50, time = 18) |>
       et(obs)
     eRef <- et(amt = 100, time = 0) |>
-      et(time = 13, amt = 25, cmt = 1, evid = 5) |>
+      et(time = 12, amt = 25, cmt = 1, evid = 5) |>
       et(amt = 50, time = 18) |>
       et(obs)
 
@@ -387,19 +390,15 @@ rxTest({
     test_that(paste0("in-model multiply() pushes a multiplication event (",
                      meth,
                      ")"), {
-                       # rxode2#1214: a pushed dose and the identical event
-                       # written in the data give different solutions on the ODE
-                       # methods, which also disagree with each other; these
-                       # expectations are built from an ODE reference and so
-                       # encode that.  indLin reproduces the explicit-event
-                       # (analytic) result instead, so it cannot match them.
-                       skip_if(meth == "indLin", "rxode2#1214")
+                       # rxode2#1214: the pushed multiplication and the
+                       # identical evid=6 event written in the data (at the same
+                       # time, t = 12) must agree on every method.
                        obs <- seq(0, 24, by = 1)
                        e <- et(amt = 100, time = 0) |>
                          et(amt = 50, time = 18) |>
                          et(obs)
                        eRef <- et(amt = 100, time = 0) |>
-                         et(time = 13, amt = 2, cmt = 1, evid = 6) |>
+                         et(time = 12, amt = 2, cmt = 1, evid = 6) |>
                          et(amt = 50, time = 18) |>
                          et(obs)
 
@@ -475,17 +474,13 @@ rxTest({
 
   for (meth in .methods0) {
     test_that(paste0("in-model bolus() passes ii to repeated bolus events (", meth, ")"), {
-      # rxode2#1214: a pushed dose and the identical event written in the
-      # data give different solutions on the ODE methods, which also disagree
-      # with each other; these expectations are built from an ODE reference and
-      # so encode that.  indLin reproduces the explicit-event (analytic) result
-      # instead, so it cannot match them.
-      skip_if(meth == "indLin", "rxode2#1214")
+      # rxode2#1214: the pushed bolus series and the identical evid=1 events
+      # written in the data (t = 12, 24, 36) must agree on every method.
       obs <- seq(0, 40, by = 1)
       e <- et(amt = 100, time = 0) |>
         et(obs)
       eRef <- et(amt = 100, time = 0) |>
-        et(time = 13, amt = 50, cmt = 1, evid = 1) |>
+        et(time = 12, amt = 50, cmt = 1, evid = 1) |>
         et(time = 24, amt = 50, cmt = 1, evid = 1) |>
         et(time = 36, amt = 50, cmt = 1, evid = 1) |>
         et(obs)
@@ -545,7 +540,10 @@ rxTest({
     e <- et(amt = 100, time = 0) |> et(c(0, 6, 12))
     p <- c(cl = 1, vd = 10)
     r <- rxSolve(m4, p, e)
-    expect_equal(nrow(r), 5) # 5 observations should be in the output
+    # 0, 6, 12 from the data; 5.5 pushed from t=0, 11 from t=5.5, 11.5 from
+    # t=6, then 16.5 and 17 from t=11 and t=11.5 (the model body runs once per
+    # distinct record time, so each newly pushed time pushes again while t<12)
+    expect_equal(sort(r$time), c(0, 5.5, 6, 11, 11.5, 12, 16.5, 17))
   })
 
   test_that("obs() pushes multiple observation rows", {

--- a/tests/testthat/test-evid-push.R
+++ b/tests/testthat/test-evid-push.R
@@ -689,6 +689,78 @@ rxTest({
     expect_equal(sum(!is.na(r$evid) & r$evid == 1 & r$amt == 50), 0)
   })
 
+  test_that("mtime() at a time already in the event table pushes once (rxode2#1152)", {
+    # The classic block form and the functional/ui form of the same model must
+    # push the same single dose.  They did not: rxSolve() defaults to
+    # useLinCmt=TRUE for a ui model, so this one is auto-converted to a
+    # linCmt() model and solved by the linCmt driver -- which used to fire
+    # evid_() from BOTH its internal dydt(xout) and a calc_lhs() pass for the
+    # same-time observation.  With mtime(visit1) <- 24 and 24 also in the
+    # sampling grid, both fired and the bolus was pushed twice.  There is now a
+    # single firing point (rxode2#1214), so every path pushes once.
+    ev <- et(amt = 300, cmt = "depot", time = 0) |> et(seq(0, 72, by = 1))
+    cnt <- function(d) {
+      d <- as.data.frame(d)
+      dose <- d[!is.na(d$evid) & d$evid != 0, ]
+      c(nAt24 = sum(dose$time == 24), total = sum(dose$amt))
+    }
+    p <- c(ka = 1.57, cl = 2.72, v = 31.5)
+
+    classic <- rxode2({
+      mtime(visit1) <- 24
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      if (t == visit1) bolus(300, depot, 0, 0, 0)
+    })
+    ui <- suppressMessages(function() {
+      ini({
+        ka <- 1.57
+        cl <- 2.72
+        v <- 31.5
+      })
+      model({
+        mtime(visit1) <- 24
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        if (t == visit1) bolus(300, depot, 0, 0, 0)
+      })
+    })
+
+    want <- c(nAt24 = 1, total = 600)
+    expect_equal(cnt(rxSolve(classic, p, ev, addDosing = TRUE)), want)
+    expect_equal(cnt(suppressMessages(rxSolve(ui, ev, addDosing = TRUE))), want)
+    # the ODE form of the same ui model (no linCmt conversion) must agree
+    expect_equal(cnt(suppressMessages(
+      rxSolve(ui, ev, addDosing = TRUE, useLinCmt = FALSE))), want)
+
+    # dropping 24 from the grid was the documented workaround; it must give the
+    # same answer as keeping it
+    evNo24 <- et(amt = 300, cmt = "depot", time = 0) |>
+      et(setdiff(seq(0, 72, by = 1), 24))
+    expect_equal(cnt(suppressMessages(rxSolve(ui, evNo24, addDosing = TRUE))), want)
+
+    # two mtime()s in the grid scaled the doubling; 300 + 300 + 300, not 1500
+    ui2 <- suppressMessages(function() {
+      ini({
+        ka <- 1.57
+        cl <- 2.72
+        v <- 31.5
+      })
+      model({
+        mtime(visit1) <- 24
+        mtime(visit2) <- 48
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        if (t == visit1 || t == visit2) bolus(300, depot, 0, 0, 0)
+      })
+    })
+    expect_equal(cnt(suppressMessages(rxSolve(ui2, ev, addDosing = TRUE))),
+                 c(nAt24 = 1, total = 900))
+  })
+
   test_that("past-time evid_() produces a warning", {
     m3 <- rxode2({
       d/dt(x) <- -x

--- a/tests/testthat/test-evid-push.R
+++ b/tests/testthat/test-evid-push.R
@@ -671,6 +671,37 @@ rxTest({
     expect_equal(dens$central, plain$central, tolerance = 1e-5)
   })
 
+  test_that("delay() combined with an evid_() push is refused", {
+    # rxode2#1214: delay() needs dense output (a non-dense method records no
+    # history and silently returns wrong lagged values), while a dense segment
+    # integrates across every observation between two key events at once and so
+    # cannot apply an event pushed at one of those observations.  Honouring
+    # either one silently breaks the other -- delay() returned 0 for every
+    # lookup -- so the combination is refused.
+    expect_error(
+      rxSolve(rxode2({
+        d/dt(central) <- -cl / v * central
+        d/dt(eff) <- delay(central, 1.0) - eff
+        if (t >= 5 && t < 5.1) {
+          bolus(100, central, 0, 0, 0)
+        }
+      }), c(cl = 1, v = 10), et(amt = 100, time = 0) |> et(seq(0, 20, by = 1))),
+      regexp = "delay\\(\\) with evid_\\(\\)")
+
+    # the same delay() model without a push still solves, and matches the
+    # identical dose written in the data
+    ref <- rxode2({
+      d/dt(central) <- -cl / v * central
+      d/dt(eff) <- delay(central, 1.0) - eff
+    })
+    p <- c(cl = 1, v = 10)
+    obs <- seq(0, 20, by = 1)
+    r <- rxSolve(ref, p, et(amt = 100, time = 0) |>
+                   et(time = 5, amt = 100, cmt = 1, evid = 1) |> et(obs))
+    expect_true(all(is.finite(r$eff)))
+    expect_true(r$eff[r$time == 20][1] > 1)
+  })
+
   test_that("evid_() at the final record does not extend the timeline", {
     # The last record starts no integration interval, so it does not push --
     # otherwise an unconditional evid_() would append a record that pushes

--- a/tests/testthat/test-evid-push.R
+++ b/tests/testthat/test-evid-push.R
@@ -624,6 +624,71 @@ rxTest({
     })
   }
 
+  for (meth in .methods0) {
+    test_that(paste0("a rescheduled mtime() fires evid_() only once (", meth, ")"), {
+      # rxode2#1214: recomputeMtimeIfNeeded() reschedules a state-dependent
+      # mtime and the driver re-processes the same slot (its `i--`).  The record
+      # in that slot moves away, so the model body must run once for that time,
+      # on the settled pass -- not once per pass.
+      mod <- rxode2({
+        mtime(pushAt) <- 12 + 0.02 * central
+        d/dt(depot) <- -ka * depot
+        d/dt(central) <- ka * depot - cl / v * central
+        cp <- central / v
+        if (t >= 11.9 && t < 12.05) {
+          bolus(10, depot, 0, 0, 0)
+        }
+      })
+      p <- c(ka = 0.5, cl = 1, v = 10)
+      e <- et(amt = 100, time = 0) |> et(seq(0, 24, by = 1))
+      r <- rxSolve(mod, p, e, method = meth, addDosing = TRUE)
+      pushed <- r[!is.na(r$evid) & r$evid == 1 & r$amt == 10, ]
+      expect_equal(nrow(pushed), 1)
+      expect_equal(pushed$time, 12)
+    })
+  }
+
+  test_that("evid_() pushes are unaffected by dense=TRUE", {
+    # rxode2#1214: a dense segment integrates across every observation between
+    # two key events at once, which cannot honour an event the model decides on
+    # at one of those observations.  dense= is dropped (with a warning) for a
+    # model that pushes, and the solution matches the non-dense one exactly.
+    mod <- rxode2({
+      d/dt(depot) <- -ka * depot
+      d/dt(central) <- ka * depot - cl / v * central
+      cp <- central / v
+      if (t >= 12 && t < 12.5) {
+        bolus(50, depot, 0, 0, 0)
+      }
+    })
+    p <- c(ka = 0.5, cl = 1, v = 10)
+    e <- et(amt = 100, time = 0) |> et(seq(0, 24, by = 1))
+    plain <- rxSolve(mod, p, e, method = "dop853")
+    expect_warning(dens <- rxSolve(mod, p, e, method = "dop853", dense = TRUE),
+                   regexp = "evid_")
+    expect_equal(dens$time, plain$time)
+    expect_equal(dens$depot, plain$depot, tolerance = 1e-5)
+    expect_equal(dens$central, plain$central, tolerance = 1e-5)
+  })
+
+  test_that("evid_() at the final record does not extend the timeline", {
+    # The last record starts no integration interval, so it does not push --
+    # otherwise an unconditional evid_() would append a record that pushes
+    # again, without bound.
+    mod <- rxode2({
+      d/dt(central) <- -cl / vd * central
+      cp <- central / vd
+      if (t >= 5) {
+        bolus(50, central, 0, 0, 0)
+      }
+    })
+    p <- c(cl = 1, vd = 10)
+    e <- et(amt = 100, time = 0) |> et(seq(0, 5, by = 1))
+    r <- rxSolve(mod, p, e, addDosing = TRUE)
+    expect_equal(max(r$time), 5)
+    expect_equal(sum(!is.na(r$evid) & r$evid == 1 & r$amt == 50), 0)
+  })
+
   test_that("past-time evid_() produces a warning", {
     m3 <- rxode2({
       d/dt(x) <- -x


### PR DESCRIPTION
Closes #1214. Closes #1152.

## The bug

`evid_()` -- and its helpers `bolus()`, `infuse()`, `replace()`, `multiply()`,
`reset()`, `phantom()`, `obs()` -- let a model push an event into its own event
timeline while solving. Where that push actually happened depended on which
solver was running, and none of the ODE methods got it right.

The model body fired from `dydt()` at the **start of the next integration
interval**. The time value was right, but the point in the solve loop was not:
the solver had already been asked to integrate from that time to the next
record, so the event was inserted *behind* the integration front.

For #1214's reproducer -- `replace(25, depot)` at `t = 12`, so `depot` at
`t = 13` must be `25 * exp(-0.5) = 15.16327`:

| method | before | after |
|---|---|---|
| `liblsoda` | 25.00000 | 15.16329 |
| `lsoda` | 0.15034 | 15.16329 |
| `dop853` | 25.00000 | 15.16327 |
| `cvode` | 25.00000 | 15.16327 |
| `indLin` | 15.16327 | 15.16327 |

`liblsoda`/`dop853`/`cvode` applied the jump only after integrating past it,
`lsoda` dropped it entirely, and `indLin` -- the one method that fired from
`calc_lhs` at the record -- was already correct.

#1152 is the same root cause seen from the other side. It was reported as
"functional/ui models only", but that turned out to be a red herring: both
model forms normalize to byte-identical model text. `rxSolve()` defaults to
`useLinCmt=TRUE` for a function model, so that one is auto-converted to a
`linCmt()` model and solved by the linCmt driver -- which had **two** firing
points (its internal `dydt(xout)` and a `calc_lhs` pass for the same-time
observation). With `mtime(visit1) <- 24` and 24 also in the sampling grid, both
fired and the bolus was pushed twice:

| | events at 24 | total amt |
|---|---|---|
| ui, `useLinCmt=TRUE` (default) | 2 | 900 |
| ui, `useLinCmt=FALSE` | 1 | 600 |
| classic `rxode2({})` block | 1 | 600 |

So it was never about `ini()`/`model()` -- it was "any model that lands on the
linCmt driver", which the ui path silently opts into.

## The fix

One firing point for every method: `updateSolve()` in `src/par_solve.cpp`, the
static inline all ~100 per-method drivers already call. It runs the model body
once per distinct record time, at the first record of that time, and pushes are
re-sorted into the slot immediately after that record -- so a pushed event is
applied before the solver advances, exactly where the same event written in the
data would sort. `preSolve()` no longer sets `_atEventTime`, which also removes
the extra `dydt()` pre-evaluations `lsoda`/`liblsoda`/`iem`/the implicit bridge
carried to work around the old firing point.

Every method now reproduces the explicit-event solution to 0.0e+00 for
`reset()`, `replace()`, `multiply()` and `bolus(ii, addl)`, including `linCmt()`
and mixed `linCmt` + ODE models.

Along the way:

- A model with an `evid_()` push but no `lhs` variable compiled to an empty
  `calc_lhs()` and never pushed at all -- its body is now emitted (`tb.evid_`).
- The last record does not fire (it starts no integration interval, which is
  where the old path also drew the line); this keeps an unconditional `evid_()`
  self-limiting.
- A state-dependent `mtime()` that reschedules made every driver re-process the
  same slot, firing the body twice and applying the pushed dose twice.
- `ind_dop0_dense()` and `ind_linCmt0H()` cached the loop bound and silently
  dropped a push that extended the timeline.
- `dense=TRUE` is dropped (with a warning) for a pushing model: a dense segment
  integrates across every observation between two key events at once and cannot
  honour an event decided at one of them.
- A model combining `delay()` with a pushed event is now refused. The two are
  incompatible -- `delay()` needs the dense output a push rules out -- and it
  previously returned a silent wrong answer either way (`delay()` evaluating to
  0 for every lookup). Enforced both in `rxSolve()` and in solver setup, so a
  caller not coming through `rxSolve.default()` cannot bypass it.
- `_rxPushDose()` published its six `realloc` results only after all six
  succeeded; a later failure left `ind` pointing at memory `realloc` had already
  freed and the driver loop keeps reading it. Each result is now published as it
  lands.

## Testing

Full suite: **FAIL 2 | PASS 37707**. Both failures are pre-existing and
unrelated -- `test-oom.R`'s mirai daemons load the *installed* rxode2, which
predates this branch's `indLin*` controls. (The `mm` fixture package also fails
to compile on this toolchain; it is reported as a skip.)

`test-evid-push.R` is 464 passing / 0 skipped. New coverage: pushed events
matching the identical data event across every method in `.methods0` (the four
groups that previously encoded the buggy ODE behaviour had their reference
events written a full observation interval late, at `t = 13` for a push made at
`t = 12`, and skipped `indLin` because it was already correct -- both fixed);
`linCmt()` and mixed `linCmt` + ODE models; the #1152 case pinned on both sides
of the `useLinCmt` split; the rescheduled-`mtime()` single fire; the
`dense=TRUE` fallback; the last-record boundary; and the `delay()` refusal on
both entry paths.

## Review

Seven independent review passes (Antigravity/Gemini), which surfaced nine
issues -- the `mtime()` requeue double-fire, the dense-driver truncation, the
`realloc` publication order, an unreachable branch, the `delay()` history kill,
the stranded thread-locals, and the bypassable refusal among them. Two further
regressions were caught by the full suite rather than by review, both predicates
that did not mean what their names suggested: `op->indOwnAlloc` is a formal
`TRUE` default on `rxSolve.default()` rather than "model uses `evid_()`", and
keying the dense guard on it disabled dense output package-wide and broke every
`delay()` model.
