### PR TITLE
fix(eventSens): jump sensitivities for linCmt() models, and a linCmtB() dose-time sensitivity (#1119)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -218,6 +218,19 @@
 
 ### Sensitivities
 
+- `linCmtB()` gained a dose-time (moving boundary) sensitivity, `which1 = -3`:
+  the derivative of a `linCmt()` model with respect to a delay applied to every
+  dose feeding it, which is what a modeled `alag()` on its dosed compartment
+  produces.  `which2 = -3` gives it for the reported concentration, `which2 >= 0`
+  for the amount in that compartment; chain-rule it with `d(alag)/dp` for the
+  sensitivity wrt a model parameter.  The system is linear and its whole input
+  is delayed together, so the derivative is exactly `-dA/dt` -- it matches a
+  finite difference to round-off for bolus and steady-state-bolus regimens
+  across one to three compartments, IV and oral.  It reports `NA` for an
+  individual with an infusion (`dA/dt` needs the infusion rate, which is not
+  carried into the pass that computes the output) and requires that every dose
+  reaching the linear system share the same `alag()` (#1119).
+
 - A model that mixes `linCmt()` with `d/dt()` now expands its sensitivities
   once.  The `linCmt()` call has to be resolved before the sensitivity
   expansion, and the model was re-parsed with `calcSens=` afterwards, which

--- a/NEWS.md
+++ b/NEWS.md
@@ -216,6 +216,45 @@
   supplied (`The following parameter(s) are required for solving: eta.b`).  The
   matching `sigma` code already guarded this.
 
+### Sensitivities
+
+- A model that mixes `linCmt()` with `d/dt()` now expands its sensitivities
+  once.  The `linCmt()` call has to be resolved before the sensitivity
+  expansion, and the model was re-parsed with `calcSens=` afterwards, which
+  differentiated the already-expanded model a second (and, with
+  `eventSens=`, a third) time.  The result carried
+  `rx__sens_rx__sens_<state>_BY_<p>___BY_<p>__` compartments nobody asked for
+  and an interleaved compartment layout, which the event-sensitivity map then
+  read as a second-order Hessian block.  The `linCmt()` text is now built
+  first and the sensitivities expanded once, from that text.  As a
+  consequence `summary()` of such a model prints the `linCmt()` model as
+  written, without the generated `rx__sens_*` equations after it (#1119).
+
+- `.rxLinCmt()` no longer invents a `peripheral1` compartment for a one
+  compartment oral `linCmt()` (nor a `peripheral2` for a two compartment oral
+  one): the compartment count it decodes includes the depot, and it was read as
+  the number of disposition compartments.  An ODE state named like the invented
+  compartment was dropped from `rxStateOde()`, so it never got a sensitivity
+  expansion -- its `rx__sens_<state>_BY_<param>__` compartment did not exist at
+  all -- and it also raised a bogus "share a name with linCmt() reserved
+  compartments" warning (#1119).
+
+- `eventSens="jump"` now applies to the ODE compartments of a model that also
+  has a `linCmt()`.  Every `linCmt()` model was downgraded to finite differences
+  because the moving-boundary jump for a modeled `alag()`/`f()` on a `linCmt()`
+  compartment is not implemented; the ODE compartments of such a model carry
+  ordinary solved sensitivity compartments and are unaffected by that.  The
+  downgrade is now limited to the models that need it: a pure `linCmt()` model,
+  a reserved-name collision, or a modeled `alag()`/`f()`/`rate()`/`dur()` on a
+  `linCmt()` compartment itself (#1119).
+
+- The event-sensitivity jump map is now checked against the true compartment
+  indices rather than assuming them.  The runtime injection addresses the
+  sensitivity compartment of (state `k`, parameter `p`) as
+  `nState + p*nState + k`; a model whose compartments do not lie that way falls
+  back to finite differences instead of having jumps written into the wrong
+  compartment (#1119).
+
 ### Compilation
 
 - The statement form of `ifelse()` -- `ifelse(cond, stmt, stmt)`, where each

--- a/R/eventSens.R
+++ b/R/eventSens.R
@@ -242,6 +242,46 @@
     grepl(paste0("d/dt(", .nm, ")"), .norm, fixed = TRUE), logical(1))]
 }
 
+#' ODE (non-linCmt) physical states of a model
+#'
+#' The linCmt() compartments are identified by NAME (`.rxLinCmt()`); everything
+#' else in `normal.state` is an ordinary ODE state.
+#'
+#' @param mv A model-vars list.
+#' @return character vector of ODE state names (possibly empty).
+#' @noRd
+.rxEventSensOdeStates <- function(mv) {
+  setdiff(mv$normal.state, .rxLinCmt(mv))
+}
+
+#' Does the jump map match the compartment layout the runtime assumes?
+#'
+#' `handle_evid()` addresses the first-order sensitivity compartment of
+#' (state `k`, param `p`) as `nState + p*nState + k` (0-based), i.e. the ODE
+#' states are the leading `nState` compartments and their sensitivity
+#' compartments follow as one param-major block.  `.rxEventSensMap()` carries
+#' the TRUE compartment indices, so check them rather than assume.
+#'
+#' @param states ODE state names, in map order.
+#' @param sensParams Sensitivity parameter names, in map order.
+#' @param map1 First-order map rows (columns `state`, `param`, `stateCmt`,
+#'   `sensCmt`).
+#' @return `TRUE` when the true indices match the assumed layout.
+#' @noRd
+.rxEventSensLayoutOk <- function(states, sensParams, map1) {
+  .ns <- length(states)
+  if (.ns == 0L || length(sensParams) == 0L) return(FALSE)
+  ## every (state, param) pair must be present exactly once
+  if (nrow(map1) != .ns * length(sensParams)) return(FALSE)
+  .k <- match(map1$state, states)
+  .p <- match(map1$param, sensParams)
+  if (anyNA(.k) || anyNA(.p)) return(FALSE)
+  ## the states themselves must be compartments 1..nState (`cmt < nState` is
+  ## how the runtime decides a dosed compartment is one of them)
+  if (!identical(as.integer(map1$stateCmt), as.integer(.k))) return(FALSE)
+  identical(as.integer(map1$sensCmt), as.integer(.ns + (.p - 1L) * .ns + .k))
+}
+
 #' Restrict jump sensitivities to ODE states for mixed ODE+linCmt models
 #'
 #' For pure linCmt models (no ODE states), event sensitivities are handled by the
@@ -255,21 +295,34 @@
 .rxEventSensFilterMap <- function(obj, map) {
   .mv <- rxModelVars(obj)
   .lin <- .rxLinNcmt(.mv)
-  if (.lin["numLin"] <= 0L) return(map)
+  if (.lin["numLin"] <= 0L) {
+    if (!.rxEventSensLayoutOk(map$states, map$sensParams, map$map)) return(NULL)
+    return(map)
+  }
   ## Defensive: a linCmt reserved-name collision (see .rxLinCmtNameCollision)
-  ## yields silently-incorrect sensitivities; disable jump.  (linCmt models now
+  ## yields silently-incorrect sensitivities; disable jump.  (Such models
   ## downgrade to FD upstream via .rxEventSensEffectiveMode, so this is a guard
   ## for any path that still reaches here.)
   if (length(.rxLinCmtNameCollision(obj)) > 0L) return(NULL)
-  .odeStates <- setdiff(.mv$normal.state, .rxLinCmt(.mv))
-  if (length(.odeStates) == 0L) return(map)
+  .odeStates <- .rxEventSensOdeStates(.mv)
+  ## Pure linCmt: no ODE compartment can carry an analytic jump.
+  if (length(.odeStates) == 0L) return(NULL)
   .stateCmt <- unname(map$stateCmt[.odeStates])
   ## The jump runtime assumes ODE states are the leading contiguous block
   ## [1..nState]. If not, keep behavior safe by disabling jump for this model.
-  if (!identical(.stateCmt, seq_along(.stateCmt))) return(NULL)
+  if (anyNA(.stateCmt) || !identical(.stateCmt, seq_along(.stateCmt))) return(NULL)
   .map1 <- map$map[map$map$state %in% .odeStates, , drop = FALSE]
   if (nrow(.map1) == 0L) return(NULL)
-  .sensParams <- unique(.map1$param)
+  ## Keep `map$sensParams`' order: it is the order of the sensitivity
+  ## COMPARTMENTS, which is what the runtime addresses with (nState + p*nState
+  ## + k) and what `.rxEventSensCLines()` builds its parameter index from.
+  ## `map$map` is sorted by parameter NAME, so taking the order from it put a
+  ## multi-parameter model's jump values in the wrong compartment.
+  .sensParams <- map$sensParams[map$sensParams %in% .map1$param]
+  ## The linCmt() block sits after the ODE states and their sensitivity
+  ## compartments, so the assumed (nState + p*nState + k) addressing still has
+  ## to hold for the ODE part; verify against the true indices.
+  if (!.rxEventSensLayoutOk(.odeStates, .sensParams, .map1)) return(NULL)
   .map2 <- map$map2
   if (!is.null(.map2) && nrow(.map2) > 0L) {
     .map2 <- .map2[
@@ -303,25 +356,57 @@
 
 #' Resolve effective event-sensitivity mode for linCmt-containing models
 #'
-#' `fdAll` is the explicit full finite-difference fallback. Models that include
-#' linCmt() always resolve to `fd` regardless of the requested mode (see the
-#' comment in the body); the requested mode is honored otherwise.
+#' `fdAll` is the explicit full finite-difference fallback.  A linCmt() model
+#' downgrades to `fd` only when the analytic jump cannot cover it -- no ODE
+#' compartment to jump, a linCmt reserved-name collision, or a modeled
+#' alag/F/rate/dur on a linCmt() compartment itself (nlmixr2/rxode2#1119 part
+#' B, not implemented); the requested mode is honored otherwise.
 #'
 #' @param requested Requested mode from `.rxEventSensMode()`.
-#' @param mv Parsed model vars.
+#' @param obj Parsed model vars (or anything `rxModelVars()` accepts).
 #' @return Effective mode string (`jump`, `fd`, or `both`).
 #' @noRd
-.rxEventSensEffectiveMode <- function(requested, mv) {
-  if (identical(requested, "fdAll")) return("fd")
-  ## linCmt() models downgrade to finite differences for event-timing
-  ## sensitivities.  The analytic moving-boundary (jump) sensitivity for a
-  ## modeled alag()/f() on a linCmt compartment is not implemented (see
-  ## nlmixr2/rxode2#1119); rather than emit an incomplete/incorrect analytic
-  ## jump, all linCmt models use FD for event sensitivities (the FOCEi/nlmixr2est
-  ## finite-difference event path).  Structural-parameter linCmt sensitivities
-  ## are unaffected (they are continuous and handled by linCmtB directly).
-  if (.rxLinNcmt(mv)["numLin"] > 0L) return("fd")
+.rxEventSensEffectiveMode <- function(requested, obj) {
+  if (identical(requested, "fdAll") || identical(requested, "fd")) return("fd")
+  .mv <- rxModelVars(obj)
+  if (.rxLinNcmt(.mv)["numLin"] <= 0L) return(requested)
+  ## Mixed ODE+linCmt(): the ODE compartments keep the analytic jump (their
+  ## sensitivity compartments are ordinary solved states; the linCmt() block
+  ## sits after them and is untouched by the injection).
+  if (length(.rxEventSensOdeStates(.mv)) == 0L) return("fd")
+  ## A d/dt() on a linCmt()-reserved name conflates the two compartments, so
+  ## the ODE state never gets its sensitivity expansion.
+  if (length(.rxLinCmtNameCollision(obj)) > 0L) return("fd")
+  ## The moving-boundary jump for a modeled alag()/f()/rate()/dur() on a
+  ## linCmt() COMPARTMENT is not implemented: linCmt amounts and their
+  ## sensitivities are recomputed from linCmt's own analytic solution every
+  ## step, so a jump written into them is overwritten.  Fall back to finite
+  ## differences for the whole model rather than report a partial answer.
+  .linCmt <- unname(.mv$stateOrd[.rxLinCmt(.mv)])
+  .prop <- .rxEventSensProp(.mv)
+  .eventCmt <- unique(c(.prop$lagCmt, .prop$fCmt, .prop$rateCmt, .prop$durCmt))
+  if (any(.eventCmt %in% .linCmt[!is.na(.linCmt)])) return("fd")
   requested
+}
+
+#' Downgrade to `fd` when the jump map cannot be built for this model
+#'
+#' `.rxEventSensFilterMap()` rejects a model whose compartment layout does not
+#' match what the runtime jump injection addresses.  Record that as `fd` so the
+#' model falls back to the finite-difference event path instead of ending up
+#' with neither.  Models with no sensitivity compartments at all keep the
+#' requested mode (there is nothing to jump).
+#'
+#' @param mode Mode from `.rxEventSensEffectiveMode()`.
+#' @param obj Built model (rxUi, rxode2, modelVars).
+#' @return Effective mode string.
+#' @noRd
+.rxEventSensModeForMap <- function(mode, obj) {
+  if (identical(mode, "fd")) return("fd")
+  .map <- .rxEventSensMap(obj)
+  if (is.null(.map)) return(mode)
+  if (is.null(.rxEventSensFilterMap(obj, .map))) return("fd")
+  mode
 }
 
 #' Decode which compartments carry modeled alag/F/rate/dur

--- a/R/rxode2.R
+++ b/R/rxode2.R
@@ -428,19 +428,26 @@ rxode2 <- # nolint
       linCmtSens <- "linCmtA"
     }
     assignInMyNamespace(".linCmtSens", linCmtSens)
-    .env$.mv <- rxGetModel(model, calcSens = calcSens, calcJac = calcJac, collapseModel = collapseModel, indLin = indLin, calcSens2 = calcSens2, calcSens3 = calcSens3)
+    ## Detection parse -- no sensitivity/Jacobian expansion yet.  A linCmt()
+    ## model has to have its linCmt() resolved (linCmtGen) BEFORE the
+    ## sensitivities are expanded: expanding first and then re-parsing the
+    ## expanded text with `calcSens=` (what this used to do) ran the expansion
+    ## twice, splicing spurious 2nd/3rd-order rx__sens_rx__sens_*__ compartments
+    ## into the model and interleaving the state layout, which broke the
+    ## sensitivities of every mixed ODE+linCmt() model (nlmixr2/rxode2#1119).
+    ## `linCmtGen()` rewrites the text of whatever was parsed LAST, so it has to
+    ## run directly after this parse -- hence also `indLin=FALSE` here, since
+    ## rxToIndLin() would leave a rewritten matrix-exponential model as the last
+    ## parse.
+    .env$.mv <- rxGetModel(model, collapseModel = collapseModel, indLin = FALSE)
     .isLinCmt <- .Call(`_rxode2_isLinCmt`) == 1L
     if (.eventSensNeedsJac && !.isLinCmt && !isTRUE(calcJac)) {
       calcJac <- TRUE
-      .env$.mv <- rxGetModel(model, calcSens = calcSens, calcJac = calcJac,
-                             collapseModel = collapseModel, indLin = indLin,
-                             calcSens2 = calcSens2, calcSens3 = calcSens3)
-      .isLinCmt <- .Call(`_rxode2_isLinCmt`) == 1L
     }
     if (.isLinCmt) {
       .env$.linCmtM <- rxNorm(.env$.mv)
       .vars <- c(.env$.mv$params, .env$.mv$lhs, .env$.mv$slhs)
-      .env$.mv <- rxGetModel(.Call(
+      model <- .Call(
         `_rxode2_linCmtGen`,
         length(.env$.mv$state),
         .vars,
@@ -450,10 +457,54 @@ rxode2 <- # nolint
           )[match.arg(linCmtSens)],
           NULL
         ), verbose
-      ),
-      calcSens = calcSens, calcJac = calcJac, collapseModel = collapseModel,
-      indLin = indLin, calcSens2 = calcSens2, calcSens3 = calcSens3)
+      )
     }
+    ## The linCmt()-resolved but NOT yet sensitivity-expanded text.  Every
+    ## re-parse below restarts from here: re-parsing the EXPANDED text with
+    ## `calcSens=` expands a second time (nlmixr2/rxode2#1119).
+    .modelBase <- model
+    .eventSensKeyAtParse <- .rxEventSensCacheKey
+    .env$.mv <- rxGetModel(.modelBase, calcSens = calcSens, calcJac = calcJac,
+                           collapseModel = collapseModel, indLin = indLin,
+                           calcSens2 = calcSens2, calcSens3 = calcSens3)
+    .eventSensEffectiveMode <- .rxEventSensEffectiveMode(.eventSensMode, .env$.mv)
+    ## Warn when sensitivities are requested on a linCmt() model whose ODE
+    ## compartment name collides with a linCmt reserved name: the ODE state loses
+    ## its sensitivity expansion, so its sensitivities are silently incorrect.
+    if (!is.null(calcSens)) {
+      .linCollide <- .rxLinCmtNameCollision(.env$.mv)
+      if (length(.linCollide) > 0L) {
+        warning("ODE compartment(s) '", paste(.linCollide, collapse = "', '"),
+                "' share a name with linCmt() reserved compartments; ",
+                "sensitivities will be incorrect -- rename them", call. = FALSE)
+      }
+    }
+    .indLinSens <- length(.env$.mv$indLin) > 0L &&
+      length(.env$.mv$sens) > 0L
+    if (.indLinSens) {
+      .eventSensEffectiveMode <- "jump"
+    }
+    if (.eventSensActiveReq || .indLinSens) {
+      .eventSensEffectiveMode <- .rxEventSensModeForMap(.eventSensEffectiveMode, .env$.mv)
+    }
+    .eventSensActive <- (!missing(eventSens) && !identical(.eventSensEffectiveMode, "fd")) ||
+      .indLinSens
+    .eventSensNeedsJac <- .eventSensActive && !is.null(calcSens) &&
+      length(.rxEventSensOdeStates(.env$.mv)) > 0L
+    .eventSensCacheKey <- if (.eventSensActive) .eventSensEffectiveMode else ""
+    assignInMyNamespace(".rxEventSensCacheKey", .eventSensCacheKey)
+    ## Re-parse only when the decision above changed an input to the parse: the
+    ## jump injection needs the full state Jacobian, and the mode is folded into
+    ## the parsed md5/cache key.  Always from `.modelBase`, never from the
+    ## already-expanded text.
+    if ((.eventSensNeedsJac && !isTRUE(calcJac)) ||
+          !identical(.eventSensCacheKey, .eventSensKeyAtParse)) {
+      if (.eventSensNeedsJac) calcJac <- TRUE
+      .env$.mv <- rxGetModel(.modelBase, calcSens = calcSens, calcJac = calcJac,
+                             collapseModel = collapseModel, indLin = indLin,
+                             calcSens2 = calcSens2, calcSens3 = calcSens3)
+    }
+    .env$eventSens <- .eventSensEffectiveMode
     model <- rxNorm(.env$.mv)
     class(model) <- "rxModelText"
     .env$.model <- model
@@ -479,44 +530,6 @@ rxode2 <- # nolint
     .env$debug <- debug
     .env$calcJac <- calcJac
     .env$calcSens <- calcSens
-    .eventSensEffectiveMode <- .rxEventSensEffectiveMode(.eventSensMode, .env$.mv)
-    ## Warn when sensitivities are requested on a linCmt() model whose ODE
-    ## compartment name collides with a linCmt reserved name: the ODE state loses
-    ## its sensitivity expansion, so its sensitivities are silently incorrect.
-    if (!is.null(calcSens)) {
-      .linCollide <- .rxLinCmtNameCollision(.env$.mv)
-      if (length(.linCollide) > 0L) {
-        warning("ODE compartment(s) '", paste(.linCollide, collapse = "', '"),
-                "' share a name with linCmt() reserved compartments; ",
-                "sensitivities will be incorrect -- rename them", call. = FALSE)
-      }
-    }
-    .indLinSens <- length(.env$.mv$indLin) > 0L &&
-      length(.env$.mv$sens) > 0L
-    if (.indLinSens) {
-      .eventSensEffectiveMode <- "jump"
-    }
-    .eventSensActive <- (!missing(eventSens) && !identical(.eventSensEffectiveMode, "fd")) ||
-      .indLinSens
-    .eventSensOdeStates <- setdiff(.env$.mv$normal.state, .rxLinCmt(.env$.mv))
-    .eventSensNeedsJac <- .eventSensActive && !is.null(calcSens) &&
-      length(.eventSensOdeStates) > 0L
-    if (.eventSensNeedsJac && !isTRUE(calcJac)) {
-      calcJac <- TRUE
-      .env$.mv <- rxGetModel(rxNorm(.env$.mv), calcSens = calcSens,
-                             calcJac = calcJac, collapseModel = collapseModel,
-                             indLin = indLin, calcSens2 = calcSens2, calcSens3 = calcSens3)
-      .eventSensOdeStates <- setdiff(.env$.mv$normal.state, .rxLinCmt(.env$.mv))
-    }
-    .eventSensCacheKey <- if (.eventSensActive) .eventSensEffectiveMode else ""
-    if (!identical(.eventSensCacheKey, .rxEventSensCacheKey)) {
-      assignInMyNamespace(".rxEventSensCacheKey", .eventSensCacheKey)
-      .env$.mv <- rxGetModel(rxNorm(.env$.mv), calcSens = calcSens,
-                             calcJac = calcJac, collapseModel = collapseModel,
-                             indLin = indLin, calcSens2 = calcSens2, calcSens3 = calcSens3)
-      .eventSensOdeStates <- setdiff(.env$.mv$normal.state, .rxLinCmt(.env$.mv))
-    }
-    .env$eventSens <- .eventSensEffectiveMode
     ## Phase-A event-sensitivity metadata (index map + dosing-parameter total
     ## derivatives); NULL for mode "fd" or models without sensitivities.
     .env$eventSensInfo <- if (.eventSensActive) .rxEventSensInfo(.env$.mv, .eventSensEffectiveMode) else NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -1631,35 +1631,35 @@ rxDerived <- function(..., verbose = FALSE, digits = 0) {
   if (.ncmt["numLin"] <= 0) {
     return(.ret)
   }
-  .vars <- c("p1", "v1","p2", "p3", "p4", "p5")
-  .vars <- .vars[seq(1, 2*.ncmt["numLin"])]
+  ## `numLin` counts every physical linCmt compartment, the depot included, so
+  ## the number of disposition (central + peripheral) compartments -- and hence
+  ## the number of structural parameters -- is `numLin - depotLin`.  Treating
+  ## `numLin` as the disposition count invented a `peripheral1` for every oral
+  ## model, which then dropped a same-named ODE state out of `rxStateOde()` (so
+  ## it never got a sensitivity expansion) and tripped a bogus reserved-name
+  ## collision (nlmixr2/rxode2#1119).
+  .nDisp <- .ncmt["numLin"] - .ncmt["depotLin"]
+  if (.nDisp <= 0) {
+    return(.ret)
+  }
+  .vars <- c("p1", "v1", "p2", "p3", "p4", "p5")[seq_len(2 * .nDisp)]
+  .periph <- if (.nDisp > 1L) paste0("peripheral", seq_len(.nDisp - 1L)) else character(0)
   if (.ncmt["depotLin"] > 0) {
     .ret <- c(.ret, "depot")
     .vars <- c(.vars, "ka")
   }
-  if (.ncmt["numLin"] > 0L) {
-    .ret <- c(.ret, "central")
-    if (.ncmt["numLin"] > 1L) {
-        .ret <- c(.ret, paste0("peripheral", seq_len(.ncmt["numLin"] - 1L)))
-    }
-  }
+  .ret <- c(.ret, "central", .periph)
   if (.ncmt["numLinSens"] > 0L) {
     .ret <- c(.ret,
-              paste0("rx__sens_central_BY_", .vars))
-    if (.ncmt["numLin"] > 1L) {
-      .ret <- c(.ret,
-                do.call(`c`,
-                        lapply(paste0("peripheral", seq_len(.ncmt["numLin"] - 1L)),
-                               function(x) {
-                                 paste0("rx__sens_", x, "_BY_", .vars)
-                               })))
-    }
+              unlist(lapply(c("central", .periph), function(.x) {
+                paste0("rx__sens_", .x, "_BY_", .vars)
+              }), use.names = FALSE))
     if (.ncmt["depotLin"] > 0) {
       .ret <- c(.ret,
                 "rx__sens_depot_BY_ka")
     }
   }
-  .ret
+  unname(.ret)
 }
 
 #' Get the ODE states only

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -539,6 +539,26 @@ extern "C" int linCmtZeroJac(int i) {
  * @author Matthew Fidler
  *
 */
+// Fill a macro-parameter vector in the order macros2micros() expects, which
+// depends on the compartment count and whether the model is oral.  Returns 0
+// for a shape that is not a linCmt() model.
+static inline int linCmtFillTheta(Eigen::Matrix<double, Eigen::Dynamic, 1> &th,
+                                  int ncmt, int oral0,
+                                  double p1, double v1,
+                                  double p2, double p3,
+                                  double p4, double p5,
+                                  double ka) {
+  switch (ncmt + 10*oral0) {
+  case 1:  th << p1, v1; return 1;
+  case 11: th << p1, v1, ka; return 1;
+  case 2:  th << p1, v1, p2, p3; return 1;
+  case 12: th << p1, v1, p2, p3, ka; return 1;
+  case 3:  th << p1, v1, p2, p3, p4, p5; return 1;
+  case 13: th << p1, v1, p2, p3, p4, p5, ka; return 1;
+  }
+  return 0;
+}
+
 // linCmtB's which1 = -3 case: the dose-time (moving boundary) sensitivity.
 //
 // `amt` holds the amounts at the requested time from the which1=-1/which2=-1
@@ -562,14 +582,8 @@ static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
   }
   if (linCmtHasInfusion(ind)) return NA_REAL;
   Eigen::Matrix<double, Eigen::Dynamic, 1> th(lc.getNpars());
-  switch (ncmt + 10*oral0) {
-  case 1:  th << p1, v1; break;
-  case 11: th << p1, v1, ka; break;
-  case 2:  th << p1, v1, p2, p3; break;
-  case 12: th << p1, v1, p2, p3, ka; break;
-  case 3:  th << p1, v1, p2, p3, p4, p5; break;
-  case 13: th << p1, v1, p2, p3, p4, p5, ka; break;
-  default: return NA_REAL;
+  if (!linCmtFillTheta(th, ncmt, oral0, p1, v1, p2, p3, p4, p5, ka)) {
+    return NA_REAL;
   }
   Eigen::Matrix<double, Eigen::Dynamic, 2> gm =
     stan::math::macros2micros(th, ncmt, trans);

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -107,6 +107,28 @@ static inline double * getLinCmtDoubleAddr(linB_t &lcb, int type) {
   return NULL;
 }
 
+// Fill a macro-parameter vector in the order macros2micros() expects, which
+// depends on the compartment count and whether the model is oral.  Templated
+// on the target because the callers hold theta either as its own Matrix or as
+// an Eigen::Map over per-thread scratch.  Returns 0 for a shape that is not a
+// linCmt() model, leaving the vector untouched.
+template <typename T>
+static inline int linCmtFillTheta(T &th, int ncmt, int oral0,
+                                  double p1, double v1,
+                                  double p2, double p3,
+                                  double p4, double p5,
+                                  double ka) {
+  switch (ncmt + 10*oral0) {
+  case 1:  th << p1, v1; return 1;
+  case 11: th << p1, v1, ka; return 1;
+  case 2:  th << p1, v1, p2, p3; return 1;
+  case 12: th << p1, v1, p2, p3, ka; return 1;
+  case 3:  th << p1, v1, p2, p3, p4, p5; return 1;
+  case 13: th << p1, v1, p2, p3, p4, p5, ka; return 1;
+  }
+  return 0;
+}
+
 // [[Rcpp::export]]
 RObject linCmtModelDouble(double dt,
                           double p1, double v1, double p2,
@@ -138,15 +160,7 @@ RObject linCmtModelDouble(double dt,
   theta0.resize(lc.getNpars());
   Eigen::Map<Eigen::Matrix<double, -1, 1>> theta(theta0.data(), theta0.size());
 
-  int sw = ncmt + 10*oral0;
-  switch (sw) {
-  case 1:  theta << p1, v1; break;
-  case 11: theta << p1, v1, ka; break;
-  case 2:  theta << p1, v1, p2, p3; break;
-  case 12: theta << p1, v1, p2, p3, ka; break;
-  case 3:  theta << p1, v1, p2, p3, p4, p5; break;
-  case 13: theta << p1, v1, p2, p3, p4, p5, ka; break;
-  }
+  linCmtFillTheta(theta, ncmt, oral0, p1, v1, p2, p3, p4, p5, ka);
 
   int numSens = lc.numSens();
   Eigen::Matrix<double, Eigen::Dynamic, 1> thetaSens0(numSens);
@@ -347,15 +361,7 @@ extern "C" double linCmtA(rx_solve *rx, int id,
   }
   lc.setPtr(a, r, asave);
   // Setup parameter matrix
-  int sw = ncmt + 10*oral0;
-  switch (sw) {
-  case 1:  theta << p1, v1; break;
-  case 11: theta << p1, v1, ka; break;
-  case 2:  theta << p1, v1, p2, p3; break;
-  case 12: theta << p1, v1, p2, p3, ka; break;
-  case 3:  theta << p1, v1, p2, p3, p4, p5; break;
-  case 13: theta << p1, v1, p2, p3, p4, p5, ka; break;
-  }
+  linCmtFillTheta(theta, ncmt, oral0, p1, v1, p2, p3, p4, p5, ka);
 
   // Here we restore the last solved value
   if (!ind->doSS && ind->solvedIdx >= idx) {
@@ -452,6 +458,41 @@ extern "C" int linCmtZeroJac(int i) {
 
 
 
+// linCmtB's which1 = -3 case: the dose-time (moving boundary) sensitivity.
+//
+// `amt` holds the amounts at the requested time from the which1=-1/which2=-1
+// call the caller is required to have made, and the linear system's own
+// right-hand side gives d/dL exactly (see linCmtStan::dAdt()).  Returns
+// NA_REAL for a call that does not describe the model `lc` is set up for, for
+// an individual with an infusion (linCmtHasInfusion()), or for an out of range
+// `which2`.
+static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
+                                     const Eigen::Matrix<double, Eigen::Dynamic, 1> &amt,
+                                     rx_solving_options_ind *ind,
+                                     const double *rate,
+                                     int ncmt, int oral0, int which2, int trans,
+                                     double p1, double v1,
+                                     double p2, double p3,
+                                     double p4, double p5,
+                                     double ka) {
+  if (lc.ncmt_ != ncmt || lc.oral0_ != oral0 || lc.trans_ != trans ||
+      (int)amt.size() != ncmt + oral0) {
+    return NA_REAL;
+  }
+  if (linCmtHasInfusion(ind)) return NA_REAL;
+  Eigen::Matrix<double, Eigen::Dynamic, 1> th(lc.getNpars());
+  if (!linCmtFillTheta(th, ncmt, oral0, p1, v1, p2, p3, p4, p5, ka)) {
+    return NA_REAL;
+  }
+  Eigen::Matrix<double, Eigen::Dynamic, 2> gm =
+    stan::math::macros2micros(th, ncmt, trans);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> dot(ncmt + oral0);
+  lc.dAdt(amt, gm, ka, rate, dot);
+  if (which2 == -3) return -dot(oral0, 0) / lc.getVc(th);
+  if (which2 >= 0 && which2 < ncmt + oral0) return -dot(which2, 0);
+  return NA_REAL;
+}
+
 /*
  *  linCmtB
  *
@@ -539,61 +580,6 @@ extern "C" int linCmtZeroJac(int i) {
  * @author Matthew Fidler
  *
 */
-// Fill a macro-parameter vector in the order macros2micros() expects, which
-// depends on the compartment count and whether the model is oral.  Returns 0
-// for a shape that is not a linCmt() model.
-static inline int linCmtFillTheta(Eigen::Matrix<double, Eigen::Dynamic, 1> &th,
-                                  int ncmt, int oral0,
-                                  double p1, double v1,
-                                  double p2, double p3,
-                                  double p4, double p5,
-                                  double ka) {
-  switch (ncmt + 10*oral0) {
-  case 1:  th << p1, v1; return 1;
-  case 11: th << p1, v1, ka; return 1;
-  case 2:  th << p1, v1, p2, p3; return 1;
-  case 12: th << p1, v1, p2, p3, ka; return 1;
-  case 3:  th << p1, v1, p2, p3, p4, p5; return 1;
-  case 13: th << p1, v1, p2, p3, p4, p5, ka; return 1;
-  }
-  return 0;
-}
-
-// linCmtB's which1 = -3 case: the dose-time (moving boundary) sensitivity.
-//
-// `amt` holds the amounts at the requested time from the which1=-1/which2=-1
-// call the caller is required to have made, and the linear system's own
-// right-hand side gives d/dL exactly (see linCmtStan::dAdt()).  Returns
-// NA_REAL for a call that does not describe the model `lc` is set up for, for
-// an individual with an infusion (linCmtHasInfusion()), or for an out of range
-// `which2`.
-static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
-                                     const Eigen::Matrix<double, Eigen::Dynamic, 1> &amt,
-                                     rx_solving_options_ind *ind,
-                                     const double *rate,
-                                     int ncmt, int oral0, int which2, int trans,
-                                     double p1, double v1,
-                                     double p2, double p3,
-                                     double p4, double p5,
-                                     double ka) {
-  if (lc.ncmt_ != ncmt || lc.oral0_ != oral0 || lc.trans_ != trans ||
-      (int)amt.size() != ncmt + oral0) {
-    return NA_REAL;
-  }
-  if (linCmtHasInfusion(ind)) return NA_REAL;
-  Eigen::Matrix<double, Eigen::Dynamic, 1> th(lc.getNpars());
-  if (!linCmtFillTheta(th, ncmt, oral0, p1, v1, p2, p3, p4, p5, ka)) {
-    return NA_REAL;
-  }
-  Eigen::Matrix<double, Eigen::Dynamic, 2> gm =
-    stan::math::macros2micros(th, ncmt, trans);
-  Eigen::Matrix<double, Eigen::Dynamic, 1> dot(ncmt + oral0);
-  lc.dAdt(amt, gm, ka, rate, dot);
-  if (which2 == -3) return -dot(oral0, 0) / lc.getVc(th);
-  if (which2 >= 0 && which2 < ncmt + oral0) return -dot(which2, 0);
-  return NA_REAL;
-}
-
 // linCmtSensIsAD() (the AD jacobian classifier; forward-mode fvar 3/30,
 // reverse-mode 31, auto 100 -> unscaled thetaSens + passthrough trueTheta; the
 // finite-difference methods keep the scaled path) lives in linCmtSensType.h so
@@ -675,15 +661,7 @@ extern "C" double linCmtB(rx_solve *rx, int id,
   Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, 1> >
     theta(getLinCmtDoubleAddr(lcb, linCmtBaddrTheta), lc.getNpars());
 
-  int sw = ncmt + 10*oral0;
-  switch (sw) {
-  case 1:  theta << p1, v1; break;
-  case 11: theta << p1, v1, ka; break;
-  case 2:  theta << p1, v1, p2, p3; break;
-  case 12: theta << p1, v1, p2, p3, ka; break;
-  case 3:  theta << p1, v1, p2, p3, p4, p5; break;
-  case 13: theta << p1, v1, p2, p3, p4, p5, ka; break;
-  }
+  linCmtFillTheta(theta, ncmt, oral0, p1, v1, p2, p3, p4, p5, ka);
 
   Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, 1> >
     thetaSens(getLinCmtDoubleAddr(lcb, linCmtBaddrThetaSens), lcb.numSens);

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -539,6 +539,47 @@ extern "C" int linCmtZeroJac(int i) {
  * @author Matthew Fidler
  *
 */
+// linCmtB's which1 = -3 case: the dose-time (moving boundary) sensitivity.
+//
+// `amt` holds the amounts at the requested time from the which1=-1/which2=-1
+// call the caller is required to have made, and the linear system's own
+// right-hand side gives d/dL exactly (see linCmtStan::dAdt()).  Returns
+// NA_REAL for a call that does not describe the model `lc` is set up for, for
+// an individual with an infusion (linCmtHasInfusion()), or for an out of range
+// `which2`.
+static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
+                                     const Eigen::Matrix<double, Eigen::Dynamic, 1> &amt,
+                                     rx_solving_options_ind *ind,
+                                     const double *rate,
+                                     int ncmt, int oral0, int which2, int trans,
+                                     double p1, double v1,
+                                     double p2, double p3,
+                                     double p4, double p5,
+                                     double ka) {
+  if (lc.ncmt_ != ncmt || lc.oral0_ != oral0 || lc.trans_ != trans ||
+      (int)amt.size() != ncmt + oral0) {
+    return NA_REAL;
+  }
+  if (linCmtHasInfusion(ind)) return NA_REAL;
+  Eigen::Matrix<double, Eigen::Dynamic, 1> th(lc.getNpars());
+  switch (ncmt + 10*oral0) {
+  case 1:  th << p1, v1; break;
+  case 11: th << p1, v1, ka; break;
+  case 2:  th << p1, v1, p2, p3; break;
+  case 12: th << p1, v1, p2, p3, ka; break;
+  case 3:  th << p1, v1, p2, p3, p4, p5; break;
+  case 13: th << p1, v1, p2, p3, p4, p5, ka; break;
+  default: return NA_REAL;
+  }
+  Eigen::Matrix<double, Eigen::Dynamic, 2> gm =
+    stan::math::macros2micros(th, ncmt, trans);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> dot(ncmt + oral0);
+  lc.dAdt(amt, gm, ka, rate, dot);
+  if (which2 == -3) return -dot(oral0, 0) / lc.getVc(th);
+  if (which2 >= 0 && which2 < ncmt + oral0) return -dot(which2, 0);
+  return NA_REAL;
+}
+
 // linCmtSensIsAD() (the AD jacobian classifier; forward-mode fvar 3/30,
 // reverse-mode 31, auto 100 -> unscaled thetaSens + passthrough trueTheta; the
 // finite-difference methods keep the scaled path) lives in linCmtSensType.h so
@@ -588,35 +629,8 @@ extern "C" double linCmtB(rx_solve *rx, int id,
     } else if (which1 == -2 && which2 >= 0) {
       return Jg(which2);
     } else if (which1 == -3) {
-      // Dose-time (moving boundary) sensitivity; see the header comment.
-      // `fx` holds the amounts at `_t` from the which1=-1/which2=-1 call that
-      // the caller is required to have made, and the linear system's own
-      // right-hand side gives d/dL exactly.
-      if (lc.ncmt_ != ncmt || lc.oral0_ != oral0 || lc.trans_ != trans ||
-          (int)fx.size() != ncmt + oral0) {
-        return NA_REAL;
-      }
-      Eigen::Matrix<double, Eigen::Dynamic, 1> th(lc.getNpars());
-      switch (ncmt + 10*oral0) {
-      case 1:  th << p1, v1; break;
-      case 11: th << p1, v1, ka; break;
-      case 2:  th << p1, v1, p2, p3; break;
-      case 12: th << p1, v1, p2, p3, ka; break;
-      case 3:  th << p1, v1, p2, p3, p4, p5; break;
-      case 13: th << p1, v1, p2, p3, p4, p5, ka; break;
-      default: return NA_REAL;
-      }
-      if (linCmtHasInfusion(ind)) return NA_REAL;
-      Eigen::Matrix<double, Eigen::Dynamic, 2> gm =
-        stan::math::macros2micros(th, ncmt, trans);
-      Eigen::Matrix<double, Eigen::Dynamic, 1> dot(ncmt + oral0);
-      lc.dAdt(fx, gm, ka, getLinRate, dot);
-      if (which2 == -3) {
-        return -dot(oral0, 0) / lc.getVc(th);
-      } else if (which2 >= 0 && which2 < ncmt + oral0) {
-        return -dot(which2, 0);
-      }
-      return NA_REAL;
+      return linCmtBdoseTime(lc, fx, ind, getLinRate, ncmt, oral0, which2,
+                             trans, p1, v1, p2, p3, p4, p5, ka);
     }
   } else if (!lc.isSame(ncmt, oral0, trans, rx->ndiff)) {
     lc.setModelType(ncmt, oral0, trans, ind->linSS, rx->ndiff);

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -9,6 +9,7 @@
 #define SORT gfx::timsort
 #include "linCmt.h"
 #include "linCmtSensType.h"
+#include "../inst/include/rxode2EventTranslate.h"
 
 #ifdef RXODE2_NO_STAN_TBB_OBSERVER
 // stan-math's init_chainablestack.hpp is kept out of the build (no linkable
@@ -27,6 +28,27 @@ extern t_update_inis update_inis;
 
 #define getLinRate ind->InfusionRate + op->linOffset
 #define isSameTime(xout, xp) (fabs((xout)-(xp)) <= 2.0*DBL_EPSILON*max2(fabs(xout),fabs(xp)))
+
+// Does this individual have any infusion (or steady-state infusion) dose?
+//
+// The dose-time sensitivity (linCmtB which1 = -3) needs dA/dt, which includes
+// the infusion rate -- and `ind->InfusionRate` is only maintained while
+// SOLVING.  rxode2_df.cpp's output pass re-runs calc_lhs from the saved
+// amounts after iniSubject() has cleared the rates, so an infusion's
+// contribution would silently drop out of the reported value.  Report NA
+// instead of a wrong number; a bolus (including steady-state bolus) regimen is
+// exact.
+static inline int linCmtHasInfusion(rx_solving_options_ind *ind) {
+  if (ind->linSS == linCmtSsInf || ind->linSS == linCmtSsInf8) return 1;
+  for (int i = 0; i < ind->ndoses; ++i) {
+    int wh, cmt, wh100, whI, wh0;
+    getWh(getEvid(ind, ind->idose[i]), &wh, &cmt, &wh100, &whI, &wh0);
+    if (whI != EVIDF_NORMAL && whI != EVIDF_REPLACE && whI != EVIDF_MULT) {
+      return 1;
+    }
+  }
+  return 0;
+}
 
 // Create linear compartment models for testing
 using namespace Rcpp;
@@ -466,6 +488,19 @@ extern "C" int linCmtZeroJac(int i) {
  *  When which1 is -2, the gradient of the linear compartment model
  *  with respect to the parameter is returned.
  *
+ *  When which1 is -3, the DOSE-TIME (moving boundary) sensitivity is
+ *  returned -- the derivative with respect to a delay applied to every dose
+ *  feeding the linear system, i.e. what a modeled `alag()` on its dosed
+ *  compartment produces (nlmixr2/rxode2#1119).  which2 = -3 gives it for the
+ *  reported concentration, which2 >= 0 for the amount in that compartment.
+ *  The system is linear and its whole input is delayed together, so
+ *  A(t; L) = A(t - L; 0) and the derivative is exactly -dA/dt; chain-rule it
+ *  with d(alag)/dp to get the sensitivity wrt a model parameter.  This
+ *  requires that EVERY dose reaching the linear system carries the same
+ *  `alag()`; it is not the per-compartment derivative of a model that lags
+ *  its compartments differently.  An individual with any infusion gets
+ *  `NA_REAL` -- see linCmtHasInfusion().
+ *
  *  The parameter order is as follows:
  *
  *   p1, v1, p2, p3, p4, p5, ka; for 3 compartment models
@@ -552,6 +587,36 @@ extern "C" double linCmtB(rx_solve *rx, int id,
       return fx(which1);
     } else if (which1 == -2 && which2 >= 0) {
       return Jg(which2);
+    } else if (which1 == -3) {
+      // Dose-time (moving boundary) sensitivity; see the header comment.
+      // `fx` holds the amounts at `_t` from the which1=-1/which2=-1 call that
+      // the caller is required to have made, and the linear system's own
+      // right-hand side gives d/dL exactly.
+      if (lc.ncmt_ != ncmt || lc.oral0_ != oral0 || lc.trans_ != trans ||
+          (int)fx.size() != ncmt + oral0) {
+        return NA_REAL;
+      }
+      Eigen::Matrix<double, Eigen::Dynamic, 1> th(lc.getNpars());
+      switch (ncmt + 10*oral0) {
+      case 1:  th << p1, v1; break;
+      case 11: th << p1, v1, ka; break;
+      case 2:  th << p1, v1, p2, p3; break;
+      case 12: th << p1, v1, p2, p3, ka; break;
+      case 3:  th << p1, v1, p2, p3, p4, p5; break;
+      case 13: th << p1, v1, p2, p3, p4, p5, ka; break;
+      default: return NA_REAL;
+      }
+      if (linCmtHasInfusion(ind)) return NA_REAL;
+      Eigen::Matrix<double, Eigen::Dynamic, 2> gm =
+        stan::math::macros2micros(th, ncmt, trans);
+      Eigen::Matrix<double, Eigen::Dynamic, 1> dot(ncmt + oral0);
+      lc.dAdt(fx, gm, ka, getLinRate, dot);
+      if (which2 == -3) {
+        return -dot(oral0, 0) / lc.getVc(th);
+      } else if (which2 >= 0 && which2 < ncmt + oral0) {
+        return -dot(which2, 0);
+      }
+      return NA_REAL;
     }
   } else if (!lc.isSame(ncmt, oral0, trans, rx->ndiff)) {
     lc.setModelType(ncmt, oral0, trans, ind->linSS, rx->ndiff);

--- a/src/linCmt.h
+++ b/src/linCmt.h
@@ -2813,6 +2813,48 @@ namespace stan {
         return Jf;
       }
 
+      //' Right-hand side of the linear compartment system at given amounts
+      //'
+      //' dA/dt = M A + r, with M built from the micro-constants (k10/k12/k21/
+      //' k13/k31 and ka) and r the infusion rates set by `setPtr()` (depot
+      //' first when oral, then central).
+      //'
+      //' This is the moving-boundary (dose-time) sensitivity of the system: a
+      //' linear system whose WHOLE input is delayed by L solves
+      //' A(t; L) = A(t - L; 0), so dA/dL = -dA/dt exactly, at every t and for
+      //' any dosing regimen (bolus, infusion or steady state).  It holds only
+      //' while every dose feeding the system carries that same L.
+      //'
+      //' @param A Current amounts.
+      //' @param g Micro-constant matrix from `macros2micros()`.
+      //' @param ka Absorption rate (ignored when not oral).
+      //' @param rate Infusion rates, depot first when oral (`getNrate()` long).
+      //' @param out Filled with dA/dt; resized by the caller.
+      //'
+      //' @return nothing, updates `out` instead
+      void dAdt(const Eigen::Matrix<double, Eigen::Dynamic, 1>& A,
+                const Eigen::Matrix<double, Eigen::Dynamic, 2>& g,
+                double ka, const double *rate,
+                Eigen::Matrix<double, Eigen::Dynamic, 1>& out) const {
+        const int c = oral0_;  // central compartment index
+        out.setZero();
+        if (oral0_) {
+          out(0, 0) = -ka * A(0, 0) + rate[0];
+          out(c, 0) = ka * A(0, 0) + rate[1];
+        } else {
+          out(c, 0) = rate[0];
+        }
+        out(c, 0) -= g(0, 1) * A(c, 0);
+        if (ncmt_ >= 2) {
+          out(c, 0)     += -g(1, 0) * A(c, 0) + g(1, 1) * A(c + 1, 0);
+          out(c + 1, 0)  =  g(1, 0) * A(c, 0) - g(1, 1) * A(c + 1, 0);
+          if (ncmt_ >= 3) {
+            out(c, 0)     += -g(2, 0) * A(c, 0) + g(2, 1) * A(c + 2, 0);
+            out(c + 2, 0)  =  g(2, 0) * A(c, 0) - g(2, 1) * A(c + 2, 0);
+          }
+        }
+      }
+
       double adjustF(const Eigen::VectorXd ret0,
                      const Eigen::Matrix<double, Eigen::Dynamic, 1>& theta,
                      double &vc) {

--- a/tests/testthat/test-event-sensitivities.R
+++ b/tests/testthat/test-event-sensitivities.R
@@ -201,6 +201,15 @@ rxTest({
     # pure linCmt downgrades to FD (#1119)
     expect_equal(m$eventSens, "fd")
     expect_null(m$eventSensInfo)
+    # ... and still does when the analytic jump is asked for explicitly: there
+    # is no ODE compartment to carry it (#1119 part B).
+    mJump <- rxode2({
+      C2 <- linCmt(CL, V)
+      alag(central) <- exp(tlag + eta_lag)
+    }, calcSens = "eta_lag", eventSens = "jump",
+    linCmtSens = "linCmtA", linCmtSensType = "A")
+    expect_equal(mJump$eventSens, "fd")
+    expect_null(mJump$eventSensInfo)
   })
 
   test_that("pure linCmt hybrid event path matches the ODE equivalent", {
@@ -225,13 +234,30 @@ rxTest({
     expect_equal(sLin$central, sOde$central, tolerance = 1e-5)
   })
 
-  test_that("mixed ODE+linCmt with explicit jump still downgrades to fd", {
-    # Even eventSens="jump" downgrades to FD when linCmt() is present (#1119):
-    # the linCmt-compartment moving-boundary jump is not implemented, so all
-    # linCmt models use finite differences for event sensitivities.
+  test_that("mixed ODE+linCmt keeps the analytic jump on its ODE compartments", {
+    # The ODE compartments of a mixed model carry ordinary solved sensitivity
+    # compartments, so the analytic jump applies to them (#1119); only the
+    # linCmt() compartments' own moving-boundary jump is unimplemented.
     m <- rxode2({
       C2 <- linCmt(CL, V)
       alag(eff) <- exp(tlag + eta_lag)
+      d/dt(eff) <- kin - kout * eff
+    }, calcSens = "eta_lag", eventSens = "jump",
+    linCmtSens = "linCmtA", linCmtSensType = "A")
+    expect_equal(m$eventSens, "jump")
+    expect_false(is.null(m$eventSensInfo))
+    # the map covers the ODE compartment only -- the linCmt block is excluded
+    expect_equal(m$eventSensInfo$map$states, "eff")
+    expect_equal(m$eventSensInfo$map$sensParams, "eta_lag")
+  })
+
+  test_that("a modeled alag on a linCmt() compartment still downgrades to fd", {
+    # The linCmt() amounts (and their sensitivities) are recomputed from the
+    # analytic solution at every step, so a jump written into them would be
+    # overwritten -- fall back to finite differences (#1119 part B).
+    m <- rxode2({
+      C2 <- linCmt(CL, V)
+      alag(central) <- exp(tlag + eta_lag)
       d/dt(eff) <- kin - kout * eff
     }, calcSens = "eta_lag", eventSens = "jump",
     linCmtSens = "linCmtA", linCmtSensType = "A")
@@ -239,12 +265,252 @@ rxTest({
     expect_null(m$eventSensInfo)
   })
 
+  test_that("mixed ODE+linCmt jump sensitivities match finite differences", {
+    # The regression #1119 reports: adding a linCmt() term to a model whose ODE
+    # compartment carries a modeled alag() used to zero out (or drop entirely)
+    # that compartment's sensitivity.
+    .mk <- function(lin) {
+      if (lin) {
+        rxode2({
+          ka <- exp(tka)
+          cl <- exp(tcl)
+          v <- exp(tv)
+          alag(gut) <- 2 * exp(eta_lag)
+          d/dt(gut) <- -ka * gut
+          d/dt(eff) <- ka * gut - 0.3 * eff
+          C2 <- linCmt(cl, v)
+        }, calcSens = "eta_lag", eventSens = "jump",
+        linCmtSens = "linCmtA", linCmtSensType = "A")
+      } else {
+        rxode2({
+          ka <- exp(tka)
+          alag(gut) <- 2 * exp(eta_lag)
+          d/dt(gut) <- -ka * gut
+          d/dt(eff) <- ka * gut - 0.3 * eff
+        }, calcSens = "eta_lag", eventSens = "jump")
+      }
+    }
+    e <- eventTable() |>
+      add.dosing(dose = 100, cmt = "gut") |>
+      add.sampling(seq(0, 12, 0.25))
+    p <- c(tka = log(1.2), tcl = log(4), tv = log(20), eta_lag = 0.1)
+    .fd <- function(m, st, h = 1e-5) {
+      .p1 <- p; .p1[["eta_lag"]] <- p[["eta_lag"]] + h
+      .p0 <- p; .p0[["eta_lag"]] <- p[["eta_lag"]] - h
+      (rxSolve(m, e, params = .p1)[[st]] - rxSolve(m, e, params = .p0)[[st]]) / (2 * h)
+    }
+    mLin <- .mk(TRUE)
+    mOde <- .mk(FALSE)
+    expect_equal(mLin$eventSens, "jump")
+    sLin <- rxSolve(mLin, e, params = p)
+    sOde <- rxSolve(mOde, e, params = p)
+    for (.st in c("gut", "eff")) {
+      .an <- sLin[[paste0("rx__sens_", .st, "_BY_eta_lag__")]]
+      expect_false(is.null(.an))
+      expect_true(max(abs(.an)) > 1)                       # not silently zero
+      expect_equal(.an, .fd(mLin, .st), tolerance = 1e-4)  # matches FD
+      # and matches the pure-ODE model it was derived from
+      expect_equal(.an, sOde[[paste0("rx__sens_", .st, "_BY_eta_lag__")]],
+                   tolerance = 1e-6)
+    }
+  })
+
+  test_that("a mixed model's jump parameters keep their compartment order", {
+    # The filter took its parameter order from `map$map`, which is sorted by
+    # parameter NAME -- but the runtime addresses the sensitivity compartment of
+    # (state k, param p) as nState + p*nState + k, i.e. in COMPARTMENT order.
+    # With two event parameters whose alphabetical order differs from their
+    # compartment order the jump values landed in the wrong compartment (#1119).
+    .mk <- function(lin) {
+      if (lin) {
+        rxode2({
+          ka <- exp(tka); cl <- exp(tcl); v <- exp(tv)
+          alag(gut) <- 2 * exp(eta_lag)
+          f(gut) <- expit(eta_f)
+          d/dt(gut) <- -ka * gut
+          d/dt(eff) <- ka * gut - 0.3 * eff
+          C2 <- linCmt(cl, v)
+        }, calcSens = c("eta_lag", "eta_f"), eventSens = "jump",
+        linCmtSens = "linCmtA", linCmtSensType = "A")
+      } else {
+        rxode2({
+          ka <- exp(tka)
+          alag(gut) <- 2 * exp(eta_lag)
+          f(gut) <- expit(eta_f)
+          d/dt(gut) <- -ka * gut
+          d/dt(eff) <- ka * gut - 0.3 * eff
+        }, calcSens = c("eta_lag", "eta_f"), eventSens = "jump")
+      }
+    }
+    mLin <- .mk(TRUE)
+    mOde <- .mk(FALSE)
+    expect_equal(mLin$eventSens, "jump")
+    # declaration order, not alphabetical
+    expect_equal(mLin$eventSensInfo$map$sensParams, c("eta_lag", "eta_f"))
+    e <- eventTable() |>
+      add.dosing(dose = 100, nbr.doses = 3, dosing.interval = 8, cmt = "gut") |>
+      add.sampling(seq(0.1, 24, 0.25))
+    p <- c(tka = log(1.2), tcl = log(4), tv = log(20),
+           eta_lag = 0.1, eta_f = 0.05)
+    sLin <- rxSolve(mLin, e, params = p)
+    sOde <- rxSolve(mOde, e, params = p)
+    for (.st in c("gut", "eff")) {
+      for (.pr in c("eta_lag", "eta_f")) {
+        .nm <- paste0("rx__sens_", .st, "_BY_", .pr, "__")
+        .h <- 1e-5
+        .p1 <- p; .p1[[.pr]] <- p[[.pr]] + .h
+        .p0 <- p; .p0[[.pr]] <- p[[.pr]] - .h
+        .fd <- (rxSolve(mLin, e, params = .p1)[[.st]] -
+                  rxSolve(mLin, e, params = .p0)[[.st]]) / (2 * .h)
+        # the modeled-F rows carry the finite difference's own truncation error
+        # across the dose discontinuity, hence the looser bound here; the
+        # linCmt-vs-ODE identity below is the tight check
+        expect_equal(sLin[[.nm]], .fd, tolerance = 5e-3, info = .nm)
+        expect_equal(sLin[[.nm]], sOde[[.nm]], tolerance = 1e-6, info = .nm)
+      }
+    }
+  })
+
+  test_that("an ODE state named like a linCmt peripheral keeps its sensitivity", {
+    # `.rxLinCmt()` used to invent a `peripheral1` for every ORAL linCmt model
+    # (numLin counts the depot), so a same-named ODE state was dropped from
+    # rxStateOde() and never got a sensitivity expansion at all (#1119).
+    m <- rxode2({
+      ka <- exp(tka)
+      cl <- exp(tcl)
+      v <- exp(tv)
+      alag(gut) <- 2 * exp(eta_lag)
+      d/dt(gut) <- -ka * gut
+      d/dt(peripheral1) <- ka * gut - 0.3 * peripheral1
+      C2 <- linCmt(cl, v, ka)
+    }, calcSens = "eta_lag", eventSens = "jump",
+    linCmtSens = "linCmtA", linCmtSensType = "A")
+    expect_true("peripheral1" %in% rxStateOde(m))
+    expect_true("rx__sens_peripheral1_BY_eta_lag__" %in% rxState(m))
+    expect_length(.rxLinCmtNameCollision(m), 0L)
+    e <- eventTable() |>
+      add.dosing(dose = 100, cmt = "gut") |>
+      add.sampling(seq(0, 12, 0.25))
+    p <- c(tka = log(1.2), tcl = log(4), tv = log(20), eta_lag = 0.1)
+    s <- rxSolve(m, e, params = p)
+    .h <- 1e-5
+    .p1 <- p; .p1[["eta_lag"]] <- p[["eta_lag"]] + .h
+    .p0 <- p; .p0[["eta_lag"]] <- p[["eta_lag"]] - .h
+    expect_equal(s[["rx__sens_peripheral1_BY_eta_lag__"]],
+                 (rxSolve(m, e, params = .p1)$peripheral1 -
+                    rxSolve(m, e, params = .p0)$peripheral1) / (2 * .h),
+                 tolerance = 1e-4)
+  })
+
+  test_that(".rxEventSensLayoutOk accepts only the layout the runtime addresses", {
+    # handle_evid() addresses the sensitivity compartment of (state k, param p)
+    # as nState + p*nState + k, so the states have to be compartments 1..nState
+    # and their sensitivity compartments the param-major block after them.
+    .states <- c("a", "b")
+    .params <- c("p", "q")
+    .ok <- data.frame(
+      state = c("a", "b", "a", "b"), param = c("p", "p", "q", "q"),
+      stateCmt = c(1L, 2L, 1L, 2L), sensCmt = c(3L, 4L, 5L, 6L),
+      stringsAsFactors = FALSE)
+    expect_true(.rxEventSensLayoutOk(.states, .params, .ok))
+    # state-major instead of param-major
+    .swap <- .ok; .swap$sensCmt <- c(3L, 5L, 4L, 6L)
+    expect_false(.rxEventSensLayoutOk(.states, .params, .swap))
+    # sensitivity block does not start right after the states
+    .shift <- .ok; .shift$sensCmt <- .ok$sensCmt + 1L
+    expect_false(.rxEventSensLayoutOk(.states, .params, .shift))
+    # states are not compartments 1..nState
+    .moved <- .ok; .moved$stateCmt <- c(2L, 3L, 2L, 3L)
+    expect_false(.rxEventSensLayoutOk(.states, .params, .moved))
+    # a (state, param) pair is missing
+    expect_false(.rxEventSensLayoutOk(.states, .params, .ok[-1, , drop = FALSE]))
+    expect_false(.rxEventSensLayoutOk(character(0), .params, .ok))
+    expect_false(.rxEventSensLayoutOk(.states, character(0), .ok))
+  })
+
+  test_that(".rxEventSensFilterMap disables jump on an unaddressable layout", {
+    # The safety fallback: rather than write jump values into whatever
+    # compartment the assumed formula lands on, drop the jump metadata (the
+    # caller then records the model as `fd`).
+    .mk <- function(lin) {
+      if (lin) {
+        rxode2({
+          ka <- exp(tka); cl <- exp(tcl); v <- exp(tv)
+          alag(gut) <- 2 * exp(eta_lag)
+          d/dt(gut) <- -ka * gut
+          d/dt(eff) <- ka * gut - 0.3 * eff
+          C2 <- linCmt(cl, v)
+        }, calcSens = "eta_lag", eventSens = "jump",
+        linCmtSens = "linCmtA", linCmtSensType = "A")
+      } else {
+        rxode2({
+          ka <- exp(tka)
+          alag(gut) <- 2 * exp(eta_lag)
+          d/dt(gut) <- -ka * gut
+          d/dt(eff) <- ka * gut - 0.3 * eff
+        }, calcSens = "eta_lag", eventSens = "jump")
+      }
+    }
+    for (.lin in c(FALSE, TRUE)) {
+      .m <- .mk(.lin)
+      .map <- .rxEventSensMap(.m)
+      expect_false(is.null(.rxEventSensFilterMap(.m, .map)))
+      # move the sensitivity compartments off the block the runtime assumes
+      .bad <- .map
+      .bad$map$sensCmt <- .bad$map$sensCmt + 1L
+      expect_null(.rxEventSensFilterMap(.m, .bad))
+      # and move the states off the leading block
+      .bad2 <- .map
+      .bad2$map$stateCmt <- .bad2$map$stateCmt + 1L
+      .bad2$stateCmt <- .bad2$stateCmt + 1L
+      expect_null(.rxEventSensFilterMap(.m, .bad2))
+    }
+  })
+
+  test_that(".rxLinCmt() names exactly the linCmt() compartments", {
+    .lin <- function(...) rxModelVars(rxode2(...))
+    .chk <- function(mv) {
+      .n <- .rxLinNcmt(mv)
+      expect_equal(.rxLinCmt(mv),
+                   utils::tail(mv$state, .n[["numLin"]] + .n[["numLinSens"]]))
+    }
+    .chk(.lin({cl <- exp(tcl); v <- exp(tv); C2 <- linCmt(cl, v)}, calcSens = "tcl"))
+    .chk(.lin({cl <- exp(tcl); v <- exp(tv); ka <- 1; C2 <- linCmt(cl, v, ka)},
+              calcSens = "tcl"))
+    .chk(.lin({cl <- exp(tcl); v <- exp(tv); q <- 1; v2 <- 10
+      C2 <- linCmt(cl, v, q, v2)}, calcSens = "tcl"))
+    .chk(.lin({cl <- exp(tcl); v <- exp(tv); q <- 1; v2 <- 10; ka <- 1
+      C2 <- linCmt(cl, v, q, v2, ka)}, calcSens = "tcl"))
+    .chk(.lin({cl <- exp(tcl); v <- exp(tv); q <- 1; v2 <- 10; q2 <- 0.5; v3 <- 100
+      C2 <- linCmt(cl, v, q, v2, q2, v3)}, calcSens = "tcl"))
+    .chk(.lin({cl <- exp(tcl); v <- exp(tv); q <- 1; v2 <- 10; q2 <- 0.5; v3 <- 100
+      ka <- 1
+      C2 <- linCmt(cl, v, q, v2, q2, v3, ka)}, calcSens = "tcl"))
+    # and without sensitivities at all (linCmtA): the physical compartments only
+    .chk(.lin({cl <- exp(tcl); v <- exp(tv); ka <- 1; C2 <- linCmt(cl, v, ka)}))
+  })
+
+  test_that("a linCmt() model expands its sensitivities exactly once", {
+    # The linCmt() branch used to re-parse the ALREADY expanded model with
+    # `calcSens=`, expanding a second (and third) time (#1119).
+    m <- rxode2({
+      cl <- exp(tcl)
+      v <- exp(tv)
+      d/dt(gut) <- -1 * gut
+      d/dt(eff) <- 1 * gut - 0.3 * eff
+      C2 <- linCmt(cl, v)
+    }, calcSens = "tcl")
+    expect_false(any(grepl("rx__sens_rx__sens_", rxState(m), fixed = TRUE)))
+    expect_equal(rxStateOde(m),
+                 c("gut", "eff", "rx__sens_gut_BY_tcl__", "rx__sens_eff_BY_tcl__"))
+  })
+
   test_that("ODE d/dt() colliding with a linCmt reserved compartment name warns", {
     # Naming an ODE compartment `depot` alongside an oral/multi-cmt linCmt (which
     # reserves `depot`) conflates the two compartments: the ODE state loses its
     # sensitivity expansion, so its sensitivities are silently incorrect.  Warn.
     expect_warning(
-      rxode2({
+      mBad <- rxode2({
         ka <- exp(tka)
         alag(depot) <- 2 * exp(eta_lag)
         d/dt(depot)   <- -ka * depot
@@ -254,7 +520,10 @@ rxTest({
       linCmtSens = "linCmtA", linCmtSensType = "A"),
       "share a name with linCmt"
     )
-    # a valid (non-colliding) linCmt model: no warning; downgrades to fd (#1119)
+    # ... and the analytic jump is disabled for it, not just warned about
+    expect_equal(mBad$eventSens, "fd")
+    expect_null(mBad$eventSensInfo)
+    # a valid (non-colliding) linCmt model: no warning; explicit fd is honored
     mOk <- suppressWarnings(rxode2({
       ka <- exp(tka)
       alag(gut) <- 2 * exp(eta_lag)

--- a/tests/testthat/test-lincmt-dose-time-sens.R
+++ b/tests/testthat/test-lincmt-dose-time-sens.R
@@ -1,0 +1,162 @@
+rxTest({
+  # linCmtB(which1 = -3): the dose-time (moving boundary) sensitivity of a
+  # linCmt() model -- the derivative wrt a delay applied to every dose feeding
+  # the linear system, i.e. what a modeled alag() on its dosed compartment
+  # produces.  Chain-ruled with d(alag)/dp it is the modeled-lag sensitivity a
+  # linCmt() compartment could not report before (nlmixr2/rxode2#1119).
+  #
+  # The system is linear and its whole input is delayed together, so
+  # A(t; L) = A(t - L; 0) and the derivative is exactly -dA/dt.  Every case
+  # below is checked against a central finite difference of the concentration.
+
+  .p <- c(tcl = log(4), tv = log(20), tka = log(1.1), tq = log(2),
+          tv2 = log(50), eta_lag = 0.1)
+
+  .fdCol <- function(m, e, col, h = 1e-5) {
+    .p1 <- .p; .p1[["eta_lag"]] <- .p[["eta_lag"]] + h
+    .p0 <- .p; .p0[["eta_lag"]] <- .p[["eta_lag"]] - h
+    (rxSolve(m, e, params = .p1)[[col]] - rxSolve(m, e, params = .p0)[[col]]) / (2 * h)
+  }
+
+  test_that("linCmtB(-3) dose-time sensitivity matches finite differences", {
+    .cases <- list(
+      list(
+        nm = "1cmt IV bolus",
+        m = rxode2({
+          cl <- exp(tcl); v <- exp(tv); lag <- 2 * exp(eta_lag)
+          alag(central) <- lag
+          cp <- linCmtB(rx__PTR__, t, 1, 1, 0, -1, -1, 1, cl, v, 0, 0, 0, 0, 0)
+          dcp <- lag * linCmtB(rx__PTR__, t, 1, 1, 0, -3, -3, 1, cl, v, 0, 0, 0, 0, 0)
+        }),
+        e = eventTable() |> add.dosing(dose = 100, cmt = "central") |>
+          add.sampling(seq(0.1, 12, 0.25))
+      ),
+      list(
+        nm = "1cmt IV multiple bolus",
+        m = rxode2({
+          cl <- exp(tcl); v <- exp(tv); lag <- 2 * exp(eta_lag)
+          alag(central) <- lag
+          cp <- linCmtB(rx__PTR__, t, 1, 1, 0, -1, -1, 1, cl, v, 0, 0, 0, 0, 0)
+          dcp <- lag * linCmtB(rx__PTR__, t, 1, 1, 0, -3, -3, 1, cl, v, 0, 0, 0, 0, 0)
+        }),
+        e = eventTable() |>
+          add.dosing(dose = 100, nbr.doses = 4, dosing.interval = 6, cmt = "central") |>
+          add.sampling(seq(0.1, 30, 0.25))
+      ),
+      list(
+        nm = "1cmt IV steady-state bolus",
+        m = rxode2({
+          cl <- exp(tcl); v <- exp(tv); lag <- 2 * exp(eta_lag)
+          alag(central) <- lag
+          cp <- linCmtB(rx__PTR__, t, 1, 1, 0, -1, -1, 1, cl, v, 0, 0, 0, 0, 0)
+          dcp <- lag * linCmtB(rx__PTR__, t, 1, 1, 0, -3, -3, 1, cl, v, 0, 0, 0, 0, 0)
+        }),
+        e = et(amt = 100, ii = 8, ss = 1, cmt = "central") |> et(seq(0.1, 8, 0.25))
+      ),
+      list(
+        nm = "1cmt oral multiple bolus",
+        m = rxode2({
+          cl <- exp(tcl); v <- exp(tv); ka <- exp(tka); lag <- 2 * exp(eta_lag)
+          alag(depot) <- lag
+          cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+          dcp <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -3, -3, 1, cl, v, 0, 0, 0, 0, ka)
+        }),
+        e = eventTable() |>
+          add.dosing(dose = 100, nbr.doses = 4, dosing.interval = 6, cmt = "depot") |>
+          add.sampling(seq(0.1, 30, 0.25))
+      ),
+      list(
+        nm = "2cmt IV bolus",
+        m = rxode2({
+          cl <- exp(tcl); v <- exp(tv); q <- exp(tq); v2 <- exp(tv2)
+          lag <- 2 * exp(eta_lag)
+          alag(central) <- lag
+          cp <- linCmtB(rx__PTR__, t, 2, 2, 0, -1, -1, 1, cl, v, q, v2, 0, 0, 0)
+          dcp <- lag * linCmtB(rx__PTR__, t, 2, 2, 0, -3, -3, 1, cl, v, q, v2, 0, 0, 0)
+        }),
+        e = eventTable() |> add.dosing(dose = 100, cmt = "central") |>
+          add.sampling(seq(0.1, 24, 0.25))
+      ),
+      list(
+        nm = "2cmt oral multiple bolus",
+        m = rxode2({
+          cl <- exp(tcl); v <- exp(tv); q <- exp(tq); v2 <- exp(tv2); ka <- exp(tka)
+          lag <- 2 * exp(eta_lag)
+          alag(depot) <- lag
+          cp <- linCmtB(rx__PTR__, t, 3, 2, 1, -1, -1, 1, cl, v, q, v2, 0, 0, ka)
+          dcp <- lag * linCmtB(rx__PTR__, t, 3, 2, 1, -3, -3, 1, cl, v, q, v2, 0, 0, ka)
+        }),
+        e = eventTable() |>
+          add.dosing(dose = 100, nbr.doses = 3, dosing.interval = 8, cmt = "depot") |>
+          add.sampling(seq(0.1, 30, 0.25))
+      ),
+      list(
+        nm = "3cmt IV bolus",
+        m = rxode2({
+          cl <- exp(tcl); v <- exp(tv); q <- exp(tq); v2 <- exp(tv2)
+          q2 <- 1; v3 <- 100; lag <- 2 * exp(eta_lag)
+          alag(central) <- lag
+          cp <- linCmtB(rx__PTR__, t, 3, 3, 0, -1, -1, 1, cl, v, q, v2, q2, v3, 0)
+          dcp <- lag * linCmtB(rx__PTR__, t, 3, 3, 0, -3, -3, 1, cl, v, q, v2, q2, v3, 0)
+        }),
+        e = eventTable() |> add.dosing(dose = 100, cmt = "central") |>
+          add.sampling(seq(0.1, 24, 0.25))
+      )
+    )
+    for (.c in .cases) {
+      .s <- rxSolve(.c$m, .c$e, params = .p)
+      expect_true(max(abs(.s$dcp)) > 1e-3, info = .c$nm)  # not trivially zero
+      expect_equal(.s$dcp, .fdCol(.c$m, .c$e, "cp"),
+                   tolerance = 1e-5, info = .c$nm)
+    }
+  })
+
+  test_that("linCmtB(-3, cmt) gives the per-compartment amount derivative", {
+    m <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); ka <- exp(tka); lag <- 2 * exp(eta_lag)
+      alag(depot) <- lag
+      cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+      dDepot <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -3, 0, 1, cl, v, 0, 0, 0, 0, ka)
+      dCentral <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -3, 1, 1, cl, v, 0, 0, 0, 0, ka)
+    })
+    e <- eventTable() |> add.dosing(dose = 100, cmt = "depot") |>
+      add.sampling(seq(0.1, 12, 0.25))
+    s <- rxSolve(m, e, params = .p)
+    expect_equal(s$dDepot, .fdCol(m, e, "depot"), tolerance = 1e-5)
+    expect_equal(s$dCentral, .fdCol(m, e, "central"), tolerance = 1e-5)
+    # the concentration form is the central amount scaled by the volume
+    expect_equal(s$dCentral / exp(.p[["tv"]]), .fdCol(m, e, "cp"), tolerance = 1e-5)
+  })
+
+  test_that("linCmtB(-3) reports NA for an infusion rather than a wrong value", {
+    # dA/dt includes the infusion rate, and ind->InfusionRate is only
+    # maintained while solving -- the output pass recomputes the lhs from the
+    # saved amounts with the rates cleared.  Report NA instead (#1119).
+    m <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); lag <- 2 * exp(eta_lag)
+      alag(central) <- lag
+      cp <- linCmtB(rx__PTR__, t, 1, 1, 0, -1, -1, 1, cl, v, 0, 0, 0, 0, 0)
+      dcp <- lag * linCmtB(rx__PTR__, t, 1, 1, 0, -3, -3, 1, cl, v, 0, 0, 0, 0, 0)
+    })
+    e <- eventTable() |> add.dosing(dose = 100, rate = 25, cmt = "central") |>
+      add.sampling(seq(0.1, 12, 0.25))
+    s <- rxSolve(m, e, params = .p)
+    expect_true(all(is.na(s$dcp)))
+    expect_false(any(is.na(s$cp)))   # the model itself still solves
+  })
+
+  test_that("linCmtB(-3) rejects a mismatched model shape", {
+    # which1 = -3 reads the amounts cached by the which1/which2 = -1 call, so a
+    # call describing a different model returns NA rather than reading them.
+    m <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); lag <- 2 * exp(eta_lag)
+      alag(central) <- lag
+      cp <- linCmtB(rx__PTR__, t, 1, 1, 0, -1, -1, 1, cl, v, 0, 0, 0, 0, 0)
+      bad <- linCmtB(rx__PTR__, t, 1, 1, 0, -3, 7, 1, cl, v, 0, 0, 0, 0, 0)
+    })
+    e <- eventTable() |> add.dosing(dose = 100, cmt = "central") |>
+      add.sampling(seq(0.1, 12, 0.25))
+    s <- rxSolve(m, e, params = .p)
+    expect_true(all(is.na(s$bad)))
+  })
+})


### PR DESCRIPTION
Addresses #1119 -- Part A in full, plus Part B's numeric core.  Deliberately
does **not** auto-close it: Part B is not usable end to end until
nlmixr2/nlmixr2est#920 lands.  What remains is tracked in:

* nlmixr2/nlmixr2est#920 -- FOCEi has to emit the `linCmtB(which1 = -3)` chain
  rule before a modeled `alag()` on a `linCmt()` compartment benefits.
* #1236 -- `which1 = -3` returns `NA` for infusions (the output pass does not
  carry `InfusionRate`).
* #1237 -- `which1 = -3` assumes every dose shares one `alag()`; no
  per-compartment dose-time derivative.

## Part A -- ODE-compartment jump sensitivities in a `linCmt()` model

Three separate faults, each independently enough to break the issue's reproducer.

**1. `.rxLinCmt()` read `linCmtFlg` wrong.** `numLin` counts every physical
`linCmt()` compartment, the depot included, so the number of disposition
compartments -- and hence of structural parameters -- is `numLin - depotLin`.
Reading `numLin` as the disposition count invented a `peripheral1` for every
oral model (and a `peripheral2` for a two compartment oral one). Since
`rxStateOde()` is `setdiff(rxState(), .rxLinCmt())`, an ODE state named like the
invented compartment was dropped out of it, so `.rxJacobian()`/`.rxSens()` never
expanded it: its `rx__sens_<state>_BY_<param>__` compartment did not exist at
all. That is the issue's "sensitivity is zero everywhere" symptom. The same
names also raised a bogus reserved-name collision warning.

**2. `rxode2()` expanded the sensitivities twice.** A `linCmt()` model has to
have its `linCmt()` resolved before the expansion, and the builder did that by
expanding, running `linCmtGen()`, and re-parsing the result with `calcSens=` --
but `rxGetModel()` is not idempotent, so the second parse differentiated the
already-expanded model. The result carried `rx__sens_rx__sens_*__` compartments
nobody asked for and an interleaved compartment layout, which the
event-sensitivity map then read as a second-order Hessian block. The order is
now: one detection parse with no expansion, `linCmtGen()`, then a single
expansion parse; every later re-parse restarts from that unexpanded text rather
than from the expanded one.

**3. `.rxEventSensFilterMap()` reordered the sensitivity parameters.** It took
them from `map$map`, which is sorted by parameter *name* -- but the runtime
addresses the sensitivity compartment of (state `k`, param `p`) as
`nState + p*nState + k`, i.e. in *compartment* order. A model with two event
parameters whose alphabetical order differed from their declaration order had
its jump values written into the wrong compartment. This one was found by the
new layout check, not by any pre-existing test.

With those fixed there is no reason to downgrade every `linCmt()` model to
finite differences (the interim fix in #1121): the ODE compartments of a mixed
model carry ordinary solved sensitivity compartments, and the `linCmt()` block
sits after them, untouched by the injection. The downgrade is kept for the cases
that need it -- a pure `linCmt()` model, a reserved-name collision, or a modeled
`alag()`/`f()`/`rate()`/`dur()` on a `linCmt()` compartment.

`.rxEventSensLayoutOk()` additionally checks the *true* compartment indices
(which `.rxEventSensMap()` has all along) against the layout `handle_evid()`
assumes, rather than taking it on faith, and `.rxEventSensModeForMap()` records
`fd` when the map comes out unusable -- so a model can never end up with neither
the jump nor finite differences.

### Behavior change worth flagging

`.env$.linCmtM` now holds the model as written rather than the
sensitivity-expanded text, so `summary()` of a `calcSens` `linCmt()` model no
longer prints the generated `rx__sens_*` equations after it. Noted in NEWS.

## Part B -- `linCmtB(which1 = -3)`, the dose-time (moving boundary) sensitivity

A linear system whose whole input is delayed by `L` solves `A(t; L) = A(t - L; 0)`,
so the derivative is exactly `-dA/dt` -- at every time and for any regimen. That
needs no propagated sensitivity vector and no extra storage, only the system's
own right-hand side at the current amounts. `linCmtStan::dAdt()` builds `M A + r`
from the micro-constants and the infusion rates, and `linCmtB(which1 = -3)`
returns it negated: `which2 = -3` for the reported concentration, `which2 >= 0`
for the amount in that compartment. Chain-rule with `d(alag)/dp` for the
sensitivity wrt a model parameter. (`d/dF` needs no new entry point -- the system
is linear in the dose, so it is `output/F`.)

Two limits, both explicit rather than silent:

* every dose reaching the linear system has to share the same `alag()` -- this is
  the derivative wrt one delay applied to all of them, not a per-compartment one;
* an individual with an infusion gets `NA`. `dA/dt` includes the infusion rate,
  `ind->InfusionRate` is only maintained while solving, and `rxode2_df.cpp`'s
  output pass recomputes the lhs from the saved amounts after `iniSubject()` has
  cleared the rates -- so the infusion's contribution would drop out of the
  reported value without a trace. `linCmtHasInfusion()` detects that from the
  individual's dose records.

Both limits are filed: #1236 and #1237.

**Still owed in nlmixr2est** (nlmixr2/nlmixr2est#920): its FOCEi inner-model
builder has to emit `d(alag)/d(eta) * linCmtB(..., -3, -3, ...)` before a modeled
`alag()` on a `linCmt()` compartment benefits, so those models keep downgrading
to finite differences here for now. Nothing further can be wired on the rxode2
side -- `linCmt()` sensitivity compartments read 0 in a plain `rxSolve()` (the
structural ones too); they only materialize as FOCEi lhs assignments.

## Validation

* Full suite: **254 files, 0 failures**.
* Part A jump sensitivities checked against a central finite difference and
  against the equivalent pure-ODE model, for one and two event parameters
  (modeled `alag()` and modeled `f()`), single and multiple doses.
* Part B checked against a central finite difference to ~1e-10 for bolus and
  steady-state-bolus regimens across one to three compartments, IV and oral, in
  both the concentration and per-compartment forms.
* The `rxode2()` reordering was A/B'd against `main` over 11 parse shapes
  (`calcSens=NULL`/`FALSE`, `calcJac` alone, `calcSens2`, `indLin`, an
  already-expanded model, an `rxode2` object as input): the only difference is
  the removed double expansion.
* Two independent review passes by a Gemini reviewer, no correctness findings;
  the coverage gaps it raised (the collision downgrade and the layout fallback)
  are now tested.
