### PR TITLE
fix(compile): show the compiler's error instead of always blaming Rtools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,20 +67,24 @@ summary(rxC(rxode2model))
 With a model that did not compile successfully, you can get the code by:
 
 ```r
-cat(suppressMessages(rxode2::rxLastCompile())$c)
+cat(rxode2::rxLastCompile(character(0))$c)
 ```
 
 To get the compile error you can use:
 
 ```r
-cat(suppressMessages(rxode2::rxLastCompile())$stderr)
+cat(rxode2::rxLastCompile(character(0))$stderr)
 ```
 
-If you need stout too you can get that with
+If you need stdout too you can get that with
 
 ```r
-cat(suppressMessages(rxode2::rxLastCompile())$stderr)
+cat(rxode2::rxLastCompile(character(0))$stdout)
 ```
+
+`rxLastCompile()` messages the sections named by its `what=` argument (all of
+them by default), so `character(0)` takes the list without echoing anything;
+`rxLastCompile("stderr")` echoes just the compiler error.
 
 ### Regenerate Grammar, Documentation and Build Artifacts
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,29 @@
 
 ## Bug fixes
 
+### Compilation
+
+- A model that fails to build now shows the compiler's own error lines (and
+  only those -- warnings and progress chatter are dropped, and the list is
+  capped by `options(rxode2.compileErrLines=)`), followed by how to get the
+  rest (`cat(rxode2::rxLastCompile()$stderr)` for the full compiler output,
+  `cat(rxode2::rxLastCompile()$c)` for the generated C code).  The
+  Rtools/C-compiler advice is only given when the failure actually looks like
+  a toolchain problem; when the compiler produced real diagnostics, the
+  message says the generated C code is at fault and points at the issue
+  tracker instead of sending the user off to validate their toolchain (#1197).
+
+- A model that compiles but will not load reports what the loader said rather
+  than the loader's error replacing the diagnosis, and a build failure found
+  without recompiling (the model's dll was already present) no longer errors
+  with `could not find function ".badBuild"` or reports a previous model's
+  compiler output.
+
+- `rxLastCompile()` now prints its section rules -- `cli::rule()` was called
+  but its result was never messaged -- and takes `what=` to choose which
+  sections are messaged (`rxLastCompile("stderr")` for the compiler error
+  alone).  The returned list is unchanged.
+
 ### Model interface
 
 - `ui$modelName` is now always a single character string, as it was always

--- a/NEWS.md
+++ b/NEWS.md
@@ -52,8 +52,8 @@
 - A model that fails to build now shows the compiler's own error lines (and
   only those -- warnings and progress chatter are dropped, and the list is
   capped by `options(rxode2.compileErrLines=)`), followed by how to get the
-  rest (`cat(rxode2::rxLastCompile()$stderr)` for the full compiler output,
-  `cat(rxode2::rxLastCompile()$c)` for the generated C code).  The
+  rest (`rxode2::rxLastCompile("stderr")` for the full compiler output,
+  `rxode2::rxLastCompile("c")` for the generated C code).  The
   Rtools/C-compiler advice is only given when the failure actually looks like
   a toolchain problem: a diagnostic naming a source file and line is about the
   code that was compiled, so the message says the generated C code is at fault

--- a/NEWS.md
+++ b/NEWS.md
@@ -55,9 +55,12 @@
   rest (`cat(rxode2::rxLastCompile()$stderr)` for the full compiler output,
   `cat(rxode2::rxLastCompile()$c)` for the generated C code).  The
   Rtools/C-compiler advice is only given when the failure actually looks like
-  a toolchain problem; when the compiler produced real diagnostics, the
-  message says the generated C code is at fault and points at the issue
-  tracker instead of sending the user off to validate their toolchain (#1197).
+  a toolchain problem: a diagnostic naming a source file and line is about the
+  code that was compiled, so the message says the generated C code is at fault
+  and points at the issue tracker, while a driver, linker or loader that fails
+  without reaching the source still gets the setup advice.  Previously every
+  failure blamed the toolchain, which sent users off validating Rtools when
+  the compiler had already named the generated-code defect (#1197).
 
 - A model that compiles but will not load reports what the loader said rather
   than the loader's error replacing the diagnosis, and a build failure found

--- a/R/rxode2.R
+++ b/R/rxode2.R
@@ -1769,6 +1769,10 @@ rxCompile <- function(model, dir, prefix, force = FALSE, modName = NULL,
 .rxCompileEnv$cc <- NA_character_
 #' Get the last compiled model information as alist
 #'
+#' @param what Which elements to message to the console; by default all of
+#'   them.  Use `what="stderr"` for the compiler error alone, or
+#'   `what=character(0)` to message nothing and only take the returned list.
+#'
 #' @return A list contains the following elements:
 #'
 #' * `msg` the message for a bad compilation, or NULL if successful.
@@ -1791,12 +1795,121 @@ rxCompile <- function(model, dir, prefix, force = FALSE, modName = NULL,
 #' })
 #' rxLastCompile()
 #' }
-rxLastCompile <- function() {
-  lapply(names(.rxCompileEnv$lst), function(nm) {
-    cli::rule(left = nm)
+rxLastCompile <- function(what = c("msg", "stderr", "stdout", "c")) {
+  what <- intersect(what, names(.rxCompileEnv$lst))
+  lapply(what, function(nm) {
+    message(cli::rule(left = nm))
     message(.rxCompileEnv$lst[[nm]])
   })
   return(invisible(.rxCompileEnv$lst))
+}
+#' Compiler diagnostic lines from a compilation's standard error
+#'
+#' @param stderr Character vector (or single string) of the compiler's
+#'   standard error.
+#'
+#' @param max Maximum number of diagnostic lines to return.
+#'
+#' @return Character vector of the compiler's error lines (warnings and
+#'   progress chatter dropped), at most `max` long.  The number of
+#'   diagnostic lines found before truncation is in the `"n"` attribute.
+#'
+#' @author Matthew L. Fidler
+#' @keywords internal
+#' @noRd
+.rxCompileErrLines <- function(stderr, max = getOption("rxode2.compileErrLines", 10L)) {
+  if (length(stderr) == 0L) return(structure(character(0), n = 0L))
+  .lines <- unlist(strsplit(paste(stderr, collapse = "\n"), "\n", fixed = TRUE))
+  .lines <- sub("\r$", "", .lines)
+  .lines <- .lines[nzchar(trimws(.lines))]
+  # a compiler diagnostic, not a warning or a progress line
+  .re <- paste0("(^|[^[:alnum:]_])(fatal error|error)\\s*:",
+                "|undefined reference to",
+                "|undefined symbol",
+                "|unable to load shared object",
+                "|^collect2:",
+                "|ld returned [0-9]+ exit status")
+  .err <- unique(.lines[grepl(.re, .lines, perl = TRUE, ignore.case = TRUE)])
+  # R CMD SHLIB's own wrapper line says nothing the diagnostics do not
+  .err <- .err[!grepl("^ERROR: compilation failed", .err)]
+  .n <- length(.err)
+  if (.n > max) .err <- .err[seq_len(max)]
+  structure(.err, n = .n)
+}
+#' Does a failed compilation look like a broken toolchain?
+#'
+#' @param stderr Character vector (or single string) of the compiler's
+#'   standard error.
+#'
+#' @param errLines Compiler diagnostics from [.rxCompileErrLines()].
+#'
+#' @return `TRUE` when the failure points at the user's compiler setup
+#'   (nothing was compiled, a tool was missing, a library was not found)
+#'   rather than at the C code rxode2 generated.
+#'
+#' @author Matthew L. Fidler
+#' @keywords internal
+#' @noRd
+.rxCompileToolchainProblem <- function(stderr, errLines = .rxCompileErrLines(stderr)) {
+  if (length(errLines) == 0L) return(TRUE)
+  .txt <- paste(stderr, collapse = "\n")
+  .re <- paste0("command not found",
+                "|(^|[[:space:]])(make|gcc|clang|cc|g\\+\\+|ld|sh|bash|Rcmd)[[:space:]]*:[^\n]*not found",
+                "|cannot find -l",
+                "|\\bRtools\\b",
+                "|no compilers? (is |are )?(installed|available|found)",
+                "|compilers? (is |are )?not (installed|available|found)")
+  grepl(.re, .txt, perl = TRUE, ignore.case = TRUE)
+}
+#' Message a failed model build
+#'
+#' Shows the compiler's own diagnostics (and nothing else) plus how to get
+#' the full compiler output, and blames the toolchain only when the failure
+#' actually looks like a toolchain problem.
+#'
+#' @param msg The message describing what step failed.
+#'
+#' @param stderr Standard error of the compilation, possibly `NULL`.
+#'
+#' @param kind One of `"compile"` (the model did not build), `"load"` (it
+#'   built but would not load) or `"modelVars"` (it loaded without the model
+#'   variables).
+#'
+#' @return Nothing, called for the messages
+#'
+#' @author Matthew L. Fidler
+#' @keywords internal
+#' @noRd
+.rxBadBuildMsg <- function(msg, stderr, kind = "compile") {
+  .err <- .rxCompileErrLines(stderr)
+  .toolchain <- .rxCompileToolchainProblem(stderr, .err)
+  message(paste0("Error building the model: ", msg))
+  if (length(.err) > 0L) {
+    message(paste(.err, collapse = "\n"))
+    .n <- attr(.err, "n")
+    if (.n > length(.err)) {
+      message(sprintf("(%d more compiler error line(s) not shown)", .n - length(.err)))
+    }
+  }
+  message("for the full compiler output and the generated C code use:")
+  message("  cat(rxode2::rxLastCompile()$stderr) # compiler error")
+  message("  cat(rxode2::rxLastCompile()$c)      # generated C code")
+  message("  rxode2::rxLastCompile()             # everything")
+  if (kind == "load") {
+    message("the model compiled but could not be loaded")
+  }
+  if (kind == "modelVars" || !.toolchain) {
+    message("this points at the C code rxode2 generated, not at your setup;")
+    message("please report it at https://github.com/nlmixr2/rxode2/issues")
+    return(invisible())
+  }
+  if (.Platform$OS.type == "windows") {
+    message("this could be because your Rtools is not set up correctly")
+  } else {
+    message("please make sure you have a working C compiler set up")
+  }
+  message("you may use nlmixr2::nlmixr2CheckInstall() to help diagnose installation issues")
+  invisible()
 }
 #' Was the last compilation successful?
 #'
@@ -1880,6 +1993,37 @@ rxCompile.rxModelVars <- function(model, # Model
   .cDllFile <- file.path(.dir, sprintf("%s%s", substr(prefix, 0, nchar(prefix) - 1), .Platform$dynlib.ext))
   .allModVars <- NULL
   .needCompile <- TRUE
+  # .out is filled in by the compilation below; the load/model-variable
+  # failures are reachable without compiling, so .badBuild is defined here
+  # (and tolerates a NULL .out) rather than inside the compilation branch.
+  .out <- NULL
+  .badBuild <- function(msg, cSrc = TRUE, kind = "compile") {
+    if (is.null(.out)) {
+      # nothing was compiled in this call, so any saved compiler output
+      # belongs to a different model
+      .rxCompileEnv$lst <- list()
+    } else {
+      .rxCompileEnv$lst[["stdout"]] <- rawToChar(.out$stdout)
+    }
+    .rxCompileEnv$lst[["msg"]] <- gettext(msg)
+    if (cSrc) {
+      if (file.exists(.cFile)) {
+        .rxCompileEnv$lst[["c"]] <- paste(readLines(.cFile), collapse = "\n")
+      }
+    } else {
+      # report what the loader said instead of stopping on it
+      .load <- try(dyn.load(.cDllFile), silent = TRUE)
+      if (inherits(.load, "try-error")) {
+        .rxCompileEnv$lst[["stderr"]] <-
+          paste(c(.rxCompileEnv$lst[["stderr"]],
+                  conditionMessage(attr(.load, "condition"))),
+                collapse = "\n")
+      }
+    }
+    .rxCompileEnv$success <- FALSE
+    .rxBadBuildMsg(msg, .rxCompileEnv$lst[["stderr"]], kind)
+    stop(msg, call. = FALSE)
+  }
   if (file.exists(.cDllFile)) {
     .modVars <- sprintf("%smodel_vars", prefix)
     if (!missing(prefix) && !missing(dir) &&
@@ -2082,27 +2226,9 @@ rxCompile.rxModelVars <- function(model, # Model
         .stderr <- rawToChar(.out$stderr)
         .rxCompileEnv$lst <- list()
         if (!(all(.stderr == "") && length(.stderr) == 1)) {
-          .rxCompileEnv$lst[["stderr"]] <- paste(.stderr, sep = "\n")
+          .rxCompileEnv$lst[["stderr"]] <- paste(.stderr, collapse = "\n")
         }
         .rxCompileEnv$success <- TRUE
-        .badBuild <- function(msg, cSrc = TRUE) {
-          .rxCompileEnv$lst[["msg"]] <- gettext(msg)
-          .rxCompileEnv$lst[["stdout"]] <- rawToChar(.out$stdout)
-          if (cSrc) {
-            .rxCompileEnv$lst[["c"]] <- paste(readLines(.cFile), collapse = "\n")
-          } else {
-            dyn.load(.cDllFile)
-          }
-          message("Error building the model: see rxode2::rxLastCompile()")
-          .rxCompileEnv$success <- FALSE
-          if (.Platform$OS.type == "windows") {
-            message("this could be because your Rtools is not set up correctly")
-          } else {
-            message("please make sure you have a working C compiler set up")
-          }
-          message("you may use nlmixr2::nlmixr2CheckInstall() to help diagnose installation issues")
-          stop(msg, call. = FALSE)
-        }
         if (!(.out$status == 0 && file.exists(.cDllFile))) {
           .badBuild("error building model")
         }
@@ -2114,7 +2240,7 @@ rxCompile.rxModelVars <- function(model, # Model
       rxUnloadAll()
       .tmp <- try(dynLoad(.cDllFile), silent = TRUE)
       if (inherits(.tmp, "try-error")) {
-        .badBuild("Error loading model (though dll exists)", cSrc = FALSE)
+        .badBuild("Error loading model (though dll exists)", cSrc = FALSE, kind = "load")
       } else {
         warning("unloaded all rxode2 dlls before loading the current DLL", call. = FALSE)
       }
@@ -2123,7 +2249,7 @@ rxCompile.rxModelVars <- function(model, # Model
     if (is.loaded(.modVars)) {
       .allModVars <- eval(parse(text = sprintf(".Call(\"%s\")", .modVars)), envir = .GlobalEnv)
     } else {
-      .badBuild("Error, model doesn't have correct model variables.")
+      .badBuild("Error, model doesn't have correct model variables.", kind = "modelVars")
     }
   }
   ## removeSource() so this generated closure does not carry a srcref back to

--- a/R/rxode2.R
+++ b/R/rxode2.R
@@ -1825,12 +1825,16 @@ rxLastCompile <- function(what = c("msg", "stderr", "stdout", "c")) {
     max <- 10L
   }
   if (length(stderr) == 0L) return(structure(character(0), n = 0L))
-  .lines <- unlist(strsplit(paste(stderr, collapse = "\n"), "\n", fixed = TRUE))
+  # a localized toolchain emits bytes that need not be valid in this locale,
+  # and strsplit() and every regex below would choke on them
+  .txt <- iconv(paste(stderr, collapse = "\n"), "", "UTF-8", sub = "?")
+  if (length(.txt) != 1L || is.na(.txt)) return(structure(character(0), n = 0L))
+  .lines <- unlist(strsplit(.txt, "\n", fixed = TRUE))
   .lines <- sub("\r$", "", .lines)
   .lines <- .lines[nzchar(trimws(.lines))]
   # "error:", "fatal error:" and the MSVC-style "error C2065:"
   .reErr <- paste0("(^|[^[:alnum:]_])(fatal error|error)[[:space:]]*:",
-                   "|(^|[^[:alnum:]_])error[[:space:]]+[A-Z][0-9]+[[:space:]]*:")
+                   "|(^|[^[:alnum:]_])error[[:space:]]+[A-Z]+[0-9]+[[:space:]]*:")
   # a compiler, linker or loader diagnostic, not a warning or a progress line
   .re <- paste0(.reErr,
                 "|undefined reference to",
@@ -1877,7 +1881,7 @@ rxLastCompile <- function(what = c("msg", "stderr", "stdout", "c")) {
   .located <- paste0(
     "(^|[[:space:]])[^[:space:]]+",
     "(:[0-9]+(:[0-9]+)?:|\\([0-9]+(,[0-9]+)?\\)[[:space:]]*:)",
-    "[[:space:]]*(fatal[[:space:]]+)?error([[:space:]]+[A-Z][0-9]+)?[[:space:]]*:"
+    "[[:space:]]*(fatal[[:space:]]+)?error([[:space:]]+[A-Z]+[0-9]+)?[[:space:]]*:"
   )
   if (any(grepl(.located, errLines, perl = TRUE, ignore.case = TRUE))) return(FALSE)
   # a symbol rxode2 asked for and did not supply is also rxode2's to fix

--- a/R/rxode2.R
+++ b/R/rxode2.R
@@ -1818,20 +1818,31 @@ rxLastCompile <- function(what = c("msg", "stderr", "stdout", "c")) {
 #' @keywords internal
 #' @noRd
 .rxCompileErrLines <- function(stderr, max = getOption("rxode2.compileErrLines", 10L)) {
+  # this runs while reporting a build failure, so a bad option must not throw
+  max <- suppressWarnings(as.integer(max))
+  if (length(max) != 1L || is.na(max) || max < 1L) max <- 10L
   if (length(stderr) == 0L) return(structure(character(0), n = 0L))
   .lines <- unlist(strsplit(paste(stderr, collapse = "\n"), "\n", fixed = TRUE))
   .lines <- sub("\r$", "", .lines)
   .lines <- .lines[nzchar(trimws(.lines))]
-  # a compiler diagnostic, not a warning or a progress line
-  .re <- paste0("(^|[^[:alnum:]_])(fatal error|error)\\s*:",
+  .reErr <- "(^|[^[:alnum:]_])(fatal error|error)[[:space:]]*:"
+  # a compiler, linker or loader diagnostic, not a warning or a progress line
+  .re <- paste0(.reErr,
                 "|undefined reference to",
                 "|undefined symbol",
                 "|unable to load shared object",
-                "|^collect2:",
+                "|cannot open output file",
+                "|cannot find -l",
+                "|cannot execute",
+                "|(^|[[:space:]])(ld|collect2|cc1|cc1plus)(\\.exe)?:",
                 "|ld returned [0-9]+ exit status")
   .err <- unique(.lines[grepl(.re, .lines, perl = TRUE, ignore.case = TRUE)])
   # R CMD SHLIB's own wrapper line says nothing the diagnostics do not
   .err <- .err[!grepl("^ERROR: compilation failed", .err)]
+  # a line the tool names may have dragged in that is only a warning
+  .err <- .err[!grepl("(^|[^[:alnum:]_])warning[[:space:]]*:", .err,
+                      perl = TRUE, ignore.case = TRUE) |
+                 grepl(.reErr, .err, perl = TRUE, ignore.case = TRUE)]
   .n <- length(.err)
   if (.n > max) .err <- .err[seq_len(max)]
   structure(.err, n = .n)
@@ -1845,21 +1856,22 @@ rxLastCompile <- function(what = c("msg", "stderr", "stdout", "c")) {
 #'
 #' @return `TRUE` when the failure points at the user's compiler setup
 #'   (nothing was compiled, a tool was missing, a library was not found)
-#'   rather than at the C code rxode2 generated.
+#'   rather than at the C code rxode2 generated.  A diagnostic naming a
+#'   source file and line is about the code being compiled -- that is,
+#'   rxode2's generated C -- while a compiler driver, linker or loader that
+#'   fails without ever reaching the source is about the setup.
 #'
 #' @author Matthew L. Fidler
 #' @keywords internal
 #' @noRd
 .rxCompileToolchainProblem <- function(stderr, errLines = .rxCompileErrLines(stderr)) {
   if (length(errLines) == 0L) return(TRUE)
-  .txt <- paste(stderr, collapse = "\n")
-  .re <- paste0("command not found",
-                "|(^|[[:space:]])(make|gcc|clang|cc|g\\+\\+|ld|sh|bash|Rcmd)[[:space:]]*:[^\n]*not found",
-                "|cannot find -l",
-                "|\\bRtools\\b",
-                "|no compilers? (is |are )?(installed|available|found)",
-                "|compilers? (is |are )?not (installed|available|found)")
-  grepl(.re, .txt, perl = TRUE, ignore.case = TRUE)
+  # eg "rx_abc.c:214:23: error: 'ETA' undeclared"
+  .located <- "(^|[[:space:]])[^[:space:]]+:[0-9]+(:[0-9]+)?:[[:space:]]*(fatal[[:space:]]+)?error[[:space:]]*:"
+  if (any(grepl(.located, errLines, perl = TRUE, ignore.case = TRUE))) return(FALSE)
+  # a symbol rxode2 asked for and did not supply is also rxode2's to fix
+  !any(grepl("undefined reference to|undefined symbol", errLines,
+             perl = TRUE, ignore.case = TRUE))
 }
 #' Message a failed model build
 #'
@@ -1997,12 +2009,11 @@ rxCompile.rxModelVars <- function(model, # Model
   # failures are reachable without compiling, so .badBuild is defined here
   # (and tolerates a NULL .out) rather than inside the compilation branch.
   .out <- NULL
+  # whatever is saved belongs to an earlier model; a cached load that never
+  # compiles would otherwise leave rxLastCompile() reporting that one
+  .rxCompileEnv$lst <- list()
   .badBuild <- function(msg, cSrc = TRUE, kind = "compile") {
-    if (is.null(.out)) {
-      # nothing was compiled in this call, so any saved compiler output
-      # belongs to a different model
-      .rxCompileEnv$lst <- list()
-    } else {
+    if (!is.null(.out)) {
       .rxCompileEnv$lst[["stdout"]] <- rawToChar(.out$stdout)
     }
     .rxCompileEnv$lst[["msg"]] <- gettext(msg)

--- a/R/rxode2.R
+++ b/R/rxode2.R
@@ -1819,13 +1819,18 @@ rxLastCompile <- function(what = c("msg", "stderr", "stdout", "c")) {
 #' @noRd
 .rxCompileErrLines <- function(stderr, max = getOption("rxode2.compileErrLines", 10L)) {
   # this runs while reporting a build failure, so a bad option must not throw
-  max <- suppressWarnings(as.integer(max))
-  if (length(max) != 1L || is.na(max) || max < 1L) max <- 10L
+  max <- suppressWarnings(try(as.integer(max), silent = TRUE))
+  if (inherits(max, "try-error") || length(max) != 1L ||
+        is.na(max) || max < 1L) {
+    max <- 10L
+  }
   if (length(stderr) == 0L) return(structure(character(0), n = 0L))
   .lines <- unlist(strsplit(paste(stderr, collapse = "\n"), "\n", fixed = TRUE))
   .lines <- sub("\r$", "", .lines)
   .lines <- .lines[nzchar(trimws(.lines))]
-  .reErr <- "(^|[^[:alnum:]_])(fatal error|error)[[:space:]]*:"
+  # "error:", "fatal error:" and the MSVC-style "error C2065:"
+  .reErr <- paste0("(^|[^[:alnum:]_])(fatal error|error)[[:space:]]*:",
+                   "|(^|[^[:alnum:]_])error[[:space:]]+[A-Z][0-9]+[[:space:]]*:")
   # a compiler, linker or loader diagnostic, not a warning or a progress line
   .re <- paste0(.reErr,
                 "|undefined reference to",
@@ -1834,7 +1839,8 @@ rxLastCompile <- function(what = c("msg", "stderr", "stdout", "c")) {
                 "|cannot open output file",
                 "|cannot find -l",
                 "|cannot execute",
-                "|(^|[[:space:]])(ld|collect2|cc1|cc1plus)(\\.exe)?:",
+                # the tool may be named by its full path
+                "|(^|[[:space:]])([^[:space:]]*[/\\\\])?(ld|collect2|cc1|cc1plus)(\\.exe)?:",
                 "|ld returned [0-9]+ exit status")
   .err <- unique(.lines[grepl(.re, .lines, perl = TRUE, ignore.case = TRUE)])
   # R CMD SHLIB's own wrapper line says nothing the diagnostics do not
@@ -1866,8 +1872,13 @@ rxLastCompile <- function(what = c("msg", "stderr", "stdout", "c")) {
 #' @noRd
 .rxCompileToolchainProblem <- function(stderr, errLines = .rxCompileErrLines(stderr)) {
   if (length(errLines) == 0L) return(TRUE)
-  # eg "rx_abc.c:214:23: error: 'ETA' undeclared"
-  .located <- "(^|[[:space:]])[^[:space:]]+:[0-9]+(:[0-9]+)?:[[:space:]]*(fatal[[:space:]]+)?error[[:space:]]*:"
+  # eg "rx_abc.c:214:23: error: 'ETA' undeclared", or the MSVC-style
+  # "rx_abc.c(214): error C2065: 'ETA': undeclared identifier"
+  .located <- paste0(
+    "(^|[[:space:]])[^[:space:]]+",
+    "(:[0-9]+(:[0-9]+)?:|\\([0-9]+(,[0-9]+)?\\)[[:space:]]*:)",
+    "[[:space:]]*(fatal[[:space:]]+)?error([[:space:]]+[A-Z][0-9]+)?[[:space:]]*:"
+  )
   if (any(grepl(.located, errLines, perl = TRUE, ignore.case = TRUE))) return(FALSE)
   # a symbol rxode2 asked for and did not supply is also rxode2's to fix
   !any(grepl("undefined reference to|undefined symbol", errLines,
@@ -2010,8 +2021,10 @@ rxCompile.rxModelVars <- function(model, # Model
   # (and tolerates a NULL .out) rather than inside the compilation branch.
   .out <- NULL
   # whatever is saved belongs to an earlier model; a cached load that never
-  # compiles would otherwise leave rxLastCompile() reporting that one
+  # compiles would otherwise leave rxLastCompile() reporting that one, and
+  # .rxLastCompileSuccess() still reporting its failure
   .rxCompileEnv$lst <- list()
+  .rxCompileEnv$success <- TRUE
   .badBuild <- function(msg, cSrc = TRUE, kind = "compile") {
     if (!is.null(.out)) {
       .rxCompileEnv$lst[["stdout"]] <- rawToChar(.out$stdout)

--- a/R/rxode2.R
+++ b/R/rxode2.R
@@ -1919,9 +1919,9 @@ rxLastCompile <- function(what = c("msg", "stderr", "stdout", "c")) {
     }
   }
   message("for the full compiler output and the generated C code use:")
-  message("  cat(rxode2::rxLastCompile()$stderr) # compiler error")
-  message("  cat(rxode2::rxLastCompile()$c)      # generated C code")
-  message("  rxode2::rxLastCompile()             # everything")
+  message("  rxode2::rxLastCompile(\"stderr\") # the whole compiler error")
+  message("  rxode2::rxLastCompile(\"c\")      # the generated C code")
+  message("  rxode2::rxLastCompile()         # everything, as a list too")
   if (kind == "load") {
     message("the model compiled but could not be loaded")
   }
@@ -2029,24 +2029,18 @@ rxCompile.rxModelVars <- function(model, # Model
   # .rxLastCompileSuccess() still reporting its failure
   .rxCompileEnv$lst <- list()
   .rxCompileEnv$success <- TRUE
-  .badBuild <- function(msg, cSrc = TRUE, kind = "compile") {
+  .badBuild <- function(msg, cSrc = TRUE, kind = "compile", detail = NULL) {
     if (!is.null(.out)) {
       .rxCompileEnv$lst[["stdout"]] <- rawToChar(.out$stdout)
     }
     .rxCompileEnv$lst[["msg"]] <- gettext(msg)
-    if (cSrc) {
-      if (file.exists(.cFile)) {
-        .rxCompileEnv$lst[["c"]] <- paste(readLines(.cFile), collapse = "\n")
-      }
-    } else {
-      # report what the loader said instead of stopping on it
-      .load <- try(dyn.load(.cDllFile), silent = TRUE)
-      if (inherits(.load, "try-error")) {
-        .rxCompileEnv$lst[["stderr"]] <-
-          paste(c(.rxCompileEnv$lst[["stderr"]],
-                  conditionMessage(attr(.load, "condition"))),
-                collapse = "\n")
-      }
+    if (cSrc && file.exists(.cFile)) {
+      .rxCompileEnv$lst[["c"]] <- paste(readLines(.cFile), collapse = "\n")
+    }
+    if (length(detail) > 0L) {
+      # eg what the loader said, which is the only account of that failure
+      .rxCompileEnv$lst[["stderr"]] <-
+        paste(c(.rxCompileEnv$lst[["stderr"]], detail), collapse = "\n")
     }
     .rxCompileEnv$success <- FALSE
     .rxBadBuildMsg(msg, .rxCompileEnv$lst[["stderr"]], kind)
@@ -2268,7 +2262,9 @@ rxCompile.rxModelVars <- function(model, # Model
       rxUnloadAll()
       .tmp <- try(dynLoad(.cDllFile), silent = TRUE)
       if (inherits(.tmp, "try-error")) {
-        .badBuild("Error loading model (though dll exists)", cSrc = FALSE, kind = "load")
+        .badBuild("Error loading model (though dll exists)", cSrc = FALSE,
+                  kind = "load",
+                  detail = conditionMessage(attr(.tmp, "condition")))
       } else {
         warning("unloaded all rxode2 dlls before loading the current DLL", call. = FALSE)
       }

--- a/man/rxLastCompile.Rd
+++ b/man/rxLastCompile.Rd
@@ -4,7 +4,12 @@
 \alias{rxLastCompile}
 \title{Get the last compiled model information as alist}
 \usage{
-rxLastCompile()
+rxLastCompile(what = c("msg", "stderr", "stdout", "c"))
+}
+\arguments{
+\item{what}{Which elements to message to the console; by default all of
+them.  Use \code{what="stderr"} for the compiler error alone, or
+\code{what=character(0)} to message nothing and only take the returned list.}
 }
 \value{
 A list contains the following elements:

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,45 @@
+## Goal Description
+Review the provided diff for `rxode2` compilation error handling and report on correctness bugs, regex matching flaws, state leakage, and test coverage gaps as requested by the user.
+
+## Proposed Changes
+I have identified 6 issues in the diff that match the user's priorities. 
+
+### Finding 1: False negatives in `.rxCompileErrLines` (drops context and root cause)
+**File:line:** `R/rxode2.R:84-93` (regex and filtering in `.rxCompileErrLines`)
+**What breaks:** The regex only retains lines containing specific strings like `error:` or `undefined reference`. This drops crucial source code context lines (like the caret `^~~~` pointing at the syntax error). More importantly, for toolchain errors, it drops root cause lines that lack the word "error" (e.g., `ld.exe: cannot open output file: Permission denied`), leaving the user with only a useless `collect2: error: ld returned 1` without knowing why.
+**Concrete input:** A linker failure `stderr`:
+```
+c:/rtools40/mingw64/bin/ld.exe: cannot open output file rx.so: Permission denied
+collect2.exe: error: ld returned 1 exit status
+```
+
+### Finding 2: False negatives in `.rxCompileToolchainProblem` (blaming generated C code for setup errors)
+**File:line:** `R/rxode2.R:112-122` (regex in `.rxCompileToolchainProblem`)
+**What breaks:** If a toolchain/setup failure happens to include the string `error:` or `fatal error:` (like most compiler driver errors do), `errLines` is not empty. The code then checks the `.re` regex, which is extremely narrow. It returns `FALSE`, incorrectly telling the user "this points at the C code rxode2 generated, not at your setup;" which is completely wrong for a toolchain/filesystem failure.
+**Concrete input:** Toolchain `stderr` containing: `g++: error: unrecognized command line option '-bad-flag'` or `g++: fatal error: cannot execute 'cc1plus': execvp: No such file or directory`.
+
+### Finding 3: False positives in `.rxCompileToolchainProblem` (blaming toolchain for unrecognised codegen bugs)
+**File:line:** `R/rxode2.R:113` (`if (length(errLines) == 0L) return(TRUE)`)
+**What breaks:** This line assumes that *any* output lacking a recognized compiler error must be a toolchain problem. If a compiler fails due to a real codegen bug but its diagnostic format simply isn't matched by `.rxCompileErrLines` (e.g., `make: *** [rx_abc.o] Error 1`), it unconditionally blames Rtools instead of directing the user to look at the logs for their code bug.
+**Concrete input:** `stderr` containing only `"make: *** [rx_abc.o] Error 1"` with no `error:` keyword.
+
+### Finding 4: Unhandled exceptions from `options(rxode2.compileErrLines)`
+**File:line:** `R/rxode2.R:95` (`if (.n > max) .err <- .err[seq_len(max)]`)
+**What breaks:** If the user configures `options(rxode2.compileErrLines = NULL)` or a negative number, `max` becomes `NULL` or negative. `if (.n > max)` will throw `argument is of length zero` (or `seq_len` will fail). This completely crashes `.badBuild`, hiding the original compilation error entirely.
+**Concrete input:** The user runs `options(rxode2.compileErrLines = NULL)` followed by compiling a broken model.
+
+### Finding 5: State leakage in `.rxCompileEnv$lst` across successive cached compiles
+**File:line:** `R/rxode2.R:1993-2250` (in `rxCompile.rxModelVars`)
+**What breaks:** `.rxCompileEnv$lst` is cleared inside the `if (force || .needCompile)` block, but *not* before it. If a model is loaded from cache (`.needCompile = FALSE`) and loading succeeds, `.badBuild` is never called, and `.rxCompileEnv$lst` is never cleared. It permanently retains the `stderr` or `msg` from the *last compiled* model in the session.
+**Concrete input:** 
+1. Compile Model A with an error (populates `lst`). 
+2. Compile Model B which is already cached on disk (skips compilation, loads successfully). 
+3. Call `rxLastCompile()` - it incorrectly returns Model A's failure output.
+
+### Finding 6: Missing test coverage for the core diff claims
+**File:line:** `tests/testthat/test-compile-error.R`
+**What breaks:** The diff claims that a cached build failure "no longer errors with could not find function \".badBuild\"" and that a load failure "reports the loader's message". However, the tests only pass strings into the internal helpers `.rxCompileErrLines` and `.rxBadBuildMsg`. There are no tests invoking `rxCompile.rxModelVars` (or `rxode2`) that actually follow the `needCompile == FALSE` or `try(dynLoad)` failure paths to verify the closures and environment state behave correctly.
+**Concrete input:** A test suite run. It does not execute the modified paths in `rxCompile.rxModelVars` to prevent regressions.
+
+## Verification Plan
+These findings are generated from static analysis of the diff. No modifications are being made as the task is purely to review the diff and report findings.

--- a/test_leak.R
+++ b/test_leak.R
@@ -1,0 +1,18 @@
+library(rxode2)
+# Compile a bad model
+bad_mod <- "d/dt(A) = B; # B is undeclared"
+try(rxode2(bad_mod))
+print(rxode2::.rxLastCompileSuccess())
+
+# Now compile a good model that we ALREADY compiled so it hits the cache
+good_mod <- "d/dt(A) = 1"
+# first compile (this will clear the error)
+invisible(rxode2(good_mod))
+print(rxode2::.rxLastCompileSuccess())
+
+# Now compile a bad model again
+try(rxode2(bad_mod))
+
+# Now compile the good model again, it should hit cache
+invisible(rxode2(good_mod))
+print(rxode2::.rxLastCompileSuccess())

--- a/tests/testthat/test-compile-error.R
+++ b/tests/testthat/test-compile-error.R
@@ -122,6 +122,10 @@ rxTest({
       .rxCompileErrLines("rx_abc.c(214): error C2065: 'ETA': undeclared identifier"),
       1L
     )
+    expect_length(
+      .rxCompileErrLines("LINK : fatal error LNK1104: cannot open file 'rx.dll'"),
+      1L
+    )
     expect_length(.rxCompileErrLines("/usr/bin/ld: warning: something harmless"), 0L)
   })
 
@@ -199,13 +203,32 @@ rxTest({
 
   test_that("a later model does not report the earlier model's failure", {
     skip_on_cran()
+    # seed the state a failed build leaves behind, so this holds however the
+    # file is run and whether or not the model below comes from the cache
+    .rxCompileEnv$lst <- list(msg = "error building model",
+                              stderr = "rx_prior.c:1:1: error: nope",
+                              c = "// prior model")
+    .rxLastCompileSuccess(FALSE)
     # deliberately a model other tests build too, so this is the cached path
     .m <- rxode2({
       d / dt(center) <- -kel * center
     })
     on.exit(rxDelete(.m))
     expect_true(.rxLastCompileSuccess())
-    expect_null(rxLastCompile(what = character(0))$msg)
-    expect_null(rxLastCompile(what = character(0))$c)
+    .last <- rxLastCompile(what = character(0))
+    expect_null(.last$msg)
+    expect_null(.last$c)
+    expect_false(isTRUE(grepl("rx_prior.c", .last$stderr, fixed = TRUE)))
+  })
+
+  test_that("output that is not valid in this locale does not throw", {
+    # a localized toolchain can put bytes in stderr that R cannot decode
+    .bad <- rawToChar(as.raw(c(0x72, 0x78, 0x2e, 0x63, 0x3a, 0x31, 0x3a, 0x31,
+                               0x3a, 0x20, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x3a,
+                               0x20, 0x91, 0x45, 0x54, 0x41, 0x92, 0x20, 0x62,
+                               0x61, 0x64)))
+    expect_length(.rxCompileErrLines(.bad), 1L)
+    expect_false(.rxCompileToolchainProblem(.bad))
+    expect_silent(invisible(capture_messages(.rxBadBuildMsg("error building model", .bad))))
   })
 })

--- a/tests/testthat/test-compile-error.R
+++ b/tests/testthat/test-compile-error.R
@@ -52,6 +52,30 @@ rxTest({
       .rxCompileErrLines("unable to load shared object 'rx_abc.so': undefined symbol: rxFoo"),
       1L
     )
+    # the line saying why the link failed, not just that it failed
+    .ld <- paste(
+      c("c:/rtools40/mingw64/bin/ld.exe: cannot open output file rx.dll: Permission denied",
+        "collect2.exe: error: ld returned 1 exit status"),
+      collapse = "\n"
+    )
+    expect_length(.rxCompileErrLines(.ld), 2L)
+  })
+
+  test_that(".rxCompileErrLines() keeps linker warnings out", {
+    expect_length(.rxCompileErrLines("ld: warning: directory not found for option '-L/x'"), 0L)
+  })
+
+  test_that(".rxCompileErrLines() survives a bad rxode2.compileErrLines option", {
+    .many <- paste(sprintf("rx.c:%d:1: error: bad %d", 1:25, 1:25), collapse = "\n")
+    withr::with_options(list(rxode2.compileErrLines = NULL), {
+      expect_length(.rxCompileErrLines(.many), 10L)
+    })
+    withr::with_options(list(rxode2.compileErrLines = -1L), {
+      expect_length(.rxCompileErrLines(.many), 10L)
+    })
+    withr::with_options(list(rxode2.compileErrLines = "bad"), {
+      expect_length(.rxCompileErrLines(.many), 10L)
+    })
   })
 
   test_that(".rxCompileToolchainProblem() separates codegen bugs from setup", {
@@ -65,6 +89,21 @@ rxTest({
     expect_false(.rxCompileToolchainProblem(
       "rx_abc.c:1:10: fatal error: rx_abc_extra.h: No such file or directory"
     ))
+    # the compiler driver failing before it ever read the source is not
+    expect_true(.rxCompileToolchainProblem(
+      "g++: error: unrecognized command line option '-bad-flag'"
+    ))
+    expect_true(.rxCompileToolchainProblem(
+      "g++: fatal error: cannot execute 'cc1plus': execvp: No such file or directory"
+    ))
+    expect_true(.rxCompileToolchainProblem("ld: cannot find -lRblas"))
+    expect_true(.rxCompileToolchainProblem(paste(
+      c("c:/rtools40/mingw64/bin/ld.exe: cannot open output file rx.dll: Permission denied",
+        "collect2.exe: error: ld returned 1 exit status"),
+      collapse = "\n"
+    )))
+    # a symbol rxode2 asked for and did not supply is rxode2's to fix
+    expect_false(.rxCompileToolchainProblem("rx.o: undefined reference to `rxFoo'"))
   })
 
   test_that("a codegen failure shows the compiler error and does not blame Rtools", {
@@ -111,5 +150,39 @@ rxTest({
 
   test_that("rxLastCompile(what=) selects what is messaged", {
     expect_type(rxLastCompile(what = character(0)), "list")
+  })
+
+  test_that("a real build failure reaches the console and rxLastCompile()", {
+    skip_on_cran()
+    .msg <- NULL
+    withr::with_options(
+      list(rxode2.compile.O = "3 -include /rxode2-1197-does-not-exist.h"), {
+        .msg <- capture_messages(
+          expect_error(
+            rxode2({
+              d / dt(depot) <- -ka * depot
+            }),
+            "error building model"
+          )
+        )
+      }
+    )
+    .msg <- paste(.msg, collapse = "")
+    expect_match(.msg, "rxode2-1197-does-not-exist.h", fixed = TRUE)
+    expect_match(.msg, "rxode2::rxLastCompile()", fixed = TRUE)
+    .last <- rxLastCompile(what = character(0))
+    expect_match(.last$stderr, "rxode2-1197-does-not-exist.h", fixed = TRUE)
+    expect_true(is.character(.last$c))
+    expect_false(.rxLastCompileSuccess())
+  })
+
+  test_that("a later model does not report the earlier model's failure", {
+    skip_on_cran()
+    .m <- rxode2({
+      d / dt(center) <- -kel * center
+    })
+    on.exit(rxDelete(.m))
+    expect_true(.rxLastCompileSuccess())
+    expect_null(rxLastCompile(what = character(0))$msg)
   })
 })

--- a/tests/testthat/test-compile-error.R
+++ b/tests/testthat/test-compile-error.R
@@ -104,6 +104,25 @@ rxTest({
     )))
     # a symbol rxode2 asked for and did not supply is rxode2's to fix
     expect_false(.rxCompileToolchainProblem("rx.o: undefined reference to `rxFoo'"))
+    # a source-located diagnostic in the other spelling is still our bug
+    expect_false(.rxCompileToolchainProblem(
+      "rx_abc.c(214): error C2065: 'ETA': undeclared identifier"
+    ))
+    expect_false(.rxCompileToolchainProblem(
+      "C:\\tmp\\rx_abc.c:214:23: error: 'ETA' undeclared"
+    ))
+  })
+
+  test_that(".rxCompileErrLines() handles tools named by path and error codes", {
+    expect_length(
+      .rxCompileErrLines("c:/rtools40/mingw64/bin/ld.exe: unrecognized emulation mode"),
+      1L
+    )
+    expect_length(
+      .rxCompileErrLines("rx_abc.c(214): error C2065: 'ETA': undeclared identifier"),
+      1L
+    )
+    expect_length(.rxCompileErrLines("/usr/bin/ld: warning: something harmless"), 0L)
   })
 
   test_that("a codegen failure shows the compiler error and does not blame Rtools", {
@@ -154,19 +173,21 @@ rxTest({
 
   test_that("a real build failure reaches the console and rxLastCompile()", {
     skip_on_cran()
-    .msg <- NULL
-    withr::with_options(
-      list(rxode2.compile.O = "3 -include /rxode2-1197-does-not-exist.h"), {
-        .msg <- capture_messages(
-          expect_error(
-            rxode2({
-              d / dt(depot) <- -ka * depot
-            }),
-            "error building model"
-          )
-        )
-      }
+    # names nothing else compiles, so this cannot be answered from the cache
+    .broken <- NULL
+    .msg <- withr::with_options(
+      list(rxode2.compile.O = "3 -include /rxode2-1197-does-not-exist.h"),
+      capture_messages(
+        .broken <- try(rxode2({
+          d / dt(rx1197depot) <- -rx1197ka * rx1197depot
+        }), silent = TRUE)
+      )
     )
+    if (!inherits(.broken, "try-error")) {
+      # -include is a gcc/clang spelling; another compiler may ignore it
+      rxDelete(.broken)
+      skip("the compiler ignored the injected flag, so nothing failed to build")
+    }
     .msg <- paste(.msg, collapse = "")
     expect_match(.msg, "rxode2-1197-does-not-exist.h", fixed = TRUE)
     expect_match(.msg, "rxode2::rxLastCompile()", fixed = TRUE)
@@ -178,11 +199,13 @@ rxTest({
 
   test_that("a later model does not report the earlier model's failure", {
     skip_on_cran()
+    # deliberately a model other tests build too, so this is the cached path
     .m <- rxode2({
       d / dt(center) <- -kel * center
     })
     on.exit(rxDelete(.m))
     expect_true(.rxLastCompileSuccess())
     expect_null(rxLastCompile(what = character(0))$msg)
+    expect_null(rxLastCompile(what = character(0))$c)
   })
 })

--- a/tests/testthat/test-compile-error.R
+++ b/tests/testthat/test-compile-error.R
@@ -1,0 +1,115 @@
+rxTest({
+  # Issue #1197: a failed build must show the compiler's own diagnostics and
+  # say how to get the rest, and blame the toolchain only when the toolchain
+  # is what failed.
+
+  .codegenStderr <- paste(
+    c(
+      "rx_abc.c: In function 'rx_abc_ode_solve':",
+      "rx_abc.c:120:9: warning: unused variable 'foo' [-Wunused-variable]",
+      "rx_abc.c:214:23: error: 'ETA' undeclared (first use in this function)",
+      "  214 |   double x = ETA[1];",
+      "rx_abc.c:215:23: error: 'THETA' undeclared (first use in this function)",
+      "make: *** [rx_abc.o] Error 1",
+      "ERROR: compilation failed for package"
+    ),
+    collapse = "\n"
+  )
+
+  .toolchainStderr <- "sh: line 1: make: command not found\nERROR: compilation failed"
+
+  test_that(".rxCompileErrLines() keeps the compiler errors and nothing else", {
+    .err <- .rxCompileErrLines(.codegenStderr)
+    expect_equal(
+      as.character(.err),
+      c(
+        "rx_abc.c:214:23: error: 'ETA' undeclared (first use in this function)",
+        "rx_abc.c:215:23: error: 'THETA' undeclared (first use in this function)"
+      )
+    )
+    expect_equal(attr(.err, "n"), 2L)
+  })
+
+  test_that(".rxCompileErrLines() is empty when nothing failed to compile", {
+    expect_length(.rxCompileErrLines(NULL), 0L)
+    expect_length(.rxCompileErrLines(character(0)), 0L)
+    expect_length(.rxCompileErrLines(""), 0L)
+    expect_length(.rxCompileErrLines("gcc -c rx_abc.c -o rx_abc.o"), 0L)
+  })
+
+  test_that(".rxCompileErrLines() truncates and reports how many were dropped", {
+    .many <- paste(sprintf("rx.c:%d:1: error: bad %d", seq_len(25), seq_len(25)),
+                   collapse = "\n")
+    .err <- .rxCompileErrLines(.many)
+    expect_length(.err, 10L)
+    expect_equal(attr(.err, "n"), 25L)
+    expect_length(.rxCompileErrLines(.many, max = 3L), 3L)
+  })
+
+  test_that(".rxCompileErrLines() picks up link and load failures", {
+    expect_length(.rxCompileErrLines("rx.o: undefined reference to `rxFoo'"), 1L)
+    expect_length(
+      .rxCompileErrLines("unable to load shared object 'rx_abc.so': undefined symbol: rxFoo"),
+      1L
+    )
+  })
+
+  test_that(".rxCompileToolchainProblem() separates codegen bugs from setup", {
+    expect_false(.rxCompileToolchainProblem(.codegenStderr))
+    expect_true(.rxCompileToolchainProblem(.toolchainStderr))
+    expect_true(.rxCompileToolchainProblem(NULL))
+    expect_true(.rxCompileToolchainProblem(
+      "Warning: this build of R requires Rtools 4.3, which was not found"
+    ))
+    # a header rxode2 generated that the compiler cannot find is our bug
+    expect_false(.rxCompileToolchainProblem(
+      "rx_abc.c:1:10: fatal error: rx_abc_extra.h: No such file or directory"
+    ))
+  })
+
+  test_that("a codegen failure shows the compiler error and does not blame Rtools", {
+    .msg <- capture_messages(.rxBadBuildMsg("error building model", .codegenStderr))
+    .msg <- paste(.msg, collapse = "")
+    expect_match(.msg, "'ETA' undeclared", fixed = TRUE)
+    expect_match(.msg, "rxode2::rxLastCompile()", fixed = TRUE)
+    expect_match(.msg, "https://github.com/nlmixr2/rxode2/issues", fixed = TRUE)
+    expect_false(grepl("Rtools", .msg, fixed = TRUE))
+    expect_false(grepl("nlmixr2CheckInstall", .msg, fixed = TRUE))
+    # the warning and the compiler's chatter stay out of the console
+    expect_false(grepl("unused variable", .msg, fixed = TRUE))
+    expect_false(grepl("In function", .msg, fixed = TRUE))
+  })
+
+  test_that("a toolchain failure still gets the toolchain advice", {
+    .msg <- capture_messages(.rxBadBuildMsg("error building model", .toolchainStderr))
+    .msg <- paste(.msg, collapse = "")
+    expect_match(.msg, "nlmixr2CheckInstall", fixed = TRUE)
+    expect_match(.msg, "rxode2::rxLastCompile()", fixed = TRUE)
+    expect_false(grepl("github.com/nlmixr2/rxode2/issues", .msg, fixed = TRUE))
+  })
+
+  test_that("a load failure says so", {
+    .msg <- capture_messages(
+      .rxBadBuildMsg("Error loading model (though dll exists)",
+                     "unable to load shared object 'rx_abc.so': undefined symbol: rxFoo",
+                     kind = "load")
+    )
+    .msg <- paste(.msg, collapse = "")
+    expect_match(.msg, "compiled but could not be loaded", fixed = TRUE)
+    expect_match(.msg, "undefined symbol: rxFoo", fixed = TRUE)
+  })
+
+  test_that("missing model variables are reported as an rxode2 bug", {
+    .msg <- capture_messages(
+      .rxBadBuildMsg("Error, model doesn't have correct model variables.",
+                     NULL, kind = "modelVars")
+    )
+    .msg <- paste(.msg, collapse = "")
+    expect_match(.msg, "https://github.com/nlmixr2/rxode2/issues", fixed = TRUE)
+    expect_false(grepl("nlmixr2CheckInstall", .msg, fixed = TRUE))
+  })
+
+  test_that("rxLastCompile(what=) selects what is messaged", {
+    expect_type(rxLastCompile(what = character(0)), "list")
+  })
+})


### PR DESCRIPTION
Closes #1197.

## The problem

Every build failure printed the same thing:

```
Error building the model: see rxode2::rxLastCompile()
this could be because your Rtools is not set up correctly
you may use nlmixr2::nlmixr2CheckInstall() to help diagnose installation issues
```

`.badBuild()` never looked at *why* the build failed. In the case behind the
issue the compiler had already named the defect -- undeclared `ETA` and `THETA`,
a codegen bug -- and the message sent the user off validating their toolchain
instead. The one pointer it did give, `rxLastCompile()`, echoed every section
including the whole generated C file, so the alternative to no information was
a flooded console.

## What this does

Show the compiler's own error lines, and only those, then say how to get the
rest:

```
Error building the model: error building model
rx_abc.c:214:23: error: 'ETA' undeclared (first use in this function)
rx_abc.c:215:23: error: 'THETA' undeclared (first use in this function)
for the full compiler output and the generated C code use:
  rxode2::rxLastCompile("stderr") # the whole compiler error
  rxode2::rxLastCompile("c")      # the generated C code
  rxode2::rxLastCompile()         # everything, as a list too
this points at the C code rxode2 generated, not at your setup;
please report it at https://github.com/nlmixr2/rxode2/issues
```

- `.rxCompileErrLines()` keeps the diagnostics and drops warnings, progress
  chatter and `R CMD SHLIB`'s own wrapper line, capped by
  `options(rxode2.compileErrLines=)` (default 10) with a count of what was cut.
  It handles gcc/clang, tools named by absolute path (`c:/rtools40/.../ld.exe:`),
  MSVC-style `file.c(214): error C2065:` and `fatal error LNK1104:`, linker root
  causes (`cannot open output file`, `cannot find -l`) and loader failures
  (`undefined symbol`).
- `.rxCompileToolchainProblem()` decides who is at fault: a diagnostic naming a
  source file and line is about the code that was compiled -- rxode2's generated
  C -- so the message points at the issue tracker. A driver, linker or loader
  that fails before reaching the source keeps the Rtools/compiler advice, as
  does a failure with no diagnostics at all.
- `rxLastCompile(what=)` chooses which sections are messaged
  (`rxLastCompile("stderr")` for the compiler error alone, `character(0)` for
  none). The returned list is unchanged. Its `cli::rule()` calls were computed
  and thrown away; they are printed now.

Also fixed along the way, all on this same path:

- `.badBuild` was defined inside the compile branch but called from the load and
  model-variable failures, which are reachable without recompiling; those would
  have died with `could not find function ".badBuild"`. It is hoisted, and
  `.rxCompileEnv$lst`/`$success` are reset when `rxCompile` starts so a model
  answered from the cache no longer reports an earlier model's failure.
- A load failure reports the error `dynLoad()` actually raised, rather than
  re-running `dyn.load()` and reporting whatever the second attempt said.
- The reporter no longer throws while reporting: a bad
  `options(rxode2.compileErrLines=)` is coerced defensively, and stderr is
  transcoded before `strsplit()`/regex so a localized toolchain's bytes cannot
  abort the message with `invalid multibyte string`.

## Testing

`tests/testthat/test-compile-error.R` (59 assertions): the helpers against
canned gcc/clang/ld/MSVC/Rtools output, the three message shapes, the option and
locale guards, and end-to-end -- a forced build failure (skipped if the compiler
ignores the injected flag) and the stale-state case. `test-parsing.R` (350) and
`test-basic.R`, `test-000-modelVars.R`, `test-recompile-model.R` pass.

Reviewed independently across five rounds with Antigravity (Gemini); 17 findings,
all accepted ones fixed, one rejected (the `$success` reset does not change what
`badParse()` observes -- that helper sets the flag itself immediately before).