### PR TITLE
parse: diagnose undeclared adaptive dosing arguments (#1231)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,26 @@
 
 ## Bug fixes
 
+### Parsing
+
+- A variable that is used *only* as an argument to an adaptive dosing call
+  (`evid_()`, `bolus()`, `infuse()`, `infuseDur()`, `replace()`, `multiply()`,
+  `phantom()`, `obs()`) is now a parse-time error instead of an uncompilable
+  model.  These statements consume their arguments as text, so such a variable
+  was never registered and the generated C referenced an undeclared identifier;
+  the failure only showed up as a compiler error that looked like a broken
+  toolchain.  The message now names the variable, the argument and the
+  function, and points at the fix (assign it to a model variable first):
+
+  ```
+  'DOSE' is only used as the 'amt' argument of 'infuseDur()'; an adaptive
+  dosing argument does not declare a model variable, assign it first (like
+  'amtVal <- DOSE')
+  ```
+
+  The check runs once the whole model is parsed, so a variable assigned below
+  the dosing statement still counts as declared (#1231).
+
 ### Compilation
 
 - A model that fails to build now shows the compiler's own error lines (and

--- a/NEWS.md
+++ b/NEWS.md
@@ -62,9 +62,7 @@
   function, and points at the fix (assign it to a model variable first):
 
   ```
-  'DOSE' is only used as the 'amt' argument of 'infuseDur()'; an adaptive
-  dosing argument does not declare a model variable, assign it first (like
-  'amtVal <- DOSE')
+  undeclared 'DOSE' in 'amt' of 'infuseDur()'; assign first: 'amtVal <- DOSE'
   ```
 
   The check runs once the whole model is parsed, so a variable assigned below

--- a/src/parseFuns.h
+++ b/src/parseFuns.h
@@ -7,6 +7,9 @@
 
 SEXP rxode2_getUdf2(const char *fun, const int nargs);
 
+// defined below, used by the adaptive dosing statement handlers
+static inline void rxPushDoseNoteArg(const char *fn, const char *arg, const char *v);
+
 static inline int isAtFunctionArg(const char *name) {
   return !strcmp("(", name) ||
     !strcmp(")", name) ||
@@ -79,6 +82,7 @@ static inline int handleObsStatement(nodeInfo ni, char *name, int *i, int nch,
     int ii = d_get_number_of_children(d_get_child(fPn, 3)) + 1;
     D_ParseNode *xpn0 = d_get_child(fPn, 2);
     char *v0 = (char*)rc_dup_str(xpn0->start_loc.s, xpn0->end);
+    rxPushDoseNoteArg("obs", "value", v0);
     sAppend(&sb, "_obs(_cSub, t, %d, (double) %s", ii, v0);
     sAppend(&sbDt, "_obs(_cSub, t, %d, (double) %s", ii, v0);
     sAppend(&sbt, "obs(%s", v0);
@@ -88,6 +92,7 @@ static inline int handleObsStatement(nodeInfo ni, char *name, int *i, int nch,
                                     d_get_child(rest, j)->end);
       char *arg = cur + 1;
       while (*arg == ' ' || *arg == '\t') arg++;
+      rxPushDoseNoteArg("obs", "value", arg);
       sAppend(&sb, ", (double) %s", arg);
       sAppend(&sbDt, ", (double) %s", arg);
       sAppend(&sbt, ", %s", arg);
@@ -546,6 +551,96 @@ static inline int isStrInteger(const char *s) {
   return 1;
 }
 
+// The adaptive dosing statements (evid_(), bolus(), infuse(), infuseDur(),
+// replace(), multiply(), phantom(), obs()) consume their arguments as raw text
+// and skip the parse-tree children, so an identifier appearing *only* there is
+// never registered as a model variable; the generated C then references an
+// undeclared symbol and the model fails to build with a compiler error that
+// looks like a broken toolchain.  Record the identifiers here and check them
+// once the whole model has been parsed -- the variable may legitimately be
+// assigned further down the model.  See #1231.
+static inline void rxPushDoseNoteArg(const char *fn, const char *arg, const char *v) {
+  if (v == NULL) return;
+  const char *p = v;
+  while (*p != '\0') {
+    if (isdigit((unsigned char)(*p)) ||
+        (*p == '.' && isdigit((unsigned char)(p[1])))) {
+      // numeric literal, including an exponent like 1e-7
+      while (isdigit((unsigned char)(*p)) || *p == '.') p++;
+      if (*p == 'e' || *p == 'E') {
+        p++;
+        if (*p == '+' || *p == '-') p++;
+      }
+      continue;
+    }
+    if (*p == '"' || *p == '\'') {
+      // string literal (a compartment name); skip it wholesale
+      char quote = *p;
+      p++;
+      while (*p != '\0' && *p != quote) p++;
+      if (*p == quote) p++;
+      continue;
+    }
+    if (isalpha((unsigned char)(*p)) || *p == '.' || *p == '_') {
+      const char *st = p;
+      while (isalnum((unsigned char)(*p)) || *p == '.' || *p == '_') p++;
+      int len = (int)(p - st);
+      const char *q = p;
+      while (*q == ' ' || *q == '\t') q++;
+      // a function call or a THETA[]/ETA[] reference, not a plain variable
+      if (*q == '(' || *q == '[') continue;
+      char nm[128];
+      if (len > 0 && len < (int)sizeof(nm)) {
+        memcpy(nm, st, (size_t)len);
+        nm[len] = '\0';
+        addLine(&sbDoseArgVar, "%s", nm);
+        addLine(&sbDoseArgCtx,
+                "'%s' is only used as the '%s' argument of '%s()'; an adaptive dosing argument does not declare a model variable, assign it first (like '%sVal <- %s')",
+                nm, arg, fn, arg, nm);
+      }
+      continue;
+    }
+    p++;
+  }
+}
+
+// Is `v` something the model already knows about -- a variable/parameter, a
+// compartment, a string-assigned variable, or a reserved name?
+static inline int rxPushDoseArgIsDeclared(const char *v) {
+  if (isReservedVariable(v)) return 1;
+  if (!strcmp(v, "pi") || !strcmp(v, "NA") || !strcmp(v, "NaN") ||
+      !strcmp(v, "Inf") || !strcmp(v, "T") || !strcmp(v, "F") ||
+      !strcmp(v, "TRUE") || !strcmp(v, "FALSE")) return 1;
+  for (int i = 0; i < NV; i++) {
+    if (!strcmp(tb.ss.line[i], v)) return 1;
+  }
+  for (int i = 0; i < tb.de.n; i++) {
+    if (!strcmp(tb.de.line[i], v)) return 1;
+  }
+  for (int i = 0; i < tb.str.n; i++) {
+    if (!strcmp(tb.str.line[i], v)) return 1;
+  }
+  return 0;
+}
+
+// Report the identifiers collected by rxPushDoseNoteArg() that the model never
+// declares.  Run after the whole model has been parsed, so a variable assigned
+// below the dosing statement still counts as declared.  See #1231.
+static inline void assertAdaptiveDosingArgsDeclared(void) {
+  for (int j = 0; j < sbDoseArgVar.n; j++) {
+    const char *v = sbDoseArgVar.line[j];
+    if (rxPushDoseArgIsDeclared(v)) continue;
+    int dup = 0; // only complain once per name
+    for (int k = 0; k < j; k++) {
+      if (!strcmp(sbDoseArgVar.line[k], v)) { dup = 1; break; }
+    }
+    if (dup) continue;
+    sPrint(&_gbuf, "%s", sbDoseArgCtx.line[j]);
+    updateSyntaxCol();
+    trans_syntax_error_report_fn0(_gbuf.s);
+  }
+}
+
 static inline const char *rxPushDoseCmtExpr(nodeInfo ni, char *name, char *vCmt) {
   while (*vCmt == ' ' || *vCmt == '\t') vCmt++;
   if (isStrInteger(vCmt)) {
@@ -595,6 +690,10 @@ static inline int handleBolusStatement(nodeInfo ni, char *name, int *i, int nch,
     char *vAddl = (char*)rc_dup_str(cAddl->start_loc.s, cAddl->end);
     char *vSs   = (char*)rc_dup_str(cSs->start_loc.s,   cSs->end);
     aType(TEVID);
+    rxPushDoseNoteArg("bolus", "amt",  vAmt);
+    rxPushDoseNoteArg("bolus", "ii",   vIi);
+    rxPushDoseNoteArg("bolus", "addl", vAddl);
+    rxPushDoseNoteArg("bolus", "ss",   vSs);
 
     // Children: 0='evid_', 1='(', 2=time, 3=',', 4=evid, 5=',', 6=amt, 7=',',
     //           8=cmt, 9=',', 10=rate, 11=',', 12=ii, 13=',', 14=addl, 15=',',
@@ -640,6 +739,11 @@ static inline int handleInfuseStatement(nodeInfo ni, char *name, int *i, int nch
     char *vAddl = (char*)rc_dup_str(cAddl->start_loc.s, cAddl->end);
     char *vSs   = (char*)rc_dup_str(cSs->start_loc.s,   cSs->end);
     aType(TEVID);
+    rxPushDoseNoteArg("infuse", "amt",  vAmt);
+    rxPushDoseNoteArg("infuse", "rate", vRate);
+    rxPushDoseNoteArg("infuse", "ii",   vIi);
+    rxPushDoseNoteArg("infuse", "addl", vAddl);
+    rxPushDoseNoteArg("infuse", "ss",   vSs);
 
     // Children: 0='evid_', 1='(', 2=time, 3=',', 4=evid, 5=',', 6=amt, 7=',',
     //           8=cmt, 9=',', 10=rate, 11=',', 12=ii, 13=',', 14=addl, 15=',',
@@ -687,6 +791,11 @@ static inline int handleInfuseDurStatement(nodeInfo ni, char *name, int *i, int 
     char *vAddl = (char*)rc_dup_str(cAddl->start_loc.s, cAddl->end);
     char *vSs   = (char*)rc_dup_str(cSs->start_loc.s,   cSs->end);
     aType(TEVID);
+    rxPushDoseNoteArg("infuseDur", "amt",  vAmt);
+    rxPushDoseNoteArg("infuseDur", "dur",  vDur);
+    rxPushDoseNoteArg("infuseDur", "ii",   vIi);
+    rxPushDoseNoteArg("infuseDur", "addl", vAddl);
+    rxPushDoseNoteArg("infuseDur", "ss",   vSs);
 
     const char *cmtExpr = rxPushDoseCmtExpr(ni, name, vCmt);
     sAppend(&sb,  "_rxPushDose(_ind, t, t, 1, %s, %s, %s, %s, (int)(%s), (int)(%s), 3);\n",
@@ -729,6 +838,7 @@ static inline int handleReplaceStatement(nodeInfo ni, char *name, int *i, int nc
     *i = nch; // skip all children; we process the whole statement at once
     sb.o = 0; sbDt.o = 0; sbt.o = 0;
     aType(TEVID);
+    rxPushDoseNoteArg("replace", "amt", vAmt);
     sAppend(&sb,   "_rxPushDose(_ind, t, t, 5, %s, %s, 0, 0, 0, 0, 0);\n",
             vAmt, cmtExpr);
     sAppend(&sbDt, "_rxPushDose(_ind, t, t, 5, %s, %s, 0, 0, 0, 0, 0);\n",
@@ -768,6 +878,7 @@ static inline int handleMultiplyStatement(nodeInfo ni, char *name, int *i, int n
     *i = nch; // skip all children; we process the whole statement at once
     sb.o = 0; sbDt.o = 0; sbt.o = 0;
     aType(TEVID);
+    rxPushDoseNoteArg("multiply", "amt", vAmt);
     sAppend(&sb,   "_rxPushDose(_ind, t, t, 6, %s, %s, 0, 0, 0, 0, 0);\n",
             vAmt, cmtExpr);
     sAppend(&sbDt, "_rxPushDose(_ind, t, t, 6, %s, %s, 0, 0, 0, 0, 0);\n",
@@ -807,6 +918,10 @@ static inline int handlePhantomStatement(nodeInfo ni, char *name, int *i, int nc
     // Children: 0='evid_', 1='(', 2=time, 3=',', 4=evid, 5=',', 6=amt, 7=',',
     //           8=cmt, 9=',', 10=rate, 11=',', 12=ii, 13=',', 14=addl, 15=',',
     //           16=ss, 17=')'
+    rxPushDoseNoteArg("phantom", "amt",  vAmt);
+    rxPushDoseNoteArg("phantom", "ii",   vIi);
+    rxPushDoseNoteArg("phantom", "addl", vAddl);
+    rxPushDoseNoteArg("phantom", "ss",   vSs);
     const char *cmtExpr = rxPushDoseCmtExpr(ni, name, vCmt);
     sAppend(&sb,  "_rxPushDose(_ind, t, t, 7, %s, %s, 0.0, %s, (int)(%s), (int)(%s), 0);\n",
             vAmt, cmtExpr, vIi, vAddl, vSs);
@@ -886,6 +1001,13 @@ static inline int handleEvidStatement(nodeInfo ni, char *name, int *i, int nch,
     char *vAddl = (char*)rc_dup_str(cAddl->start_loc.s, cAddl->end);
     char *vSs   = (char*)rc_dup_str(cSs->start_loc.s,   cSs->end);
     aType(TEVID);
+    rxPushDoseNoteArg("evid_", "time", vTime);
+    rxPushDoseNoteArg("evid_", "evid", vEvid);
+    rxPushDoseNoteArg("evid_", "amt",  vAmt);
+    rxPushDoseNoteArg("evid_", "rate", vRate);
+    rxPushDoseNoteArg("evid_", "ii",   vIi);
+    rxPushDoseNoteArg("evid_", "addl", vAddl);
+    rxPushDoseNoteArg("evid_", "ss",   vSs);
     const char *cmtExpr = rxPushDoseCmtExpr(ni, name, vCmt);
     sAppend(&sb,  "_rxPushDose(_ind, t, %s, (int)(%s), %s, %s, %s, %s, (int)(%s), (int)(%s), 0);\n",
             vTime, vEvid, vAmt, cmtExpr, vRate, vIi, vAddl, vSs);

--- a/src/parseFuns.h
+++ b/src/parseFuns.h
@@ -594,8 +594,7 @@ static inline void rxDoseArgRecord(const char *fn, const char *arg, const char *
   memcpy(nm, st, (size_t)len);
   nm[len] = '\0';
   addLine(&sbDoseArgVar, "%s", nm);
-  addLine(&sbDoseArgCtx,
-          "'%s' is only used as the '%s' argument of '%s()'; an adaptive dosing argument does not declare a model variable, assign it first (like '%sVal <- %s')",
+  addLine(&sbDoseArgCtx, "undeclared '%s' in '%s' of '%s()'; assign first: '%sVal <- %s'",
           nm, arg, fn, arg, nm);
 }
 

--- a/src/parseFuns.h
+++ b/src/parseFuns.h
@@ -558,69 +558,97 @@ static inline int isStrInteger(const char *s) {
 // undeclared symbol and the model fails to build with a compiler error that
 // looks like a broken toolchain.  Record the identifiers here and check them
 // once the whole model has been parsed -- the variable may legitimately be
-// assigned further down the model.  See #1231.
+// assigned further down the model.  See #1231.  The scan is split into the
+// per-token helpers below, driven by the loop in rxPushDoseNoteArg().
+static inline int rxDoseArgIsNumStart(const char *p) {
+  return isdigit((unsigned char)(*p)) || (*p == '.' && isdigit((unsigned char)(p[1])));
+}
+
+static inline int rxDoseArgIsIdStart(const char *p) {
+  return isalpha((unsigned char)(*p)) || *p == '.' || *p == '_';
+}
+
+// numeric literal, including an exponent like 1e-7; the exponent digits are
+// picked up by the next pass through the tokenizer loop
+static inline const char *rxDoseArgSkipNum(const char *p) {
+  while (isdigit((unsigned char)(*p)) || *p == '.') p++;
+  if (*p == 'e' || *p == 'E') {
+    p++;
+    if (*p == '+' || *p == '-') p++;
+  }
+  return p;
+}
+
+// string literal (a compartment name); skip it wholesale
+static inline const char *rxDoseArgSkipStr(const char *p) {
+  char quote = *p;
+  p++;
+  while (*p != '\0' && *p != quote) p++;
+  if (*p == quote) p++;
+  return p;
+}
+
+static inline void rxDoseArgRecord(const char *fn, const char *arg, const char *st, int len) {
+  char nm[128];
+  if (len <= 0 || len >= (int)sizeof(nm)) return;
+  memcpy(nm, st, (size_t)len);
+  nm[len] = '\0';
+  addLine(&sbDoseArgVar, "%s", nm);
+  addLine(&sbDoseArgCtx,
+          "'%s' is only used as the '%s' argument of '%s()'; an adaptive dosing argument does not declare a model variable, assign it first (like '%sVal <- %s')",
+          nm, arg, fn, arg, nm);
+}
+
+static inline const char *rxDoseArgSkipId(const char *fn, const char *arg, const char *p) {
+  const char *st = p;
+  while (isalnum((unsigned char)(*p)) || *p == '.' || *p == '_') p++;
+  const char *q = p;
+  while (*q == ' ' || *q == '\t') q++;
+  // a function call or a THETA[]/ETA[] reference, not a plain variable
+  if (*q != '(' && *q != '[') rxDoseArgRecord(fn, arg, st, (int)(p - st));
+  return p;
+}
+
 static inline void rxPushDoseNoteArg(const char *fn, const char *arg, const char *v) {
   if (v == NULL) return;
   const char *p = v;
   while (*p != '\0') {
-    if (isdigit((unsigned char)(*p)) ||
-        (*p == '.' && isdigit((unsigned char)(p[1])))) {
-      // numeric literal, including an exponent like 1e-7
-      while (isdigit((unsigned char)(*p)) || *p == '.') p++;
-      if (*p == 'e' || *p == 'E') {
-        p++;
-        if (*p == '+' || *p == '-') p++;
-      }
-      continue;
-    }
-    if (*p == '"' || *p == '\'') {
-      // string literal (a compartment name); skip it wholesale
-      char quote = *p;
+    if (rxDoseArgIsNumStart(p)) {
+      p = rxDoseArgSkipNum(p);
+    } else if (*p == '"' || *p == '\'') {
+      p = rxDoseArgSkipStr(p);
+    } else if (rxDoseArgIsIdStart(p)) {
+      p = rxDoseArgSkipId(fn, arg, p);
+    } else {
       p++;
-      while (*p != '\0' && *p != quote) p++;
-      if (*p == quote) p++;
-      continue;
     }
-    if (isalpha((unsigned char)(*p)) || *p == '.' || *p == '_') {
-      const char *st = p;
-      while (isalnum((unsigned char)(*p)) || *p == '.' || *p == '_') p++;
-      int len = (int)(p - st);
-      const char *q = p;
-      while (*q == ' ' || *q == '\t') q++;
-      // a function call or a THETA[]/ETA[] reference, not a plain variable
-      if (*q == '(' || *q == '[') continue;
-      char nm[128];
-      if (len > 0 && len < (int)sizeof(nm)) {
-        memcpy(nm, st, (size_t)len);
-        nm[len] = '\0';
-        addLine(&sbDoseArgVar, "%s", nm);
-        addLine(&sbDoseArgCtx,
-                "'%s' is only used as the '%s' argument of '%s()'; an adaptive dosing argument does not declare a model variable, assign it first (like '%sVal <- %s')",
-                nm, arg, fn, arg, nm);
-      }
-      continue;
-    }
-    p++;
   }
+}
+
+static inline int rxDoseArgInLines(vLines *l, int n, const char *v) {
+  for (int i = 0; i < n; i++) {
+    if (!strcmp(l->line[i], v)) return 1;
+  }
+  return 0;
+}
+
+static inline int rxDoseArgIsConstant(const char *v) {
+  static const char *constants[] = {"pi", "NA", "NaN", "Inf",
+                                    "T", "F", "TRUE", "FALSE"};
+  for (int i = 0; i < (int)(sizeof(constants)/sizeof(*constants)); i++) {
+    if (!strcmp(constants[i], v)) return 1;
+  }
+  return 0;
 }
 
 // Is `v` something the model already knows about -- a variable/parameter, a
 // compartment, a string-assigned variable, or a reserved name?
 static inline int rxPushDoseArgIsDeclared(const char *v) {
-  if (isReservedVariable(v)) return 1;
-  if (!strcmp(v, "pi") || !strcmp(v, "NA") || !strcmp(v, "NaN") ||
-      !strcmp(v, "Inf") || !strcmp(v, "T") || !strcmp(v, "F") ||
-      !strcmp(v, "TRUE") || !strcmp(v, "FALSE")) return 1;
-  for (int i = 0; i < NV; i++) {
-    if (!strcmp(tb.ss.line[i], v)) return 1;
-  }
-  for (int i = 0; i < tb.de.n; i++) {
-    if (!strcmp(tb.de.line[i], v)) return 1;
-  }
-  for (int i = 0; i < tb.str.n; i++) {
-    if (!strcmp(tb.str.line[i], v)) return 1;
-  }
-  return 0;
+  return isReservedVariable(v) ||
+    rxDoseArgIsConstant(v) ||
+    rxDoseArgInLines(&tb.ss, NV, v) ||
+    rxDoseArgInLines(&tb.de, tb.de.n, v) ||
+    rxDoseArgInLines(&tb.str, tb.str.n, v);
 }
 
 // Report the identifiers collected by rxPushDoseNoteArg() that the model never

--- a/src/tran.c
+++ b/src/tran.c
@@ -95,6 +95,7 @@ sbuf firstErr;
 int firstErrD=0;
 
 vLines sbPm, sbPmDt, sbNrmL;
+vLines sbDoseArgVar, sbDoseArgCtx;
 sbuf sbNrm;
 sbuf sbExtra;
 vLines depotLines, centralLines;
@@ -287,6 +288,8 @@ void parseFree(int last) {
   lineFree(&sbPm);
   lineFree(&sbPmDt);
   lineFree(&sbNrmL);
+  lineFree(&sbDoseArgVar);
+  lineFree(&sbDoseArgCtx);
   lineFree(&(tb.ss));
   lineFree(&(tb.de));
   lineFree(&(tb.str));
@@ -375,6 +378,8 @@ void reset(void) {
   lineIni(&sbPm);
   lineIni(&sbPmDt);
   lineIni(&sbNrmL);
+  lineIni(&sbDoseArgVar);
+  lineIni(&sbDoseArgCtx);
   lineIni(&depotLines);
   lineIni(&centralLines);
   lineIni(&_dupStrs);
@@ -620,6 +625,8 @@ void trans_internal(const char* parse_file, int isStr){
   lineIni(&sbPm);
   lineIni(&sbPmDt);
   lineIni(&sbNrmL);
+  lineIni(&sbDoseArgVar);
+  lineIni(&sbDoseArgCtx);
   // do not free these, they remain until next parse for quick parsing of linCmt() models
   lineIni(&depotLines);
   lineIni(&centralLines);
@@ -642,6 +649,7 @@ void trans_internal(const char* parse_file, int isStr){
     if (tb.hasIndLinProp && !tb.isMexp) {
       trans_syntax_error_report_fn0("indLin() cannot be used without matExp() defined in the model");
     }
+    assertAdaptiveDosingArgsDeclared();
     nodeInfo dummyNi;
     niReset(&dummyNi);
     for (int j = 0; j < NV; j++) {
@@ -873,6 +881,8 @@ void transIniNull(void) {
   lineNull(&(sbPm));
   lineNull(&(sbPmDt));
   lineNull(&(sbNrmL));
+  lineNull(&(sbDoseArgVar));
+  lineNull(&(sbDoseArgCtx));
   lineNull(&(depotLines));
   lineNull(&(centralLines));
   sNull(&(_gbuf));

--- a/src/tran.h
+++ b/src/tran.h
@@ -229,6 +229,10 @@ static inline int parse_micro_constant(const char *name, char *cmt1, char *cmt2)
 extern vLines depotLines;
 extern vLines centralLines;
 extern vLines sbPm, sbPmDt, sbNrmL;
+// Identifiers seen inside an adaptive dosing argument, and a description of
+// where each came from.  Checked once the whole model has been parsed, since
+// the variable may be assigned further down (see #1231).
+extern vLines sbDoseArgVar, sbDoseArgCtx;
 
 #define FBIO 1
 #define ALAG 2

--- a/tests/testthat/test-adaptive-dosing-arg-vars.R
+++ b/tests/testthat/test-adaptive-dosing-arg-vars.R
@@ -1,0 +1,128 @@
+rxTest({
+
+  # The adaptive dosing statements consume their arguments as raw text and skip
+  # the parse-tree children, so an identifier that appears *only* there is never
+  # registered as a model variable.  That used to surface as generated C
+  # referencing an undeclared symbol, reported as a compiler failure that looks
+  # like a broken toolchain.  It is now a parse-time error.  See #1231.
+
+  test_that("a covariate used only as a dosing argument is a parse error", {
+    expect_error(rxode2(function() {
+      ini({ ka <- 0.8; cl <- 15; v <- 100 })
+      model({
+        d/dt(depot) <- -ka * depot
+        d/dt(central) <- ka * depot - (cl / v) * central
+        cp <- central / v
+        if (t <= 0) infuseDur(DOSE, TINF, cmt = 1, ii = TAU, addl = 3)
+      })
+    }))
+  })
+
+  test_that("every adaptive dosing function reports an undeclared argument", {
+    mk <- function(call) {
+      f <- function() {
+        ini({ ka <- 0.8; cl <- 15; v <- 100 })
+        model({
+          d/dt(depot) <- -ka * depot
+          d/dt(central) <- ka * depot - (cl / v) * central
+          cp <- central / v
+          if (t <= 0) bolus(1, cmt = 1)
+        })
+      }
+      body(f)[[3]][[2]][[5]][[3]] <- str2lang(call)
+      f
+    }
+    for (cur in c("bolus(DOSE, cmt=1)",
+                  "infuse(DOSE, RATE, cmt=1)",
+                  "infuseDur(DOSE, TINF, cmt=1)",
+                  "replace(DOSE, cmt=1)",
+                  "multiply(DOSE, cmt=1)",
+                  "phantom(DOSE, cmt=1)",
+                  "evid_(t, 1, DOSE, 1, 0, 24, 3, 0)")) {
+      expect_error(rxode2(mk(cur)), info = cur)
+    }
+  })
+
+  test_that("assigning the covariate first is accepted, wherever it is assigned", {
+    # assigned above the dosing statement
+    expect_error(rxode2(function() {
+      ini({ ka <- 0.8; cl <- 15; v <- 100 })
+      model({
+        amtI <- DOSE
+        durI <- TINF
+        iiI <- TAU
+        d/dt(depot) <- -ka * depot
+        d/dt(central) <- ka * depot - (cl / v) * central
+        cp <- central / v
+        if (t <= 0) infuseDur(amtI, durI, cmt = 1, ii = iiI, addl = 3)
+      })
+    }), NA)
+    # ...and below it, since the check runs once the whole model is parsed
+    expect_error(rxode2(function() {
+      ini({ ka <- 0.8; cl <- 15; v <- 100 })
+      model({
+        d/dt(depot) <- -ka * depot
+        d/dt(central) <- ka * depot - (cl / v) * central
+        cp <- central / v
+        if (t <= 0) infuseDur(amtI, durI, cmt = 1)
+        amtI <- DOSE
+        durI <- TINF
+      })
+    }), NA)
+  })
+
+  test_that("literals, builtins, states and THETA[] are not flagged", {
+    expect_error(rxode2(function() {
+      ini({ ka <- 0.8; cl <- 15; v <- 100 })
+      model({
+        d/dt(depot) <- -ka * depot
+        d/dt(central) <- ka * depot - (cl / v) * central
+        cp <- central / v
+        # 1e-7 must not be read as an identifier 'e'
+        if (t <= 0) evid_(t + 1e-7, 1, 100 * exp(-0.5), depot, 0, 24, 3, 0)
+      })
+    }), NA)
+    # a compartment name as the amount, and as the cmt
+    expect_error(rxode2(function() {
+      ini({ ka <- 0.8; cl <- 15; v <- 100 })
+      model({
+        d/dt(depot) <- -ka * depot
+        d/dt(central) <- ka * depot - (cl / v) * central
+        cp <- central / v
+        if (t <= 12) replace(depot * 0 + 25, depot)
+      })
+    }), NA)
+    expect_error(rxode2(function() {
+      model({
+        d/dt(depot) <- -THETA[1] * depot
+        cp <- depot
+        if (t <= 0) bolus(THETA[2], cmt = depot)
+      })
+    }), NA)
+  })
+
+  test_that("the error names the variable, the argument and the function", {
+    expect_error(rxode2(function() {
+      ini({ ka <- 0.8; cl <- 15; v <- 100 })
+      model({
+        d/dt(depot) <- -ka * depot
+        cp <- depot
+        if (t <= 0) bolus(DOSE, cmt = 1)
+      })
+    }))
+    msg <- utils::capture.output(
+      try(rxode2(function() {
+        ini({ ka <- 0.8; cl <- 15; v <- 100 })
+        model({
+          d/dt(depot) <- -ka * depot
+          cp <- depot
+          if (t <= 0) bolus(DOSE, cmt = 1)
+        })
+      }), silent = TRUE))
+    msg <- paste(msg, collapse = "\n")
+    expect_match(msg, "'DOSE'")
+    expect_match(msg, "'amt'")
+    expect_match(msg, "'bolus\\(\\)'")
+  })
+
+})


### PR DESCRIPTION
Closes #1231, taking the diagnostic half of it: the registration behaviour is
unchanged, but the failure is now caught at parse time with a message that says
what to do.

## Before

```r
mod <- function() {
  ini({ ka <- 0.8; cl <- 15; v <- 100 })
  model({
    d/dt(depot)   <- -ka*depot
    d/dt(central) <-  ka*depot - (cl/v)*central
    cp <- central/v
    if (t <= 0) infuseDur(DOSE, TINF, cmt=1, ii=TAU, addl=3)
  })
}
rxSolve(mod, et(c(0, 1, 2, 24)), c(DOSE=180, TINF=1, TAU=24))
```

`rxode2(mod)` succeeded and printed a normal-looking model; the problem only
appeared at compile time as

```
error: 'DOSE' undeclared (first use in this function)
...
Error building the model: see rxode2::rxLastCompile()
please make sure you have a working C compiler set up
```

which sends people off auditing their toolchain for what is a model-code
problem.

## After

```
rxode2 model syntax error:
================================================================================
:ERR: 'DOSE' is only used as the 'amt' argument of 'infuseDur()'; an adaptive dosing argument does not declare a model variable, assign it first (like 'amtVal <- DOSE'):

:ERR: 'TINF' is only used as the 'dur' argument of 'infuseDur()'; an adaptive dosing argument does not declare a model variable, assign it first (like 'durVal <- TINF'):

:ERR: 'TAU' is only used as the 'ii' argument of 'infuseDur()'; an adaptive dosing argument does not declare a model variable, assign it first (like 'iiVal <- TAU'):

:001: /dt(depot) <- -ka * depot
:002: d/dt(central) <- ka * depot - (cl/v) * central
:003: cp <- central/v
:004: if (t <= 0) infuseDur(DOSE, TINF, 1, TAU, 3, 0)
================================================================================
```

All the offending names are listed at once, each named once.

## How

The statement handlers already take their arguments as raw text (they set
`*i = nch` and never descend into the children), so `rxPushDoseNoteArg()` scans
that text for identifiers and records them along with a ready-made message.
`assertAdaptiveDosingArgsDeclared()` then runs in `trans_internal()` alongside
the other post-parse checks -- *after* the whole model is parsed, so a variable
assigned **below** the dosing statement still counts as declared:

```r
model({
  ...
  if (t <= 0) infuseDur(amtI, durI, cmt=1)
  amtI <- DOSE      # still fine
  durI <- TINF
})
```

The scanner deliberately leaves alone anything that is not a bare variable
reference: numeric literals including exponents (`1e-7` must not read as an
identifier `e`), string literals, function calls, `THETA[]`/`ETA[]`,
compartments and states, string-assigned variables, and reserved names.

Covers all eight statements: `evid_()`, `bolus()`, `infuse()`, `infuseDur()`,
`replace()`, `multiply()`, `phantom()` and the variadic `obs()`.
`splitBolus()` is untouched -- it only takes compartments and already
registers them.

## Tests

New `tests/testthat/test-adaptive-dosing-arg-vars.R` (17 assertions, all
passing) covers the error itself, all eight functions, both assignment
positions, the non-flagged forms above, and the message content.

No existing model trips the new check: every test file that uses an adaptive
dosing function (`test-evid-push.R`, `test-capture-adaptive-dosing.R`,
`test-odeToLin.R`, `test-event-sensitivities.R`, `test-adjoint-sens.R`,
`test-altrep-output.R`, `test-ind-lin.R`) was run and the new message appears
zero times.  The failures in those runs are `could not find function
".<internal>"` from calling `test_file()` outside the package namespace, plus
pre-existing unrelated ones, none in a model with a dosing statement.

## Note

`dose0()`/`dose()`/`dose0(cmt)` remain the right tool when the amount is
already in the event table.  This is about the covariate-driven case (e.g.
making a dose/duration/interval a PopED design variable in
nlmixr2/babelmixr2#131), where there is no dose record to read from and the
`x <- COV` shim is the only route.
