### PR TITLE
fix(events): re-pair tied modeled rate/duration doses after the sort

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -85,6 +85,25 @@
 
 ### Solving
 
+- Modeled duration (`rate = -2`) and modeled rate (`rate = -1`) doses that fall
+  at exactly the same time now solve.  Each such dose is expanded into a
+  start/stop pair sharing one time and the solver pairs the two positionally, but
+  the event sort keys on the compartment-bearing `evid`, so tied doses
+  interleaved (`start2 start1 stop2 stop1`) and the solve failed with data errors
+  686/886 (or 797/997 for a modeled rate) -- even for doses into different
+  compartments, which is a legal data set.  `etTrans()` now re-pairs each start
+  with its own stop after the sort, matching on compartment and infusion type;
+  the pass only runs when the data set has a modeled rate/duration dose and it
+  leaves already-correct records in place.  The four data-error messages now say
+  what the problem is instead of only naming a number (#1218).
+
+- Fixed an out-of-bounds read of the extra-dose pool while advancing to the
+  first extra dose at or after the current step.  The index was bounds checked
+  before it was incremented rather than after, so a subject whose extra doses all
+  precede the step -- reachable with tied modeled duration steady state doses --
+  read one element past the end and then dereferenced it as a record index,
+  corrupting the heap.
+
 - `rxSolve()` no longer returns silently wrong, run-to-run varying results when
   a multi-row `params` data.frame (one parameter set per `id`) is combined with
   `omega = NA` or `sigma = NA`.  `c()` on a data.frame drops the data.frame

--- a/inst/include/rxode2EventTranslate.h
+++ b/inst/include/rxode2EventTranslate.h
@@ -17,6 +17,66 @@ typedef struct {
   int    isDose[2];    /* 1 if this event contributes an idose entry */
 } rx_translated_event;
 
+// EVID = 0; Observations
+// EVID = 1; is illegal, but converted from NONMEM
+// EVID = 2; Non-observation, possibly covariate
+// EVID = 3; Reset ODE states to zero; Non-observation event
+// EVID = 4; Reset and then dose event;  Illegal
+// EVID = 9; Non-observation event to ini system at time zero; This is to set the INIs at the correct place.
+// EVID = 10-99; mtime events (from ODE system)
+// When EVID > 100
+// EVID: ## # ## ##
+//       c2 I c1 xx
+// c2 = Compartment numbers over 100
+//  I = Infusion Flag/ Special event flag
+#define EVIDF_NORMAL 0
+
+#define EVIDF_INF_RATE 1
+#define EVIDF_INF_DUR  2
+
+#define EVIDF_REPLACE  4
+#define EVIDF_MULT     5
+
+#define EVIDF_MODEL_DUR_ON   8
+#define EVIDF_MODEL_DUR_OFF  6
+
+#define EVIDF_MODEL_RATE_ON  9
+#define EVIDF_MODEL_RATE_OFF 7
+//      0 = no Infusion
+//      1 = Infusion, AMT=rate (mg/hr for instance)
+//      2 = Infusion, duration is fixed
+//      4 = Replacement event
+//      5 = Multiplication event
+//      6 = Turn off modeled duration
+//      7 = Turn off modeled rate compartment
+//      8 = Duration is modeled, AMT=dose; Rate = AMT/(Modeled Duration) NONMEM RATE=-2
+//      9 = Rate is modeled, AMT=dose; Duration = AMT/(Modeled Rate) NONMEM RATE=-1
+// c1 = Compartment numbers below 99
+// xx =  1, regular event (no lag time)
+// xx =  2, An infusion/rate event that doesn't look for start/end of infusion AND does not apply lags
+// xx =  8, possibly turn off steady state infusion with lag time (needed in case spans dur)
+// xx =  9, steady state event SS=1 with lag time
+// xx = 10, steady state event SS=1 (no lag)
+// xx = 19, steady state event at dose time (SS=2) with lag
+// xx = 20, steady state event + last observed info (not lagged)
+// xx = 21, steady state event at dose time (with absorption lag) + last observed info
+// xx = 30, Turn off compartment
+// xx = 40, Steady state constant infusion
+// xx = 50, Phantom event, used for transit compartments
+// xx = 60, Dose that does not track as a dose turn on system
+// Steady state events need a II data item > 0
+#define EVID0_REGULAR  1
+#define EVID0_RATEADJ 2
+#define EVID0_INFRM 8
+#define EVID0_SS0 9
+#define EVID0_SS 10
+#define EVID0_SS20 19
+#define EVID0_SS2 20
+#define EVID0_OFF 30
+#define EVID0_SSINF 40
+#define EVID0_PHANTOM 50
+#define EVID0_ONDOSE 60
+
 static inline void getWh(int evid, int *wh, int *cmt, int *wh100, int *whI, int *wh0) {
   *wh = evid;
   *cmt = 0;

--- a/inst/include/rxode2parseHandleEvid.h
+++ b/inst/include/rxode2parseHandleEvid.h
@@ -31,65 +31,7 @@ extern "C" {
 }
 #endif
 
-// EVID = 0; Observations
-// EVID = 1; is illegal, but converted from NONMEM
-// EVID = 2; Non-observation, possibly covariate
-// EVID = 3; Reset ODE states to zero; Non-observation event
-// EVID = 4; Reset and then dose event;  Illegal
-// EVID = 9; Non-observation event to ini system at time zero; This is to set the INIs at the correct place.
-// EVID = 10-99; mtime events (from ODE system)
-// When EVID > 100
-// EVID: ## # ## ##
-//       c2 I c1 xx
-// c2 = Compartment numbers over 100
-//  I = Infusion Flag/ Special event flag
-#define EVIDF_NORMAL 0
-
-#define EVIDF_INF_RATE 1
-#define EVIDF_INF_DUR  2
-
-#define EVIDF_REPLACE  4
-#define EVIDF_MULT     5
-
-#define EVIDF_MODEL_DUR_ON   8
-#define EVIDF_MODEL_DUR_OFF  6
-
-#define EVIDF_MODEL_RATE_ON  9
-#define EVIDF_MODEL_RATE_OFF 7
-//      0 = no Infusion
-//      1 = Infusion, AMT=rate (mg/hr for instance)
-//      2 = Infusion, duration is fixed
-//      4 = Replacement event
-//      5 = Multiplication event
-//      6 = Turn off modeled duration
-//      7 = Turn off modeled rate compartment
-//      8 = Duration is modeled, AMT=dose; Rate = AMT/(Modeled Duration) NONMEM RATE=-2
-//      9 = Rate is modeled, AMT=dose; Duration = AMT/(Modeled Rate) NONMEM RATE=-1
-// c1 = Compartment numbers below 99
-// xx =  1, regular event (no lag time)
-// xx =  2, An infusion/rate event that doesn't look for start/end of infusion AND does not apply lags
-// xx =  8, possibly turn off steady state infusion with lag time (needed in case spans dur)
-// xx =  9, steady state event SS=1 with lag time
-// xx = 10, steady state event SS=1 (no lag)
-// xx = 19, steady state event at dose time (SS=2) with lag
-// xx = 20, steady state event + last observed info (not lagged)
-// xx = 21, steady state event at dose time (with absorption lag) + last observed info
-// xx = 30, Turn off compartment
-// xx = 40, Steady state constant infusion
-// xx = 50, Phantom event, used for transit compartments
-// xx = 60, Dose that does not track as a dose turn on system
-// Steady state events need a II data item > 0
-#define EVID0_REGULAR  1
-#define EVID0_RATEADJ 2
-#define EVID0_INFRM 8
-#define EVID0_SS0 9
-#define EVID0_SS 10
-#define EVID0_SS20 19
-#define EVID0_SS2 20
-#define EVID0_OFF 30
-#define EVID0_SSINF 40
-#define EVID0_PHANTOM 50
-#define EVID0_ONDOSE 60
+// The EVIDF_*/EVID0_* evid flags live in rxode2EventTranslate.h (included above)
 
 static inline double getDoseNumber(rx_solving_options_ind *ind, int i) {
   return getDose(ind, ind->idose[i]);

--- a/src/etTran.cpp
+++ b/src/etTran.cpp
@@ -804,6 +804,101 @@ LogicalVector cmtSupportsOff_(IntegerVector cmt, List mv) {
   return ret;
 }
 
+// Classify a record for modeled rate (RATE=-1) / modeled duration (RATE=-2)
+// start/stop pairing.  Returns +1/+2 for a duration/rate start, -1/-2 for the
+// matching stop and 0 for anything else; `cmt` is the 0-based compartment.
+// The starts getTime__() skips the pairing for are excluded: flg 9/19 pair
+// through the lagged flg=1 record that follows, and flg 40 (steady state
+// constant infusion) has no stop record at all.
+static inline int etTransModeledPairType(int evid, int *cmt) {
+  int wh, eCmt, wh100, whI, wh0;
+  getWh(evid, &wh, &eCmt, &wh100, &whI, &wh0);
+  *cmt = eCmt;
+  int unpaired = (wh0 == EVID0_SS0 || wh0 == EVID0_SS20 || wh0 == EVID0_SSINF);
+  switch (whI) {
+  case EVIDF_MODEL_DUR_ON:
+    return unpaired ? 0 : 1;
+  case EVIDF_MODEL_RATE_ON:
+    return unpaired ? 0 : 2;
+  case EVIDF_MODEL_DUR_OFF:
+    return -1;
+  case EVIDF_MODEL_RATE_OFF:
+    return -2;
+  }
+  return 0;
+}
+
+// Modeled rate/duration doses are emitted as a start record immediately
+// followed by its stop record sharing one time; the solver pairs the two
+// positionally (handleTurnOn/OffModeled*() in rxode2parseGetTime.h).  The
+// final sort keys on (id, time, evid) and the compartment is encoded in the
+// evid, so several such doses tied at a single time interleave (start2 start1
+// stop2 stop1) and the positional pairing breaks -- see issue #1218.  Walk
+// each tied (id, time) block and put every stop back after its start, matching
+// on compartment and infusion type.  Blocks that are already correct keep
+// their order, so this only moves records the solver could not have used.
+static void etTransPairModeledRateDur(std::vector<int>& idxOutput,
+                                      const std::vector<int>& id,
+                                      const std::vector<double>& time,
+                                      const std::vector<int>& evid,
+                                      const CharacterVector& idLvl) {
+  int n = (int)idxOutput.size();
+  std::vector<int> block;
+  std::vector<int> type;
+  std::vector<int> bCmt;
+  std::vector<int> mate;
+  std::vector<bool> claimed;
+  std::string orphanWarn;
+  int i = 0;
+  while (i < n) {
+    int curId = id[idxOutput[i]];
+    double curTime = time[idxOutput[i]];
+    int j = i + 1;
+    while (j < n && id[idxOutput[j]] == curId && time[idxOutput[j]] == curTime) j++;
+    int len = j - i;
+    if (len > 1) {
+      block.assign(idxOutput.begin() + i, idxOutput.begin() + j);
+      type.resize(len);
+      bCmt.resize(len);
+      int nModeled = 0;
+      for (int k = 0; k < len; ++k) {
+        type[k] = etTransModeledPairType(evid[block[k]], &bCmt[k]);
+        if (type[k] != 0) nModeled++;
+      }
+      if (nModeled > 1) {
+        mate.assign(len, -1);
+        claimed.assign(len, false);
+        for (int k = 0; k < len; ++k) {
+          if (type[k] <= 0) continue;
+          for (int m = k + 1; m < len; ++m) {
+            if (claimed[m] || type[m] != -type[k] || bCmt[m] != bCmt[k]) continue;
+            mate[k] = m;
+            claimed[m] = true;
+            break;
+          }
+          if (mate[k] == -1) {
+            orphanWarn += " (id: " + as<std::string>(idLvl[curId-1]) +
+              ", time: " + std::to_string(curTime) +
+              ", cmt: " + std::to_string(bCmt[k]+1) + ")";
+          }
+        }
+        int pos = i;
+        for (int k = 0; k < len; ++k) {
+          if (claimed[k]) continue; // emitted next to its start
+          idxOutput[pos++] = block[k];
+          if (mate[k] != -1) idxOutput[pos++] = block[mate[k]];
+        }
+      }
+    }
+    i = j;
+  }
+  if (!orphanWarn.empty()) {
+    Rf_warningcall(R_NilValue, "%s%s",
+                   _("modeled 'rate'/'dur' dose without a matching infusion end record:"),
+                   orphanWarn.c_str());
+  }
+}
+
 List rxModelVars_(const RObject &obj); // model variables section
 //' Event translation for rxode2
 //'
@@ -1531,6 +1626,7 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
   int nid=0;
   int cmt = 0;
   int rateI = 0;
+  bool hasModeledRateDur = false; // any RATE=-1/-2 dose (needs start/stop re-pairing after the sort)
   int cmt100; //= amt[i]/100;
   int cmt99;  //= amt[i]-amt100*100;
   int cevid;
@@ -2114,8 +2210,10 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
     if (cevid != -1){
       if (rateI == 9){
         nevid = cmt100*100000+70001+cmt99*100;
+        hasModeledRateDur = true;
       } else if (rateI == 8) {
         nevid = cmt100*100000+60001+cmt99*100;
+        hasModeledRateDur = true;
       }
       id.push_back(cid);
       evid.push_back(cevid);
@@ -2615,6 +2713,10 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
   idxOutput = as<std::vector<int>>(ord);
   while (idxOutput.size() > 0 && IntegerVector::is_na(ivId[idxOutput.back()])) {
     idxOutput.pop_back();
+  }
+  if (hasModeledRateDur) {
+    // only needed when RATE=-1/-2 is present; see issue #1218
+    etTransPairModeledRateDur(idxOutput, id, time, evid, idLvl);
   }
   if (hasIcov) {
     ordI = order1(inIdCov);

--- a/src/etTran.cpp
+++ b/src/etTran.cpp
@@ -837,65 +837,86 @@ static inline int etTransModeledPairType(int evid, int *cmt) {
 // each tied (id, time) block and put every stop back after its start, matching
 // on compartment and infusion type.  Blocks that are already correct keep
 // their order, so this only moves records the solver could not have used.
+// scratch buffers reused across blocks
+typedef struct {
+  std::vector<int> block;   // record indexes of the current block
+  std::vector<int> type;    // etTransModeledPairType() of each
+  std::vector<int> bCmt;    // compartment of each
+  std::vector<int> mate;    // index of the stop each start pairs with, or -1
+  std::vector<bool> claimed;// stop already paired to a start
+  std::string orphanWarn;
+} etTransPairBuf;
+
+// Load the block at [start, start+len) and classify each record; returns how
+// many of them take part in modeled rate/duration pairing.
+static int etTransClassifyBlock(etTransPairBuf& b, const std::vector<int>& idxOutput,
+                                int start, int len, const std::vector<int>& evid) {
+  b.block.assign(idxOutput.begin() + start, idxOutput.begin() + start + len);
+  b.type.resize(len);
+  b.bCmt.resize(len);
+  int nModeled = 0;
+  for (int k = 0; k < len; ++k) {
+    b.type[k] = etTransModeledPairType(evid[b.block[k]], &b.bCmt[k]);
+    if (b.type[k] != 0) nModeled++;
+  }
+  return nModeled;
+}
+
+// Rewrite one classified block in place so each start is followed by its own
+// stop.  A start always precedes its own stop (the pair shares the compartment
+// and differs only in the infusion flag, which sorts the start first), so the
+// mate is searched forward.  Records that are not part of a pair keep their
+// relative position, and a start with no matching stop is left alone and named.
+static void etTransPairModeledBlock(etTransPairBuf& b, std::vector<int>& idxOutput,
+                                    int start, int len, int curId, double curTime,
+                                    const CharacterVector& idLvl) {
+  b.mate.assign(len, -1);
+  b.claimed.assign(len, false);
+  for (int k = 0; k < len; ++k) {
+    if (b.type[k] <= 0) continue;
+    for (int m = k + 1; m < len; ++m) {
+      if (b.claimed[m] || b.type[m] != -b.type[k] || b.bCmt[m] != b.bCmt[k]) continue;
+      b.mate[k] = m;
+      b.claimed[m] = true;
+      break;
+    }
+    if (b.mate[k] == -1) {
+      b.orphanWarn += " (id: " + as<std::string>(idLvl[curId-1]) +
+        ", time: " + std::to_string(curTime) +
+        ", cmt: " + std::to_string(b.bCmt[k]+1) + ")";
+    }
+  }
+  int pos = start;
+  for (int k = 0; k < len; ++k) {
+    if (b.claimed[k]) continue; // emitted next to its start
+    idxOutput[pos++] = b.block[k];
+    if (b.mate[k] != -1) idxOutput[pos++] = b.block[b.mate[k]];
+  }
+}
+
 static void etTransPairModeledRateDur(std::vector<int>& idxOutput,
                                       const std::vector<int>& id,
                                       const std::vector<double>& time,
                                       const std::vector<int>& evid,
                                       const CharacterVector& idLvl) {
   int n = (int)idxOutput.size();
-  std::vector<int> block;
-  std::vector<int> type;
-  std::vector<int> bCmt;
-  std::vector<int> mate;
-  std::vector<bool> claimed;
-  std::string orphanWarn;
+  etTransPairBuf b;
   int i = 0;
   while (i < n) {
     int curId = id[idxOutput[i]];
     double curTime = time[idxOutput[i]];
     int j = i + 1;
     while (j < n && id[idxOutput[j]] == curId && time[idxOutput[j]] == curTime) j++;
-    int len = j - i;
-    if (len > 1) {
-      block.assign(idxOutput.begin() + i, idxOutput.begin() + j);
-      type.resize(len);
-      bCmt.resize(len);
-      int nModeled = 0;
-      for (int k = 0; k < len; ++k) {
-        type[k] = etTransModeledPairType(evid[block[k]], &bCmt[k]);
-        if (type[k] != 0) nModeled++;
-      }
-      if (nModeled > 1) {
-        mate.assign(len, -1);
-        claimed.assign(len, false);
-        for (int k = 0; k < len; ++k) {
-          if (type[k] <= 0) continue;
-          for (int m = k + 1; m < len; ++m) {
-            if (claimed[m] || type[m] != -type[k] || bCmt[m] != bCmt[k]) continue;
-            mate[k] = m;
-            claimed[m] = true;
-            break;
-          }
-          if (mate[k] == -1) {
-            orphanWarn += " (id: " + as<std::string>(idLvl[curId-1]) +
-              ", time: " + std::to_string(curTime) +
-              ", cmt: " + std::to_string(bCmt[k]+1) + ")";
-          }
-        }
-        int pos = i;
-        for (int k = 0; k < len; ++k) {
-          if (claimed[k]) continue; // emitted next to its start
-          idxOutput[pos++] = block[k];
-          if (mate[k] != -1) idxOutput[pos++] = block[mate[k]];
-        }
-      }
+    // a single modeled record in the block is already next to its own pair
+    if (j - i > 1 && etTransClassifyBlock(b, idxOutput, i, j - i, evid) > 1) {
+      etTransPairModeledBlock(b, idxOutput, i, j - i, curId, curTime, idLvl);
     }
     i = j;
   }
-  if (!orphanWarn.empty()) {
+  if (!b.orphanWarn.empty()) {
     Rf_warningcall(R_NilValue, "%s%s",
                    _("modeled 'rate'/'dur' dose without a matching infusion end record:"),
-                   orphanWarn.c_str());
+                   b.orphanWarn.c_str());
   }
 }
 

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -229,28 +229,28 @@ extern "C" void printErr(int err, int id){
     RSprintf("  Modeled duration requested in event table, but not in model; use 'dur(cmt) ='\n");
   }
   if (err & rxErrModelData686){
-    RSprintf("  Data error 686\n");
+    RSprintf("  Data error 686: end of a modeled duration ('rate=-2') infusion is not preceded by its start\n");
   }
   if (err & rxErrModelDataNeg6){
-    RSprintf("  Data Error -6\n");
+    RSprintf("  Data Error -6: end of a modeled duration ('rate=-2') infusion is the first record\n");
   }
   if (err & rxErrModelDataErr8){
-    RSprintf("  Data Error 8\n");
+    RSprintf("  Data Error 8: a modeled duration ('rate=-2') infusion starts on the last record, so it has no end\n");
   }
   if (err & rxErrModelDataErr886){
-    RSprintf("  Data error 886\n");
+    RSprintf("  Data error 886: start of a modeled duration ('rate=-2') infusion is not followed by its end\n");
   }
   if (err & rxErrModelDataErr797){
-    RSprintf("  Data error 797\n");
+    RSprintf("  Data error 797: end of a modeled rate ('rate=-1') infusion is not preceded by its start\n");
   }
   if (err & rxErrModelDataNeg7){
-    RSprintf("  Data Error -7\n");
+    RSprintf("  Data Error -7: end of a modeled rate ('rate=-1') infusion is the first record\n");
   }
   if (err & rxErrModelDataErr9){
-    RSprintf("  Data Error 9\n");
+    RSprintf("  Data Error 9: a modeled rate ('rate=-1') infusion starts on the last record, so it has no end\n");
   }
   if (err & rxErrModelDataErr997){
-    RSprintf("  Data error 997\n");
+    RSprintf("  Data error 997: start of a modeled rate ('rate=-1') infusion is not followed by its end\n");
   }
   if (err & rxErrCorruptETSort3){
     RSprintf("  Corrupted event table during sort (3)\n");

--- a/src/par_solve.h
+++ b/src/par_solve.h
@@ -349,7 +349,10 @@ static inline int handleExtraDose(int *neq,
     int trueIdx = ind->extraDoseTimeIdx[ind->idxExtra];
     ind->idx = -1-trueIdx;
     double time = getAllTimes(ind, ind->idx);
-    while (!isSameTimeOp(time, xp) && time < xp && ind->idxExtra < ind->extraDoseN[0]) {
+    // bound before the increment; every extra dose can be before xp (e.g. two
+    // modeled duration steady state doses tied at one time), and reading
+    // extraDoseTimeIdx[extraDoseN[0]] then walks off the end of the pool
+    while (!isSameTimeOp(time, xp) && time < xp && ind->idxExtra + 1 < ind->extraDoseN[0]) {
       ind->idxExtra++;
       trueIdx = ind->extraDoseTimeIdx[ind->idxExtra];
       ind->idx = -1-trueIdx;

--- a/tests/testthat/test-tied-modeled-rate-dur.R
+++ b/tests/testthat/test-tied-modeled-rate-dur.R
@@ -94,6 +94,20 @@ rxTest({
                  .sim(rbind(.dose(0, 150, -2, 2), .dose(0, 150, 0, 1), .obs)))
   })
 
+  # the data error text is printed by the solver rather than raised, so the
+  # condition message is only "could not solve the system"
+  test_that("an unpaired infusion record says what is wrong", {
+    .err <- function(evid) {
+      .ev <- data.frame(ID = 1, TIME = c(0, 1), EVID = c(evid, 0L),
+                        CMT = c(1, 2), AMT = c(150, NA))
+      paste(capture.output(try(rxSolve(mod, .ev), silent = TRUE)), collapse = " ")
+    }
+    expect_match(.err(60101L), "end of a modeled duration")
+    expect_match(.err(80101L), "start of a modeled duration")
+    expect_match(.err(70101L), "end of a modeled rate")
+    expect_match(.err(90101L), "start of a modeled rate")
+  })
+
   test_that("tied modeled duration start/stop records are adjacent", {
     .ev <- rbind(.dose(0, 150, -2, 1), .dose(0, 150, -2, 2), .obs)
     .evid <- etTrans(.ev, mod)$EVID

--- a/tests/testthat/test-tied-modeled-rate-dur.R
+++ b/tests/testthat/test-tied-modeled-rate-dur.R
@@ -1,0 +1,103 @@
+rxTest({
+  # rxode2#1218: modeled rate (RATE=-1) / modeled duration (RATE=-2) doses tied
+  # at exactly the same TIME used to break the positional start/stop pairing and
+  # fail with data errors 686/886 (and 797/997 for modeled rate).  etTrans() now
+  # re-pairs each start with its own stop after the sort.
+
+  mod <- rxode2({
+    ka <- 1
+    cl <- 3
+    v <- 30
+    D1 <- 2
+    R1 <- 75
+    dur(depot) <- D1
+    dur(central) <- D1
+    rate(depot) <- R1
+    rate(central) <- R1
+    d/dt(depot) <- -ka * depot
+    d/dt(central) <- ka * depot - (cl / v) * central
+  })
+
+  .obs <- data.frame(ID = 1L, TIME = c(1, 4, 8, 12, 24), EVID = 0L,
+                     AMT = NA_real_, RATE = NA_real_, CMT = 2L)
+  .dose <- function(t, amt, rate, cmt) {
+    data.frame(ID = 1L, TIME = t, EVID = 1L, AMT = amt, RATE = rate, CMT = cmt)
+  }
+  .sim <- function(ev) {
+    as.data.frame(rxSolve(mod, ev))[, c("time", "depot", "central")]
+  }
+
+  # A tie must give the same answer as the same doses separated by an
+  # imperceptible amount of time (the workaround before this was fixed).
+  test_that("two modeled duration doses tied at one time solve", {
+    .tied <- rbind(.dose(0, 150, -2, 1), .dose(0, 150, -2, 2), .obs)
+    .stag <- rbind(.dose(0, 150, -2, 1), .dose(1e-8, 150, -2, 2), .obs)
+    expect_equal(.sim(.tied), .sim(.stag), tolerance = 1e-5)
+  })
+
+  test_that("two modeled duration doses tied in the same compartment solve", {
+    .tied <- rbind(.dose(0, 150, -2, 2), .dose(0, 150, -2, 2), .obs)
+    .stag <- rbind(.dose(0, 150, -2, 2), .dose(1e-8, 150, -2, 2), .obs)
+    expect_equal(.sim(.tied), .sim(.stag), tolerance = 1e-5)
+  })
+
+  test_that("three modeled duration doses tied at one time solve", {
+    .tied <- rbind(.dose(0, 150, -2, 1), .dose(0, 150, -2, 2),
+                   .dose(0, 100, -2, 2), .obs)
+    .stag <- rbind(.dose(0, 150, -2, 1), .dose(1e-8, 150, -2, 2),
+                   .dose(2e-8, 100, -2, 2), .obs)
+    expect_equal(.sim(.tied), .sim(.stag), tolerance = 1e-5)
+  })
+
+  test_that("two modeled rate doses tied at one time solve", {
+    .tied <- rbind(.dose(0, 150, -1, 1), .dose(0, 150, -1, 2), .obs)
+    .stag <- rbind(.dose(0, 150, -1, 1), .dose(1e-8, 150, -1, 2), .obs)
+    expect_equal(.sim(.tied), .sim(.stag), tolerance = 1e-5)
+  })
+
+  test_that("a modeled rate and a modeled duration dose tied at one time solve", {
+    .tied <- rbind(.dose(0, 150, -2, 1), .dose(0, 150, -1, 2), .obs)
+    .stag <- rbind(.dose(0, 150, -2, 1), .dose(1e-8, 150, -1, 2), .obs)
+    expect_equal(.sim(.tied), .sim(.stag), tolerance = 1e-5)
+  })
+
+  test_that("tied modeled duration doses with addl solve", {
+    .tied <- rbind(cbind(.dose(0, 150, -2, 1), II = 6, ADDL = 2L),
+                   cbind(.dose(0, 150, -2, 2), II = 6, ADDL = 2L),
+                   cbind(.obs, II = 0, ADDL = 0L))
+    .stag <- .tied
+    .stag$TIME[2] <- 1e-8
+    expect_equal(.sim(.tied), .sim(.stag), tolerance = 1e-5)
+  })
+
+  # steady state doses in different compartments reset the system, so the tied
+  # answer is order dependent; it only needs to solve without error and match
+  # the ordering the sort produces (highest compartment last)
+  test_that("tied modeled duration steady state doses solve", {
+    .tied <- rbind(cbind(.dose(0, 150, -2, 1), II = 6, SS = 1L),
+                   cbind(.dose(0, 150, -2, 2), II = 6, SS = 1L),
+                   cbind(.obs, II = 0, SS = 0L))
+    .stag <- rbind(cbind(.dose(0, 150, -2, 2), II = 6, SS = 1L),
+                   cbind(.dose(1e-8, 150, -2, 1), II = 6, SS = 1L),
+                   cbind(.obs, II = 0, SS = 0L))
+    expect_equal(.sim(.tied), .sim(.stag), tolerance = 1e-5)
+  })
+
+  # regressions: the re-pairing must not disturb tables it does not need to fix
+  test_that("a single modeled duration dose is unchanged", {
+    expect_equal(.sim(rbind(.dose(0, 150, -2, 1), .obs)),
+                 .sim(rbind(.dose(0, 150, -2, 1), .obs)))
+  })
+
+  test_that("a bolus tied with a modeled duration dose is order independent", {
+    expect_equal(.sim(rbind(.dose(0, 150, 0, 1), .dose(0, 150, -2, 2), .obs)),
+                 .sim(rbind(.dose(0, 150, -2, 2), .dose(0, 150, 0, 1), .obs)))
+  })
+
+  test_that("tied modeled duration start/stop records are adjacent", {
+    .ev <- rbind(.dose(0, 150, -2, 1), .dose(0, 150, -2, 2), .obs)
+    .evid <- etTrans(.ev, mod)$EVID
+    # 8xxxx starts each immediately followed by their own 6xxxx stop
+    expect_equal(.evid[1:4], c(80201L, 60201L, 80101L, 60101L))
+  })
+})


### PR DESCRIPTION
Fixes #1218.

## The problem

A `RATE = -2` (modeled duration) or `RATE = -1` (modeled rate) dose is expanded by `etTrans()` into **two** records sharing one time: an infusion *start* and an infusion *stop*. At solve time the two are paired **positionally** -- `handleTurnOnModeledDuration()` / `handleTurnOffModeledDuration()` in `inst/include/rxode2parseGetTime.h` read `ind->evid[idx+1]` / `ind->evid[idx-1]` in the raw record array.

The final sort keys on `(id, time, evid)`, and the compartment is *encoded* in the evid (`cmt100*100000 + rateI*10000 + cmt99*100 + flg`). So two such doses tied at one time interleaved as `start2 start1 stop2 stop1`, and both adjacency checks failed:

```
Recovered solving errors for internal ID 1 (576):
  Data error 686
  Data error 886
Error: could not solve the system
```

This hit doses into **different compartments**, which is a perfectly legal data set -- staggering them by `1e-8` solved fine, so it was purely the exact tie.

## The fix

Rather than declining to support the paradigm, `etTrans()` now re-arranges the records so both `rate=-1` and `rate=-2` doses are always ordered correctly. A post-sort pass (`etTransPairModeledRateDur`) walks each tied `(id, time)` block and puts every stop back immediately after its own start, matched on compartment and infusion type.

- The pass **only runs when the data set actually builds a modeled rate/duration dose**, so nothing else pays for a second pass over the records.
- Blocks already in the right order come out unchanged, so it can only move records the solver could not have used anyway.
- Starts the runtime does not pair positionally are left alone: `flg` 9/19 pair through the lagged `flg=1` record that follows, and `flg` 40 (steady state constant infusion) has no stop record at all.

The `EVIDF_*` / `EVID0_*` defines moved from `inst/include/rxode2parseHandleEvid.h` to `inst/include/rxode2EventTranslate.h` (which the former already includes) so `etTran.cpp` can name them. Pure move, no redefinition.

## A pre-existing bug this surfaced

`handleExtraDose()` in `src/par_solve.h` bounds-checked its index **before** incrementing rather than after, so a subject whose extra doses all precede the current step read one element past the end of the extra-dose pool and dereferenced it as a record index -- corrupting the heap.

It was latent because the tied steady-state path errored out before reaching it. Once the fix let that path solve, it segfaulted roughly half of all runs. Found with valgrind, verified clean afterward.

## Messages

Data errors 686 / 886 / 797 / 997 / 8 / 9 / -6 / -7 now state the problem instead of only naming a number, e.g.

```
Data error 886: start of a modeled duration ('rate=-2') infusion is not followed by its end
```

## Validation

Every combination from the issue's table now solves and matches its `1e-8`-staggered reference:

| records tied at one TIME | before | after |
|---|---|---|
| two `RATE = -2`, same CMT | 576 | solves |
| two `RATE = -2`, different CMT | 576 | solves |
| three `RATE = -2` | 576 | solves |
| `RATE = -2` + `RATE = -1` | 9792 | solves |
| two `RATE = -1` | 9792 | solves |
| `RATE = 0` + `RATE = -2` | ok | ok, unchanged |

Plus the `addl` and `ss` expansions. Tied **steady state** doses in different compartments are inherently order dependent (a later SS dose resets the system), so the tied answer matches the ordering the sort produces rather than any one staggered variant.

14 new tests in `tests/testthat/test-tied-modeled-rate-dur.R`, all passing, along with `test-model-rate.R` (75), `test-dur-0.R` (18), `test-infusion-bolus.R` (2), `test-state-dep-dur.R` (12), `test-state-dep-rate.R` (12), `test-evid2.R` (16) and `test-evid3.R` (19). The full suite is left to CI.

## Notes for review

- No new `rxControl` option, no new load-time or `rxSolve` check, no renamed/reordered pointer-table slots.
- Unpairable records raise a `warning()` naming ID/TIME/CMT rather than an error, and only inside a block that already holds more than one modeled record -- everything else still fails exactly where it did before, just with a readable message.
- An independent Antigravity (Gemini 3.1 Pro) review found no correctness, memory-safety or concurrency issues; its one finding was the missing error-message test coverage, added in 04f20f390.