### PR TITLE
fix: keep %% infix in rxPrune()/rxOptExpr() so it can be estimated (#1229)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -112,6 +112,17 @@
   dropped silently -- the model still parsed and built, it simply lost the label
   (#1205).
 
+### Estimation / symengine translation
+
+- A model using the modulo operator `%%` can now be estimated.  `%%` was
+  missing from the infix operator tables of the `if`/`else` rewriter
+  (`rxPrune()`) and of `rxOptExpr()`, so both emitted it as the prefix call
+  `%%(a, b)`, which is not parsable rxode2.  Since every nlmixr2 estimation
+  method runs those two stages, a model that solved fine failed to fit with a
+  syntax error -- blocking `%%` as the way to write a square-wave or circadian
+  time-dependent parameter.  Operands that are not a plain name or number are
+  parenthesized, as the grammar requires (#1229).
+
 ### Solving
 
 - Modeled duration (`rate = -2`) and modeled rate (`rate = -1`) doses that fall

--- a/R/rxOptExpr.R
+++ b/R/rxOptExpr.R
@@ -69,7 +69,15 @@
 }
 
 .rxOptMod <- function(e1, e2) {
-  .addExpr(paste0(.rxModOperand(e1), "%%", .rxModOperand(e2)))
+  .ret <- paste0(.rxModOperand(e1), "%%", .rxModOperand(e2))
+  .num <- rex::rex(start, any_spaces, regNum, any_spaces, end)
+  if (regexpr(.num, paste0(e1), perl = TRUE) != -1 &&
+        regexpr(.num, paste0(e2), perl = TRUE) != -1) {
+    # constants are left inline, as the other binary operators do; unlike them
+    # `%%` is not folded here, since rxode2 truncates toward zero and R floors
+    return(.ret)
+  }
+  .addExpr(.ret)
 }
 
 .rxOptEnv <- new.env(parent = emptyenv())

--- a/R/rxOptExpr.R
+++ b/R/rxOptExpr.R
@@ -68,7 +68,12 @@
   }
 }
 
+.rxOptMod <- function(e1, e2) {
+  .addExpr(paste0(.rxModOperand(e1), "%%", .rxModOperand(e2)))
+}
+
 .rxOptEnv <- new.env(parent = emptyenv())
+.rxOptEnv[["%%"]] <- .rxOptMod
 .rxOptEnv[["^"]] <- .rxOptBin("^")
 .rxOptEnv[["**"]] <- .rxOptBin("^")
 
@@ -225,6 +230,11 @@
         }
       }
       return(paste0("(", ..rxOpt(.x2), ")"))
+    } else if (identical(x[[1]], quote(`%%`))) {
+      return(paste0(
+        .rxModOperand(..rxOpt(x[[2]])), "%%",
+        .rxModOperand(..rxOpt(x[[3]]))
+      ))
     } else if (identical(x[[1]], quote(`*`)) ||
       identical(x[[1]], quote(`^`)) ||
       identical(x[[1]], quote(`+`)) ||

--- a/R/rxOptExpr.R
+++ b/R/rxOptExpr.R
@@ -332,10 +332,10 @@
         ))
       } else {
         ## Unary Operators
-        return(paste0(
+        paste0(
           as.character(x[[1]]),
           ..rxOpt(x[[2]])
-        ))
+        )
       }
     } else if (identical(x[[1]], quote(`~`)) ||
       identical(x[[1]], quote(`=`)) ||

--- a/R/rxPrune.R
+++ b/R/rxPrune.R
@@ -165,10 +165,10 @@
         ))
       } else {
         ## Unary Operators
-        return(paste0(
+        paste0(
           as.character(x[[1]]),
           .rxPrune(x[[2]], envir = envir, strAssign=strAssign)
-        ))
+        )
       }
     } else if (identical(x[[1]], quote(`ifelse`))) {
       .f2 <- .rxPrune(x[[2]], envir = envir, strAssign=strAssign)

--- a/R/rxPrune.R
+++ b/R/rxPrune.R
@@ -30,6 +30,25 @@
   ret
 }
 
+#' Parenthesize an operand of `%%` when needed
+#'
+#' The rxode2 grammar requires a primary expression on both sides of
+#' `%%`, so anything that is not a plain identifier or number has to be
+#' wrapped in parentheses.
+#'
+#' @param x character string of an already-translated operand
+#' @return `x`, parenthesized when it is not a primary expression
+#' @noRd
+#' @author Matthew L. Fidler
+.rxModOperand <- function(x) {
+  if (grepl("^[a-zA-Z._][a-zA-Z0-9._]*$", x) ||
+        grepl("^[0-9]+[.]?[0-9]*([eE][-+]?[0-9]+)?$", x)) {
+    x
+  } else {
+    paste0("(", x, ")")
+  }
+}
+
 #'  Internal Pruning function
 #'
 #' @param x List of quoted lines
@@ -129,6 +148,11 @@
           .rxPrune(x[[3]], envir = envir, strAssign=strAssign)
         ))
       }
+    } else if (identical(x[[1]], quote(`%%`))) {
+      return(paste0(
+        .rxModOperand(.rxPrune(x[[2]], envir = envir, strAssign=strAssign)), "%%",
+        .rxModOperand(.rxPrune(x[[3]], envir = envir, strAssign=strAssign))
+      ))
     } else if (identical(x[[1]], quote(`*`)) ||
       identical(x[[1]], quote(`^`)) ||
       identical(x[[1]], quote(`+`)) ||

--- a/R/rxPrune.R
+++ b/R/rxPrune.R
@@ -41,8 +41,8 @@
 #' @noRd
 #' @author Matthew L. Fidler
 .rxModOperand <- function(x) {
-  if (grepl("^[a-zA-Z._][a-zA-Z0-9._]*$", x) ||
-        grepl("^[0-9]+[.]?[0-9]*([eE][-+]?[0-9]+)?$", x)) {
+  if (grepl("^([0-9]+[.]?[0-9]*|[.][0-9]+)([eE][-+]?[0-9]+)?$", x) ||
+        grepl("^[a-zA-Z._][a-zA-Z0-9._]*$", x)) {
     x
   } else {
     paste0("(", x, ")")

--- a/tests/testthat/test-rxode-issue-1229.R
+++ b/tests/testthat/test-rxode-issue-1229.R
@@ -29,18 +29,37 @@ rxTest({
 
   test_that("non-primary `%%` operands are parenthesized", {
     # the grammar wants a primary expression on either side of `%%`, so
-    # anything else has to be wrapped
-    .chk <- function(txt) {
+    # anything else has to be wrapped.  The emitted text is checked exactly:
+    # dropping a pair of parentheses can silently change the operand of `%%`
+    # while still parsing (`-t%%24` is `-(t%%24)` to the grammar, but `(-t)%%24`
+    # to R, which binds unary minus tighter).
+    .chk <- function(txt, prune, opt = prune) {
       .p <- rxPrune(rxGetModel(eval(parse(text = paste0("quote({", txt, "})")))))
-      expect_error(rxGetModel(paste(.p, collapse = "\n")), NA)
+      expect_equal(.p, paste0(prune, "\nd/dt(A)=-ka*A*fl"))
+      expect_error(rxGetModel(.p), NA)
       .o <- suppressMessages(rxOptExpr(txt))
+      expect_equal(.o, paste0(opt, "\nd/dt(A)=-ka*A*fl"))
       expect_error(rxGetModel(.o), NA)
     }
-    .chk("fl<-(time+3)%%(24*2)\nd/dt(A)<--ka*A*fl\n")
-    .chk("fl<-exp(a)%%exp(b)\nd/dt(A)<--ka*A*fl\n")
-    .chk("fl<--time%%24\nd/dt(A)<--ka*A*fl\n")
-    .chk("fl<-2*time%%24\nd/dt(A)<--ka*A*fl\n")
-    .chk("fl<-time%%24*2\nd/dt(A)<--ka*A*fl\n")
+    .chk("fl<-(time+3)%%(24*2)\nd/dt(A)<--ka*A*fl\n",
+         "fl=((t+3))%%((24*2))", "fl=((t+3))%%((48))")
+    .chk("fl<-exp(a)%%exp(b)\nd/dt(A)<--ka*A*fl\n",
+         "fl=(exp(a))%%(exp(b))", "fl=((exp(a)))%%((exp(b)))")
+    .chk("fl<--time%%24\nd/dt(A)<--ka*A*fl\n",
+         "fl=(-t)%%24", "fl=((-t))%%24")
+    # `%%` binds tighter than `*`, in both R and the grammar, so neither of
+    # these needs a parenthesis
+    .chk("fl<-2*time%%24\nd/dt(A)<--ka*A*fl\n", "fl=2*t%%24")
+    .chk("fl<-time%%24*2\nd/dt(A)<--ka*A*fl\n", "fl=t%%24*2")
+    # `.5` is a constant, not a name
+    .chk("fl<-time%%.5\nd/dt(A)<--ka*A*fl\n", "fl=t%%0.5")
+  })
+
+  test_that("a constant `%%` is left inline", {
+    # `%%` is never folded -- rxode2 truncates toward zero where R floors --
+    # but it is not hoisted into a rx_expr_ either
+    expect_equal(suppressMessages(rxOptExpr("fl1=24%%2+z\nfl2=24%%2+y\nd/dt(A)=fl1+fl2\n")),
+                 "fl1=24%%2+z\nfl2=24%%2+y\nd/dt(A)=fl1+fl2")
   })
 
   test_that("a `%%` model builds its symengine estimation model", {

--- a/tests/testthat/test-rxode-issue-1229.R
+++ b/tests/testthat/test-rxode-issue-1229.R
@@ -1,0 +1,70 @@
+rxTest({
+  # rxode2#1229: `%%` was missing from the infix tables of .rxPrune() and
+  # rxOptExpr(), so it was deparsed as the prefix call `%%(a, b)`, which is not
+  # parsable rxode2.  This blocked every nlmixr2 estimation method, since they
+  # all run the prune/optimize stages.
+
+  test_that(".rxPrune() keeps `%%` infix", {
+    m <- rxGetModel(quote({
+      fl <- 0
+      if ((time %% 24) > 12) {
+        fl <- 1
+      }
+      d/dt(A) <- -ka*A*(1 + fl)
+    }))
+    .p <- rxPrune(m)
+    expect_false(any(grepl("%%(", .p, fixed = TRUE)))
+    expect_equal(.p,
+                 paste("fl=0",
+                       "fl=((t%%24)>12)*(1)+(1-(((t%%24)>12)))*(fl)",
+                       "d/dt(A)=-ka*A*(1+fl)", sep = "\n"))
+    # the whole point: the pruned model is still rxode2
+    expect_error(rxGetModel(paste(.p, collapse = "\n")), NA)
+  })
+
+  test_that("rxOptExpr() keeps `%%` infix", {
+    expect_equal(suppressMessages(rxOptExpr("fl=1*((t%%24)>12)\nkFI=exp(a*(1-fl)+b*fl)\nd/dt(A)=kFI\n")),
+                 "fl=((t%%24)>12)\nkFI=exp(a*(1-fl)+b*fl)\nd/dt(A)=kFI")
+  })
+
+  test_that("non-primary `%%` operands are parenthesized", {
+    # the grammar wants a primary expression on either side of `%%`, so
+    # anything else has to be wrapped
+    .chk <- function(txt) {
+      .p <- rxPrune(rxGetModel(eval(parse(text = paste0("quote({", txt, "})")))))
+      expect_error(rxGetModel(paste(.p, collapse = "\n")), NA)
+      .o <- suppressMessages(rxOptExpr(txt))
+      expect_error(rxGetModel(.o), NA)
+    }
+    .chk("fl<-(time+3)%%(24*2)\nd/dt(A)<--ka*A*fl\n")
+    .chk("fl<-exp(a)%%exp(b)\nd/dt(A)<--ka*A*fl\n")
+    .chk("fl<--time%%24\nd/dt(A)<--ka*A*fl\n")
+    .chk("fl<-2*time%%24\nd/dt(A)<--ka*A*fl\n")
+    .chk("fl<-time%%24*2\nd/dt(A)<--ka*A*fl\n")
+  })
+
+  test_that("a `%%` model builds its symengine estimation model", {
+    one <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- -3.2
+        tv <- -1
+        eta.ka ~ 0.1
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        fl <- 1.0*((time %% 24) > 12)
+        d/dt(depot) <- -ka*depot
+        d/dt(center) <- ka*depot - cl/v*center*(1 + fl)
+        cp <- center/v
+        cp ~ add(add.sd)
+      })
+    }
+    ui <- one()
+    expect_error(rxUiGet.symengineModelPrune(list(ui, TRUE)), NA)
+    expect_error(rxS("fl=1*((t%%24)>12)\nd/dt(A)=-ka*A*(1+fl)\n", TRUE), NA)
+  })
+})


### PR DESCRIPTION
Fixes #1229.

`%%` solved correctly but could not be used in any nlmixr2 estimation method:
two of the model-rewriting stages every method runs emitted it as a *prefix*
call `%%(a, b)` instead of the infix form, which is not parsable rxode2.

```
rxode2 syntax error:
:009: fl<-1*((%%(time, 24))>12)
              ^
```

## Cause

`%%` was missing from the infix operator tables of

* `.rxPrune()` (`R/rxPrune.R`) -- the `if`/`else` -> indicator rewriter, whose
  infix branch listed `* ^ + - /` only, and
* `..rxOpt()` / `.rxOptEnv` (`R/rxOptExpr.R`),

so it fell through to the generic function-call path and was deparsed as a
prefix call.

## Fix

A `%%` branch in both walkers plus a `.rxOptEnv[["%%"]]` handler.  Operands are
parenthesized when they are not a plain name or number, because the grammar
(`mod_expression : primary_expression mod_operator exponent_expression`) wants a
primary expression on either side -- and because R binds unary minus *tighter*
than `%%` while the grammar does not, so `(-t)%%24` has to keep its
parentheses.

`%%` is deliberately **not** constant-folded the way `*`/`+`/`-`/`/` are:
rxode2 truncates toward zero (C `fmod`) where R floors, so folding `-5 %% 3` in
R would give `1` instead of `-2`.  A constant `%%` is left inline rather than
hoisted into a `rx_expr_`.

## Tests

`tests/testthat/test-rxode-issue-1229.R` asserts the exact emitted text for the
prune and the optimizer (so a dropped parenthesis cannot silently change an
operand), that the rewritten model re-parses, and that a `%%` model builds its
symengine estimation model.  The related suites (`opt-expr`, `lhs-str`,
`named-id`, `rxode-issue-054`, `rxode-issue-1211`, `capture-adaptive-dosing`,
`dde-past`) are green: 573 passing, 0 failing.

Reviewed independently with Antigravity (gemini-3.1-pro-high) over two rounds;
its two findings -- the constant-`%%` hoisting and tests that only asserted
parseability -- are fixed in the second commit, and the follow-up round found
nothing further.