### PR TITLE
fix(indLin): convert only the d/dt() block of a mixed linCmt() model (#1215)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -184,6 +184,25 @@
 
 ### Matrix exponential / inductive linearization
 
+- `rxToIndLin()` -- and therefore `rxSolve(method="indLin")` -- now converts a
+  model that mixes `linCmt()` with `d/dt()`.  It walked `$state`, which counts
+  the `linCmt()` pseudo-compartments (`depot`, `central`, `peripheral*`); those
+  have no `d/dt()` behind them, so it emitted `cmt()`/`indLin()` lines for
+  derivatives that do not exist -- one of them the literal R variable name
+  `.tmp` -- and the generated model did not parse.  Only the `d/dt()` block is
+  converted now; the solved compartments stay with the analytic solver and are
+  copied back after each step.  A term reading a `linCmt()` goes to the
+  `indLin()` forcing rather than into a rate constant, since a solved
+  compartment moves within the matrix-exponential step, and such a forcing takes
+  the iterating path so the driver refines it.
+
+- A `df(<state>)/dy(<state>)` Jacobian entry may now reference `linCmt()`.  A
+  `linCmt()` call retyped the whole statement, so the entry lost its Jacobian
+  routing and was emitted into `dydt()`, where `__PDStateVar__` does not exist:
+  the model failed to compile.  For the same reason a `matExp()` rate constant
+  or `indLin()` forcing built from a `linCmt()` concentration now reaches the
+  `ME()`/`IndF()` functions instead of reading a stale value.
+
 - `rxSensMatExp(calcSens3=)` now carries the `indLin()` forcing at third order,
   as `calcSens` and `calcSens2` already did.  Only the rate-matrix cross terms
   were generated, so third-order sensitivities of a nonlinear model were short

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,8 +34,11 @@
   from parameters or covariates (e.g. `indLin(Gc) <- Gprod`) stays unflagged, as
   does one whose variables were reassigned to something state free before it
   reads them.  A forcing inside an `if`/`while` may not run, so it adds to what
-  the forcings before it established rather than replacing them.  The entries
-  are the 0-indexed positions in `$state`, named with those states.
+  the forcings before it established rather than replacing them.  In a model
+  that also has a `linCmt()`, every forcing is flagged: a solved concentration
+  moves within the step, so such a forcing cannot be treated as constant over
+  the interval the way a locf covariate can.  The entries are the 0-indexed
+  positions in `$state`, named with those states.
 
 - `rxModelNameLhs()` registers the name an assignment is making, for
   assignment operators like `nlmixr2save`'s `:=` (`fit := nlmixr2(...)`).  It

--- a/R/indLin.R
+++ b/R/indLin.R
@@ -14,13 +14,21 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
   
   # 1. Parse model to get model variables and load symengine environment
   .mv <- rxModelVars(model)
-  .env <- .rxLoadPrune(model, doConst = doConst)
-  .states <- rxState(.env)
-  
+  # promoteLinSens=FALSE: a linCmt() the conversion inlines into a rate constant
+  # must stay `linCmtA()`.  Promoting it to `linCmtB()` would make the CONVERTED
+  # model request Stan sensitivities the source model never had, adding
+  # rx__sens_* pseudo-compartments to it (rxode2#1215).
+  .env <- .rxLoadPrune(model, doConst = doConst, promoteLinSens = FALSE)
+  # `$state` counts linCmt() pseudo-compartments (depot/central/peripheral*),
+  # which have no d/dt() behind them: nothing to convert, and the analytic
+  # solver keeps handling them.  Converting them emitted cmt()/indLin() lines
+  # for a derivative that does not exist (rxode2#1215).
+  .states <- setdiff(rxState(.env), .rxLinCmt(.mv))
+
   if (length(.states) == 0L) {
     stop("No state variables (compartments) found in the model.", call. = FALSE)
   }
-  
+
   # 2. Call the C/C++ registered function to get inductive linearization matrices
   .ret <- eval(parse(text = rxIndLin_((.states))))
   

--- a/R/rxIndLin.R
+++ b/R/rxIndLin.R
@@ -160,7 +160,14 @@ rxIndLinState <- function(preferred = NULL) {
         }
       }
     }
-    if (length(.curStates) == 1) {
+    if (any(grepl("linCmt[AB]?[(]", .mult))) {
+      ## A linCmt() call reads the solved compartments, which are states of the
+      ## system even though they carry no d/dt().  A coefficient built from one
+      ## is therefore not constant over the matrix-exponential step, so the term
+      ## is the nonlinear residual and belongs in the forcing, where the solver
+      ## re-evaluates it as it iterates (rxode2#1215).
+      .addForcing(.mult)
+    } else if (length(.curStates) == 1) {
       .addState(.curStates, .mult)
     } else if (length(.curStates) > 1) {
       ## A product of two states (or a state with itself) can never leave a

--- a/R/rxIndLin.R
+++ b/R/rxIndLin.R
@@ -160,7 +160,7 @@ rxIndLinState <- function(preferred = NULL) {
         }
       }
     }
-    if (any(grepl("linCmt[AB]?[(]", .mult))) {
+    if (any(grepl("(^|[^A-Za-z0-9._])linCmt[AB]?[(]", .mult))) {
       ## A linCmt() call reads the solved compartments, which are states of the
       ## system even though they carry no d/dt().  A coefficient built from one
       ## is therefore not constant over the matrix-exponential step, so the term

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -542,10 +542,18 @@ void codegen(char *model, int show_ode, const char *prefix, const char *libname,
         if (ode_is_es_dcode(show_ode)) break;
         switch(sbPm.lType[i]){
         case TLIN:
-          if (show_ode != ode_mexp && show_ode != ode_indLinVec &&
+          // Same routing as TASSIGN -- a linCmt()-bearing assignment is still an
+          // assignment -- except that linCmt() cannot be evaluated from the
+          // F/alag/rate/dur/past functions.  `tb.isMexp` is what lets a matExp()
+          // rate constant read a linCmt() concentration: without it the ME/IndF
+          // functions skipped the line and used a stale _PL[] value
+          // (rxode2#1215).
+          if ((tb.isMexp || (show_ode != ode_mexp && show_ode != ode_indLinVec)) &&
               show_ode != ode_fbio && show_ode != ode_lag &&
               show_ode != ode_rate && show_ode != ode_dur && show_ode != ode_past){
-            sAppend(&sbOut,"  %s",show_ode == ode_dydt ? sbPm.line[i] : sbPmDt.line[i]);
+            sAppend(&sbOut,"  %s",
+                    (show_ode == ode_dydt || show_ode == ode_mexp || show_ode == ode_indLinVec) ?
+                    sbPm.line[i] : sbPmDt.line[i]);
           }
           break;
         case TMTIME:

--- a/src/genModelVars.h
+++ b/src/genModelVars.h
@@ -449,15 +449,21 @@ static inline int indLinStmtTarget(int s, int *dep) {
   return t;
 }
 
-static inline void indLinReplay(int *dep, int *fdep) {
+// `fany` (optional) records which compartments have an indLin() forcing at all,
+// state dependent or not.
+static inline void indLinReplay(int *dep, int *fdep, int *fany) {
   indLinSeedStateDep(dep);
-  for (int d = 0; d < tb.de.n; ++d) fdep[d] = 0;
+  for (int d = 0; d < tb.de.n; ++d) {
+    fdep[d] = 0;
+    if (fany != NULL) fany[d] = 0;
+  }
   for (int s = 0; s < tb.stmtN; ++s) {
     int t = indLinStmtTarget(s, dep);
     if (t < 0) continue;
     int v = indLinStmtReadsDep(s, dep);
     int *cur = (tb.stmtK[s] == 0) ? dep : fdep;
     cur[t] = tb.stmtC[s] ? (cur[t] || v) : v;
+    if (tb.stmtK[s] == 1 && fany != NULL) fany[t] = 1;
   }
 }
 
@@ -500,7 +506,7 @@ static inline void assertNoStateDependentMicro(void) {
   if (!tb.isMexp || tb.de.n <= 0 || NV <= 0) return;
   int *dep  = (int*)R_alloc(NV, sizeof(int));
   int *fdep = (int*)R_alloc(tb.de.n, sizeof(int));
-  indLinReplay(dep, fdep);
+  indLinReplay(dep, fdep, NULL);
   char cmt1[100], cmt2[100];
   for (int j = 0; j < NV; ++j) {
     if (dep[j] != 1) continue;
@@ -530,14 +536,19 @@ static inline SEXP calcWIndLin(SEXP state) {
   int ns = Rf_length(state);
   int *dep  = (int*)R_alloc(NV > 0 ? NV : 1, sizeof(int));
   int *fdep = (int*)R_alloc(tb.de.n > 0 ? tb.de.n : 1, sizeof(int));
-  indLinReplay(dep, fdep);
+  int *fany = (int*)R_alloc(tb.de.n > 0 ? tb.de.n : 1, sizeof(int));
+  indLinReplay(dep, fdep, fany);
   int *isDep = (int*)R_alloc(ns > 0 ? ns : 1, sizeof(int));
   int n = 0;
   for (int k = 0; k < ns; ++k) {
     isDep[k] = 0;
     for (int d = 0; d < tb.de.n; ++d) {
       if (!strcmp(tb.de.line[d], CHAR(STRING_ELT(state, k)))) {
-        isDep[k] = fdep[d];
+        // A linCmt() concentration moves continuously within a step, so a
+        // forcing in a model that has one cannot be treated as constant over
+        // the interval the way a locf covariate can -- take the iterating path
+        // so the driver re-evaluates and refines it (rxode2#1215).
+        isDep[k] = fdep[d] || (tb.linCmt && fany[d]);
         break;
       }
     }

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -984,11 +984,17 @@ static inline void copyLinCmt(int *neq,
   }
 }
 
-// The inductive-linearization driver never steps through dydt(), and fires
-// evid_() from calc_lhs instead (see ind_indLin0).  copyLinCmt() reaches the
-// linCmt() amounts through dydt(), so hide the event-time flag across it: left
-// set, dydt() would fire evid_() as well and a dose the model pushes at run
-// time would happen twice.
+// The inductive-linearization driver makes no dydt() call of its own, so it
+// fires evid_() from calc_lhs (see ind_indLin0).  copyLinCmt() reaches the
+// linCmt() amounts through dydt(), which fires evid_() too, so hide the
+// event-time flag across it: left set, a dose the model pushes at run time
+// happens twice.
+//
+// Letting the dydt() firing stand instead and standing calc_lhs down would also
+// work and would match ind_linCmt0() -- but it MOVES the pushed dose, which
+// sorts before the observation when pushed mid-solve and after it when pushed
+// from calc_lhs.  That is rxode2#1214 (evid_() placement differs by method),
+// not this fix, so keep the placement this driver already had.
 static inline void copyLinCmtIndLin(int *neq, rx_solving_options_ind *ind,
                                     rx_solving_options *op, double *yp) {
   if (op->numLin <= 0) return;
@@ -1956,7 +1962,7 @@ static inline void _rxSolveOneInterval(int method, bool autoSwitchPrimary,
         preSolve(op, ind, *xp, xout, yp);
         *idid = indLin(ind->id, op, ind, *xp, yp, xout, ind->InfusionRate, ind->on,
                        (ind->fns ? ind->fns->me : NULL), (ind->fns ? ind->fns->indf : NULL));
-        copyLinCmtIndLin(neq, ind, op, yp);
+        copyLinCmt(neq, ind, op, yp);
       }
       if (*idid <= 0) {
         ind->rc[0] = *idid;
@@ -4163,8 +4169,9 @@ extern "C" void ind_indLin0(rx_solve *rx, rx_solving_options *op, int solveid,
       // (src/codegen.c TEVID), and a matExp()/indLin() model's dydt is a no-op
       // stub -- so without this, doses pushed by the model at run time
       // (bolus(), infuse(), replace(), multiply(), reset(), ...) never happen
-      // on this method.  Unlike linCmt there is no internal dydt call to have
-      // already consumed the flag, so calc_lhs is the only firing point.
+      // on this method.  There is no internal dydt call to have already consumed
+      // the flag -- copyLinCmtIndLin() deliberately hides it -- so calc_lhs is
+      // the only firing point.
       // Observation AND model-time (mtime, evid 10-99) records: an ODE method
       // fires evid_() from dydt continuously, so a guard like
       // `t >= mt && t < mt + 0.5` triggers wherever the integrator steps.  With

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -1942,6 +1942,7 @@ static inline void _rxSolveOneInterval(int method, bool autoSwitchPrimary,
         preSolve(op, ind, *xp, xout, yp);
         *idid = indLin(ind->id, op, ind, *xp, yp, xout, ind->InfusionRate, ind->on,
                        (ind->fns ? ind->fns->me : NULL), (ind->fns ? ind->fns->indf : NULL));
+        copyLinCmt(neq, ind, op, yp);
       }
       if (*idid <= 0) {
         ind->rc[0] = *idid;
@@ -4076,6 +4077,7 @@ extern "C" void ind_indLin0(rx_solve *rx, rx_solving_options *op, int solveid,
                           ind->InfusionRate, ind->on,
                           (ind->fns ? ind->fns->me : NULL),
                           (ind->fns ? ind->fns->indf : NULL));
+            copyLinCmt(neq, ind, op, yp);
             postSolve(neq, &idid, rc, &i, yp, NULL, 0, true, ind, op, rx);
             if (*rc < 0) localBadSolve = 1;
             xp = ind->extraDoseNewXout;
@@ -4097,6 +4099,7 @@ extern "C" void ind_indLin0(rx_solve *rx, rx_solving_options *op, int solveid,
                             ind->InfusionRate, ind->on,
                             (ind->fns ? ind->fns->me : NULL),
                             (ind->fns ? ind->fns->indf : NULL));
+              copyLinCmt(neq, ind, op, yp);
               postSolve(neq, &idid, rc, &idx, yp, NULL, 0, false, ind, op, rx);
               if (*rc < 0) localBadSolve = 1;
               ind->extraDoseNewXout = xout;
@@ -4108,6 +4111,7 @@ extern "C" void ind_indLin0(rx_solve *rx, rx_solving_options *op, int solveid,
           preSolve(op, ind, xp, xout, yp);
           idid = indLin(solveid, op, ind, xp, yp, xout, ind->InfusionRate, ind->on,
                         (ind->fns ? ind->fns->me : NULL), (ind->fns ? ind->fns->indf : NULL));
+          copyLinCmt(neq, ind, op, yp);
           postSolve(neq, &idid, rc, &i, yp, NULL, 0, true, ind, op, rx);
           if (*rc < 0) localBadSolve = 1;
         }

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -984,6 +984,20 @@ static inline void copyLinCmt(int *neq,
   }
 }
 
+// The inductive-linearization driver never steps through dydt(), and fires
+// evid_() from calc_lhs instead (see ind_indLin0).  copyLinCmt() reaches the
+// linCmt() amounts through dydt(), so hide the event-time flag across it: left
+// set, dydt() would fire evid_() as well and a dose the model pushes at run
+// time would happen twice.
+static inline void copyLinCmtIndLin(int *neq, rx_solving_options_ind *ind,
+                                    rx_solving_options *op, double *yp) {
+  if (op->numLin <= 0) return;
+  int _atEventTime = ind->_atEventTime;
+  ind->_atEventTime = 0;
+  copyLinCmt(neq, ind, op, yp);
+  ind->_atEventTime = _atEventTime;
+}
+
 static inline void postSolve(int *neq, int *idid, int *rc, int *i, double *yp, const char** err_msg, int nerr, bool doPrint,
                              rx_solving_options_ind *ind, rx_solving_options *op, rx_solve *rx) {
   if (*idid <= 0) {
@@ -1942,7 +1956,7 @@ static inline void _rxSolveOneInterval(int method, bool autoSwitchPrimary,
         preSolve(op, ind, *xp, xout, yp);
         *idid = indLin(ind->id, op, ind, *xp, yp, xout, ind->InfusionRate, ind->on,
                        (ind->fns ? ind->fns->me : NULL), (ind->fns ? ind->fns->indf : NULL));
-        copyLinCmt(neq, ind, op, yp);
+        copyLinCmtIndLin(neq, ind, op, yp);
       }
       if (*idid <= 0) {
         ind->rc[0] = *idid;
@@ -4077,7 +4091,7 @@ extern "C" void ind_indLin0(rx_solve *rx, rx_solving_options *op, int solveid,
                           ind->InfusionRate, ind->on,
                           (ind->fns ? ind->fns->me : NULL),
                           (ind->fns ? ind->fns->indf : NULL));
-            copyLinCmt(neq, ind, op, yp);
+            copyLinCmtIndLin(neq, ind, op, yp);
             postSolve(neq, &idid, rc, &i, yp, NULL, 0, true, ind, op, rx);
             if (*rc < 0) localBadSolve = 1;
             xp = ind->extraDoseNewXout;
@@ -4099,7 +4113,7 @@ extern "C" void ind_indLin0(rx_solve *rx, rx_solving_options *op, int solveid,
                             ind->InfusionRate, ind->on,
                             (ind->fns ? ind->fns->me : NULL),
                             (ind->fns ? ind->fns->indf : NULL));
-              copyLinCmt(neq, ind, op, yp);
+              copyLinCmtIndLin(neq, ind, op, yp);
               postSolve(neq, &idid, rc, &idx, yp, NULL, 0, false, ind, op, rx);
               if (*rc < 0) localBadSolve = 1;
               ind->extraDoseNewXout = xout;
@@ -4111,7 +4125,7 @@ extern "C" void ind_indLin0(rx_solve *rx, rx_solving_options *op, int solveid,
           preSolve(op, ind, xp, xout, yp);
           idid = indLin(solveid, op, ind, xp, yp, xout, ind->InfusionRate, ind->on,
                         (ind->fns ? ind->fns->me : NULL), (ind->fns ? ind->fns->indf : NULL));
-          copyLinCmt(neq, ind, op, yp);
+          copyLinCmtIndLin(neq, ind, op, yp);
           postSolve(neq, &idid, rc, &i, yp, NULL, 0, true, ind, op, rx);
           if (*rc < 0) localBadSolve = 1;
         }

--- a/src/parseFunsLinCmt.h
+++ b/src/parseFunsLinCmt.h
@@ -29,7 +29,15 @@ static inline int handleFunctionLinCmt(transFunctions *tf) {
 
     if (tf->isLinB) tf->isLinB=1;
     tb.linB = tf->isLinB;
-    aType(TLIN);
+    // TLIN marks "this statement calls linCmt()", which keeps it out of the
+    // F/alag/rate/dur/past functions.  It must not overwrite a line type that
+    // already routes the statement elsewhere: a df()/dy() entry (TJAC) belongs
+    // to calc_jac/calc_lhs, and retyping it emitted `__PDStateVar__[...]` into
+    // dydt, where that argument does not exist -- the model did not compile
+    // (rxode2#1215).
+    if (sbPm.lType[sbPm.n] != TJAC) {
+      aType(TLIN);
+    }
     if (tf->isLinB) {
       // Here we figure out what derivatives are requested.
       // This allows the linCmtB Jacobian to focus only on

--- a/test_rx.R
+++ b/test_rx.R
@@ -1,0 +1,9 @@
+library(rxode2)
+model <- rxode2({
+  KA <- 1
+  CL <- 1
+  V2 <- 1
+  eff(0) <- 1
+  d/dt(eff) <- Kin * linCmt() - Kout * eff
+})
+cat(rxSensMatExp(model$model["normModel"], calcSens=c("KA")))

--- a/test_rx.R
+++ b/test_rx.R
@@ -1,9 +1,0 @@
-library(rxode2)
-model <- rxode2({
-  KA <- 1
-  CL <- 1
-  V2 <- 1
-  eff(0) <- 1
-  d/dt(eff) <- Kin * linCmt() - Kout * eff
-})
-cat(rxSensMatExp(model$model["normModel"], calcSens=c("KA")))

--- a/tests/testthat/test-ind-lin.R
+++ b/tests/testthat/test-ind-lin.R
@@ -1611,4 +1611,41 @@ d/dt(blood)     = a*intestine - b*blood
     expect_false(any(is.na(suppressMessages(
       rxSolve(.m, .p, .e, method = "indLin"))$eff)))
   })
+
+  test_that("evid_() fires once in a mixed linCmt() indLin solve (rxode2#1215)", {
+    # This driver makes no dydt() call of its own and fires evid_() from
+    # calc_lhs.  Refreshing the linCmt() amounts now calls dydt(), which would
+    # fire evid_() a second time, so the copy hides the event-time flag.  (Where
+    # in the record order the pushed dose lands is rxode2#1214 and is not
+    # asserted here; that it lands exactly once is.)
+    .m <- suppressMessages(rxode2({
+      cp <- linCmt(ka, cl, v)
+      d/dt(eff) <- ke0 * (cp - eff)
+      if (t == 24) {
+        bolus(50, depot, 0, 0, 0)
+      }
+    }))
+    .noPush <- suppressMessages(rxode2({
+      cp <- linCmt(ka, cl, v)
+      d/dt(eff) <- ke0 * (cp - eff)
+    }))
+    .p <- c(ka = 0.5, cl = 1, v = 10, ke0 = 0.3)
+    .e <- et(amt = 100, time = 0) |> et(seq(0, 48, by = 1))
+    .e1 <- et(amt = 100, time = 0) |> et(amt = 50, time = 24) |>
+      et(seq(0, 48, by = 1))
+    .e2 <- et(amt = 100, time = 0) |> et(amt = 50, time = 24) |>
+      et(amt = 50, time = 24) |> et(seq(0, 48, by = 1))
+    .r <- suppressMessages(rxSolve(.m, .p, .e, method = "indLin"))
+    .one <- suppressMessages(rxSolve(.noPush, .p, .e1, method = "indLin"))
+    .two <- suppressMessages(rxSolve(.noPush, .p, .e2, method = "indLin"))
+    expect_equal(.r$cp, .one$cp)
+    expect_equal(.r$eff, .one$eff)
+    expect_false(isTRUE(all.equal(.one$cp, .two$cp)))
+    # and the dose shows up exactly once in the returned event rows
+    expect_equal(
+      nrow(suppressMessages(rxSolve(.m, .p, .e, method = "indLin",
+                                    addDosing = TRUE)) |>
+             subset(evid == 1L & time == 24)),
+      1L)
+  })
 })

--- a/tests/testthat/test-ind-lin.R
+++ b/tests/testthat/test-ind-lin.R
@@ -1528,4 +1528,87 @@ d/dt(blood)     = a*intestine - b*blood
                    info = paste("event type:", .nm))
     }
   })
+
+  test_that("a model mixing linCmt() with d/dt() converts and solves (rxode2#1215)", {
+    .mixed <- suppressMessages(rxode2({
+      CL <- TCL * exp(eta.Cl)
+      C2 <- linCmt(KA, CL, V2, Q, V3)
+      eff(0) <- 1
+      d/dt(eff) <- Kin - Kout * (1 - C2 / (EC50 + C2)) * eff
+      resp <- eff
+    }))
+    .txt <- rxToIndLin(.mixed)
+    .lines <- unlist(strsplit(.txt, "\n"))
+    # The linCmt() pseudo-compartments have no d/dt() to convert: they used to
+    # get cmt()/indLin() lines of their own, the forcing being the literal R
+    # variable name `.tmp`.
+    for (.cmt in c("depot", "central", "peripheral1")) {
+      expect_false(any(grepl(paste0("^(cmt|indLin)[(]", .cmt, "[)]"), .lines)),
+                   info = .cmt)
+    }
+    expect_false(any(grepl(".tmp", .lines, fixed = TRUE)))
+    # An inlined linCmt() must stay linCmtA(): promoting it to linCmtB() would
+    # add rx__sens_* compartments the source model never had.
+    expect_false(any(grepl("linCmtB", .lines, fixed = TRUE)))
+    # A linCmt() concentration is not constant over a matrix-exponential step,
+    # so a term reading one belongs in the forcing, never in a rate constant.
+    expect_false(any(grepl("^k_[^ ]*=.*linCmt", gsub(" ", "", .lines))))
+
+    .me <- suppressMessages(rxode2(.txt))
+    expect_equal(rxode2::rxState(.me),
+                 c("eff", "output", "depot", "central", "peripheral1"))
+    # The forcing carries a linCmt(), so the solve must take the iterating path.
+    expect_true(rxModelVars(.me)$indLin$fullIndLin)
+
+    .p <- c(KA = 2.94e-01, TCL = 1.86e+01, V2 = 4.02e+01, Q = 1.05e+01,
+            V3 = 2.97e+02, Kin = 1, Kout = 1, EC50 = 200, eta.Cl = 0)
+    .e <- et(amt = 10000, addl = 4, ii = 12, cmt = 2) |> et(0:120)
+    .ref <- suppressMessages(rxSolve(.mixed, .p, .e, method = "liblsoda",
+                                     atol = 1e-12, rtol = 1e-12))
+    .r <- suppressMessages(rxSolve(.mixed, .p, .e, method = "indLin"))
+    expect_equal(.r$resp, .ref$resp, tolerance = 1e-5)
+    # the analytic compartments still come from linCmt(), not from the ME step
+    expect_equal(.r$central, .ref$central, tolerance = 1e-10)
+    expect_equal(.r$peripheral1, .ref$peripheral1, tolerance = 1e-10)
+  })
+
+  test_that("a linCmt() that only forces the ODE is still refined (rxode2#1215)", {
+    # Here the linCmt() term multiplies no state, so the forcing is state free.
+    # Without flagging it the solver kept the single-pass code and held the
+    # concentration constant across the whole output interval.
+    .add <- suppressMessages(rxode2({
+      C2 <- linCmt(KA, CL, V2, Q, V3)
+      eff(0) <- 1
+      d/dt(eff) <- Kin * C2 - Kout * eff
+    }))
+    .me <- suppressMessages(rxode2(rxToIndLin(.add)))
+    expect_true(rxModelVars(.me)$indLin$fullIndLin)
+    .p <- c(KA = 2.94e-01, CL = 1.86e+01, V2 = 4.02e+01, Q = 1.05e+01,
+            V3 = 2.97e+02, Kin = 1, Kout = 1)
+    .e <- et(amt = 10000, addl = 4, ii = 12, cmt = 2) |> et(0:120)
+    expect_equal(
+      suppressMessages(rxSolve(.add, .p, .e, method = "indLin"))$eff,
+      suppressMessages(rxSolve(.add, .p, .e, method = "liblsoda",
+                               atol = 1e-12, rtol = 1e-12))$eff,
+      tolerance = 1e-5)
+  })
+
+  test_that("a df()/dy() entry may read a linCmt() (rxode2#1215)", {
+    # linCmt() retyped the whole statement, so the Jacobian entry lost its
+    # df()/dy() routing and was emitted into dydt(), where __PDStateVar__ does
+    # not exist -- the model did not compile at all.
+    .m <- suppressMessages(rxode2(paste(
+      "matExp()",
+      "cmt(eff)",
+      "C2 = linCmt(KA, CL, V2)",
+      "k_eff_output = Kout",
+      "indLin(eff) <- Kin*C2",
+      "df(eff)/dy(eff) = -Kout",
+      sep = "\n")))
+    expect_true(any(rxModelVars(.m)$lhs == "C2"))
+    .e <- et(amt = 100, cmt = "depot") |> et(seq(0, 24, by = 2))
+    .p <- c(KA = 0.5, CL = 3, V2 = 20, Kin = 1, Kout = 0.2)
+    expect_false(any(is.na(suppressMessages(
+      rxSolve(.m, .p, .e, method = "indLin"))$eff)))
+  })
 })

--- a/tests/testthat/test-par-solve.R
+++ b/tests/testthat/test-par-solve.R
@@ -54,12 +54,6 @@ rxTest({
     })
 
     ## Test mixed solved and ODEs
-    ## rxode2#1215: rxToIndLin() cannot rewrite a model that mixes linCmt()
-    ## with d/dt() -- the linCmt() pseudo-compartments have no derivative to
-    ## convert and the generated model does not parse.
-    if (meth == "indLin") {
-      skip("rxode2#1215")
-    }
     mod2 <- rxode2({
       ## the order of variables do not matter, the type of compartmental
       ## model is determined by the parameters specified.


### PR DESCRIPTION
Fixes #1215.

`rxToIndLin()` -- and therefore `rxSolve(..., method = "indLin")`, which calls it
automatically -- produced an invalid model for a model that mixes `linCmt()` with
`d/dt()`.  It walked `$state`, which counts the `linCmt()` pseudo-compartments
(`depot`, `central`, `peripheral*`); those have no `d/dt()` behind them, so the
conversion emitted `cmt()`/`indLin()` lines for derivatives that do not exist --
one of them carrying the literal R variable name `.tmp` -- and the generated
model did not parse.

## What changed

**Only the `d/dt()` block is converted.**  `indLin()` drops the `linCmt()`
compartments from the states it converts and loads with `promoteLinSens = FALSE`,
so a `linCmt()` the conversion inlines stays `linCmtA()`; promoting it to
`linCmtB()` would have made the converted model request Stan sensitivities and
grow `rx__sens_*` compartments the source model never had.

**A term reading a `linCmt()` goes to the `indLin()` forcing.**  The solved
compartments are states of the system, so a rate constant built from one is not
constant over the matrix-exponential step -- which is the premise of `matExp()`.
This is the same rule `.rxIndLinLine()` already applies to ODE states, extended
to the solved ones.  `calcWIndLin()` then flags a forcing in a `linCmt()` model
as iterating, so the driver refines a concentration that moves within the step
instead of holding it at the left endpoint.  On the issue's model that is the
difference between 3.6% and 7e-9 relative error against `liblsoda` at 1e-12.

**Two codegen fixes this exposed.**  A `linCmt()` call retyped the whole
statement `TLIN`, so a `df()/dy()` Jacobian entry that referenced one lost its
Jacobian routing and was emitted into `dydt()`, where `__PDStateVar__` does not
exist -- the model failed to compile at all.  And a `TLIN` statement was skipped
in the `ME()`/`IndF()` functions, so a `matExp()` rate constant or `indLin()`
forcing built from a `linCmt()` concentration read a stale `_PL[]` value.

**The driver copies the solved amounts back.**  `ind_indLin0()` and
`solveWith1Pt()` now call `copyLinCmt()` after each step, the way every other
driver does.  It reaches those amounts through `dydt()`, which fires `evid_()`;
this driver fires `evid_()` from `calc_lhs` instead, so the flag is hidden across
the copy -- otherwise a dose the model pushes at run time happens twice.
Deliberately *not* the other way round: letting the `dydt()` firing stand and
standing `calc_lhs` down would also work, but it moves where a pushed dose sorts
relative to the observation, which is #1214 and not this fix.

## Behavior for models without `linCmt()`

Unchanged, hunk by hunk: the R-side `setdiff`/`promoteLinSens` remove nothing,
the `linCmt` regex never matches, `calcWIndLin()`'s new term is gated on
`tb.linCmt`, `TLIN` statements only exist for a `linCmt()` call, and
`copyLinCmtIndLin()` returns immediately when `op->numLin <= 0`.

## Tests

`method="indLin"` is no longer skipped for the mixed model in the shared method
matrix (`test-par-solve.R`).  `test-ind-lin.R` gains the conversion shape, the
solve against `liblsoda`, the state-free-forcing case that needs the iterating
path, a `df()/dy()` entry reading a `linCmt()`, and the single `evid_()` firing.

Run locally: `test-ind-lin`, `test-par-solve`, `test-evid-push` (1325 pass), plus
a `solve|evid|event|steady|dosing|cov|nmtest` sweep (9079 pass).  A full-suite run
was cut short in favor of CI, which is the more robust check here.

Reviewed independently with Antigravity (Gemini) over two passes.  Its one
finding -- that `evid_()` does not fire during the steady-state pre-solve on this
driver -- is real but predates this change (the driver made no `dydt()` call
there at all before) and belongs to #1214; the patch preserves that behavior
rather than changing it.  A third pass was cut short by an API quota limit.