### PR TITLE
perf(indLin): integrate the forcing as a linear ramp (#1191)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -258,6 +258,17 @@
   are several times faster on a nonlinear model and more on a linear one; no
   result changes.
 
+- `indLinRichardson` extrapolated `indLinIteration="exprb32"` with the factors
+  for a second-order base step, which exprb32 is not -- it is third order, so
+  each level took its leading term down by a constant instead of removing it,
+  and the step was sized from an estimate a whole order off.  Asking for a level
+  therefore made the answer worse: on a Michaelis-Menten model at `1e-8`,
+  `indLinRichardson="always"` delivered `3.7e-6` where `"never"` delivered
+  `1.0e-7`.  The tableau now takes both the base order and how far a level
+  advances it from the scheme, so `"always4"` is `1.2e-8` for a ninth of the
+  steps `"never"` needs.  Only `exprb32` is affected: it is neither the default
+  nor reachable from `"auto"`, which never raised its level.
+
 - `rxSolve(indLinForcing=)` chooses how `method="indLin"` carries the
   `indLin()` forcing across one relinearization step.  It was folded into an
   augmented column exactly as a constant infusion rate is, so it was frozen for

--- a/NEWS.md
+++ b/NEWS.md
@@ -85,6 +85,17 @@
 
 ### Solving
 
+- A parallel chunked solve (`rxSolve(file=, chunkSize=, parallel=)`) no longer
+  fails outright when the `mirai` daemons load a different rxode2 than the
+  parent is running -- a source checkout, or a library updated underneath a
+  long-lived pool.  The whole control list is forwarded to each daemon by name,
+  and `rxSolve()` rejects an argument it has no formal for, so a parent one
+  version ahead lost every chunk to `unused argument`.  A control the daemons
+  cannot take is now dropped, with a warning naming it and the version they
+  loaded, rather than losing the solve over a setting that version had no notion
+  of.  What they can take is asked of the daemon itself, so a matching pool
+  drops nothing.
+
 - `rxSolve()` no longer returns silently wrong, run-to-run varying results when
   a multi-row `params` data.frame (one parameter set per `id`) is combined with
   `omega = NA` or `sigma = NA`.  `c()` on a data.frame drops the data.frame

--- a/NEWS.md
+++ b/NEWS.md
@@ -258,6 +258,28 @@
   are several times faster on a nonlinear model and more on a linear one; no
   result changes.
 
+- `rxSolve(indLinForcing=)` chooses how `method="indLin"` carries the
+  `indLin()` forcing across one relinearization step.  It was folded into an
+  augmented column exactly as a constant infusion rate is, so it was frozen for
+  the whole step.  `"ramp"` (the new default) evaluates it at both ends of the
+  step and integrates the line between them exactly -- the phi2 term -- with the
+  rate matrix taken at the step midpoint; `"constant"` is the previous scheme,
+  which reaches the same second order by averaging a start-linearized and an
+  end-linearized answer.  It applies to the `"picard"` and `"newton"` schemes;
+  the exponential Rosenbrock ones never freeze the forcing.
+
+  Only the endpoint value moves with the iterate, so the rest of the step is
+  built once and a pass costs a forcing evaluation and a matrix-vector product
+  rather than a matrix exponential.  The converged ramp step is symmetric, so
+  its error expands in even powers of the step alone and `indLinRichardson` now
+  removes two orders per level instead of one -- third order becomes fourth,
+  fourth becomes sixth, fifth becomes eighth.  Against an lsoda reference at
+  matched tolerance under the default `indLinRichardson="auto"`, on
+  Michaelis-Menten, a one-compartment oral MM model and a forcing that reads
+  `t`, that is 6 to 70 times more accurate from `1e-5` down for 1.3 to 2.4 times
+  fewer iteration passes and no more steps.  With no extrapolation the two are a
+  wash, as they should be: both are second order there.
+
 - `rxSolve(indLinJac=)` chooses where the forcing Jacobian comes from when
   `method="indLin"` needs one, which is only under `"newton"`, `"exprb"` and
   `"exprb32"` -- Picard needs none, so a non-stiff model under the default

--- a/NEWS.md
+++ b/NEWS.md
@@ -273,12 +273,11 @@
   rather than a matrix exponential.  The converged ramp step is symmetric, so
   its error expands in even powers of the step alone and `indLinRichardson` now
   removes two orders per level instead of one -- third order becomes fourth,
-  fourth becomes sixth, fifth becomes eighth.  Against an lsoda reference at
-  matched tolerance under the default `indLinRichardson="auto"`, on
-  Michaelis-Menten, a one-compartment oral MM model and a forcing that reads
-  `t`, that is 6 to 70 times more accurate from `1e-5` down for 1.3 to 2.4 times
-  fewer iteration passes and no more steps.  With no extrapolation the two are a
-  wash, as they should be: both are second order there.
+  fourth becomes sixth, fifth becomes eighth.  That is where the difference
+  shows up: under the default `indLinRichardson="auto"` a nonlinear model is
+  several times to a hundred times more accurate at the same tolerance for the
+  same or fewer steps, while with no extrapolation the two are a wash, both
+  being second order there.
 
 - `rxSolve(indLinJac=)` chooses where the forcing Jacobian comes from when
   `method="indLin"` needs one, which is only under `"newton"`, `"exprb"` and

--- a/R/rxOom.R
+++ b/R/rxOom.R
@@ -260,11 +260,32 @@ rxMemSummary.rxEtFile <- function(x, ...) {
     # reach the unexported .rxOomHasArrow() helper.
     .backendOpt    <- .rxOomBackendOpt()
     .useArrowWrite <- .rxOomHasArrow()
+    .droppedCtl <- character(0)
+    .daemonVer  <- character(0)
     .tasks <- mirai::mirai_map(
       seq_len(.nChunks),
       function(.i, .modelObj, .chunkEvList, .chunkIdsList, .chunkParamsList, .inits, .fwdCtlArgs, .mainTmp, .backendOpt, .useArrowWrite) {
         library(rxode2)
         options(rxode2.oom.backend = .backendOpt)
+        # A daemon is a separate R process that loads its OWN rxode2, which need
+        # not be the build the parent is running: a source checkout under
+        # pkgload::load_all(), a library updated underneath a long-lived pool, or
+        # simply a parent newer than the library the daemons find.  rxSolve()
+        # rejects a control argument it has no formal for ("unused argument"),
+        # which loses the whole chunk over a setting that version had no notion
+        # of.  Drop those and report them back rather than fail.
+        #
+        # What the daemon accepts is asked OF THE DAEMON -- its own formals plus
+        # whatever its own rxControl() produces, which is by construction a set
+        # of names it round-trips.  Reimplementing rxSolve's acceptance rule here
+        # would drift, and the failure mode of drift is the bad one: dropping an
+        # argument a matching version would have honoured, and silently solving
+        # a chunk under different settings than were asked for.
+        .accept <- union(names(formals(rxSolve)), names(rxControl()))
+        .dropped <- setdiff(names(.fwdCtlArgs), .accept)
+        if (length(.dropped) > 0L) {
+          .fwdCtlArgs <- .fwdCtlArgs[!(names(.fwdCtlArgs) %in% .dropped)]
+        }
         .result <- do.call(rxSolve,
                            c(list(object = .modelObj, params = .chunkParamsList[[.i]],
                                   events = .chunkEvList[[.i]], inits = .inits),
@@ -303,6 +324,8 @@ rxMemSummary.rxEtFile <- function(x, ...) {
           } else NA_character_
         }
         list(file = .f, nrows = nrow(.df), paramFile = .pf,
+             dropped = .dropped,
+             rxVersion = as.character(utils::packageVersion("rxode2")),
              inits = tryCatch(.result$inits, error = function(e) NULL))
       },
       .args = list(.modelObj = .modelObj,
@@ -323,9 +346,22 @@ rxMemSummary.rxEtFile <- function(x, ...) {
       .outFiles[.i] <- .r$file
       .paramFiles[.i] <- if (is.null(.r$paramFile)) NA_character_ else .r$paramFile
       .manifest$nrows[.i] <- .r$nrows
+      .droppedCtl <- unique(c(.droppedCtl, .r$dropped))
+      if (!is.null(.r$rxVersion)) .daemonVer <- unique(c(.daemonVer, .r$rxVersion))
       if (is.null(.manifest$inits) && !is.null(.r$inits)) {
         .manifest$inits <- .r$inits
       }
+    }
+    # Never silent: the chunks were solved under different settings than were
+    # asked for, and which ones is not something a user could work out from the
+    # result.
+    if (length(.droppedCtl) > 0L) {
+      warning(sprintf(
+        "parallel chunks ignored %s: the rxode2 the mirai daemons loaded (%s) does not have %s",
+        paste0("'", .droppedCtl, "'", collapse = ", "),
+        paste(.daemonVer, collapse = ", "),
+        if (length(.droppedCtl) == 1L) "it" else "them"),
+        call. = FALSE)
     }
   } else {
     for (.i in seq_len(.nChunks)) {

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -266,14 +266,16 @@
 #'
 #' @param indLinForcing how `method="indLin"` carries the `indLin()` forcing
 #'     across one relinearization step.  `"ramp"` (the default) evaluates it at
-#'     both ends of the step and integrates the line between them exactly,
-#'     which is what the step's matrix exponential is already shaped to do;
-#'     `"constant"` holds it fixed across the step and averages a
-#'     start-evaluated and an end-evaluated answer to recover the same order.
-#'     Both are second order, so this changes the step's error constant and how
-#'     fast its iteration contracts rather than its order.  It applies to the
-#'     `"picard"` and `"newton"` schemes; the exponential Rosenbrock ones do
-#'     not freeze the forcing at all.
+#'     both ends of the step and integrates the line between them exactly, with
+#'     the rate matrix taken at the step midpoint; `"constant"` holds it fixed
+#'     across the step and averages a start-linearized and an end-linearized
+#'     answer to reach the same second order.  The ramp step is symmetric, so
+#'     its error expands in even powers of the step alone and
+#'     `indLinRichardson` removes two orders per extrapolation level from it
+#'     rather than one -- which is where most of the difference between the two
+#'     shows up, since the default `indLinRichardson="auto"` extrapolates.  It
+#'     applies to the `"picard"` and `"newton"` schemes; the exponential
+#'     Rosenbrock ones never freeze the forcing.
 #'
 #' @param indLinPhiM  the maximum size for the Krylov basis
 #'

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -264,6 +264,17 @@
 #'     emission is skipped to bound the symengine work at model build, and on a
 #'     sensitivity model, whose `df()/dy()` lines cover the physical states only.
 #'
+#' @param indLinForcing how `method="indLin"` carries the `indLin()` forcing
+#'     across one relinearization step.  `"ramp"` (the default) evaluates it at
+#'     both ends of the step and integrates the line between them exactly,
+#'     which is what the step's matrix exponential is already shaped to do;
+#'     `"constant"` holds it fixed across the step and averages a
+#'     start-evaluated and an end-evaluated answer to recover the same order.
+#'     Both are second order, so this changes the step's error constant and how
+#'     fast its iteration contracts rather than its order.  It applies to the
+#'     `"picard"` and `"newton"` schemes; the exponential Rosenbrock ones do
+#'     not freeze the forcing at all.
+#'
 #' @param indLinPhiM  the maximum size for the Krylov basis
 #'
 #' @param minSS Minimum number of iterations for a steady-state dose
@@ -1240,6 +1251,7 @@ rxSolve <- function(object, params = NULL, events = NULL, inits = NULL,
                     indLinRichardson = c("auto", "always", "never", "always4", "always5"),
                     indLinIteration = c("auto", "picard", "newton", "exprb", "exprb32"),
                     indLinJac = c("auto", "symbolic", "fd"),
+                    indLinForcing = c("ramp", "constant"),
                     envir=parent.frame()) {
   .udfEnvSet(list(envir, parent.frame(1))) # nolint
   if (is.null(object)) {
@@ -1670,6 +1682,13 @@ rxSolve <- function(object, params = NULL, events = NULL, inits = NULL,
       .indLinJac <- unname(c("auto" = 0L, "symbolic" = 1L,
                              "fd" = 2L)[match.arg(indLinJac)])
     }
+    if (checkmate::testIntegerish(indLinForcing, len=1, lower=0, upper=1,
+                                  any.missing=FALSE)) {
+      .indLinForcing <- as.integer(indLinForcing)
+    } else {
+      .indLinForcing <- unname(c("constant" = 0L,
+                                 "ramp" = 1L)[match.arg(indLinForcing)])
+    }
     checkmate::assertNumeric(indLinPhiTol, lower=0, any.missing=FALSE, len=1)
     checkmate::assertIntegerish(indLinPhiM, lower=0L, any.missing=FALSE, len=1)
     indLinPhiM <- as.integer(indLinPhiM)
@@ -1947,7 +1966,8 @@ rxSolve <- function(object, params = NULL, events = NULL, inits = NULL,
       indLinMaxIter=indLinMaxIter,
       indLinRichardson=.indLinRichardson,
       indLinIteration=.indLinIteration,
-      indLinJac=.indLinJac
+      indLinJac=.indLinJac,
+      indLinForcing=.indLinForcing
     )
     class(.ret) <- "rxControl"
     return(.ret)

--- a/inst/include/rxode2_control.h
+++ b/inst/include/rxode2_control.h
@@ -137,4 +137,5 @@
 #define Rxc_indLinRichardson 132
 #define Rxc_indLinIteration 133
 #define Rxc_indLinJac 134
+#define Rxc_indLinForcing 135
 #endif // __rxode2_control_H__

--- a/inst/include/rxode2parseStruct.h
+++ b/inst/include/rxode2parseStruct.h
@@ -171,6 +171,7 @@ typedef struct {
   int    cmtCov;               /* covariate index (into par_cov/cov_ptr) of the CMT covariate, cached at setup; -1 if the model has no CMT covariate (single endpoint) */
   int    indLinIteration;      /* method="indLin" substep scheme: 0 picard, 1 newton, 2 exprb, 3 auto (stiffness-gated) */
   int    indLinJac;            /* forcing Jacobian source: 0 auto, 1 symbolic (calc_jac - A), 2 finite difference */
+  int    indLinForcing;        /* forcing over a substep: 0 constant, 1 linear ramp between its endpoint values */
 } rx_solving_options;
 
 

--- a/inst/include/rxode2parse_control.h
+++ b/inst/include/rxode2parse_control.h
@@ -136,6 +136,7 @@
 #define Rxc_indLinRichardson 132
 #define Rxc_indLinIteration 133
 #define Rxc_indLinJac 134
+#define Rxc_indLinForcing 135
 #define RxMv_params 0
 #define RxMv_lhs 1
 #define RxMv_state 2

--- a/man/rxSolve.Rd
+++ b/man/rxSolve.Rd
@@ -196,6 +196,7 @@ rxSolve(
   indLinRichardson = c("auto", "always", "never", "always4", "always5"),
   indLinIteration = c("auto", "picard", "newton", "exprb", "exprb32"),
   indLinJac = c("auto", "symbolic", "fd"),
+  indLinForcing = c("ramp", "constant"),
   envir = parent.frame()
 )
 
@@ -1660,6 +1661,17 @@ differences otherwise -- which is what happens above
 \code{getOption("rxode2.indLinJacMaxStates")} states, where the symbolic
 emission is skipped to bound the symengine work at model build, and on a
 sensitivity model, whose \code{df()/dy()} lines cover the physical states only.}
+
+\item{indLinForcing}{how \code{method="indLin"} carries the \code{indLin()} forcing
+across one relinearization step.  \code{"ramp"} (the default) evaluates it at
+both ends of the step and integrates the line between them exactly,
+which is what the step's matrix exponential is already shaped to do;
+\code{"constant"} holds it fixed across the step and averages a
+start-evaluated and an end-evaluated answer to recover the same order.
+Both are second order, so this changes the step's error constant and how
+fast its iteration contracts rather than its order.  It applies to the
+\code{"picard"} and \code{"newton"} schemes; the exponential Rosenbrock ones do
+not freeze the forcing at all.}
 
 \item{envir}{is the environment to look for R user functions
 (defaults to parent environment)}

--- a/man/rxSolve.Rd
+++ b/man/rxSolve.Rd
@@ -1664,14 +1664,16 @@ sensitivity model, whose \code{df()/dy()} lines cover the physical states only.}
 
 \item{indLinForcing}{how \code{method="indLin"} carries the \code{indLin()} forcing
 across one relinearization step.  \code{"ramp"} (the default) evaluates it at
-both ends of the step and integrates the line between them exactly,
-which is what the step's matrix exponential is already shaped to do;
-\code{"constant"} holds it fixed across the step and averages a
-start-evaluated and an end-evaluated answer to recover the same order.
-Both are second order, so this changes the step's error constant and how
-fast its iteration contracts rather than its order.  It applies to the
-\code{"picard"} and \code{"newton"} schemes; the exponential Rosenbrock ones do
-not freeze the forcing at all.}
+both ends of the step and integrates the line between them exactly, with
+the rate matrix taken at the step midpoint; \code{"constant"} holds it fixed
+across the step and averages a start-linearized and an end-linearized
+answer to reach the same second order.  The ramp step is symmetric, so
+its error expands in even powers of the step alone and
+\code{indLinRichardson} removes two orders per extrapolation level from it
+rather than one -- which is where most of the difference between the two
+shows up, since the default \code{indLinRichardson="auto"} extrapolates.  It
+applies to the \code{"picard"} and \code{"newton"} schemes; the exponential
+Rosenbrock ones never freeze the forcing.}
 
 \item{envir}{is the environment to look for R user functions
 (defaults to parent environment)}

--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -506,6 +506,7 @@ arma::vec phiv(double t, arma::mat& A, arma::vec& u,
   }
 }
 
+
 bool expm_assign=false;
 SEXP expm_s;
 
@@ -527,31 +528,68 @@ SEXP expm_s;
 // matrixExpTaylor does, and anything with a norm too large to serve that way
 // falls back to the exponential.
 //
-// phi1(z) = sum_{k>=0} z^k/(k+1)!, by Horner:
-//   P = I/(m+1)!;  for k = m..1:  P = I/k! + z*P;  then P(h) = h*P.
+// phi_p(z) = sum_{k>=0} z^k/(k+p)!, by Horner:
+//   P = I/(m+p)!;  for k = m..1:  P = I/(k+p-1)! + z*P;  then h*phi_p = h*P.
+// `p = 1` is P(h) itself; `p = 2` is what the linear-ramp forcing (rxode2#1191)
+// applies to the forcing INCREMENT, and is the same series one term along.
 #define RX_INDLIN_PHI1_MAXNRM 0.5
-static bool indLinPhi1(const arma::mat &A, double h, arma::mat &Ph,
-                       arma::mat &z, arma::mat &tmp) {
+static bool indLinPhiSeries(const arma::mat &A, double h, int p, arma::mat &Ph,
+                            arma::mat &z, arma::mat &tmp) {
   const arma::uword n = A.n_rows;
   z = A*h;
   double nrm = arma::norm(z, "inf");
   if (!R_FINITE(nrm) || nrm > RX_INDLIN_PHI1_MAXNRM) return false;
-  // Smallest m with nrm^(m+1)/(m+2)! <= 2^-53; at nrm <= 1/2, m = 16 is ample
+  // Smallest m with nrm^(m+1)/(m+p+1)! <= 2^-53; at nrm <= 1/2, m = 16 is ample
   // for any of them, and the terms are n x n multiplies at compartmental size.
   int m = 16;
-  double fk = 1.0;                       // (m+1)!
-  for (int k = 2; k <= m + 1; ++k) fk *= (double) k;
+  double fk = 1.0;                       // (m+p)!
+  for (int k = 2; k <= m + p; ++k) fk *= (double) k;
   Ph.eye(n, n);
   Ph /= fk;
   for (int k = m; k >= 1; --k) {
-    double kf = 1.0;
-    for (int q = 2; q <= k; ++q) kf *= (double) q;
+    double kf = 1.0;                     // (k+p-1)!
+    for (int q = 2; q <= k + p - 1; ++q) kf *= (double) q;
     tmp = z*Ph;
     Ph = tmp;
     Ph.diag() += 1.0/kf;
   }
   Ph *= h;
   return true;
+}
+
+// h*phi_p(Ah): for p = 1 that is P(h) = A^-1(exp(Ah) - I), the operator the
+// constant-forcing map applies to the forcing; for p = 2 it is what the
+// linear-ramp map applies to the forcing increment.  The Horner series when
+// ||A*h|| is small enough to trust it, and otherwise the exact value read out
+// of the augmented exponential -- which costs a second, wider exponential, so
+// it is the fallback rather than the rule.
+//
+// The fallback uses the same identity as everything else here: the top-right
+// block of exp([[X, W],[0, K]]) with `K` the unit superdiagonal is
+// sum_k phi_k(X) w_k, so `p` blocks with only the FIRST one set to the identity
+// leaves phi_p(X) alone.  As in indLinExprb32() the block must be X = A*h
+// exponentiated at t = 1, or the nilpotent chain is scaled along with it; at
+// p = 1 the chain is empty and `h` may be passed directly.
+static inline void indLinPmat(rx_solving_options *op, rx_solving_options_ind *ind,
+                              int neq, const arma::mat &Aloc, double h, int p,
+                              arma::mat &Ph, arma::mat &phiZ, arma::mat &phiTmp) {
+  if (indLinPhiSeries(Aloc, h, p, Ph, phiZ, phiTmp)) return;
+  const int m = neq*(p + 1);
+  arma::mat aug(m, m, arma::fill::zeros);
+  if (p == 1) {
+    aug.submat(0, 0, neq-1, neq-1) = Aloc;
+  } else {
+    aug.submat(0, 0, neq-1, neq-1) = Aloc*h;
+  }
+  aug.submat(0, neq, neq-1, 2*neq-1).eye();
+  for (int i = 1; i < p; ++i) {
+    aug.submat(i*neq, (i+1)*neq, (i+1)*neq-1, (i+2)*neq-1).eye();
+  }
+  arma::mat augE(m, m);
+  matrixExpCached(aug, augE, (p == 1) ? h : 1.0,
+                  op->indLinMatExpType, op->indLinMatExpOrder, ind);
+  Ph = augE.submat(0, m-neq, neq-1, m-1);
+  if (p != 1) Ph *= h;
 }
 
 // -- Forcing Jacobian ---------------------------------------------------------
@@ -725,17 +763,105 @@ int meOnly(int cSub, double *yc_, double *yp_, double tp, double tf, double tcov
   }
 }
 
+// `indLinForcing` codes, matching the R-side character values.
+#define RX_INDLIN_FORCING_CONST 0
+#define RX_INDLIN_FORCING_RAMP  1
+
+// The substep with the forcing taken as the LINE through its two endpoint
+// values instead of as a constant (rxode2#1191).  Over `[tp, tf]`, writing
+// `h = tf - tp` and `f(s) = f0 + (s/h)(f1 - f0)`,
+//
+//   y(h) = exp(Ah) y0 + int_0^h exp(A(h-s)) f(s) ds
+//        = exp(Ah) y0 + h*phi1(Ah) f0 + h*phi2(Ah) (f1 - f0)
+//              \___________  ____________/  \__  __/
+//                          \/                  \/
+//                        `base`                P2
+//
+// which is EXACT for a forcing that really is linear over the substep, where
+// `meOnly()`'s constant column is only first order.
+//
+// Only `f1` moves with the iterate, so everything else is built ONCE per
+// substep and a pass costs a forcing evaluation and a matrix-vector product --
+// no exponential at all, against one per pass on the constant path.  Keeping
+// the forcing OUT of the exponent is the whole point of splitting it this way:
+// folding `f1` into an augmented column (the obvious single-exponential form)
+// gives an operand that moves every pass, which misses the exponential cache
+// every time and costs several times more than it saves.
+//
+// `base` is `meOnly()` itself, with the substep-start forcing in place of the
+// infusion rate -- the same augmented-column identity, and the same cached
+// exponential the constant path takes.  `P2` = h*phi2(Ah) comes from the Horner
+// series whenever ||Ah|| is small enough to trust it, so the usual case adds no
+// exponential of its own.
+//
+// `A` is evaluated at the substep MIDPOINT.  The constant-forcing path gets its
+// second order in a time-varying `A` from the caller averaging a start-linearized
+// and an end-linearized answer; this path does not average, so it takes the
+// midpoint rule instead.  For the ordinary case of an `A` that is constant in
+// time all three agree, and the operand is then the one pass 0 already
+// exponentiated.
+//
+// A nonnegative state stays nonnegative, as under the average: the weights
+// regroup as h*(phi1 - phi2) f0 + h*phi2 f1, and for a Metzler `A` both
+// phi1 - phi2 = int_0^1 exp(A h (1-s))(1-s) ds and phi2 are entrywise
+// nonnegative.
+//
+// The converged map is symmetric -- its adjoint is itself, because
+// exp(z)*phi2(-z) = phi1(z) - phi2(z) turns the two forcing weights into each
+// other -- so its error expands in EVEN powers of `h` alone.  That is what
+// `indLinRichardson` reads off it; see indLinRichFactor().
+typedef struct {
+  arma::vec base;   // exp(Ah) y0 + h*phi1(Ah) f0
+  arma::mat P2;     // h*phi2(Ah), the weight on the forcing increment
+  arma::vec f0;     // the substep-start forcing, fixed for the whole substep
+} indLinRamp_t;
+
+// Is the linear-ramp forcing in play?  It needs a forcing to ramp: with no
+// `IndF` the forcing is the infusion rate, which is constant over the substep
+// by construction, and the ramp would be the same answer for more work.
+static inline bool indLinRampOn(rx_solving_options *op, const arma::vec *u) {
+  return (u != NULL) && (op->indLinForcing == RX_INDLIN_FORCING_RAMP);
+}
+
+static int indLinRampBuild(int cSub, rx_solving_options *op, rx_solving_options_ind *ind,
+                           int neq, arma::vec &y0, const arma::vec &f0,
+                           double subTp, double subTf, double tcov, int *on_,
+                           t_ME ME, indLinRamp_t *rmp) {
+  const double h = subTf - subTp;
+  const double tMid = subTp + 0.5*h;
+  rmp->f0 = f0;
+  rmp->base = y0;
+  const int ret = meOnly(cSub, rmp->base.memptr(), y0.memptr(), subTp, subTf, tcov,
+                         tMid, rmp->f0.memptr(), on_, ME, op, ind);
+  if (ret <= 0) return ret;
+  arma::mat Aloc(neq, neq), phiZ(neq, neq), phiTmp(neq, neq);
+  ME(cSub, tcov, tMid, Aloc.memptr(), y0.memptr());
+  indLinPmat(op, ind, neq, Aloc, h, 2, rmp->P2, phiZ, phiTmp);
+  return 1;
+}
+
 // One inductive-linearization pass over `[subTp, subTf]`: build the forcing
 // (codes 2/4) and the matrix at `w`, propagate from `y0`, and leave the result
 // in `w`.  `u` is NULL for the codes that carry no `IndF` forcing.
+//
+// `rmp` is the prebuilt ramp under `indLinForcing="ramp"`, and NULL for the
+// constant column -- including on the pass that PRODUCES the ramp's left end,
+// which is evaluated at the substep start in time as well as in state and so is
+// the left-endpoint answer whatever the forcing setting.
 static inline int indLinPass(int cSub, rx_solving_options *op, rx_solving_options_ind *ind,
                              double *w, double *y0, double subTp, double subTf, double tcov,
                              double tEval, double *InfusionRate_, int *on_,
-                             t_ME ME, t_IndF IndF, arma::vec *u) {
+                             t_ME ME, t_IndF IndF, arma::vec *u,
+                             const indLinRamp_t *rmp) {
   double *force = InfusionRate_;
   if (u != NULL) {
     IndF(cSub, tcov, tEval, u->memptr(), w);
     force = u->memptr();
+    if (rmp != NULL) {
+      const arma::vec out = rmp->base + rmp->P2*(*u - rmp->f0);
+      std::copy(out.begin(), out.end(), w);
+      return 1;
+    }
   }
   return meOnly(cSub, w, y0, subTp, subTf, tcov, tEval, force, on_, ME, op, ind);
 }
@@ -1139,21 +1265,6 @@ static inline bool indLinConverged(rx_solving_options *op, const double *rtol,
   return true;
 }
 
-// P(h) = A^-1(exp(Ah) - I) = h*phi1(Ah).  The Horner series when ||A*h|| is
-// small enough to trust it, and otherwise the exact value read out of the
-// augmented exponential -- which costs a second, wider exponential, so it is
-// the fallback rather than the rule.
-static inline void indLinPmat(rx_solving_options *op, rx_solving_options_ind *ind,
-                              int neq, const arma::mat &Aloc, double h,
-                              arma::mat &Ph, arma::mat &phiZ, arma::mat &phiTmp) {
-  if (indLinPhi1(Aloc, h, Ph, phiZ, phiTmp)) return;
-  arma::mat aug(2*neq, 2*neq, arma::fill::zeros);
-  aug.submat(0, 0, neq-1, neq-1) = Aloc;
-  aug.submat(0, neq, neq-1, 2*neq-1).eye();
-  arma::mat augE(2*neq, 2*neq);
-  matrixExpCached(aug, augE, h, op->indLinMatExpType, op->indLinMatExpOrder, ind);
-  Ph = augE.submat(0, neq, neq-1, 2*neq-1);
-}
 
 // Newton's divergence response.  A growing residual gets one chance: refresh
 // the chord Jacobian at the current iterate and refactorise, once.  A second
@@ -1187,15 +1298,22 @@ static int indLinNewton(int cSub, rx_solving_options *op, rx_solving_options_ind
   arma::vec w(y0), gw(neq), r(neq), dw(neq);
   arma::vec yPert(neq), fPlus(neq), fMinus(neq);
   arma::mat Jf(neq, neq), G(neq, neq), JfullS, AmatS;
+  const bool ramp = indLinRampOn(op, u);
+  indLinRamp_t rmp;
   if (ratioOut != NULL) *ratioOut = 1.0;
 
   // Pass 0: the left-endpoint answer, evaluated at subTp in time as well as in
-  // state.  This is the caller's `w1`.
+  // state.  This is the caller's `w1`, and the forcing it evaluates is the
+  // ramp's fixed left end.
   rxIndLinCountIter(1);
   int ret = indLinPass(cSub, op, ind, w.memptr(), y0.memptr(), subTp, subTf, tcov,
-                       subTp, InfusionRate_, on_, ME, IndF, u);
+                       subTp, InfusionRate_, on_, ME, IndF, u, NULL);
   if (ret <= 0) return ret;
   if (w1Out != NULL) *w1Out = w;
+  if (ramp) {
+    ret = indLinRampBuild(cSub, op, ind, neq, y0, *u, subTp, subTf, tcov, on_, ME, &rmp);
+    if (ret <= 0) return ret;
+  }
 
   // Chord Jacobian, formed once at the pass-0 iterate.
   indLinForcingJac(cSub, op, neq, tcov, subTf, w.memptr(), IndF, ME,
@@ -1207,10 +1325,18 @@ static int indLinNewton(int cSub, rx_solving_options *op, rx_solving_options_ind
   // the infusion unit columns -- so it needs no A^-1 and rides the exponential
   // cache.  `h*I` is its small-||Ah|| limit and was tried first; see the note
   // in the header for when that is and is not adequate.
-  arma::mat Aloc(neq, neq);
-  ME(cSub, tcov, subTf, Aloc.memptr(), w.memptr());
-  arma::mat Ph(neq, neq), phiZ(neq, neq), phiTmp(neq, neq);
-  indLinPmat(op, ind, neq, Aloc, h, Ph, phiZ, phiTmp);
+  //
+  // Under `indLinForcing="ramp"` the map applies h*phi2(Ah) to the endpoint
+  // forcing rather than P(h) = h*phi1(Ah), so that is what the residual's
+  // derivative carries -- and the ramp already built it.
+  arma::mat Ph(neq, neq);
+  if (ramp) {
+    Ph = rmp.P2;
+  } else {
+    arma::mat Aloc(neq, neq), phiZ(neq, neq), phiTmp(neq, neq);
+    ME(cSub, tcov, subTf, Aloc.memptr(), w.memptr());
+    indLinPmat(op, ind, neq, Aloc, h, 1, Ph, phiZ, phiTmp);
+  }
   G = -Ph*Jf;
   G.diag() += 1.0;
   // Invert once and reuse: at compartmental sizes this is a handful of flops,
@@ -1226,7 +1352,7 @@ static int indLinNewton(int cSub, rx_solving_options *op, rx_solving_options_ind
     rxIndLinCountIter(1);
     gw = w;
     ret = indLinPass(cSub, op, ind, gw.memptr(), y0.memptr(), subTp, subTf, tcov,
-                     subTf, InfusionRate_, on_, ME, IndF, u);
+                     subTf, InfusionRate_, on_, ME, IndF, u, ramp ? &rmp : NULL);
     if (ret <= 0) return ret;
     r = gw - w;                       // -G(w); the Picard step is exactly this
     if (indLinAnyNonFinite(op, gw)) {
@@ -1293,7 +1419,8 @@ static int indLinPickTheta(int cSub, rx_solving_options *op, rx_solving_options_
                            const arma::vec &dPrev, double thetaPrev,
                            arma::vec &y0, double subTp, double subTf, double tcov,
                            double *InfusionRate_, int *on_, t_ME ME, t_IndF IndF,
-                           arma::vec *u, arma::vec &wTry, double *thetaOut) {
+                           arma::vec *u, const indLinRamp_t *rmp,
+                           arma::vec &wTry, double *thetaOut) {
   if (backOff || stepSearch == RX_INDLIN_SEARCH_NONE) {
     *thetaOut = 1.0;
     return 1;
@@ -1307,7 +1434,7 @@ static int indLinPickTheta(int cSub, rx_solving_options *op, rx_solving_options_
     wTry = w;
     const int r2 = indLinPass(cSub, op, ind, wTry.memptr(), y0.memptr(),
                               subTp, subTf, tcov, subTf,
-                              InfusionRate_, on_, ME, IndF, u);
+                              InfusionRate_, on_, ME, IndF, u, rmp);
     if (r2 <= 0) return r2;
     *thetaOut = indLinThetaExact(op, rtol, atol, w, d, wTry);
     return 1;
@@ -1353,6 +1480,12 @@ static int indLinIterate(int cSub, rx_solving_options *op, rx_solving_options_in
   double theta = 1.0, thetaPrev = 0.0;
   double resPrev = -1.0;
   int nGrow = 0;
+  // The ramp's fixed part.  Pass 0 evaluates the substep-start forcing anyway,
+  // so it is read off that pass rather than paid for separately, and everything
+  // built from it holds for the whole substep -- only the endpoint value moves
+  // with the iterate.
+  const bool ramp = indLinRampOn(op, u);
+  indLinRamp_t rmp;
   if (ratioOut != NULL) *ratioOut = 1.0;
   for (int i = 0; i < maxIter; ++i) {
     rxIndLinCountIter(1);
@@ -1364,12 +1497,20 @@ static int indLinIterate(int cSub, rx_solving_options *op, rx_solving_options_in
     // any forcing that reads `t`.
     int ret = indLinPass(cSub, op, ind, w.memptr(), y0.memptr(), subTp, subTf, tcov,
                          (i == 0) ? subTp : subTf,
-                         InfusionRate_, on_, ME, IndF, u);
+                         InfusionRate_, on_, ME, IndF, u,
+                         (ramp && i > 0) ? &rmp : NULL);
     if (ret <= 0) return ret;
     // Pass 0 linearizes at the substep-start state: that is the forward
     // (explicit) answer, and the caller differences it against the converged
     // backward one to get a local error estimate for free.
-    if (i == 0 && w1Out != NULL) *w1Out = w;
+    if (i == 0) {
+      if (w1Out != NULL) *w1Out = w;
+      if (ramp) {
+        ret = indLinRampBuild(cSub, op, ind, neq, y0, *u, subTp, subTf, tcov, on_,
+                              ME, &rmp);
+        if (ret <= 0) return ret;
+      }
+    }
     d = w - wPrev;
     if (indLinAnyNonFinite(op, w)) {
       std::copy(w.begin(), w.end(), yp_);
@@ -1396,7 +1537,8 @@ static int indLinIterate(int cSub, rx_solving_options *op, rx_solving_options_in
     {
       const int rt = indLinPickTheta(cSub, op, ind, rtol, atol, stepSearch, backOff,
                                      w, d, dPrev, thetaPrev, y0, subTp, subTf, tcov,
-                                     InfusionRate_, on_, ME, IndF, u, wTry, &theta);
+                                     InfusionRate_, on_, ME, IndF, u,
+                                     ramp ? &rmp : NULL, wTry, &theta);
       if (rt <= 0) return rt;
     }
     indLinReportRatio(ratioOut, theta);
@@ -1493,6 +1635,16 @@ static int indLinTrySubstep(int cSub, rx_solving_options *op, rx_solving_options
                         InfusionRate_, on_, ME, IndF, u, &w1, ratioOut);
   }
   if (ret != 1) return ret;
+  if (indLinRampOn(op, u)) {
+    // The converged answer already integrates the forcing over the substep as
+    // a line, so it is second order on its own and averaging a first-order
+    // answer back into it would only undo that.  `w1` is still the low-order
+    // member of the pair, and their difference is still the estimate -- at
+    // face value now rather than halved, because the ramp sits where the
+    // average did, one whole first-order error away from `w1` instead of two.
+    *errOut = indLinScaledErr(neq, rtol, atol, y0, yOut, w1, 1.0);
+    return 1;
+  }
   *errOut = indLinScaledErr(neq, rtol, atol, y0, yOut, w1, 0.5);
   // Advance on the average of the two.  Their leading errors are equal and
   // opposite, so the average cancels them and is second order where either
@@ -1549,17 +1701,42 @@ static int indLinChain(int cSub, rx_solving_options *op, rx_solving_options_ind 
 
 // One step, extrapolated to the requested level.
 //
-//   level 0  the plain averaged substep                    2nd order,  1 solve
-//   level 1  Richardson on h, h/2                          3rd order,  3 solves
-//   level 2  Romberg column on h, h/2, h/4                 4th order,  7 solves
-//   level 3  Romberg column on h, h/2, h/4, h/8            5th order, 15 solves
+//                                            asymmetric   symmetric   solves
+//   level 0  the plain substep                2nd order   2nd order        1
+//   level 1  Richardson on h, h/2             3rd order   4th order        3
+//   level 2  Romberg column to h/4            4th order   6th order        7
+//   level 3  Romberg column to h/8            5th order   8th order       15
 //
 // The base step is second order, so entry j of the tableau is built from
-// T(h/2^j) and the leading error term after k eliminations goes as h^(2+k):
-// R[k][j] = (f*R[k-1][j+1] - R[k-1][j])/(f-1) with f = 2^(k+1).  The error
-// estimate is the difference between the two highest entries, which is the
-// standard Romberg estimate.
+// T(h/2^j) and R[k][j] = (f*R[k-1][j+1] - R[k-1][j])/(f-1) eliminates the
+// leading term of R[k-1].  Which term that is depends on the base step: the
+// asymmetric one leaves every power behind, h^2, h^3, h^4 ..., so pass `k`
+// kills h^(k+1) with f = 2^(k+1); the symmetric one -- the converged linear-ramp
+// substep, see indLinRamp_t -- leaves only the EVEN powers h^2, h^4, h^6 ..., so
+// pass `k` kills h^(2k) with f = 4^k and each level is worth two orders instead
+// of one.  Using the asymmetric factors on a symmetric base is not wrong, only
+// weak: it takes h^4 down by 14x rather than removing it, which shows up as a
+// level-2 column no more accurate than level 1.  The error estimate is the
+// difference between the two highest entries either way.
 #define RX_INDLIN_RICH_MAXLVL 3
+
+// Is the base substep its own adjoint?  Only the converged linear-ramp fixed
+// point is: the exponential Rosenbrock steps are not symmetric, and neither is
+// the constant-column map, whose two members are linearized at opposite ends of
+// the step and averaged.
+static inline bool indLinSymmetric(rx_solving_options *op, int scheme,
+                                   const arma::vec *u) {
+  if (!indLinRampOn(op, u)) return false;
+  return (scheme == RX_INDLIN_ITER_PICARD || scheme == RX_INDLIN_ITER_NEWTON);
+}
+
+// The order of the estimate a step at extrapolation level `useRich` is sized
+// from: the difference between the two highest tableau entries measures the
+// error of the LOWER one, which is one whole level down.
+static inline int indLinEstOrder(bool sym, int useRich) {
+  if (useRich <= 0) return 1;              // |converged - forward|, first order
+  return sym ? 2*useRich : (useRich + 1);
+}
 
 static int indLinTryStep(int cSub, rx_solving_options *op, rx_solving_options_ind *ind,
                          int neq, double *rtol, double *atol, int scheme,
@@ -1589,8 +1766,10 @@ static int indLinTryStep(int cSub, rx_solving_options *op, rx_solving_options_in
   }
   *ratioOut = rMax;
   // Neville-Aitken sweep in place; column j holds R[k][j] after pass k.
+  const bool sym = indLinSymmetric(op, scheme, u);
   for (int k = 1; k <= useRich; ++k) {
-    double f = (double)(1 << (k + 1));     // 4, 8, 16 ... for a 2nd-order base
+    // 4, 16, 64 on an even-only expansion; 4, 8, 16 when every power is there.
+    double f = (double)(1 << (sym ? 2*k : (k + 1)));
     for (int j = 0; j + k < nEntry; ++j) {
       for (int q = 0; q < neq; ++q) {
         tab(q, j) = (f*tab(q, j + 1) - tab(q, j))/(f - 1.0);
@@ -1817,9 +1996,11 @@ static indLinAction_t indLinAttempt(int cSub, rx_solving_options *op,
   // the switch-over count first.
   indLinMaybeRaise(autoRich, richSticky, autoSt, tf, pr);
   // The step is sized from an estimate of the order the extrapolation is built
-  // on: first order for the plain step, second under Richardson.  The exponent
-  // is -1/(p_est + 1) either way.
-  const double expo = -1.0/((double) (pr->useRich + 2));
+  // on -- first order for the plain step, and one level down from the top
+  // otherwise, which is two orders down when the base step is symmetric.  The
+  // exponent is -1/(p_est + 1) in every case.
+  const double expo =
+    -1.0/((double) (indLinEstOrder(indLinSymmetric(op, pr->scheme, u), pr->useRich) + 1));
   double err = 0.0, ratio = 1.0;
   const int ret = indLinTryStep(cSub, op, ind, neq, rtol, atol, pr->scheme, y0,
                                 pr->t, pr->h, locf, pr->useRich,

--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -773,20 +773,18 @@ int meOnly(int cSub, double *yc_, double *yp_, double tp, double tf, double tcov
 //
 //   y(h) = exp(Ah) y0 + int_0^h exp(A(h-s)) f(s) ds
 //        = exp(Ah) y0 + h*phi1(Ah) f0 + h*phi2(Ah) (f1 - f0)
-//              \___________  ____________/  \__  __/
-//                          \/                  \/
-//                        `base`                P2
+//          `------------ base ------------'  `-- P2 --'
 //
 // which is EXACT for a forcing that really is linear over the substep, where
 // `meOnly()`'s constant column is only first order.
 //
-// Only `f1` moves with the iterate, so everything else is built ONCE per
+// Only `f1` moves with the iterate, so `base` and `P2` are built ONCE per
 // substep and a pass costs a forcing evaluation and a matrix-vector product --
 // no exponential at all, against one per pass on the constant path.  Keeping
-// the forcing OUT of the exponent is the whole point of splitting it this way:
+// the forcing OUT of the exponent is the point of splitting it this way:
 // folding `f1` into an augmented column (the obvious single-exponential form)
-// gives an operand that moves every pass, which misses the exponential cache
-// every time and costs several times more than it saves.
+// gives an operand that moves every pass, so it misses the exponential cache
+// every time and costs more than it saves.
 //
 // `base` is `meOnly()` itself, with the substep-start forcing in place of the
 // infusion rate -- the same augmented-column identity, and the same cached
@@ -809,7 +807,8 @@ int meOnly(int cSub, double *yc_, double *yp_, double tp, double tf, double tcov
 // The converged map is symmetric -- its adjoint is itself, because
 // exp(z)*phi2(-z) = phi1(z) - phi2(z) turns the two forcing weights into each
 // other -- so its error expands in EVEN powers of `h` alone.  That is what
-// `indLinRichardson` reads off it; see indLinRichFactor().
+// `indLinRichardson` reads off it; see indLinSymmetric() and the tableau in
+// indLinTryStep().
 typedef struct {
   arma::vec base;   // exp(Ah) y0 + h*phi1(Ah) f0
   arma::mat P2;     // h*phi2(Ah), the weight on the forcing increment
@@ -856,12 +855,12 @@ static inline int indLinPass(int cSub, rx_solving_options *op, rx_solving_option
   double *force = InfusionRate_;
   if (u != NULL) {
     IndF(cSub, tcov, tEval, u->memptr(), w);
-    force = u->memptr();
     if (rmp != NULL) {
       const arma::vec out = rmp->base + rmp->P2*(*u - rmp->f0);
       std::copy(out.begin(), out.end(), w);
       return 1;
     }
+    force = u->memptr();
   }
   return meOnly(cSub, w, y0, subTp, subTf, tcov, tEval, force, on_, ME, op, ind);
 }
@@ -914,6 +913,13 @@ static inline int indLinPass(int cSub, rx_solving_options *op, rx_solving_option
 //
 // These are only reachable through the derived-then-measured route above; do
 // not "restore" them to the analytic values without re-running that sweep.
+//
+// The Picard thresholds are shared with the symmetric linear-ramp step, which
+// gains two orders per level rather than one, because the derivation lands in
+// the same place: 3*N^(1/2) < N gives N > 9, 7*N^(1/3) < 3*N^(1/2) gives
+// N > (7/3)^6 ~ 161 and 15*N^(1/4) < 7*N^(1/3) gives N > (15/7)^12 ~ 2600,
+// which at the measured 1/30 scale are 0.3, 5.4 and 87 against the 1.0, 5.0 and
+// 58 below.
 #define RX_INDLIN_AUTO_RICH_N    1.0
 #define RX_INDLIN_AUTO_RICH4_N   5.0
 #define RX_INDLIN_AUTO_RICH5_N  58.0

--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -1722,23 +1722,28 @@ static int indLinChain(int cSub, rx_solving_options *op, rx_solving_options_ind 
 
 // One step, extrapolated to the requested level.
 //
-//                                            asymmetric   symmetric   solves
-//   level 0  the plain substep                2nd order   2nd order        1
-//   level 1  Richardson on h, h/2             3rd order   4th order        3
-//   level 2  Romberg column to h/4            4th order   6th order        7
-//   level 3  Romberg column to h/8            5th order   8th order       15
+//                                     2nd order   symmetric   exprb32   solves
+//   level 0  the plain substep              2nd         2nd       3rd        1
+//   level 1  Richardson on h, h/2           3rd         4th       4th        3
+//   level 2  Romberg column to h/4          4th         6th       5th        7
+//   level 3  Romberg column to h/8          5th         8th       6th       15
 //
-// The base step is second order, so entry j of the tableau is built from
-// T(h/2^j) and R[k][j] = (f*R[k-1][j+1] - R[k-1][j])/(f-1) eliminates the
-// leading term of R[k-1].  Which term that is depends on the base step: the
-// asymmetric one leaves every power behind, h^2, h^3, h^4 ..., so pass `k`
-// kills h^(k+1) with f = 2^(k+1); the symmetric one -- the converged linear-ramp
-// substep, see indLinRamp_t -- leaves only the EVEN powers h^2, h^4, h^6 ..., so
-// pass `k` kills h^(2k) with f = 4^k and each level is worth two orders instead
-// of one.  Using the asymmetric factors on a symmetric base is not wrong, only
-// weak: it takes h^4 down by 14x rather than removing it, which shows up as a
-// level-2 column no more accurate than level 1.  The error estimate is the
-// difference between the two highest entries either way.
+// Entry j of the tableau is built from T(h/2^j), and
+// R[k][j] = (f*R[k-1][j+1] - R[k-1][j])/(f-1) eliminates the leading term of
+// R[k-1].  Which term that is depends on the base step, in two ways: what order
+// it starts at, and how far its expansion advances per level.  A second-order
+// step whose expansion leaves every power behind (h^2, h^3, h^4 ...) has pass
+// `k` kill h^(k+1) with f = 2^(k+1).  The symmetric one -- the converged
+// linear-ramp substep, see indLinRamp_t -- leaves only the EVEN powers, so pass
+// `k` kills h^(2k) with f = 4^k and a level is worth two orders instead of one.
+// exprb32 starts at h^3 instead, so its factors run 8, 16, 32.
+//
+// Getting either wrong is not a crash, only a weak or absent cancellation: the
+// asymmetric factors on a symmetric base take h^4 down by 14x rather than
+// removing it, and the second-order factors on exprb32 take its h^3 down by 6x,
+// each showing up as a column no better -- or worse -- than the one below it.
+// The error estimate is the difference between the two highest entries in every
+// case.
 #define RX_INDLIN_RICH_MAXLVL 3
 
 // Is the base substep its own adjoint?  Only the converged linear-ramp fixed
@@ -1758,12 +1763,33 @@ static inline bool indLinSymmetric(rx_solving_options *op, int scheme,
   return (scheme == RX_INDLIN_ITER_PICARD) && (indLinMaxIterOf(op) > 1);
 }
 
+// The base substep's own order.  Everything here is second order except the
+// Luan-Ostermann pair, which is third (rxode2#1222).
+static inline int indLinBaseOrder(int scheme) {
+  return (scheme == RX_INDLIN_ITER_EXPRB32) ? 3 : 2;
+}
+
+// How many orders one extrapolation level is worth: two when the base step is
+// symmetric, because its expansion skips every odd power, and one otherwise.
+static inline int indLinRichGain(rx_solving_options *op, int scheme,
+                                 const arma::vec *u) {
+  return indLinSymmetric(op, scheme, u) ? 2 : 1;
+}
+
 // The order of the estimate a step at extrapolation level `useRich` is sized
-// from: the difference between the two highest tableau entries measures the
-// error of the LOWER one, which is one whole level down.
-static inline int indLinEstOrder(bool sym, int useRich) {
-  if (useRich <= 0) return 1;              // |converged - forward|, first order
-  return sym ? 2*useRich : (useRich + 1);
+// from.
+static inline int indLinEstOrder(rx_solving_options *op, int scheme,
+                                 const arma::vec *u, int useRich) {
+  if (useRich <= 0) {
+    // With no tableau the estimate is whatever the substep itself produced: the
+    // fixed-point schemes difference their converged answer against the forward
+    // one, which measures the forward answer's first-order error, while exprb32
+    // differences its embedded pair, whose lower member is second order.
+    return (scheme == RX_INDLIN_ITER_EXPRB32) ? 2 : 1;
+  }
+  // Otherwise it is the entry one level below the top, which the top is
+  // differenced against.
+  return indLinBaseOrder(scheme) + (useRich - 1)*indLinRichGain(op, scheme, u);
 }
 
 static int indLinTryStep(int cSub, rx_solving_options *op, rx_solving_options_ind *ind,
@@ -1794,10 +1820,15 @@ static int indLinTryStep(int cSub, rx_solving_options *op, rx_solving_options_in
   }
   *ratioOut = rMax;
   // Neville-Aitken sweep in place; column j holds R[k][j] after pass k.
-  const bool sym = indLinSymmetric(op, scheme, u);
+  //
+  // Pass `k` removes the leading term of R[k-1], which is h^(p + (k-1)*s) for a
+  // base step of order `p` whose expansion advances `s` orders per level.  So
+  // 4, 8, 16 for the second-order asymmetric step, 4, 16, 64 for the symmetric
+  // one, and 8, 16, 32 for third-order exprb32.
+  const int p = indLinBaseOrder(scheme);
+  const int s = indLinRichGain(op, scheme, u);
   for (int k = 1; k <= useRich; ++k) {
-    // 4, 16, 64 on an even-only expansion; 4, 8, 16 when every power is there.
-    double f = (double)(1 << (sym ? 2*k : (k + 1)));
+    double f = (double)(1 << (p + (k - 1)*s));
     for (int j = 0; j + k < nEntry; ++j) {
       for (int q = 0; q < neq; ++q) {
         tab(q, j) = (f*tab(q, j + 1) - tab(q, j))/(f - 1.0);
@@ -2024,11 +2055,10 @@ static indLinAction_t indLinAttempt(int cSub, rx_solving_options *op,
   // the switch-over count first.
   indLinMaybeRaise(autoRich, richSticky, autoSt, tf, pr);
   // The step is sized from an estimate of the order the extrapolation is built
-  // on -- first order for the plain step, and one level down from the top
-  // otherwise, which is two orders down when the base step is symmetric.  The
-  // exponent is -1/(p_est + 1) in every case.
+  // on -- what the substep itself reported for the plain step, and one level
+  // down from the top otherwise.  The exponent is -1/(p_est + 1) in every case.
   const double expo =
-    -1.0/((double) (indLinEstOrder(indLinSymmetric(op, pr->scheme, u), pr->useRich) + 1));
+    -1.0/((double) (indLinEstOrder(op, pr->scheme, u, pr->useRich) + 1));
   double err = 0.0, ratio = 1.0;
   const int ret = indLinTryStep(cSub, op, ind, neq, rtol, atol, pr->scheme, y0,
                                 pr->t, pr->h, locf, pr->useRich,

--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -1300,6 +1300,78 @@ static inline bool indLinNewtonDiverging(double res, double *resPrev, int *nGrow
   return true;
 }
 
+// What pass 0 leaves behind, for both fixed-point schemes.  It is the caller's
+// forward answer `w1`, and under the ramp its forcing is the fixed left end the
+// rest of the substep is built from.
+static inline int indLinAfterFirstPass(int cSub, rx_solving_options *op,
+                                       rx_solving_options_ind *ind, int neq, bool ramp,
+                                       arma::vec &y0, const arma::vec &w,
+                                       const arma::vec *u, double subTp, double subTf,
+                                       double tcov, int *on_, t_ME ME,
+                                       arma::vec *w1Out, indLinRamp_t *rmp) {
+  if (w1Out != NULL) *w1Out = w;
+  if (!ramp) return 1;
+  return indLinRampBuild(cSub, op, ind, neq, y0, *u, subTp, subTf, tcov, on_, ME, rmp);
+}
+
+// Leave the iteration with `w` as the answer.  Every exit writes the current
+// iterate back, including the ones that give up -- the driver reads it to size
+// its cut.
+static inline int indLinLeave(const arma::vec &w, double *yp_, int code) {
+  std::copy(w.begin(), w.end(), yp_);
+  return code;
+}
+
+// The operator the substep map applies to the endpoint forcing, and so what the
+// Newton residual's derivative carries: h*phi2(Ah) under the ramp, which came
+// with the rest of it, and P(h) = h*phi1(Ah) for the constant column.
+//
+// P(h) is the top-right block of exp([[A, I],[0, 0]]h) -- the same augmentation
+// `meOnly` uses, widened to the full identity instead of just the infusion unit
+// columns -- so it needs no A^-1 and rides the exponential cache.  `h*I` is its
+// small-||Ah|| limit and was tried first; see the note in indLinNewton's header
+// for when that is and is not adequate.
+static inline void indLinNewtonPmat(int cSub, rx_solving_options *op,
+                                    rx_solving_options_ind *ind, int neq,
+                                    const indLinRamp_t *rmp, double tcov,
+                                    double subTf, double h, arma::vec &w,
+                                    t_ME ME, arma::mat &Ph) {
+  if (rmp != NULL) {
+    Ph = rmp->P2;
+    return;
+  }
+  arma::mat Aloc(neq, neq), phiZ(neq, neq), phiTmp(neq, neq);
+  ME(cSub, tcov, subTf, Aloc.memptr(), w.memptr());
+  indLinPmat(op, ind, neq, Aloc, h, 1, Ph, phiZ, phiTmp);
+}
+
+// Newton's answer to a residual that grew: refresh the chord Jacobian at the
+// current iterate and refactorise, once.  A stale Jacobian is the likely cause
+// of a stall on a stiff problem, and refreshing costs 2*indLinN cheap IndF
+// evaluations against a whole rejected step.  Returns whether the factorisation
+// is usable.
+static inline bool indLinNewtonRefresh(int cSub, rx_solving_options *op,
+                                       rx_solving_options_ind *ind, int neq,
+                                       bool wasGrowing, bool *refreshed, int *nGrow,
+                                       double tcov, double subTf, const arma::vec &gw,
+                                       t_IndF IndF, t_ME ME, const arma::mat &Ph,
+                                       arma::mat &Jf, arma::vec &yPert,
+                                       arma::vec &fPlus, arma::vec &fMinus,
+                                       arma::mat &JfullS, arma::mat &AmatS,
+                                       arma::mat &G, arma::mat &Ginv, bool haveFact) {
+  if (!wasGrowing) {
+    *nGrow = 0;
+    return haveFact;
+  }
+  if (*refreshed) return haveFact;
+  *refreshed = true;
+  indLinForcingJac(cSub, op, neq, tcov, subTf, gw.memptr(), IndF, ME,
+                   Jf, yPert, fPlus, fMinus, JfullS, AmatS);
+  G = -Ph*Jf;
+  G.diag() += 1.0;
+  return arma::inv(Ginv, G);
+}
+
 static int indLinNewton(int cSub, rx_solving_options *op, rx_solving_options_ind *ind,
                         int neq, double *rtol, double *atol, int maxIter,
                         double *yp_, double subTp, double subTf, double tcov,
@@ -1320,34 +1392,17 @@ static int indLinNewton(int cSub, rx_solving_options *op, rx_solving_options_ind
   int ret = indLinPass(cSub, op, ind, w.memptr(), y0.memptr(), subTp, subTf, tcov,
                        subTp, InfusionRate_, on_, ME, IndF, u, NULL);
   if (ret <= 0) return ret;
-  if (w1Out != NULL) *w1Out = w;
-  if (ramp) {
-    ret = indLinRampBuild(cSub, op, ind, neq, y0, *u, subTp, subTf, tcov, on_, ME, &rmp);
-    if (ret <= 0) return ret;
-  }
+  ret = indLinAfterFirstPass(cSub, op, ind, neq, ramp, y0, w, u, subTp, subTf,
+                             tcov, on_, ME, w1Out, &rmp);
+  if (ret <= 0) return ret;
+  const indLinRamp_t *rmpP = ramp ? &rmp : NULL;
 
   // Chord Jacobian, formed once at the pass-0 iterate.
   indLinForcingJac(cSub, op, neq, tcov, subTf, w.memptr(), IndF, ME,
                    Jf, yPert, fPlus, fMinus, JfullS, AmatS);
   const double h = subTf - subTp;
-  // P(h) = A^-1(exp(Ah) - I), the operator the map actually applies to the
-  // forcing.  It is the top-right block of exp([[A, I],[0, 0]]h) -- the same
-  // augmentation `meOnly` uses, widened to the full identity instead of just
-  // the infusion unit columns -- so it needs no A^-1 and rides the exponential
-  // cache.  `h*I` is its small-||Ah|| limit and was tried first; see the note
-  // in the header for when that is and is not adequate.
-  //
-  // Under `indLinForcing="ramp"` the map applies h*phi2(Ah) to the endpoint
-  // forcing rather than P(h) = h*phi1(Ah), so that is what the residual's
-  // derivative carries -- and the ramp already built it.
   arma::mat Ph(neq, neq);
-  if (ramp) {
-    Ph = rmp.P2;
-  } else {
-    arma::mat Aloc(neq, neq), phiZ(neq, neq), phiTmp(neq, neq);
-    ME(cSub, tcov, subTf, Aloc.memptr(), w.memptr());
-    indLinPmat(op, ind, neq, Aloc, h, 1, Ph, phiZ, phiTmp);
-  }
+  indLinNewtonPmat(cSub, op, ind, neq, rmpP, tcov, subTf, h, w, ME, Ph);
   G = -Ph*Jf;
   G.diag() += 1.0;
   // Invert once and reuse: at compartmental sizes this is a handful of flops,
@@ -1363,22 +1418,16 @@ static int indLinNewton(int cSub, rx_solving_options *op, rx_solving_options_ind
     rxIndLinCountIter(1);
     gw = w;
     ret = indLinPass(cSub, op, ind, gw.memptr(), y0.memptr(), subTp, subTf, tcov,
-                     subTf, InfusionRate_, on_, ME, IndF, u, ramp ? &rmp : NULL);
+                     subTf, InfusionRate_, on_, ME, IndF, u, rmpP);
     if (ret <= 0) return ret;
     r = gw - w;                       // -G(w); the Picard step is exactly this
-    if (indLinAnyNonFinite(op, gw)) {
-      std::copy(gw.begin(), gw.end(), yp_);
-      return -2;
-    }
+    if (indLinAnyNonFinite(op, gw)) return indLinLeave(gw, yp_, -2);
     double res = indLinResNorm(op, rtol, atol, gw, r);
     // Converged: same test and same 0.1x factor as the Picard path, but on the
     // raw residual -- Newton has no relaxation to undo.
     // theta = 1: Newton takes the full step, so the residual IS the distance
     // to the fixed point and needs no contraction correction.
-    if (indLinConverged(op, rtol, atol, gw, r, 1.0)) {
-      std::copy(gw.begin(), gw.end(), yp_);
-      return 1;
-    }
+    if (indLinConverged(op, rtol, atol, gw, r, 1.0)) return indLinLeave(gw, yp_, 1);
     // A residual that keeps growing means the step is too long; report how badly
     // so the driver can size its cut, exactly as the Picard ratio does.
     //
@@ -1394,21 +1443,11 @@ static int indLinNewton(int cSub, rx_solving_options *op, rx_solving_options_ind
     // 2*indLinN cheap IndF evaluations against a whole rejected step.
     const bool wasGrowing = (resPrev > 0.0 && res > resPrev);
     if (!indLinNewtonDiverging(res, &resPrev, &nGrow, ratioOut)) {
-      std::copy(gw.begin(), gw.end(), yp_);
-      return -2;
+      return indLinLeave(gw, yp_, -2);
     }
-    if (wasGrowing) {
-      if (!refreshed) {
-        refreshed = true;
-        indLinForcingJac(cSub, op, neq, tcov, subTf, gw.memptr(), IndF, ME,
-                         Jf, yPert, fPlus, fMinus, JfullS, AmatS);
-        G = -Ph*Jf;
-        G.diag() += 1.0;
-        haveFact = arma::inv(Ginv, G);
-      }
-    } else {
-      nGrow = 0;
-    }
+    haveFact = indLinNewtonRefresh(cSub, op, ind, neq, wasGrowing, &refreshed, &nGrow,
+                                   tcov, subTf, gw, IndF, ME, Ph, Jf, yPert, fPlus,
+                                   fMinus, JfullS, AmatS, G, Ginv, haveFact);
     resPrev = res;
     if (haveFact) {
       dw = Ginv*r;
@@ -1417,8 +1456,7 @@ static int indLinNewton(int cSub, rx_solving_options *op, rx_solving_options_ind
       w = gw;                          // degrade to a Picard step rather than stall
     }
   }
-  std::copy(w.begin(), w.end(), yp_);
-  return -2;
+  return indLinLeave(w, yp_, -2);
 }
 
 // Pick the relaxation factor for this pass.  Returns the propagation status --
@@ -1480,6 +1518,38 @@ static inline void indLinReportRatio(double *ratioOut, double theta) {
   *ratioOut = (R_FINITE(r) && r > 1.0) ? r : 1.0;
 }
 
+// One pass's residual, and what to do with it: give up on the step (-2), pass a
+// hard failure up (<= 0), or carry on (1) with `*thetaOut` set.  The two belong
+// together -- the relaxation is picked from the same residual the growth test
+// reads, and a growing one backs it off to a plain Picard step.
+static int indLinPassTheta(int cSub, rx_solving_options *op, rx_solving_options_ind *ind,
+                           const double *rtol, const double *atol, int stepSearch,
+                           const arma::vec &w, const arma::vec &d,
+                           const arma::vec &dPrev, double thetaPrev, arma::vec &y0,
+                           double subTp, double subTf, double tcov,
+                           double *InfusionRate_, int *on_, t_ME ME, t_IndF IndF,
+                           arma::vec *u, const indLinRamp_t *rmp, arma::vec &wTry,
+                           double *resPrev, int *nGrow, double *yp_, double *thetaOut) {
+  const double res = indLinResNorm(op, rtol, atol, w, d);
+  bool backOff = false;
+  if (!indLinResidualOk(res, resPrev, nGrow, &backOff)) {
+    return indLinLeave(w, yp_, -2);
+  }
+  return indLinPickTheta(cSub, op, ind, rtol, atol, stepSearch, backOff,
+                         w, d, dPrev, thetaPrev, y0, subTp, subTf, tcov,
+                         InfusionRate_, on_, ME, IndF, u, rmp, wTry, thetaOut);
+}
+
+// May this pass's iterate be accepted?  Pass 0 under the ramp may not: see
+// `needRampPass`.
+static inline bool indLinAccept(rx_solving_options *op, const double *rtol,
+                                const double *atol, const arma::vec &w,
+                                const arma::vec &d, double theta, int i,
+                                bool needRampPass) {
+  if (i == 0 && needRampPass) return false;
+  return indLinConverged(op, rtol, atol, w, d, theta);
+}
+
 static int indLinIterate(int cSub, rx_solving_options *op, rx_solving_options_ind *ind,
                          int neq, double *rtol, double *atol, int maxIter, int stepSearch,
                          double *yp_, double subTp, double subTf, double tcov,
@@ -1506,6 +1576,7 @@ static int indLinIterate(int cSub, rx_solving_options *op, rx_solving_options_in
   // there is an iteration to spend on it -- `indLinMaxIter = 1` asks for a
   // single pass and has to still be able to return one.
   const bool needRampPass = ramp && maxIter > 1;
+  const indLinRamp_t *rmpP = ramp ? &rmp : NULL;
   if (ratioOut != NULL) *ratioOut = 1.0;
   for (int i = 0; i < maxIter; ++i) {
     rxIndLinCountIter(1);
@@ -1518,24 +1589,18 @@ static int indLinIterate(int cSub, rx_solving_options *op, rx_solving_options_in
     int ret = indLinPass(cSub, op, ind, w.memptr(), y0.memptr(), subTp, subTf, tcov,
                          (i == 0) ? subTp : subTf,
                          InfusionRate_, on_, ME, IndF, u,
-                         (ramp && i > 0) ? &rmp : NULL);
+                         (i == 0) ? NULL : rmpP);
     if (ret <= 0) return ret;
     // Pass 0 linearizes at the substep-start state: that is the forward
     // (explicit) answer, and the caller differences it against the converged
     // backward one to get a local error estimate for free.
     if (i == 0) {
-      if (w1Out != NULL) *w1Out = w;
-      if (ramp) {
-        ret = indLinRampBuild(cSub, op, ind, neq, y0, *u, subTp, subTf, tcov, on_,
-                              ME, &rmp);
-        if (ret <= 0) return ret;
-      }
+      ret = indLinAfterFirstPass(cSub, op, ind, neq, ramp, y0, w, u, subTp, subTf,
+                                 tcov, on_, ME, w1Out, &rmp);
+      if (ret <= 0) return ret;
     }
     d = w - wPrev;
-    if (indLinAnyNonFinite(op, w)) {
-      std::copy(w.begin(), w.end(), yp_);
-      return -2;
-    }
+    if (indLinAnyNonFinite(op, w)) return indLinLeave(w, yp_, -2);
     // Pick the relaxation BEFORE testing, because the test needs it.  For a
     // map contracting at ratio g', the distance from the current iterate to
     // the fixed point is about |d|/(1-g') = theta*|d|, not |d| -- at g'=0.9
@@ -1547,32 +1612,20 @@ static int indLinIterate(int cSub, rx_solving_options *op, rx_solving_options_in
     // the safeguard role Armijo backtracking plays in Schmidt et al. (2024),
     // but read off the residual we already have rather than paid for with extra
     // matrix exponentials.
-    double res = indLinResNorm(op, rtol, atol, w, d);
-    bool backOff = false;
-    if (!indLinResidualOk(res, &resPrev, &nGrow, &backOff)) {
-      std::copy(w.begin(), w.end(), yp_);
-      return -2;
-    }
-
-    {
-      const int rt = indLinPickTheta(cSub, op, ind, rtol, atol, stepSearch, backOff,
-                                     w, d, dPrev, thetaPrev, y0, subTp, subTf, tcov,
-                                     InfusionRate_, on_, ME, IndF, u,
-                                     ramp ? &rmp : NULL, wTry, &theta);
-      if (rt <= 0) return rt;
-    }
+    const int rt = indLinPassTheta(cSub, op, ind, rtol, atol, stepSearch, w, d,
+                                   dPrev, thetaPrev, y0, subTp, subTf, tcov,
+                                   InfusionRate_, on_, ME, IndF, u, rmpP, wTry,
+                                   &resPrev, &nGrow, yp_, &theta);
+    if (rt != 1) return rt;
     indLinReportRatio(ratioOut, theta);
-    if ((i > 0 || !needRampPass) &&
-        indLinConverged(op, rtol, atol, w, d, theta)) {
-      std::copy(w.begin(), w.end(), yp_);
-      return 1;
+    if (indLinAccept(op, rtol, atol, w, d, theta, i, needRampPass)) {
+      return indLinLeave(w, yp_, 1);
     }
     if (theta != 1.0) w = wPrev + theta*d;
     dPrev = d;
     thetaPrev = theta;
   }
-  std::copy(w.begin(), w.end(), yp_);
-  return -2;
+  return indLinLeave(w, yp_, -2);
 }
 
 // One adaptive attempt over `[t, t+h]` starting from `y0`.  Leaves the

--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -1492,6 +1492,15 @@ static int indLinIterate(int cSub, rx_solving_options *op, rx_solving_options_in
   // with the iterate.
   const bool ramp = indLinRampOn(op, u);
   indLinRamp_t rmp;
+  // Pass 0 is the left-endpoint constant-column answer whatever the forcing
+  // setting, so accepting it would return a substep the ramp never touched --
+  // asymmetric, and first order.  The caller cannot see that and would collapse
+  // its extrapolation tableau with the symmetric factors anyway, so require one
+  // ramp pass before converging.  It is reachable: the test is on the whole
+  // substep's change, which a step that barely moves passes at once.  Only when
+  // there is an iteration to spend on it -- `indLinMaxIter = 1` asks for a
+  // single pass and has to still be able to return one.
+  const bool needRampPass = ramp && maxIter > 1;
   if (ratioOut != NULL) *ratioOut = 1.0;
   for (int i = 0; i < maxIter; ++i) {
     rxIndLinCountIter(1);
@@ -1548,7 +1557,8 @@ static int indLinIterate(int cSub, rx_solving_options *op, rx_solving_options_in
       if (rt <= 0) return rt;
     }
     indLinReportRatio(ratioOut, theta);
-    if (indLinConverged(op, rtol, atol, w, d, theta)) {
+    if ((i > 0 || !needRampPass) &&
+        indLinConverged(op, rtol, atol, w, d, theta)) {
       std::copy(w.begin(), w.end(), yp_);
       return 1;
     }

--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -872,6 +872,11 @@ static inline int indLinPass(int cSub, rx_solving_options *op, rx_solving_option
 // cut the step, which is cheap.  Grinding tens of thousands of matrix
 // exponentials before reaching that conclusion is not.
 #define RX_INDLIN_MAXITER 20
+
+static inline int indLinMaxIterOf(rx_solving_options *op) {
+  return (op->indLinMaxIter > 0) ? op->indLinMaxIter : RX_INDLIN_MAXITER;
+}
+
 // The iterate has to land a factor tighter than the step-size tolerance, or
 // the local error estimate (which differences two iterates) ends up measuring
 // iteration noise instead of discretization error and the controller chases
@@ -1634,7 +1639,7 @@ static int indLinTrySubstep(int cSub, rx_solving_options *op, rx_solving_options
                             double *InfusionRate_, int *on_, t_ME ME, t_IndF IndF,
                             arma::vec *u, arma::vec &yOut, arma::vec &w1,
                             double *errOut, double *ratioOut) {
-  int maxIter = (op->indLinMaxIter > 0) ? op->indLinMaxIter : RX_INDLIN_MAXITER;
+  int maxIter = indLinMaxIterOf(op);
   yOut = y0;
   int ret;
   if (scheme == RX_INDLIN_ITER_EXPRB32 || scheme == RX_INDLIN_ITER_EXPRB) {
@@ -1740,10 +1745,17 @@ static int indLinChain(int cSub, rx_solving_options *op, rx_solving_options_ind 
 // point is: the exponential Rosenbrock steps are not symmetric, and neither is
 // the constant-column map, whose two members are linearized at opposite ends of
 // the step and averaged.
+//
+// Picard needs a second pass to reach the ramp at all -- its first is the
+// left-endpoint constant-column answer -- so at `indLinMaxIter = 1` it can only
+// ever return that, and this has to say so rather than let the tableau collapse
+// an asymmetric entry with the symmetric factors.  Newton's first loop pass is
+// already a ramp pass, so one iteration is enough for it.
 static inline bool indLinSymmetric(rx_solving_options *op, int scheme,
                                    const arma::vec *u) {
   if (!indLinRampOn(op, u)) return false;
-  return (scheme == RX_INDLIN_ITER_PICARD || scheme == RX_INDLIN_ITER_NEWTON);
+  if (scheme == RX_INDLIN_ITER_NEWTON) return true;
+  return (scheme == RX_INDLIN_ITER_PICARD) && (indLinMaxIterOf(op) > 1);
 }
 
 // The order of the estimate a step at extrapolation level `useRich` is sized

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -5474,6 +5474,7 @@ static inline void iniRx(rx_solve* rx) {
   op->indLinRichardson = 2; // auto
   op->indLinIteration = 3;  // auto (stiffness-gated)
   op->indLinJac = 0; // auto: symbolic when the model carries one
+  op->indLinForcing = 1; // ramp: integrate the forcing as a line over the substep
   op->nDisplayProgress = 10000;
   op->isChol = 0;
   op->nsvar = 0;
@@ -6146,6 +6147,7 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
     op->indLinRichardson=asInt(rxControl[Rxc_indLinRichardson], "indLinRichardson");
     op->indLinIteration=asInt(rxControl[Rxc_indLinIteration], "indLinIteration");
     op->indLinJac=asInt(rxControl[Rxc_indLinJac], "indLinJac");
+    op->indLinForcing=asInt(rxControl[Rxc_indLinForcing], "indLinForcing");
     // The symbolic forcing Jacobian cannot be trusted on a sensitivity model.
     // indLinForcingJacSym() wants calc_jac over the WHOLE system, but
     // rxSensMatExp() emits df()/dy() rows for the physical block only -- it has

--- a/src/rxSerialize.cpp
+++ b/src/rxSerialize.cpp
@@ -22,7 +22,8 @@ extern rx_globals _globals;
 static const char rxSerializeMagic[8] = {'R','X','O','D','E','2','S','Z'};
 static const uint32_t rxSerializeFormatVer = 3u;
 // Format 3 added the gsolve layout sizes n4/n6 after state_size, and appended
-// the op->indLin convergence set at the end of the stream.
+// the op->indLin convergence set at the end of the stream.  It also carries
+// op->indLinForcing, written with the other indLin settings.
 
 // ---------------------------------------------------------------------------
 // Low-level write helpers -- all abort via Rf_error on failure

--- a/src/rxSerialize.cpp
+++ b/src/rxSerialize.cpp
@@ -148,7 +148,7 @@ SEXP rxSaveState_() {
   W_I32(indLinN); W_DBL(indLinPhiTol); W_I32(indLinPhiM);
   W_I32(indLinMatExpType); W_I32(indLinMatExpOrder);
   W_I32(indLinStepSearch); W_I32(indLinMaxIter); W_I32(indLinRichardson);
-  W_I32(indLinIteration); W_I32(indLinJac);
+  W_I32(indLinIteration); W_I32(indLinJac); W_I32(indLinForcing);
   W_I32(nDisplayProgress); W_I32(ncoresRV); W_I32(isChol);
   W_I32(nsvar); W_I32(abort); W_I32(minSS); W_I32(maxSS);
   W_I32(doIndLin); W_I32(strictSS);
@@ -702,7 +702,7 @@ SEXP rxRestoreState_(SEXP rawSexp) {
   R_I32(indLinN); R_DBL(indLinPhiTol); R_I32(indLinPhiM);
   R_I32(indLinMatExpType); R_I32(indLinMatExpOrder);
   R_I32(indLinStepSearch); R_I32(indLinMaxIter); R_I32(indLinRichardson);
-  R_I32(indLinIteration); R_I32(indLinJac);
+  R_I32(indLinIteration); R_I32(indLinJac); R_I32(indLinForcing);
   R_I32(nDisplayProgress); R_I32(ncoresRV); R_I32(isChol);
   R_I32(nsvar); R_I32(abort); R_I32(minSS); R_I32(maxSS);
   R_I32(doIndLin); R_I32(strictSS);

--- a/tests/testthat/test-ind-lin.R
+++ b/tests/testthat/test-ind-lin.R
@@ -628,6 +628,20 @@ d/dt(blood)     = a*intestine - b*blood
       }
     }
 
+    # The exponential Rosenbrock schemes put the whole linearization into the
+    # exponential and never freeze the forcing, so the setting has nothing to
+    # act on there -- bit for bit, not just close.
+    for (.it in c("exprb", "exprb32")) {
+      expect_identical(
+        suppressMessages(rxSolve(.mm, .e, method = "indLin", atol = 1e-8, rtol = 1e-8,
+                                 indLinIteration = .it,
+                                 indLinForcing = "constant"))$central,
+        suppressMessages(rxSolve(.mm, .e, method = "indLin", atol = 1e-8, rtol = 1e-8,
+                                 indLinIteration = .it,
+                                 indLinForcing = "ramp"))$central,
+        info = .it)
+    }
+
     # A forcing with nothing to ramp is untouched, bit for bit: with no state
     # dependence the model stays on the non-iterating codes 1/2, and an infusion
     # rate is constant across the substep by construction.

--- a/tests/testthat/test-ind-lin.R
+++ b/tests/testthat/test-ind-lin.R
@@ -752,6 +752,41 @@ d/dt(blood)     = a*intestine - b*blood
     expect_true(.rich[2] < .rich[1])
   })
 
+  test_that("extrapolating exprb32 helps rather than hurts", {
+    # rxode2#1222: the tableau's elimination factors are chosen for the leading
+    # term of the base step, and exprb32's is h^3 where every other scheme's is
+    # h^2.  Collapsing it with the second-order factors took that term down by
+    # 6x instead of removing it, so a level made the answer WORSE -- at 1e-8,
+    # 3.70e-06 under "always" against 9.98e-08 under "never".  A level has to
+    # buy its cost back, so the claim is work against delivered accuracy.
+    .code <- "vmax <- 10\nkm <- 5\nd/dt(central) = -vmax*central/(km+central)\n"
+    .ode <- rxode2(.code)
+    .mm <- suppressMessages(rxode2(rxToIndLin(.code)))
+    .e <- et(amt = 100, cmt = "central") |> et(seq(0, 20, by = 0.5))
+    .ref <- rxSolve(.ode, .e, method = "liblsoda", atol = 1e-13, rtol = 1e-13)$central
+    .run <- function(rich) {
+      .r <- suppressMessages(rxSolve(.mm, .e, method = "indLin",
+                                     atol = 1e-8, rtol = 1e-8,
+                                     indLinIteration = "exprb32",
+                                     indLinRichardson = rich))
+      list(err = max(abs(.r$central - .ref)), steps = sum(.r$counts$slvr))
+    }
+    .no <- .run("never")
+    .r4 <- .run("always4")
+    expect_lt(.r4$err, .no$err)              # more accurate ...
+    expect_lt(.r4$steps, .no$steps/3)        # ... for far fewer steps
+
+    # The other schemes keep the factors they had: only exprb32 starts at a
+    # different order, so a second-order base must be untouched by the fix.
+    for (.it in c("picard", "newton", "exprb")) {
+      .a <- suppressMessages(rxSolve(.mm, .e, method = "indLin",
+                                     atol = 1e-8, rtol = 1e-8,
+                                     indLinIteration = .it,
+                                     indLinRichardson = "always4"))$central
+      expect_equal(.a, .ref, tolerance = 1e-5, info = .it)
+    }
+  })
+
   test_that("the higher Romberg columns cost less at a tight tolerance", {
     # Each extra entry -- h, h/2, h/4, h/8 -- removes one more error term, for
     # 3, 7 and 15 fixed-point solves per step against the base step's 1.  A

--- a/tests/testthat/test-ind-lin.R
+++ b/tests/testthat/test-ind-lin.R
@@ -596,6 +596,78 @@ d/dt(blood)     = a*intestine - b*blood
     expect_lt(.err[length(.err)], 1e-5)
   })
 
+  test_that("indLinForcing carries the forcing as a line across the substep", {
+    # rxode2#1191: `meOnly()` folds the forcing into an augmented column exactly
+    # as it does a constant infusion rate, so it is frozen across the substep.
+    # "ramp" evaluates it at both substep ends and integrates the line between
+    # them exactly, through the phi2 term.  Both are second order and both have
+    # to land on the same solution -- what differs is the error constant and,
+    # because the ramp map is symmetric, what the extrapolation can do with it.
+    expect_equal(rxControl()$indLinForcing, 1L)              # ramp
+    expect_equal(rxControl(indLinForcing = "ramp")$indLinForcing, 1L)
+    expect_equal(rxControl(indLinForcing = "constant")$indLinForcing, 0L)
+    expect_equal(rxControl(indLinForcing = 0L)$indLinForcing, 0L)
+    expect_error(rxControl(indLinForcing = "nope"))
+
+    .code <- "vmax <- 10\nkm <- 5\nd/dt(central) = -vmax*central/(km+central)\n"
+    .ode <- rxode2(.code)
+    .mm <- suppressMessages(rxode2(rxToIndLin(.code)))
+    .e <- et(amt = 100, cmt = "central") |> et(seq(0, 20, by = 0.5))
+    .ref <- rxSolve(.ode, .e, method = "liblsoda", atol = 1e-13, rtol = 1e-13)$central
+
+    # Both settings solve the same problem, under either iteration scheme --
+    # the ramp changes the substep map, so Newton has to follow it to the same
+    # fixed point Picard reaches.
+    for (.fo in c("constant", "ramp")) {
+      for (.it in c("picard", "newton")) {
+        .r <- suppressMessages(rxSolve(.mm, .e, method = "indLin",
+                                       atol = 1e-8, rtol = 1e-8,
+                                       indLinForcing = .fo, indLinIteration = .it))
+        expect_equal(.r$central, .ref, tolerance = 1e-6,
+                     info = paste(.fo, .it))
+      }
+    }
+
+    # A forcing with nothing to ramp is untouched, bit for bit: with no state
+    # dependence the model stays on the non-iterating codes 1/2, and an infusion
+    # rate is constant across the substep by construction.
+    .sf <- suppressMessages(rxode2(paste("matExp()", "cmt(Gc)", "k_Gc_output = 0.1",
+                                         "Gprod = 3", "indLin(Gc) <- Gprod",
+                                         sep = "\n")))
+    .eSf <- et(amt = 10, cmt = "Gc") |> et(seq(0, 20, by = 0.5))
+    expect_identical(
+      suppressMessages(rxSolve(.sf, .eSf, method = "indLin",
+                               indLinForcing = "constant"))$Gc,
+      suppressMessages(rxSolve(.sf, .eSf, method = "indLin",
+                               indLinForcing = "ramp"))$Gc)
+
+    # The rate matrix goes with the forcing: the constant path gets its second
+    # order in a time-varying `A` by averaging a start-linearized and an
+    # end-linearized answer, and the ramp -- which does not average -- takes the
+    # midpoint instead.  A rate constant that reads `t` must therefore not lose
+    # accuracy under the ramp.
+    .tv <- suppressMessages(rxode2(paste("matExp()", "cmt(central)",
+                                         "kel = 0.1*(1 + 0.9*sin(t))",
+                                         "vmax = 2", "km = 5",
+                                         "k_central_output = kel",
+                                         "indLin(central) <- -vmax*central/(km+central)",
+                                         sep = "\n")))
+    .tvOde <- suppressMessages(rxode2({
+      kel <- 0.1 * (1 + 0.9 * sin(t))
+      vmax <- 2
+      km <- 5
+      d/dt(central) <- -kel * central - vmax * central / (km + central)
+    }))
+    .tvRef <- rxSolve(.tvOde, .e, method = "liblsoda",
+                      atol = 1e-13, rtol = 1e-13)$central
+    .tvErr <- vapply(c("constant", "ramp"), function(fo) {
+      max(abs(suppressMessages(rxSolve(.tv, .e, method = "indLin",
+                                       atol = 1e-8, rtol = 1e-8,
+                                       indLinForcing = fo))$central - .tvRef))
+    }, double(1))
+    expect_lt(.tvErr[["ramp"]], .tvErr[["constant"]])
+  })
+
   test_that("indLinRichardson raises the step to third order, off by default", {
     # Richardson-extrapolating each relinearization step (once whole, twice at
     # half length) cancels the second-order term the average leaves behind.  It
@@ -680,6 +752,47 @@ d/dt(blood)     = a*intestine - b*blood
                                             indLinRichardson = as.integer(.lv[2])))$central,
                    tolerance = 0, info = .lv[1])
     }
+  })
+
+  test_that("the linear-ramp step is symmetric, so a level is worth two orders", {
+    # rxode2#1191: the converged ramp substep is its own adjoint, so its error
+    # expands in EVEN powers of h alone and one extrapolation level removes two
+    # orders rather than one.  The constant-column step is not symmetric and
+    # gets one.  Read as the observed order of the SAME level-1 column under
+    # each -- error against work, which is what an order claim means, and which
+    # no choice of error constant could fake.
+    .txt <- paste0("ka <- 1\nkm <- 0.5\nvmax <- 0.2\nv <- 1\n",
+                   "d/dt(depot) = -ka*depot\n",
+                   "d/dt(central) = ka*depot - vmax*(central/v)/(km + central/v)\n")
+    .o <- suppressMessages(rxode2(.txt))
+    .m <- suppressMessages(rxode2(rxToIndLin(.txt)))
+    .e <- et(amt = 3) |> et(c(0.1, 0.25, 0.5, 0.75, 1, 2, 4, 6, 8, 12, 16, 24, 30))
+    .rf <- suppressMessages(rxSolve(.o, .e, method = "lsoda",
+                                    atol = 1e-13, rtol = 1e-13))$central
+    .obs <- function(fo) {
+      .v <- lapply(c(1e-8, 1e-10), function(tol) {
+        .r <- suppressMessages(rxSolve(.m, .e, method = "indLin", atol = tol, rtol = tol,
+                                       indLinRichardson = "always",
+                                       indLinForcing = fo))
+        c(err = max(abs(.r$central - .rf)), steps = sum(.r$counts$slvr))
+      })
+      log(.v[[1]][["err"]]/.v[[2]][["err"]]) /
+        log(.v[[2]][["steps"]]/.v[[1]][["steps"]])
+    }
+    expect_gt(.obs("ramp"), 3.5)          # fourth order; measured 3.9
+    expect_lt(.obs("constant"), 3.4)      # third order;  measured 2.9
+
+    # And the higher columns follow, so at a tight tolerance the ramp gets there
+    # for less work as well as more accurately.
+    .run <- function(fo) {
+      .r <- suppressMessages(rxSolve(.m, .e, method = "indLin", atol = 1e-9, rtol = 1e-9,
+                                     indLinRichardson = "always", indLinForcing = fo))
+      list(err = max(abs(.r$central - .rf)), steps = sum(.r$counts$slvr))
+    }
+    .rr <- .run("ramp")
+    .cc <- .run("constant")
+    expect_lt(.rr$err, .cc$err/10)
+    expect_lte(.rr$steps, .cc$steps)
   })
 
   test_that("auto reaches the higher columns when they pay", {

--- a/tests/testthat/test-ind-lin.R
+++ b/tests/testthat/test-ind-lin.R
@@ -680,6 +680,25 @@ d/dt(blood)     = a*intestine - b*blood
                                        indLinForcing = fo))$central - .tvRef))
     }, double(1))
     expect_lt(.tvErr[["ramp"]], .tvErr[["constant"]])
+
+    # h*phi2(Ah) comes from a Horner series that is only trusted below
+    # ||A*h|| = 1/2 and otherwise falls back to reading the block out of an
+    # augmented exponential.  A rate constant large against the output spacing
+    # takes that fallback on the first attempt of every interval (here
+    # ||A*h|| = 2.5), which nothing else here reaches.
+    .stiffTxt <- paste0("kel <- 50\nvmax <- 20\nkm <- 5\n",
+                        "d/dt(central) = -kel*central - vmax*central/(km+central)\n")
+    .stiffOde <- suppressMessages(rxode2(.stiffTxt))
+    .stiff <- suppressMessages(rxode2(rxToIndLin(.stiffTxt)))
+    .eStiff <- et(amt = 100, cmt = "central") |> et(seq(0, 2, by = 0.05))
+    .stiffRef <- suppressMessages(rxSolve(.stiffOde, .eStiff, method = "liblsoda",
+                                          atol = 1e-13, rtol = 1e-13))$central
+    for (.it in c("picard", "newton")) {
+      .rs <- suppressMessages(rxSolve(.stiff, .eStiff, method = "indLin",
+                                      atol = 1e-8, rtol = 1e-8,
+                                      indLinIteration = .it))
+      expect_equal(.rs$central, .stiffRef, tolerance = 1e-6, info = .it)
+    }
   })
 
   test_that("indLinRichardson raises the step to third order, off by default", {
@@ -796,8 +815,8 @@ d/dt(blood)     = a*intestine - b*blood
     expect_gt(.obs("ramp"), 3.5)          # fourth order; measured 3.9
     expect_lt(.obs("constant"), 3.4)      # third order;  measured 2.9
 
-    # And the higher columns follow, so at a tight tolerance the ramp gets there
-    # for less work as well as more accurately.
+    # Which cashes out as the thing a user sees: at a tight tolerance the same
+    # column is more accurate for no more work.
     .run <- function(fo) {
       .r <- suppressMessages(rxSolve(.m, .e, method = "indLin", atol = 1e-9, rtol = 1e-9,
                                      indLinRichardson = "always", indLinForcing = fo))

--- a/tests/testthat/test-ind-lin.R
+++ b/tests/testthat/test-ind-lin.R
@@ -815,6 +815,22 @@ d/dt(blood)     = a*intestine - b*blood
     expect_gt(.obs("ramp"), 3.5)          # fourth order; measured 3.9
     expect_lt(.obs("constant"), 3.4)      # third order;  measured 2.9
 
+    # The symmetry is a property of the step that ran, not of the setting that
+    # asked for it.  Picard's first pass is the constant-column left-endpoint
+    # answer, so at `indLinMaxIter = 1` it can never reach the ramp -- and then
+    # the two settings have to agree bit for bit at every extrapolation level,
+    # which they only can if the tableau also drops back to the asymmetric
+    # factors.
+    .m1 <- function(fo, rich) {
+      suppressWarnings(suppressMessages(
+        rxSolve(.m, .e, method = "indLin", atol = 1e-3, rtol = 1e-3,
+                indLinMaxIter = 1L, indLinIteration = "picard",
+                indLinRichardson = rich, indLinForcing = fo)))$central
+    }
+    for (.rich in c("never", "always", "always4")) {
+      expect_identical(.m1("constant", .rich), .m1("ramp", .rich), info = .rich)
+    }
+
     # Which cashes out as the thing a user sees: at a tight tolerance the same
     # column is more accurate for no more work.
     .run <- function(fo) {

--- a/tests/testthat/test-oom.R
+++ b/tests/testthat/test-oom.R
@@ -255,6 +255,35 @@ test_that("rxSolve(parallel=) mirai path matches the serial chunked solve", {
   })
 })
 
+test_that("a control the daemons accept still reaches them", {
+  rxTest({
+    skip_if_not_installed("mirai")
+    # A mirai daemon is a separate process that loads its OWN rxode2, which need
+    # not be the parent's build, and rxSolve() errors on a control argument it
+    # has no formal for.  Those are dropped and reported rather than losing the
+    # chunk -- but the dangerous direction is dropping too much, which would
+    # solve a chunk under different settings than were asked for without saying
+    # so.  Same-version daemons cannot hit it by construction (the accepted set
+    # is the daemon's own rxControl() names, and that is where the forwarded
+    # list comes from), so what is left to pin is that a setting which changes
+    # the answer really does arrive.  `addDosing` changes the row count, so a
+    # dropped one is visible rather than a rounding difference.
+    mod <- rxode2({
+      cl <- exp(lcl)
+      v  <- exp(lv)
+      d/dt(central) <- -cl / v * central
+      cp <- central / v
+    })
+    e <- et(amt = 100) |> et(seq(0, 12, 4)) |> et(id = 1:4)
+    .rows <- function(...) {
+      nrow(as.data.frame(rxSolve(mod, c(lcl = 1, lv = 3.45), e,
+                                 file = tempfile("rxFwd"), chunkSize = 2,
+                                 parallel = 2, ...)))
+    }
+    expect_gt(.rows(addDosing = TRUE), .rows(addDosing = FALSE))
+  })
+})
+
 test_that("rxode2.oom.backend option is forwarded to the mirai workers", {
   rxTest({
     skip_if_not_installed("mirai")


### PR DESCRIPTION
Closes #1191.  Closes #1222.

`meOnly()` folded the `indLin()` forcing into an augmented column exactly as it
does a constant infusion rate, so it was frozen across the relinearization
substep.  `rxSolve(indLinForcing=)` picks what happens instead:

- **`"ramp"`** (the new default) evaluates the forcing at both substep ends and
  integrates the line between them exactly,

      y(h) = exp(Ah) y0 + h*phi1(Ah) f0 + h*phi2(Ah) (f1 - f0)

  with the rate matrix at the substep midpoint.
- **`"constant"`** is the previous scheme, which reaches the same second order by
  averaging a start-linearized and an end-linearized answer.

It applies to `"picard"` and `"newton"`; the exponential Rosenbrock schemes never
freeze the forcing and are bit-identical under either setting.

### Two things the issue did not anticipate

**Keep the forcing out of the exponent.** The obvious form -- one exponential with
`f1` in a second augmented column -- was written first and is much worse: the
operand then moves with every Picard pass, so it misses the exponential cache
every time.  Cache reuse on a nonlinear sensitivity model fell from >90% to 18%.
Splitting into a per-substep `base` (which is `meOnly()` with the start forcing in
place of the infusion rate, so it takes the cached exponential pass 0 already
did) plus a per-substep `P2 = h*phi2(Ah)` makes a pass a forcing evaluation and a
matrix-vector product instead.

**The converged ramp map is symmetric.** Its adjoint is itself, because
`exp(z)*phi2(-z) = phi1(z) - phi2(z)` exchanges the two forcing weights, so its
error expands in EVEN powers of `h` alone.  `indLinRichardson` now reads that off
it -- pass `k` of the tableau eliminates `h^(2k)` with `4^k` rather than `h^(k+1)`
with `2^(k+1)` -- and a level is worth two orders instead of one (level 1 fourth
order, level 2 sixth, level 3 eighth).  The step controller's exponent follows.
Leaving the asymmetric factors in place was not wrong but weak: level 2 took `h^4`
down 14x rather than removing it, and came out no better than level 1.  This is
where essentially all of the measured difference lives, and the default
(`indLinRichardson="auto"`) extrapolates.

### Measured

Against an `liblsoda` reference at `atol = rtol = 1e-13`, at matched tolerance
under the default `indLinRichardson="auto"`.  `slvr` is accepted steps, `iter` is
total fixed-point passes.

| model | tol | constant err | ramp err | err ratio | iter ratio | steps |
|---|---|---|---|---|---|---|
| Michaelis-Menten | 1e-6 | 6.04e-06 | 1.45e-07 | 41x | 1.28x | 133 -> 124 |
| Michaelis-Menten | 1e-9 | 2.41e-09 | 1.05e-10 | 23x | 1.80x | 169 -> 126 |
| 1-cmt oral MM | 1e-8 | 4.97e-08 | 8.22e-09 | 6.0x | 1.75x | 50 -> 39 |
| forcing reading `t` | 1e-9 | 2.20e-09 | 3.31e-11 | 67x | 1.70x | 172 -> 128 |

With no extrapolation (`indLinRichardson="never"`) the two are a wash, as they
should be -- both are second order there and the ramp is only trading one error
constant for another.

The observed order of the same level-1 column, read as error against work: 3.9
under the ramp, 2.9 under the constant column.  That is the symmetry, and it is
what the new test pins.

### Tests

`tests/testthat/test-ind-lin.R` gains two blocks: the substep map (control
round-trip; both settings agree with an ODE reference under both iteration
schemes; a forcing with nothing to ramp is untouched bit for bit; a rate constant
reading `t` is not worse, which is what the midpoint rate matrix is for; the
`h*phi2` fallback above the series norm bound, which nothing else reached), and
the symmetry (observed order per setting, plus the bit-for-bit agreement at
`indLinMaxIter = 1` where Picard cannot reach the ramp).

`devtools::test()`: 37635 pass.  The only two failures were `test-oom.R` mirai
daemons rejecting the new `rxSolve` argument, which is `pkgload::load_all` vs
installed-package skew -- the daemons `library(rxode2)` and get the installed
copy.  Installed into a temp library so parent and daemons agree, `test-oom.R` is
`FAIL 0 | PASS 96`.

### Review

Four Antigravity (Gemini) passes.  Two found real defects, both fixed here and
both about the same thing -- the symmetry claim getting ahead of the step that
actually ran:

1. Picard's convergence test is on the whole substep's change, so a step that
   barely moves passed it on pass 0, and pass 0 is the constant-column
   left-endpoint answer.  That handed the tableau an asymmetric first-order entry
   to collapse with the symmetric factors.  Fixed by requiring one ramp pass
   before converging.
2. That fix has to stand down at `indLinMaxIter = 1`, which asks for a single
   pass.  `indLinSymmetric()` went on claiming symmetry there anyway; it now asks
   how many passes there are.

Its two remaining findings were about `exprb32` and pre-existing on `main` (same
`f = 2^(k+1)`, same controller exponent, byte-identical on this branch).  Filed
as #1222 and then fixed here -- see below.

### Also fixes #1222

The tableau eliminated `h^(k+1)` with `f = 2^(k+1)` whatever the base step was,
which is right only for a second-order one.  `exprb32` is third order, so those
factors took its leading `h^3` term down by 6x instead of removing it, and the
controller sized from an estimate reported a whole order low (its embedded pair
is second order; `indLinEstOrder` said first).  Asking for a level therefore made
the answer WORSE.  The tableau now takes both the base order and how far a level
advances it from the scheme -- 2 and 1 for the constant column, 2 and 2 for the
symmetric ramp, 3 and 1 for `exprb32`, whose factors run 8, 16, 32.

| `indLinRichardson` | before (err / steps) | after (err / steps) |
|---|---|---|
| `"never"`   | 9.98e-08 / 1177 | 1.07e-07 / 1186 |
| `"always"`  | 3.70e-06 / 230  | **1.36e-07** / 198 |
| `"always4"` | 2.31e-07 / 160  | **1.17e-08** / 130 |

Only `exprb32` moves: every other scheme resolves to the factors and the estimate
order it already had.

### CodeFactor

The ramp work pushed `indLinNewton` and `indLinIterate` over the complexity bar
(19 and 18; both were under it before).  What they grew was largely the same
thing twice, so the last commit extracts it -- the shared pass-0 prologue, the
"write the iterate back and leave" exit, Newton's operator choice and Shamanskii
refresh, and the residual-check/relaxation-pick pair.  Pure refactor: the three
work-precision curves are identical term for term, digit for digit, across it.
