### PR TITLE
feat(api): expose per-compartment InfusionRate and on/off accessors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,16 @@
 
 ## New features
 
+- The C function-pointer table (`.rxode2ptrs()`) gained
+  `getIndInfusionRate()`/`setIndInfusionRate()` and `getIndOn()`/`setIndOn()`,
+  which read and write a compartment's infusion rate and on/off flag.  The
+  generated `dydt()` reads both -- `_IR[]` enters the right-hand side directly
+  and `_ON[]` gates every line -- so a downstream package evaluating `dydt()` or
+  `calc_jac()` *outside* an integration (for example over a fixed grid of states
+  rather than along a solve) previously had no way to set them, and silently got
+  a right-hand side with no dosing.  The slots are appended, so packages built
+  against an older header are unaffected.
+
 - `rxSolve(zeroVarParamHandle=)` says what happens when `params` supplies a
   value for an omega/sigma item whose variance is zero (say
   `eta.base ~ fix(0)`).  Such an item is dropped from the matrix that is

--- a/inst/include/rxode2ptr.h
+++ b/inst/include/rxode2ptr.h
@@ -327,6 +327,22 @@ extern "C" {
   typedef void (*setRxThreadId_t)(int id);
   extern setRxThreadId_t setRxThreadId;
 
+  // Get/set the individual's infusion rate for compartment i.  The generated
+  // dydt() reads these as _IR[] straight into the right-hand side, so a caller
+  // evaluating dydt() outside an integration (e.g. on a discretization grid)
+  // has to set them itself.  Valid i is [0, op->neq + op->extraCmt).
+  typedef double (*getIndInfusionRate_t)(rx_solving_options_ind *ind, int i);
+  extern getIndInfusionRate_t getIndInfusionRate;
+  typedef void (*setIndInfusionRate_t)(rx_solving_options_ind *ind, int i, double val);
+  extern setIndInfusionRate_t setIndInfusionRate;
+
+  // Get/set whether compartment i is on.  Every generated right-hand side line
+  // is gated by _ON[], so a compartment left off yields a zero derivative.
+  typedef int (*getIndOn_t)(rx_solving_options_ind *ind, int i);
+  extern getIndOn_t getIndOn;
+  typedef void (*setIndOn_t)(rx_solving_options_ind *ind, int i, int val);
+  extern setIndOn_t setIndOn;
+
   static inline SEXP iniRxodePtrs0(SEXP p) {
     if (_rxode2_rxRmvnSEXP_ == NULL) {
       _rxode2_rxRmvnSEXP_ = (_rxode2_rxRmvnSEXP_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 0));
@@ -421,6 +437,14 @@ extern "C" {
       rxode2EventSensSetDims = (rxode2EventSensSetDims_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 89));
       rxode2EventSensSetActive = (rxode2EventSensSetActive_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 90));
       rxode2EventSensDeactivate = (rxode2EventSensDeactivate_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 91));
+      // Appended slots.  Reverse dependencies built against an older header stop
+      // at 91 and are unaffected; one built against this header requires an
+      // rxode2 that supplies them, which the R-level prefix check enforces
+      // before this ever runs (see babelmixr2 .iniRxode2Ptr()).
+      getIndInfusionRate = (getIndInfusionRate_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 92));
+      setIndInfusionRate = (setIndInfusionRate_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 93));
+      getIndOn = (getIndOn_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 94));
+      setIndOn = (setIndOn_t) R_ExternalPtrAddrFn(VECTOR_ELT(p, 95));
     }
     return R_NilValue;
   }
@@ -518,6 +542,10 @@ extern "C" {
   rxode2EventSensSetDims_t rxode2EventSensSetDims = NULL;           \
   rxode2EventSensSetActive_t rxode2EventSensSetActive = NULL;       \
   rxode2EventSensDeactivate_t rxode2EventSensDeactivate = NULL;     \
+  getIndInfusionRate_t getIndInfusionRate = NULL;                   \
+  setIndInfusionRate_t setIndInfusionRate = NULL;                   \
+  getIndOn_t getIndOn = NULL;                                       \
+  setIndOn_t setIndOn = NULL;                                       \
   SEXP iniRxodePtrs(SEXP ptr) {                         \
     return iniRxodePtrs0(ptr);                          \
   }                                                     \

--- a/src/init.c
+++ b/src/init.c
@@ -537,8 +537,16 @@ SEXP _rxode2_rxode2Ptr(void) {
   SEXP rxode2EventSensSetDimsPtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxode2EventSensSetDims, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2EventSensSetActivePtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxode2EventSensSetActive, R_NilValue, R_NilValue)); pro++;
   SEXP rxode2EventSensDeactivatePtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&rxode2EventSensDeactivate, R_NilValue, R_NilValue)); pro++;
+  // Appended for callers that evaluate dydt()/calc_jac() off the solver (magi):
+  // the generated right-hand side reads _IR[] and gates every line on _ON[], so
+  // both have to be settable from outside an integration.  Appended at the end
+  // so the prefix check reverse dependencies do stays backward compatible.
+  SEXP rxode2getIndInfusionRatePtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&getIndInfusionRate, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2setIndInfusionRatePtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setIndInfusionRate, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2getIndOnPtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&getIndOn, R_NilValue, R_NilValue)); pro++;
+  SEXP rxode2setIndOnPtr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&setIndOn, R_NilValue, R_NilValue)); pro++;
 
-#define nVec 92
+#define nVec 96
   SEXP ret = PROTECT(Rf_allocVector(VECSXP, nVec)); pro++;
   SET_VECTOR_ELT(ret, 0, rxode2rxRmvnSEXP);
   SET_VECTOR_ELT(ret, 1, rxode2rxParProgress);
@@ -632,6 +640,10 @@ SEXP _rxode2_rxode2Ptr(void) {
   SET_VECTOR_ELT(ret, 89, rxode2EventSensSetDimsPtr);
   SET_VECTOR_ELT(ret, 90, rxode2EventSensSetActivePtr);
   SET_VECTOR_ELT(ret, 91, rxode2EventSensDeactivatePtr);
+  SET_VECTOR_ELT(ret, 92, rxode2getIndInfusionRatePtr);
+  SET_VECTOR_ELT(ret, 93, rxode2setIndInfusionRatePtr);
+  SET_VECTOR_ELT(ret, 94, rxode2getIndOnPtr);
+  SET_VECTOR_ELT(ret, 95, rxode2setIndOnPtr);
 
 
   SEXP retN = PROTECT(Rf_allocVector(STRSXP, nVec)); pro++;
@@ -734,6 +746,10 @@ SEXP _rxode2_rxode2Ptr(void) {
   SET_STRING_ELT(retN, 89, Rf_mkChar("rxode2EventSensSetDims"));
   SET_STRING_ELT(retN, 90, Rf_mkChar("rxode2EventSensSetActive"));
   SET_STRING_ELT(retN, 91, Rf_mkChar("rxode2EventSensDeactivate"));
+  SET_STRING_ELT(retN, 92, Rf_mkChar("rxode2getIndInfusionRate"));
+  SET_STRING_ELT(retN, 93, Rf_mkChar("rxode2setIndInfusionRate"));
+  SET_STRING_ELT(retN, 94, Rf_mkChar("rxode2getIndOn"));
+  SET_STRING_ELT(retN, 95, Rf_mkChar("rxode2setIndOn"));
 
   // Nothing is validated here.  Every reverse dependency calls this at load, so a
   // check that fails takes them all down at once and they cannot be patched

--- a/src/rx2api.c
+++ b/src/rx2api.c
@@ -107,6 +107,62 @@ int getIndNallTimes(rx_solving_options_ind* ind) {
   return ind->n_all_times;
 }
 
+// InfusionRate and on are both sized (op->neq + op->extraCmt) and are NULL when
+// that count is zero (see _setIndPointersByThread in rxData.cpp), so guard on
+// both the bound and the NULL.
+static inline int rxIndCmtCount(const char *who) {
+  rx_solve* rx = getRxSolve_();
+  rx_solving_options* op = rx->op;
+  if (op == NULL) {
+    Rf_error("[%s]: no solving options are loaded", who);
+  }
+  return op->neq + op->extraCmt;
+}
+
+double getIndInfusionRate(rx_solving_options_ind* ind, int i) {
+  int n = rxIndCmtCount("getIndInfusionRate");
+  if (i < 0 || i >= n) {
+    Rf_error("[getIndInfusionRate]: i (%d) should be between [0, %d)", i, n);
+  }
+  if (ind->InfusionRate == NULL) {
+    Rf_error("[getIndInfusionRate]: the individual has no infusion rate buffer");
+  }
+  return ind->InfusionRate[i];
+}
+
+void setIndInfusionRate(rx_solving_options_ind* ind, int i, double val) {
+  int n = rxIndCmtCount("setIndInfusionRate");
+  if (i < 0 || i >= n) {
+    Rf_error("[setIndInfusionRate]: i (%d) should be between [0, %d) when assigning %f", i, n, val);
+  }
+  if (ind->InfusionRate == NULL) {
+    Rf_error("[setIndInfusionRate]: the individual has no infusion rate buffer");
+  }
+  ind->InfusionRate[i] = val;
+}
+
+int getIndOn(rx_solving_options_ind* ind, int i) {
+  int n = rxIndCmtCount("getIndOn");
+  if (i < 0 || i >= n) {
+    Rf_error("[getIndOn]: i (%d) should be between [0, %d)", i, n);
+  }
+  if (ind->on == NULL) {
+    Rf_error("[getIndOn]: the individual has no compartment on/off buffer");
+  }
+  return ind->on[i];
+}
+
+void setIndOn(rx_solving_options_ind* ind, int i, int val) {
+  int n = rxIndCmtCount("setIndOn");
+  if (i < 0 || i >= n) {
+    Rf_error("[setIndOn]: i (%d) should be between [0, %d) when assigning %d", i, n, val);
+  }
+  if (ind->on == NULL) {
+    Rf_error("[setIndOn]: the individual has no compartment on/off buffer");
+  }
+  ind->on[i] = val;
+}
+
 void setIndIdx(rx_solving_options_ind* ind, int j) {
   ind->idx = j;
 }

--- a/src/rx2api.h
+++ b/src/rx2api.h
@@ -164,6 +164,20 @@ extern "C" {
   // (RAII guard in nlmixr2est).
   void setIndNeqOverride(rx_solving_options_ind *ind, int neq);
 
+  // Get/set the individual's infusion rate for compartment i.  The generated
+  // dydt() reads these as _IR[] and adds them straight into the right-hand
+  // side, so a caller evaluating dydt() outside the solver (e.g. on a
+  // discretization grid rather than during an integration) has to set them
+  // itself.  Valid i is [0, op->neq + op->extraCmt).
+  double getIndInfusionRate(rx_solving_options_ind *ind, int i);
+  void setIndInfusionRate(rx_solving_options_ind *ind, int i, double val);
+
+  // Get/set whether compartment i is on.  Every generated right-hand side line
+  // is gated by _ON[], so a compartment left off returns a zero derivative and
+  // the caller silently gets nothing.  Valid i is [0, op->neq + op->extraCmt).
+  int getIndOn(rx_solving_options_ind *ind, int i);
+  void setIndOn(rx_solving_options_ind *ind, int i, int val);
+
   void rxSetSilentErr(int silent);
 
   int getOrdId(rx_solve *rx, int solveid);

--- a/tests/testthat/test-event-sensitivities-api.R
+++ b/tests/testthat/test-event-sensitivities-api.R
@@ -38,6 +38,10 @@ rxTest({
                       "rxode2EventSensLoadFull", "rxode2EventSensGetDims",
                       "rxode2EventSensSetDims", "rxode2EventSensSetActive",
                       "rxode2EventSensDeactivate") %in% names(p)))
+    # per-compartment infusion rate and on/off, for callers that evaluate
+    # dydt()/calc_jac() outside a solve
+    expect_true(all(c("rxode2getIndInfusionRate", "rxode2setIndInfusionRate",
+                      "rxode2getIndOn", "rxode2setIndOn") %in% names(p)))
   })
 
   # Slots whose LABEL does not describe the function they hold.  The labels are


### PR DESCRIPTION
## Why

The generated `dydt()` reads `_IR[]` straight into the right-hand side and gates every line on `_ON[]`:

```c
__DDtStateVar__[__DDT0__] = ((double)(_ON[__DDT0__]))*(_IR[__DDT0__] - cl/_div0(v)*centr);
```

Neither was reachable through the C function-pointer table. A downstream package that evaluates `dydt()` or `calc_jac()` **outside** an integration — over a fixed grid of states rather than along a solve — therefore had no way to set the dosing state, and silently got a right-hand side with no dosing at all.

This came up building a `magi` (manifold-constrained Gaussian process ODE inference) estimation method in babelmixr2, which needs `f`, `∂f/∂x` and `∂f/∂θ` evaluated at arbitrary states on a discretization grid rather than along a trajectory.

## What

Adds four accessors:

| | |
|---|---|
| `getIndInfusionRate(ind, i)` / `setIndInfusionRate(ind, i, val)` | compartment `i`'s infusion rate |
| `getIndOn(ind, i)` / `setIndOn(ind, i, val)` | whether compartment `i` is on |

Both are bounds-checked against `op->neq + op->extraCmt` — the size both buffers are allocated at in `_setIndPointersByThread()` — and guarded against the `NULL` both are set to when that count is zero.

## Compatibility

The four slots are **appended** (`nVec` 92 → 96). A package built against an older `rxode2ptr.h` stops reading at slot 91 and is unaffected; the existing name-freeze contract is preserved.

Covered by the existing invariants in `tests/testthat/test-event-sensitivities-api.R` (every slot filled/named/unique, every slot read exactly once by `iniRxodePtrs0()` with a matching name stem, existing names unchanged), plus an explicit presence assertion for the new names.