### PR TITLE
fix(indLin): size generated ME()/IndF()/calc_jac() buffers by the compiled state count (#1200)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -273,15 +273,6 @@
 
 ### Matrix exponential / inductive linearization
 
-- `meOnly()`/`indLin()` no longer write past the end of their buffers when a
-  downstream package sets a per-individual effective state count
-  (`setIndNeqOverride()`).  Those buffers were sized by the effective count
-  while the model-generated `ME()`/`IndF()`/`calc_jac()` bodies always index by
-  the compiled state count, so a shortened count overran them -- quadratically
-  for `ME()`.  The generated code is now called through a full-size buffer and
-  the leading effective block copied back; with no override, which is every
-  path rxode2 itself takes, the calls and the numerics are unchanged.
-
 - `rxToIndLin()` -- and therefore `rxSolve(method="indLin")` -- now converts a
   model that mixes `linCmt()` with `d/dt()`.  It walked `$state`, which counts
   the `linCmt()` pseudo-compartments (`depot`, `central`, `peripheral*`); those

--- a/NEWS.md
+++ b/NEWS.md
@@ -273,6 +273,15 @@
 
 ### Matrix exponential / inductive linearization
 
+- `meOnly()`/`indLin()` no longer write past the end of their buffers when a
+  downstream package sets a per-individual effective state count
+  (`setIndNeqOverride()`).  Those buffers were sized by the effective count
+  while the model-generated `ME()`/`IndF()`/`calc_jac()` bodies always index by
+  the compiled state count, so a shortened count overran them -- quadratically
+  for `ME()`.  The generated code is now called through a full-size buffer and
+  the leading effective block copied back; with no override, which is every
+  path rxode2 itself takes, the calls and the numerics are unchanged.
+
 - `rxToIndLin()` -- and therefore `rxSolve(method="indLin")` -- now converts a
   model that mixes `linCmt()` with `d/dt()`.  It walked `$state`, which counts
   the `linCmt()` pseudo-compartments (`depot`, `central`, `peripheral*`); those

--- a/inst/include/rxode2.h
+++ b/inst/include/rxode2.h
@@ -33,6 +33,16 @@
 // (caller's contract).  Used by getSolve()/getAdvan() so that a per-
 // individual pred-mode solve writes and reads at the same compact stride
 // without mutating shared op->neq from a parallel worker thread.
+// CONTRACT: an override says "the model whose dydt/calc_jac/ME/IndF are
+// CURRENTLY INSTALLED (rxUpdateFuns) has this many states"; it is not a request
+// to solve part of a wider installed model.  rxEffNeq() is therefore the size
+// the generated code writes, which is why every solver -- and meOnly()/indLin()
+// in src/expm.cpp -- sizes the buffers it hands to that code from rxEffNeq()
+// rather than op->neq, even though op->neq (the pool width, set by the widest
+// peer model) may be larger.  Sizing those buffers from op->neq instead would
+// mis-stride the generated code's output for a narrower installed model;
+// setting an override WITHOUT installing the matching model overruns them (a
+// downstream misuse, not something rxode2 guards at runtime).  See rxode2#1200.
 // NOTE: getAdvan() + neqOverride is unsupported when op->numLin > 0
 // (op->linOffset is computed from the full neq layout).  A linCmt() model
 // mixed with ODEs does reach nlmixr2est's FOCEi flow with numLin > 0 on the

--- a/inst/include/rxode2.h
+++ b/inst/include/rxode2.h
@@ -33,16 +33,14 @@
 // (caller's contract).  Used by getSolve()/getAdvan() so that a per-
 // individual pred-mode solve writes and reads at the same compact stride
 // without mutating shared op->neq from a parallel worker thread.
-// CONTRACT: an override says "the model whose dydt/calc_jac/ME/IndF are
-// CURRENTLY INSTALLED (rxUpdateFuns) has this many states"; it is not a request
-// to solve part of a wider installed model.  rxEffNeq() is therefore the size
-// the generated code writes, which is why every solver -- and meOnly()/indLin()
-// in src/expm.cpp -- sizes the buffers it hands to that code from rxEffNeq()
-// rather than op->neq, even though op->neq (the pool width, set by the widest
-// peer model) may be larger.  Sizing those buffers from op->neq instead would
-// mis-stride the generated code's output for a narrower installed model;
-// setting an override WITHOUT installing the matching model overruns them (a
-// downstream misuse, not something rxode2 guards at runtime).  See rxode2#1200.
+// An override does NOT narrow rx->fns: ME/IndF (and the calc_jac global) are
+// bound by rxAssignPtr(), which rxSolve() calls with the model that also sized
+// op->neq, and nothing rebinds them per individual -- nlmixr2est's odeSwap
+// swaps the dydt family into its own struct, which has no me/indf.  So a
+// generated ME()/IndF()/calc_jac() body still indexes by op->neq while an
+// override is armed, and a buffer handed to one must be sized op->neq even
+// where the surrounding loop runs to rxEffNeq() (rxode2#1200; see the shims in
+// src/expm.cpp).
 // NOTE: getAdvan() + neqOverride is unsupported when op->numLin > 0
 // (op->linOffset is computed from the full neq layout).  A linCmt() model
 // mixed with ODEs does reach nlmixr2est's FOCEi flow with numLin > 0 on the

--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -636,6 +636,100 @@ static inline int indLinUseSymJac(rx_solving_options *op) {
   }
 }
 
+// Shims for calling the MODEL-GENERATED `ME()`, `IndF()` and `calc_jac()`
+// bodies (rxode2#1200).
+//
+// Those bodies always write the FULL COMPILED state count (`tb.de.n`, which is
+// `op->neq`); codegen bakes that count in as a literal (`src/codegen.c`, the
+// `ode_mexp` / `ode_indLinVec` branches) and knows nothing about a
+// per-individual `ind->neqOverride`.  Everything in this file sizes its buffers
+// by the EFFECTIVE count `rxEffNeq()`, so under an override those buffers are
+// short and the generated write runs past their end -- quadratically so for
+// `ME`.  Route every generated-code call through a full-size scratch and copy
+// the leading effective block back out.
+//
+// The override always shortens (`rxEffNeq() <= op->neq`, the caller's
+// contract), and the states it drops are the trailing ones, which do not feed
+// back into the leading block, so the leading block IS the effective system's
+// matrix / forcing.  With no override -- the only case rxode2 itself reaches --
+// `neq == op->neq` and the generated code still writes straight into the
+// caller's buffer, so the numerics are bit-identical to before.
+//
+// The STATE they read is padded for the same reason: a generated body reads
+// `__zzStateVar__[0 .. op->neq-1]` too, and most of the states handed in here
+// are this file's own `neq`-sized scratch vectors (`y0`, `w`, `U2`, the
+// finite-difference `yPert`), where reading the full count is an overrun of an
+// exactly-sized heap buffer.  The padding is zero, which is the value the
+// dropped trailing states have no say over anyway.
+//
+// The scratch is a plain local vector rather than a per-thread pool: it is only
+// allocated on the override path, and there it is immediately followed by a
+// matrix exponential of the same size.
+static inline void indLinPadState(const double *y, int neq,
+                                  std::vector<double> &yFull) {
+  std::copy(y, y + neq, yFull.begin());
+}
+
+static inline void indLinME(t_ME ME, int cSub, double tcov, double tEval,
+                            double *mat, const double *y,
+                            int neq, rx_solving_options *op) {
+  if (neq >= op->neq) {
+    ME(cSub, tcov, tEval, mat, y);
+    return;
+  }
+  const int nAll = op->neq;
+  std::vector<double> yFull((size_t)nAll, 0.0);
+  indLinPadState(y, neq, yFull);
+  std::vector<double> full((size_t)nAll*(size_t)nAll);
+  ME(cSub, tcov, tEval, &full[0], &yFull[0]);
+  // Column major, both sides.
+  for (int j = 0; j < neq; ++j) {
+    std::copy(&full[0] + (size_t)j*nAll, &full[0] + (size_t)j*nAll + neq,
+              mat + (size_t)j*neq);
+  }
+}
+
+static inline void indLinIndF(t_IndF IndF, int cSub, double tcov, double tEval,
+                              double *f, const double *y,
+                              int neq, rx_solving_options *op) {
+  if (neq >= op->neq) {
+    IndF(cSub, tcov, tEval, f, y);
+    return;
+  }
+  const int nAll = op->neq;
+  std::vector<double> yFull((size_t)nAll, 0.0);
+  indLinPadState(y, neq, yFull);
+  std::vector<double> full((size_t)nAll);
+  IndF(cSub, tcov, tEval, &full[0], &yFull[0]);
+  std::copy(&full[0], &full[0] + neq, f);
+}
+
+// `calc_jac` takes its row stride as an argument (`__NROWPD__`), but the
+// entries it writes are still keyed by the compiled state count, so a short
+// stride is not enough on its own.  Unlike `ME`/`IndF` it writes only the
+// entries the model declares, hence the zero fill.  Its state argument is
+// non-const only because the generated prototype is; the body reads it.
+static inline void indLinCalcJac(int cSub, double tEval, const double *y,
+                                 double *jac, int neq, rx_solving_options *op) {
+  int nj[2]; nj[1] = cSub;
+  if (neq >= op->neq) {
+    nj[0] = neq;
+    calc_jac(nj, tEval, const_cast<double*>(y), jac, (unsigned int) neq);
+    return;
+  }
+  const int nAll = op->neq;
+  nj[0] = nAll;
+  std::vector<double> yFull((size_t)nAll, 0.0);
+  indLinPadState(y, neq, yFull);
+  std::vector<double> full((size_t)nAll*(size_t)nAll, 0.0);
+  calc_jac(nj, tEval, &yFull[0], &full[0], (unsigned int) nAll);
+  // Row major, both sides (parseDfdy.h emits `[i*__NROWPD__ + j]`).
+  for (int i = 0; i < neq; ++i) {
+    std::copy(&full[0] + (size_t)i*nAll, &full[0] + (size_t)i*nAll + neq,
+              jac + (size_t)i*neq);
+  }
+}
+
 // The forcing Jacobian from the model's own analytic Jacobian.
 //
 // `calc_jac` is d(RHS)/dy for the WHOLE right-hand side, which in this
@@ -655,14 +749,14 @@ static inline int indLinUseSymJac(rx_solving_options *op) {
 // converges to the same fixed point under any J) while exprb -- whose order
 // conditions assume J is exact -- lost four orders of accuracy and took sixty
 // times the steps.
-static void indLinForcingJacSym(int cSub, int neq, double tcov, double tEval,
+static void indLinForcingJacSym(int cSub, rx_solving_options *op, int neq,
+                                double tcov, double tEval,
                                 const double *y, t_ME ME, arma::mat &Jf,
                                 arma::mat &Jfull, arma::mat &Amat) {
   Jfull.zeros(neq, neq);
   Amat.zeros(neq, neq);
-  int nj[2]; nj[0] = neq; nj[1] = cSub;
-  calc_jac(nj, tEval, const_cast<double*>(y), Jfull.memptr(), (unsigned int) neq);
-  ME(cSub, tcov, tEval, Amat.memptr(), const_cast<double*>(y));
+  indLinCalcJac(cSub, tEval, y, Jfull.memptr(), neq, op);
+  indLinME(ME, cSub, tcov, tEval, Amat.memptr(), y, neq, op);
   Jf = Jfull.t() - Amat;
 }
 
@@ -678,9 +772,9 @@ static void indLinForcingJacFd(int cSub, rx_solving_options *op,
     const double yj = y[j];
     const double eps = 6e-6 * std::max(fabs(yj), 1.0);
     yPert[j] = yj + eps;
-    IndF(cSub, tcov, tEval, fPlus.memptr(), yPert.memptr());
+    indLinIndF(IndF, cSub, tcov, tEval, fPlus.memptr(), yPert.memptr(), neq, op);
     yPert[j] = yj - eps;
-    IndF(cSub, tcov, tEval, fMinus.memptr(), yPert.memptr());
+    indLinIndF(IndF, cSub, tcov, tEval, fMinus.memptr(), yPert.memptr(), neq, op);
     yPert[j] = yj;
     const double d = 0.5/eps;
     for (int i = 0; i < neq; ++i) {
@@ -701,7 +795,7 @@ static void indLinForcingJac(int cSub, rx_solving_options *op,
                              arma::mat &Jfull, arma::mat &Amat) {
   if (IndF == NULL) { Jf.zeros(neq, neq); return; }
   if (indLinUseSymJac(op)) {
-    indLinForcingJacSym(cSub, neq, tcov, tEval, y, ME, Jf, Jfull, Amat);
+    indLinForcingJacSym(cSub, op, neq, tcov, tEval, y, ME, Jf, Jfull, Amat);
     return;
   }
   indLinForcingJacFd(cSub, op, neq, tcov, tEval, y, IndF, Jf, yPert, fPlus, fMinus);
@@ -724,7 +818,7 @@ int meOnly(int cSub, double *yc_, double *yp_, double tp, double tf, double tcov
   int type = op->indLinMatExpType;
   int order = op->indLinMatExpOrder;
   arma::mat m0(neq, neq);
-  ME(cSub, tcov, tme, m0.memptr(), yc_);
+  indLinME(ME, cSub, tcov, tme, m0.memptr(), yc_, neq, op);
   const arma::vec InfusionRate(InfusionRate_, neq, false, false);
   arma::vec yp(yp_, neq, false, true);
   arma::vec yc(yc_, neq, false, true);
@@ -841,7 +935,7 @@ static int indLinRampBuild(int cSub, rx_solving_options *op, rx_solving_options_
                          tMid, rmp->f0.memptr(), on_, ME, op, ind);
   if (ret <= 0) return ret;
   arma::mat Aloc(neq, neq), phiZ(neq, neq), phiTmp(neq, neq);
-  ME(cSub, tcov, tMid, Aloc.memptr(), y0.memptr());
+  indLinME(ME, cSub, tcov, tMid, Aloc.memptr(), y0.memptr(), neq, op);
   indLinPmat(op, ind, neq, Aloc, h, 2, rmp->P2, phiZ, phiTmp);
   return 1;
 }
@@ -861,7 +955,8 @@ static inline int indLinPass(int cSub, rx_solving_options *op, rx_solving_option
                              const indLinRamp_t *rmp) {
   double *force = InfusionRate_;
   if (u != NULL) {
-    IndF(cSub, tcov, tEval, u->memptr(), w);
+    const int neq = (ind != NULL) ? rxEffNeq(ind, op) : op->neq;
+    indLinIndF(IndF, cSub, tcov, tEval, u->memptr(), w, neq, op);
     if (rmp != NULL) {
       const arma::vec out = rmp->base + rmp->P2*(*u - rmp->f0);
       std::copy(out.begin(), out.end(), w);
@@ -1047,11 +1142,11 @@ static int indLinExprb2(int cSub, rx_solving_options *op, rx_solving_options_ind
                         arma::mat &augE, arma::mat &Aloc,
                         arma::mat &Jfull, arma::mat &Amat) {
   // A at the step start.
-  ME(cSub, tcov, tEval, Aloc.memptr(), const_cast<double*>(y0.memptr()));
+  indLinME(ME, cSub, tcov, tEval, Aloc.memptr(), y0.memptr(), neq, op);
   // f(y_n): IndF when there is one, otherwise the bare infusion rate.
   arma::vec f0(neq);
   if (u != NULL) {
-    IndF(cSub, tcov, tEval, f0.memptr(), const_cast<double*>(y0.memptr()));
+    indLinIndF(IndF, cSub, tcov, tEval, f0.memptr(), y0.memptr(), neq, op);
     indLinForcingJac(cSub, op, neq, tcov, tEval, y0.memptr(), IndF, ME,
                      Jf, yPert, fPlus, fMinus, Jfull, Amat);
   } else {
@@ -1136,10 +1231,10 @@ static int indLinExprb32(int cSub, rx_solving_options *op, rx_solving_options_in
                          arma::vec &fMinus, arma::mat &aug, arma::vec &augY,
                          arma::mat &augE, arma::mat &Aloc,
                          arma::mat &Jfull, arma::mat &Amat) {
-  ME(cSub, tcov, tEval, Aloc.memptr(), const_cast<double*>(y0.memptr()));
+  indLinME(ME, cSub, tcov, tEval, Aloc.memptr(), y0.memptr(), neq, op);
   arma::vec f0(neq);
   if (u != NULL) {
-    IndF(cSub, tcov, tEval, f0.memptr(), const_cast<double*>(y0.memptr()));
+    indLinIndF(IndF, cSub, tcov, tEval, f0.memptr(), y0.memptr(), neq, op);
     indLinForcingJac(cSub, op, neq, tcov, tEval, y0.memptr(), IndF, ME,
                      Jf, yPert, fPlus, fMinus, Jfull, Amat);
   } else {
@@ -1173,7 +1268,7 @@ static int indLinExprb32(int cSub, rx_solving_options *op, rx_solving_options_in
     return 1;
   }
   arma::vec fU2(neq);
-  IndF(cSub, tcov, tEval, fU2.memptr(), U2.memptr());
+  indLinIndF(IndF, cSub, tcov, tEval, fU2.memptr(), U2.memptr(), neq, op);
   arma::vec D2 = fU2 - f0 - Jf*(U2 - y0);
   // phi3(hJ) D_2 from one exponential of size neq+3, using
   //   exp([[X, W],[0, K]])  with W = [w_p ... w_1] and K the UNIT superdiagonal
@@ -1348,7 +1443,7 @@ static inline void indLinNewtonPmat(int cSub, rx_solving_options *op,
     return;
   }
   arma::mat Aloc(neq, neq), phiZ(neq, neq), phiTmp(neq, neq);
-  ME(cSub, tcov, subTf, Aloc.memptr(), w.memptr());
+  indLinME(ME, cSub, tcov, subTf, Aloc.memptr(), w.memptr(), neq, op);
   indLinPmat(op, ind, neq, Aloc, h, 1, Ph, phiZ, phiTmp);
 }
 
@@ -2346,7 +2441,7 @@ extern "C" int indLin(int cSub, rx_solving_options *op, rx_solving_options_ind *
     case 2: {
       // Evaluate the forcing at the interval-start state, the same vector
       // `meOnly()` hands to `ME` below (it is `meOnly()` that advances `yp_`).
-      IndF(cSub, tcov, _subTf, u.memptr(), yp_);
+      indLinIndF(IndF, cSub, tcov, _subTf, u.memptr(), yp_, neq, op);
       _ret = meOnly(cSub, yp_, yp_, _subTp, _subTf, tcov, _subTf, u.memptr(), on_, ME, op, ind);
       break;
     }

--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -648,6 +648,14 @@ static inline int indLinUseSymJac(rx_solving_options *op) {
 // `ME`.  Route every generated-code call through a full-size scratch and copy
 // the leading effective block back out.
 //
+// An override does not narrow which bodies get called: `ME`/`IndF` come from
+// `ind->fns` (== `&rx->fns`), and `calc_jac` is a file-scope global; both are
+// bound by `rxAssignPtr()`, which `rxSolve()` calls with the model that also
+// sized `op->neq`, and nothing rebinds them per individual (nlmixr2est's
+// odeSwap swaps only the dydt family, into a struct with no `me`/`indf`).  So
+// the body running under an override is still the one compiled for `op->neq`
+// states.
+//
 // The override always shortens (`rxEffNeq() <= op->neq`, the caller's
 // contract), and the states it drops are the trailing ones, which do not feed
 // back into the leading block, so the leading block IS the effective system's
@@ -808,12 +816,8 @@ int meOnly(int cSub, double *yc_, double *yp_, double tp, double tf, double tcov
   // back to op->neq.  Keeps allocations / loops consistent with what the
   // outer indLin solver wrote.
   //
-  // This is also the right size for the `ME`/`IndF`/`calc_jac` buffers below,
-  // which the model-generated bodies index by their own compiled state count:
-  // an override says how many states the INSTALLED model has, so rxEffNeq() is
-  // that count (see the contract on rxEffNeq() in inst/include/rxode2.h, and
-  // rxode2#1200).  Sizing them from op->neq -- the pool width -- would
-  // mis-stride the output whenever a narrower model is installed.
+  // It is NOT the size the generated `ME` writes -- see the shims above -- so
+  // the `ME` call goes through `indLinME()`.
   int neq = (ind != NULL) ? rxEffNeq(ind, op) : op->neq;
   int type = op->indLinMatExpType;
   int order = op->indLinMatExpOrder;
@@ -2364,7 +2368,6 @@ extern "C" int indLin(int cSub, rx_solving_options *op, rx_solving_options_ind *
                       double tp, double *yp_, double tf,
 		      double *InfusionRate_, int *on_,
 		      t_ME ME, t_IndF  IndF){
-  // The installed model's state count, not the pool width -- see meOnly().
   int neq = (ind != NULL) ? rxEffNeq(ind, op) : op->neq;
   // Use per-individual tolerance arrays when available (set by
   // _setIndPointersByThread + iniSubject), falling back to op->rtol2/atol2.

--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -713,6 +713,13 @@ int meOnly(int cSub, double *yc_, double *yp_, double tp, double tf, double tcov
   // Honor per-individual neqOverride when ind is available; otherwise fall
   // back to op->neq.  Keeps allocations / loops consistent with what the
   // outer indLin solver wrote.
+  //
+  // This is also the right size for the `ME`/`IndF`/`calc_jac` buffers below,
+  // which the model-generated bodies index by their own compiled state count:
+  // an override says how many states the INSTALLED model has, so rxEffNeq() is
+  // that count (see the contract on rxEffNeq() in inst/include/rxode2.h, and
+  // rxode2#1200).  Sizing them from op->neq -- the pool width -- would
+  // mis-stride the output whenever a narrower model is installed.
   int neq = (ind != NULL) ? rxEffNeq(ind, op) : op->neq;
   int type = op->indLinMatExpType;
   int order = op->indLinMatExpOrder;
@@ -2262,6 +2269,7 @@ extern "C" int indLin(int cSub, rx_solving_options *op, rx_solving_options_ind *
                       double tp, double *yp_, double tf,
 		      double *InfusionRate_, int *on_,
 		      t_ME ME, t_IndF  IndF){
+  // The installed model's state count, not the pool width -- see meOnly().
   int neq = (ind != NULL) ? rxEffNeq(ind, op) : op->neq;
   // Use per-individual tolerance arrays when available (set by
   // _setIndPointersByThread + iniSubject), falling back to op->rtol2/atol2.

--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -636,100 +636,6 @@ static inline int indLinUseSymJac(rx_solving_options *op) {
   }
 }
 
-// Shims for calling the MODEL-GENERATED `ME()`, `IndF()` and `calc_jac()`
-// bodies (rxode2#1200).
-//
-// Those bodies always write the FULL COMPILED state count (`tb.de.n`, which is
-// `op->neq`); codegen bakes that count in as a literal (`src/codegen.c`, the
-// `ode_mexp` / `ode_indLinVec` branches) and knows nothing about a
-// per-individual `ind->neqOverride`.  Everything in this file sizes its buffers
-// by the EFFECTIVE count `rxEffNeq()`, so under an override those buffers are
-// short and the generated write runs past their end -- quadratically so for
-// `ME`.  Route every generated-code call through a full-size scratch and copy
-// the leading effective block back out.
-//
-// The override always shortens (`rxEffNeq() <= op->neq`, the caller's
-// contract), and the states it drops are the trailing ones, which do not feed
-// back into the leading block, so the leading block IS the effective system's
-// matrix / forcing.  With no override -- the only case rxode2 itself reaches --
-// `neq == op->neq` and the generated code still writes straight into the
-// caller's buffer, so the numerics are bit-identical to before.
-//
-// The STATE they read is padded for the same reason: a generated body reads
-// `__zzStateVar__[0 .. op->neq-1]` too, and most of the states handed in here
-// are this file's own `neq`-sized scratch vectors (`y0`, `w`, `U2`, the
-// finite-difference `yPert`), where reading the full count is an overrun of an
-// exactly-sized heap buffer.  The padding is zero, which is the value the
-// dropped trailing states have no say over anyway.
-//
-// The scratch is a plain local vector rather than a per-thread pool: it is only
-// allocated on the override path, and there it is immediately followed by a
-// matrix exponential of the same size.
-static inline void indLinPadState(const double *y, int neq,
-                                  std::vector<double> &yFull) {
-  std::copy(y, y + neq, yFull.begin());
-}
-
-static inline void indLinME(t_ME ME, int cSub, double tcov, double tEval,
-                            double *mat, const double *y,
-                            int neq, rx_solving_options *op) {
-  if (neq >= op->neq) {
-    ME(cSub, tcov, tEval, mat, y);
-    return;
-  }
-  const int nAll = op->neq;
-  std::vector<double> yFull((size_t)nAll, 0.0);
-  indLinPadState(y, neq, yFull);
-  std::vector<double> full((size_t)nAll*(size_t)nAll);
-  ME(cSub, tcov, tEval, &full[0], &yFull[0]);
-  // Column major, both sides.
-  for (int j = 0; j < neq; ++j) {
-    std::copy(&full[0] + (size_t)j*nAll, &full[0] + (size_t)j*nAll + neq,
-              mat + (size_t)j*neq);
-  }
-}
-
-static inline void indLinIndF(t_IndF IndF, int cSub, double tcov, double tEval,
-                              double *f, const double *y,
-                              int neq, rx_solving_options *op) {
-  if (neq >= op->neq) {
-    IndF(cSub, tcov, tEval, f, y);
-    return;
-  }
-  const int nAll = op->neq;
-  std::vector<double> yFull((size_t)nAll, 0.0);
-  indLinPadState(y, neq, yFull);
-  std::vector<double> full((size_t)nAll);
-  IndF(cSub, tcov, tEval, &full[0], &yFull[0]);
-  std::copy(&full[0], &full[0] + neq, f);
-}
-
-// `calc_jac` takes its row stride as an argument (`__NROWPD__`), but the
-// entries it writes are still keyed by the compiled state count, so a short
-// stride is not enough on its own.  Unlike `ME`/`IndF` it writes only the
-// entries the model declares, hence the zero fill.  Its state argument is
-// non-const only because the generated prototype is; the body reads it.
-static inline void indLinCalcJac(int cSub, double tEval, const double *y,
-                                 double *jac, int neq, rx_solving_options *op) {
-  int nj[2]; nj[1] = cSub;
-  if (neq >= op->neq) {
-    nj[0] = neq;
-    calc_jac(nj, tEval, const_cast<double*>(y), jac, (unsigned int) neq);
-    return;
-  }
-  const int nAll = op->neq;
-  nj[0] = nAll;
-  std::vector<double> yFull((size_t)nAll, 0.0);
-  indLinPadState(y, neq, yFull);
-  std::vector<double> full((size_t)nAll*(size_t)nAll, 0.0);
-  calc_jac(nj, tEval, &yFull[0], &full[0], (unsigned int) nAll);
-  // Row major, both sides (parseDfdy.h emits `[i*__NROWPD__ + j]`).
-  for (int i = 0; i < neq; ++i) {
-    std::copy(&full[0] + (size_t)i*nAll, &full[0] + (size_t)i*nAll + neq,
-              jac + (size_t)i*neq);
-  }
-}
-
 // The forcing Jacobian from the model's own analytic Jacobian.
 //
 // `calc_jac` is d(RHS)/dy for the WHOLE right-hand side, which in this
@@ -749,14 +655,14 @@ static inline void indLinCalcJac(int cSub, double tEval, const double *y,
 // converges to the same fixed point under any J) while exprb -- whose order
 // conditions assume J is exact -- lost four orders of accuracy and took sixty
 // times the steps.
-static void indLinForcingJacSym(int cSub, rx_solving_options *op, int neq,
-                                double tcov, double tEval,
+static void indLinForcingJacSym(int cSub, int neq, double tcov, double tEval,
                                 const double *y, t_ME ME, arma::mat &Jf,
                                 arma::mat &Jfull, arma::mat &Amat) {
   Jfull.zeros(neq, neq);
   Amat.zeros(neq, neq);
-  indLinCalcJac(cSub, tEval, y, Jfull.memptr(), neq, op);
-  indLinME(ME, cSub, tcov, tEval, Amat.memptr(), y, neq, op);
+  int nj[2]; nj[0] = neq; nj[1] = cSub;
+  calc_jac(nj, tEval, const_cast<double*>(y), Jfull.memptr(), (unsigned int) neq);
+  ME(cSub, tcov, tEval, Amat.memptr(), const_cast<double*>(y));
   Jf = Jfull.t() - Amat;
 }
 
@@ -772,9 +678,9 @@ static void indLinForcingJacFd(int cSub, rx_solving_options *op,
     const double yj = y[j];
     const double eps = 6e-6 * std::max(fabs(yj), 1.0);
     yPert[j] = yj + eps;
-    indLinIndF(IndF, cSub, tcov, tEval, fPlus.memptr(), yPert.memptr(), neq, op);
+    IndF(cSub, tcov, tEval, fPlus.memptr(), yPert.memptr());
     yPert[j] = yj - eps;
-    indLinIndF(IndF, cSub, tcov, tEval, fMinus.memptr(), yPert.memptr(), neq, op);
+    IndF(cSub, tcov, tEval, fMinus.memptr(), yPert.memptr());
     yPert[j] = yj;
     const double d = 0.5/eps;
     for (int i = 0; i < neq; ++i) {
@@ -795,7 +701,7 @@ static void indLinForcingJac(int cSub, rx_solving_options *op,
                              arma::mat &Jfull, arma::mat &Amat) {
   if (IndF == NULL) { Jf.zeros(neq, neq); return; }
   if (indLinUseSymJac(op)) {
-    indLinForcingJacSym(cSub, op, neq, tcov, tEval, y, ME, Jf, Jfull, Amat);
+    indLinForcingJacSym(cSub, neq, tcov, tEval, y, ME, Jf, Jfull, Amat);
     return;
   }
   indLinForcingJacFd(cSub, op, neq, tcov, tEval, y, IndF, Jf, yPert, fPlus, fMinus);
@@ -811,7 +717,7 @@ int meOnly(int cSub, double *yc_, double *yp_, double tp, double tf, double tcov
   int type = op->indLinMatExpType;
   int order = op->indLinMatExpOrder;
   arma::mat m0(neq, neq);
-  indLinME(ME, cSub, tcov, tme, m0.memptr(), yc_, neq, op);
+  ME(cSub, tcov, tme, m0.memptr(), yc_);
   const arma::vec InfusionRate(InfusionRate_, neq, false, false);
   arma::vec yp(yp_, neq, false, true);
   arma::vec yc(yc_, neq, false, true);
@@ -928,7 +834,7 @@ static int indLinRampBuild(int cSub, rx_solving_options *op, rx_solving_options_
                          tMid, rmp->f0.memptr(), on_, ME, op, ind);
   if (ret <= 0) return ret;
   arma::mat Aloc(neq, neq), phiZ(neq, neq), phiTmp(neq, neq);
-  indLinME(ME, cSub, tcov, tMid, Aloc.memptr(), y0.memptr(), neq, op);
+  ME(cSub, tcov, tMid, Aloc.memptr(), y0.memptr());
   indLinPmat(op, ind, neq, Aloc, h, 2, rmp->P2, phiZ, phiTmp);
   return 1;
 }
@@ -948,8 +854,7 @@ static inline int indLinPass(int cSub, rx_solving_options *op, rx_solving_option
                              const indLinRamp_t *rmp) {
   double *force = InfusionRate_;
   if (u != NULL) {
-    const int neq = (ind != NULL) ? rxEffNeq(ind, op) : op->neq;
-    indLinIndF(IndF, cSub, tcov, tEval, u->memptr(), w, neq, op);
+    IndF(cSub, tcov, tEval, u->memptr(), w);
     if (rmp != NULL) {
       const arma::vec out = rmp->base + rmp->P2*(*u - rmp->f0);
       std::copy(out.begin(), out.end(), w);
@@ -1135,11 +1040,11 @@ static int indLinExprb2(int cSub, rx_solving_options *op, rx_solving_options_ind
                         arma::mat &augE, arma::mat &Aloc,
                         arma::mat &Jfull, arma::mat &Amat) {
   // A at the step start.
-  indLinME(ME, cSub, tcov, tEval, Aloc.memptr(), y0.memptr(), neq, op);
+  ME(cSub, tcov, tEval, Aloc.memptr(), const_cast<double*>(y0.memptr()));
   // f(y_n): IndF when there is one, otherwise the bare infusion rate.
   arma::vec f0(neq);
   if (u != NULL) {
-    indLinIndF(IndF, cSub, tcov, tEval, f0.memptr(), y0.memptr(), neq, op);
+    IndF(cSub, tcov, tEval, f0.memptr(), const_cast<double*>(y0.memptr()));
     indLinForcingJac(cSub, op, neq, tcov, tEval, y0.memptr(), IndF, ME,
                      Jf, yPert, fPlus, fMinus, Jfull, Amat);
   } else {
@@ -1224,10 +1129,10 @@ static int indLinExprb32(int cSub, rx_solving_options *op, rx_solving_options_in
                          arma::vec &fMinus, arma::mat &aug, arma::vec &augY,
                          arma::mat &augE, arma::mat &Aloc,
                          arma::mat &Jfull, arma::mat &Amat) {
-  indLinME(ME, cSub, tcov, tEval, Aloc.memptr(), y0.memptr(), neq, op);
+  ME(cSub, tcov, tEval, Aloc.memptr(), const_cast<double*>(y0.memptr()));
   arma::vec f0(neq);
   if (u != NULL) {
-    indLinIndF(IndF, cSub, tcov, tEval, f0.memptr(), y0.memptr(), neq, op);
+    IndF(cSub, tcov, tEval, f0.memptr(), const_cast<double*>(y0.memptr()));
     indLinForcingJac(cSub, op, neq, tcov, tEval, y0.memptr(), IndF, ME,
                      Jf, yPert, fPlus, fMinus, Jfull, Amat);
   } else {
@@ -1261,7 +1166,7 @@ static int indLinExprb32(int cSub, rx_solving_options *op, rx_solving_options_in
     return 1;
   }
   arma::vec fU2(neq);
-  indLinIndF(IndF, cSub, tcov, tEval, fU2.memptr(), U2.memptr(), neq, op);
+  IndF(cSub, tcov, tEval, fU2.memptr(), U2.memptr());
   arma::vec D2 = fU2 - f0 - Jf*(U2 - y0);
   // phi3(hJ) D_2 from one exponential of size neq+3, using
   //   exp([[X, W],[0, K]])  with W = [w_p ... w_1] and K the UNIT superdiagonal
@@ -1436,7 +1341,7 @@ static inline void indLinNewtonPmat(int cSub, rx_solving_options *op,
     return;
   }
   arma::mat Aloc(neq, neq), phiZ(neq, neq), phiTmp(neq, neq);
-  indLinME(ME, cSub, tcov, subTf, Aloc.memptr(), w.memptr(), neq, op);
+  ME(cSub, tcov, subTf, Aloc.memptr(), w.memptr());
   indLinPmat(op, ind, neq, Aloc, h, 1, Ph, phiZ, phiTmp);
 }
 
@@ -2433,7 +2338,7 @@ extern "C" int indLin(int cSub, rx_solving_options *op, rx_solving_options_ind *
     case 2: {
       // Evaluate the forcing at the interval-start state, the same vector
       // `meOnly()` hands to `ME` below (it is `meOnly()` that advances `yp_`).
-      indLinIndF(IndF, cSub, tcov, _subTf, u.memptr(), yp_, neq, op);
+      IndF(cSub, tcov, _subTf, u.memptr(), yp_);
       _ret = meOnly(cSub, yp_, yp_, _subTp, _subTf, tcov, _subTf, u.memptr(), on_, ME, op, ind);
       break;
     }

--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -636,6 +636,100 @@ static inline int indLinUseSymJac(rx_solving_options *op) {
   }
 }
 
+// Shims for calling the MODEL-GENERATED `ME()`, `IndF()` and `calc_jac()`
+// bodies (rxode2#1200).
+//
+// Those bodies always write the FULL COMPILED state count (`tb.de.n`, which is
+// `op->neq`); codegen bakes that count in as a literal (`src/codegen.c`, the
+// `ode_mexp` / `ode_indLinVec` branches) and knows nothing about a
+// per-individual `ind->neqOverride`.  Everything in this file sizes its buffers
+// by the EFFECTIVE count `rxEffNeq()`, so under an override those buffers are
+// short and the generated write runs past their end -- quadratically so for
+// `ME`.  Route every generated-code call through a full-size scratch and copy
+// the leading effective block back out.
+//
+// The override always shortens (`rxEffNeq() <= op->neq`, the caller's
+// contract), and the states it drops are the trailing ones, which do not feed
+// back into the leading block, so the leading block IS the effective system's
+// matrix / forcing.  With no override -- the only case rxode2 itself reaches --
+// `neq == op->neq` and the generated code still writes straight into the
+// caller's buffer, so the numerics are bit-identical to before.
+//
+// The STATE they read is padded for the same reason: a generated body reads
+// `__zzStateVar__[0 .. op->neq-1]` too, and most of the states handed in here
+// are this file's own `neq`-sized scratch vectors (`y0`, `w`, `U2`, the
+// finite-difference `yPert`), where reading the full count is an overrun of an
+// exactly-sized heap buffer.  The padding is zero, which is the value the
+// dropped trailing states have no say over anyway.
+//
+// The scratch is a plain local vector rather than a per-thread pool: it is only
+// allocated on the override path, and there it is immediately followed by a
+// matrix exponential of the same size.
+static inline void indLinPadState(const double *y, int neq,
+                                  std::vector<double> &yFull) {
+  std::copy(y, y + neq, yFull.begin());
+}
+
+static inline void indLinME(t_ME ME, int cSub, double tcov, double tEval,
+                            double *mat, const double *y,
+                            int neq, rx_solving_options *op) {
+  if (neq >= op->neq) {
+    ME(cSub, tcov, tEval, mat, y);
+    return;
+  }
+  const int nAll = op->neq;
+  std::vector<double> yFull((size_t)nAll, 0.0);
+  indLinPadState(y, neq, yFull);
+  std::vector<double> full((size_t)nAll*(size_t)nAll);
+  ME(cSub, tcov, tEval, &full[0], &yFull[0]);
+  // Column major, both sides.
+  for (int j = 0; j < neq; ++j) {
+    std::copy(&full[0] + (size_t)j*nAll, &full[0] + (size_t)j*nAll + neq,
+              mat + (size_t)j*neq);
+  }
+}
+
+static inline void indLinIndF(t_IndF IndF, int cSub, double tcov, double tEval,
+                              double *f, const double *y,
+                              int neq, rx_solving_options *op) {
+  if (neq >= op->neq) {
+    IndF(cSub, tcov, tEval, f, y);
+    return;
+  }
+  const int nAll = op->neq;
+  std::vector<double> yFull((size_t)nAll, 0.0);
+  indLinPadState(y, neq, yFull);
+  std::vector<double> full((size_t)nAll);
+  IndF(cSub, tcov, tEval, &full[0], &yFull[0]);
+  std::copy(&full[0], &full[0] + neq, f);
+}
+
+// `calc_jac` takes its row stride as an argument (`__NROWPD__`), but the
+// entries it writes are still keyed by the compiled state count, so a short
+// stride is not enough on its own.  Unlike `ME`/`IndF` it writes only the
+// entries the model declares, hence the zero fill.  Its state argument is
+// non-const only because the generated prototype is; the body reads it.
+static inline void indLinCalcJac(int cSub, double tEval, const double *y,
+                                 double *jac, int neq, rx_solving_options *op) {
+  int nj[2]; nj[1] = cSub;
+  if (neq >= op->neq) {
+    nj[0] = neq;
+    calc_jac(nj, tEval, const_cast<double*>(y), jac, (unsigned int) neq);
+    return;
+  }
+  const int nAll = op->neq;
+  nj[0] = nAll;
+  std::vector<double> yFull((size_t)nAll, 0.0);
+  indLinPadState(y, neq, yFull);
+  std::vector<double> full((size_t)nAll*(size_t)nAll, 0.0);
+  calc_jac(nj, tEval, &yFull[0], &full[0], (unsigned int) nAll);
+  // Row major, both sides (parseDfdy.h emits `[i*__NROWPD__ + j]`).
+  for (int i = 0; i < neq; ++i) {
+    std::copy(&full[0] + (size_t)i*nAll, &full[0] + (size_t)i*nAll + neq,
+              jac + (size_t)i*neq);
+  }
+}
+
 // The forcing Jacobian from the model's own analytic Jacobian.
 //
 // `calc_jac` is d(RHS)/dy for the WHOLE right-hand side, which in this
@@ -655,14 +749,14 @@ static inline int indLinUseSymJac(rx_solving_options *op) {
 // converges to the same fixed point under any J) while exprb -- whose order
 // conditions assume J is exact -- lost four orders of accuracy and took sixty
 // times the steps.
-static void indLinForcingJacSym(int cSub, int neq, double tcov, double tEval,
+static void indLinForcingJacSym(int cSub, rx_solving_options *op, int neq,
+                                double tcov, double tEval,
                                 const double *y, t_ME ME, arma::mat &Jf,
                                 arma::mat &Jfull, arma::mat &Amat) {
   Jfull.zeros(neq, neq);
   Amat.zeros(neq, neq);
-  int nj[2]; nj[0] = neq; nj[1] = cSub;
-  calc_jac(nj, tEval, const_cast<double*>(y), Jfull.memptr(), (unsigned int) neq);
-  ME(cSub, tcov, tEval, Amat.memptr(), const_cast<double*>(y));
+  indLinCalcJac(cSub, tEval, y, Jfull.memptr(), neq, op);
+  indLinME(ME, cSub, tcov, tEval, Amat.memptr(), y, neq, op);
   Jf = Jfull.t() - Amat;
 }
 
@@ -678,9 +772,9 @@ static void indLinForcingJacFd(int cSub, rx_solving_options *op,
     const double yj = y[j];
     const double eps = 6e-6 * std::max(fabs(yj), 1.0);
     yPert[j] = yj + eps;
-    IndF(cSub, tcov, tEval, fPlus.memptr(), yPert.memptr());
+    indLinIndF(IndF, cSub, tcov, tEval, fPlus.memptr(), yPert.memptr(), neq, op);
     yPert[j] = yj - eps;
-    IndF(cSub, tcov, tEval, fMinus.memptr(), yPert.memptr());
+    indLinIndF(IndF, cSub, tcov, tEval, fMinus.memptr(), yPert.memptr(), neq, op);
     yPert[j] = yj;
     const double d = 0.5/eps;
     for (int i = 0; i < neq; ++i) {
@@ -701,7 +795,7 @@ static void indLinForcingJac(int cSub, rx_solving_options *op,
                              arma::mat &Jfull, arma::mat &Amat) {
   if (IndF == NULL) { Jf.zeros(neq, neq); return; }
   if (indLinUseSymJac(op)) {
-    indLinForcingJacSym(cSub, neq, tcov, tEval, y, ME, Jf, Jfull, Amat);
+    indLinForcingJacSym(cSub, op, neq, tcov, tEval, y, ME, Jf, Jfull, Amat);
     return;
   }
   indLinForcingJacFd(cSub, op, neq, tcov, tEval, y, IndF, Jf, yPert, fPlus, fMinus);
@@ -717,7 +811,7 @@ int meOnly(int cSub, double *yc_, double *yp_, double tp, double tf, double tcov
   int type = op->indLinMatExpType;
   int order = op->indLinMatExpOrder;
   arma::mat m0(neq, neq);
-  ME(cSub, tcov, tme, m0.memptr(), yc_);
+  indLinME(ME, cSub, tcov, tme, m0.memptr(), yc_, neq, op);
   const arma::vec InfusionRate(InfusionRate_, neq, false, false);
   arma::vec yp(yp_, neq, false, true);
   arma::vec yc(yc_, neq, false, true);
@@ -834,7 +928,7 @@ static int indLinRampBuild(int cSub, rx_solving_options *op, rx_solving_options_
                          tMid, rmp->f0.memptr(), on_, ME, op, ind);
   if (ret <= 0) return ret;
   arma::mat Aloc(neq, neq), phiZ(neq, neq), phiTmp(neq, neq);
-  ME(cSub, tcov, tMid, Aloc.memptr(), y0.memptr());
+  indLinME(ME, cSub, tcov, tMid, Aloc.memptr(), y0.memptr(), neq, op);
   indLinPmat(op, ind, neq, Aloc, h, 2, rmp->P2, phiZ, phiTmp);
   return 1;
 }
@@ -854,7 +948,8 @@ static inline int indLinPass(int cSub, rx_solving_options *op, rx_solving_option
                              const indLinRamp_t *rmp) {
   double *force = InfusionRate_;
   if (u != NULL) {
-    IndF(cSub, tcov, tEval, u->memptr(), w);
+    const int neq = (ind != NULL) ? rxEffNeq(ind, op) : op->neq;
+    indLinIndF(IndF, cSub, tcov, tEval, u->memptr(), w, neq, op);
     if (rmp != NULL) {
       const arma::vec out = rmp->base + rmp->P2*(*u - rmp->f0);
       std::copy(out.begin(), out.end(), w);
@@ -1040,11 +1135,11 @@ static int indLinExprb2(int cSub, rx_solving_options *op, rx_solving_options_ind
                         arma::mat &augE, arma::mat &Aloc,
                         arma::mat &Jfull, arma::mat &Amat) {
   // A at the step start.
-  ME(cSub, tcov, tEval, Aloc.memptr(), const_cast<double*>(y0.memptr()));
+  indLinME(ME, cSub, tcov, tEval, Aloc.memptr(), y0.memptr(), neq, op);
   // f(y_n): IndF when there is one, otherwise the bare infusion rate.
   arma::vec f0(neq);
   if (u != NULL) {
-    IndF(cSub, tcov, tEval, f0.memptr(), const_cast<double*>(y0.memptr()));
+    indLinIndF(IndF, cSub, tcov, tEval, f0.memptr(), y0.memptr(), neq, op);
     indLinForcingJac(cSub, op, neq, tcov, tEval, y0.memptr(), IndF, ME,
                      Jf, yPert, fPlus, fMinus, Jfull, Amat);
   } else {
@@ -1129,10 +1224,10 @@ static int indLinExprb32(int cSub, rx_solving_options *op, rx_solving_options_in
                          arma::vec &fMinus, arma::mat &aug, arma::vec &augY,
                          arma::mat &augE, arma::mat &Aloc,
                          arma::mat &Jfull, arma::mat &Amat) {
-  ME(cSub, tcov, tEval, Aloc.memptr(), const_cast<double*>(y0.memptr()));
+  indLinME(ME, cSub, tcov, tEval, Aloc.memptr(), y0.memptr(), neq, op);
   arma::vec f0(neq);
   if (u != NULL) {
-    IndF(cSub, tcov, tEval, f0.memptr(), const_cast<double*>(y0.memptr()));
+    indLinIndF(IndF, cSub, tcov, tEval, f0.memptr(), y0.memptr(), neq, op);
     indLinForcingJac(cSub, op, neq, tcov, tEval, y0.memptr(), IndF, ME,
                      Jf, yPert, fPlus, fMinus, Jfull, Amat);
   } else {
@@ -1166,7 +1261,7 @@ static int indLinExprb32(int cSub, rx_solving_options *op, rx_solving_options_in
     return 1;
   }
   arma::vec fU2(neq);
-  IndF(cSub, tcov, tEval, fU2.memptr(), U2.memptr());
+  indLinIndF(IndF, cSub, tcov, tEval, fU2.memptr(), U2.memptr(), neq, op);
   arma::vec D2 = fU2 - f0 - Jf*(U2 - y0);
   // phi3(hJ) D_2 from one exponential of size neq+3, using
   //   exp([[X, W],[0, K]])  with W = [w_p ... w_1] and K the UNIT superdiagonal
@@ -1341,7 +1436,7 @@ static inline void indLinNewtonPmat(int cSub, rx_solving_options *op,
     return;
   }
   arma::mat Aloc(neq, neq), phiZ(neq, neq), phiTmp(neq, neq);
-  ME(cSub, tcov, subTf, Aloc.memptr(), w.memptr());
+  indLinME(ME, cSub, tcov, subTf, Aloc.memptr(), w.memptr(), neq, op);
   indLinPmat(op, ind, neq, Aloc, h, 1, Ph, phiZ, phiTmp);
 }
 
@@ -2338,7 +2433,7 @@ extern "C" int indLin(int cSub, rx_solving_options *op, rx_solving_options_ind *
     case 2: {
       // Evaluate the forcing at the interval-start state, the same vector
       // `meOnly()` hands to `ME` below (it is `meOnly()` that advances `yp_`).
-      IndF(cSub, tcov, _subTf, u.memptr(), yp_);
+      indLinIndF(IndF, cSub, tcov, _subTf, u.memptr(), yp_, neq, op);
       _ret = meOnly(cSub, yp_, yp_, _subTp, _subTf, tcov, _subTf, u.memptr(), on_, ME, op, ind);
       break;
     }


### PR DESCRIPTION
Fixes #1200.

`meOnly()`/`indLin()` and the adaptive inductive-linearization machinery in
`src/expm.cpp` size their armadillo buffers by `rxEffNeq(ind, op)`, which honors
a per-individual `ind->neqOverride`. The model-generated `ME()`/`IndF()` bodies
index by the COMPILED state count (`tb.de.n` == `op->neq`), so with a shortened
override the generated write ran past the end of the buffer -- quadratically for
`ME`.

### Why the two counts really do diverge

Worth recording, because the code reads as if an override narrows everything:

`ME`/`IndF` are reached through `ind->fns` (`== &rx->fns`, set in `iniSubject`,
`src/par_solve.h`) and `calc_jac` is a file-scope global. Both are bound only by
`rxAssignPtr()` (`src/rxData.cpp`), which `rxSolve()` calls with the model that
also sized `op->neq`; nothing rebinds them per individual. nlmixr2est's
`odeSwap` arms `neqOverride` for a NARROWER peer model but swaps only the dydt
family, into its own `rxSolveF` struct -- which has no `me`/`indf` fields. So
the body running under an override is still the one compiled for `op->neq`
states, while the buffers around it shrank.

### Changes

All in `src/expm.cpp`, plus a comment on `rxEffNeq()` in
`inst/include/rxode2.h` recording the above.

- `indLinME()` / `indLinIndF()` / `indLinCalcJac()` shims. On the override path
  (`neq < op->neq`) they call the generated body into a full `op->neq`-sized
  scratch and copy the leading `neq` block back -- column major for `ME`, row
  major for `calc_jac` (`parseDfdy.h` emits `[i*__NROWPD__ + j]`, and
  `indLinForcingJacSym` transposes it back afterwards). `calc_jac`'s scratch is
  zero filled because it writes only the entries the model declares.
- Every `ME`/`IndF`/`calc_jac` call site in the file routed through them:
  `meOnly`, `indLinPass`, `indLinRampBuild`, `indLinForcingJacSym`,
  `indLinForcingJacFd`, `indLinExprb2`, `indLinExprb32`, `indLinNewtonPmat`,
  and `indLin` itself.
- The STATE is zero-padded to `op->neq` on the same path. This half is not in
  the issue: the generated bodies read `__zzStateVar__[0 .. op->neq-1]` too, and
  most of the states handed in here are this file's own `neq`-sized scratch
  vectors (`y0`, `w`, `U2`, the finite-difference `yPert`), i.e. exactly-sized
  heap buffers, so that was a real overrun as well -- not just the in-bounds
  read of the over-allocated `ind->solve` that the issue notes.

With no override armed -- every path rxode2 itself takes -- `neq == op->neq`,
the shims call the generated code directly, and the numerics are bit-identical.

### Verification

- `devtools::test(filter='ind-lin|mexp-nonmem')`: FAIL 0 | PASS 511, after a
  clean rebuild (a header comment changed).
- `devtools::test(filter='evid-push|modelargs|basic|matexp|sens')`:
  FAIL 0 | PASS 892.
- Independent review (Antigravity / gemini-3.1-pro-high), three passes: the
  final pass confirms call-site coverage, both memory layouts, the
  `Jfull.t()` interplay in `indLinForcingJacSym`, and the bit-identical
  no-override fast path, with no findings.

### Not covered

No regression test: nothing in rxode2 can arm `neqOverride` from R -- it is
reachable only through the `setIndNeqOverride()` pointer-table entry -- so a
test needs a downstream caller. One is added on the nlmixr2est side instead.

The branch history carries a revert and a reapply: the middle commits are a
wrong turn (an argument that `rxEffNeq()` was already the installed model's
count) and its correction, kept rather than squashed.
