### PR TITLE
Make method="indLin" thread safe and solve populations in parallel (#1216)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,17 @@
   exposes the whole naming sequence for packages that capture a model
   expression with `substitute()`.
 
+- `rxMemoryEstimate()` now accounts for what `method="indLin"` allocates, as
+  two new components: `indLinExpCache` (the per-thread matrix-exponential
+  cache) and `indLinWork` (the per-thread solver scratch).  Both depend on
+  which driver the model runs -- a pure `matExp()` model holds one rate matrix,
+  while true inductive linearization iterates and carries a Jacobian, `P(h)`
+  and its inverse as well -- and both scale with `cores` rather than with
+  subjects, so `rxSolve()` reaches the same out-of-memory decision for
+  `method="indLin"` that it already reached for every other solver, and
+  `rxSolveChunked()` sizes its chunks without charging per-thread buffers to
+  each subject.
+
 - `rxSolve(method="indLin")` now solves subjects in parallel and honors
   `cores`.  Inductive linearization was held to a single core because it was
   listed with the Fortran COMMON-block solvers (`lsoda`, `lsode`, `bdf`); it is

--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,15 @@
   exposes the whole naming sequence for packages that capture a model
   expression with `substitute()`.
 
+- `rxSolve(method="indLin")` now solves subjects in parallel and honors
+  `cores`.  Inductive linearization was held to a single core because it was
+  listed with the Fortran COMMON-block solvers (`lsoda`, `lsode`, `bdf`); it is
+  not one of them, and its matrix-exponential and scheme caches were already
+  per thread.  It now goes through the same thread-safety switch as
+  `liblsoda`, so a model whose functions are not thread safe still drops to one
+  core with the usual warning.  The answer, and the `rxIndLinSteps()` step
+  counts, are unchanged from the single-core solve.
+
 ## Bug fixes
 
 ### Compilation

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -1003,12 +1003,18 @@ rxSymInvCholEnvCalculate <- function(obj, what, theta = NULL) {
 #' @param nsub      Number of subjects.
 #' @param nallTotal Total events across all subjects (sum of obs + doses).
 #' @param maxAllTimes Maximum events for any single subject.
+#' @param stiff     The solving method (\code{op$stiff}); only 3
+#'   (\code{"indLin"}) allocates anything extra here.
+#' @param doIndLin  Which matrix-exponential driver runs: 0 not a
+#'   \code{matExp()} model, 1 pure matrix exponential, 2 plus a state-free
+#'   \code{indLin()} forcing, 3/4 true inductive linearization (the adaptive,
+#'   iterating driver).  These cost very different amounts.
 #' @return Named numeric vector; each element is bytes for that allocation.
 #'   Also includes \code{sizeofInd} (bytes per \code{rx_solving_options_ind}
 #'   struct) and \code{rxLlikSaveSize} (the compile-time constant).
 #' @noRd
-rxMemoryComponents_ <- function(neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, maxAllTimes) {
-    .Call(`_rxode2_rxMemoryComponents_`, neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, maxAllTimes)
+rxMemoryComponents_ <- function(neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, maxAllTimes, stiff, doIndLin) {
+    .Call(`_rxode2_rxMemoryComponents_`, neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, maxAllTimes, stiff, doIndLin)
 }
 
 rxOptRep_ <- function(input) {

--- a/R/rxMemoryEstimate.R
+++ b/R/rxMemoryEstimate.R
@@ -210,8 +210,32 @@ rxMemSummary <- function(nobs, ndoses, id = seq_along(nobs)) {
     linB      = as.integer(.flags["linB"]),
     nMtime    = as.integer(.mv[["nMtime"]]),
     nLlik     = as.integer(.flags["nLlik"]),
-    nIndSim   = as.integer(.flags["nIndSim"])
+    nIndSim   = as.integer(.flags["nIndSim"]),
+    doIndLin  = .rxMemDoIndLin(.mv)
   )
+}
+#' Which matrix-exponential driver a model will run under
+#'
+#' Mirrors the `op$doIndLin` assignment in `src/rxData.cpp`, because what
+#' `method="indLin"` costs depends entirely on which of the four it is: a pure
+#' matrix exponential holds one rate matrix, while true inductive linearization
+#' iterates and carries a Jacobian, `P(h)` and its inverse as well.
+#'
+#' @param mv `rxModelVars()` of the model.
+#' @return 0 (not a `matExp()` model), 1 (pure matrix exponential), 2 (plus a
+#'   state-free `indLin()` forcing), 3 or 4 (true inductive linearization,
+#'   without and with a separate inhomogeneous term).
+#' @noRd
+#' @author Matthew L. Fidler
+.rxMemDoIndLin <- function(mv) {
+  .il <- mv[["indLin"]]
+  if (length(.il) != 4L) return(0L)
+  .hasF <- !is.null(.il[[2L]])
+  if (isTRUE(as.logical(.il[[3L]]))) {
+    if (.hasF) 4L else 3L
+  } else {
+    if (.hasF) 2L else 1L
+  }
 }
 #' Extract memory-relevant options from an rxControl object
 #'
@@ -229,6 +253,7 @@ rxMemSummary <- function(nobs, ndoses, id = seq_along(nobs)) {
   .neps  <- if (is.matrix(ctrl$sigma)) nrow(ctrl$sigma) else 0L
   .nSub  <- if (is.null(ctrl$nSub))  1L else as.integer(ctrl$nSub)
   .nStud <- if (is.null(ctrl$nStud)) 1L else as.integer(ctrl$nStud)
+  .stiff <- if (is.null(ctrl$method)) NA_integer_ else as.integer(ctrl$method)
   list(
     cores      = .cores,
     nsim       = .nsim,
@@ -236,7 +261,8 @@ rxMemSummary <- function(nobs, ndoses, id = seq_along(nobs)) {
     neps       = as.integer(.neps),
     nLlikAlloc = ctrl$nLlikAlloc,
     nSub       = .nSub,
-    nStud      = .nStud
+    nStud      = .nStud,
+    stiff      = .stiff
   )
 }
 #' Detect total physical RAM in bytes
@@ -400,6 +426,16 @@ rxMemSummary <- function(nobs, ndoses, id = seq_along(nobs)) {
 #' @param numLinSens Number of linear sensitivity parameters (FOCEi +
 #'   linCmt).
 #' @param numLin Number of linear compartment terms (FOCEi + linCmt).
+#' @param stiff Solving method as an integer (\code{\link{odeMethodToInt}});
+#'   only \code{3} (\code{"indLin"}) allocates anything extra.  Taken from
+#'   \code{control} when given, and overridden to \code{3} for any
+#'   \code{matExp()} model, since \code{rxSolve()} force-selects that method
+#'   for one whatever the control says.
+#' @param doIndLin Which matrix-exponential driver runs: \code{0} not a
+#'   \code{matExp()} model, \code{1} pure matrix exponential, \code{2} plus a
+#'   state-free \code{indLin()} forcing, \code{3}/\code{4} true inductive
+#'   linearization.  Taken from \code{model} when given.  These cost very
+#'   different amounts, so it is worth getting right.
 #' @return A named list of class \code{"rxMemoryEstimate"} whose
 #'   elements are raw byte counts plus \code{outputData},
 #'   \code{ramBytes}, \code{freeRamBytes}, \code{total},
@@ -449,7 +485,9 @@ rxMemoryEstimate <- function(
   nLlik     = 0L,
   nIndSim   = NULL,
   numLinSens = 0L,
-  numLin    = 0L) {
+  numLin    = 0L,
+  stiff     = NA_integer_,
+  doIndLin  = 0L) {
   .resolved <- .rxMemResolveInput(dat, control)
   dat <- .resolved$dat
   control <- .resolved$control
@@ -475,6 +513,7 @@ rxMemoryEstimate <- function(
     linB      <- .mi$linB
     nMtime    <- .mi$nMtime
     nLlik     <- .mi$nLlik
+    doIndLin  <- .mi$doIndLin
     if (is.null(nIndSim)) nIndSim <- .mi$nIndSim
   }
 
@@ -486,10 +525,26 @@ rxMemoryEstimate <- function(
     if (.ci$neta > 0L) neta <- .ci$neta
     if (.ci$neps > 0L) neps <- .ci$neps
     if (!is.null(.ci$nLlikAlloc)) nLlik <- max(nLlik, as.integer(.ci$nLlikAlloc))
+    if (!is.na(.ci$stiff)) stiff <- .ci$stiff
   }
   if (cores <= 0L) {
     cores <- 1L
   }
+  # `rxSolve()` force-selects method 3 for any matExp() model whatever the
+  # caller asked for (rxSolve.default), so the MODEL settles this, not the
+  # control -- a `matExp()` model with `method="liblsoda"` still solves, and
+  # still allocates, as indLin.
+  if (doIndLin > 0L) {
+    stiff <- 3L
+  } else if (is.na(stiff)) {
+    stiff <- -1L
+  }
+  # `method="indLin"` on an ODE model: rxSolve() rewrites it with rxToIndLin()
+  # before it gets here, so this only fires when rxMemoryEstimate() is called
+  # directly on the unconverted model.  Cost it as the iterating driver -- that
+  # is what a converted nonlinear model runs, and guessing low is the failure
+  # mode this estimate exists to avoid.
+  if (stiff == 3L && doIndLin == 0L) doIndLin <- 3L
   if (is.null(nIndSim)) nIndSim <- neta + neps
 
   .nallVec     <- .summary$nobs + .summary$ndoses
@@ -532,7 +587,9 @@ rxMemoryEstimate <- function(
     numLin     = as.integer(numLin),
     nsub       = as.integer(.nsub),
     nallTotal  = as.double(.solveNallTotal),
-    maxAllTimes = as.double(.solveMaxAllTimes)
+    maxAllTimes = as.double(.solveMaxAllTimes),
+    stiff      = as.integer(stiff),
+    doIndLin   = as.integer(doIndLin)
   )
 
   .meta    <- c("sizeofInd", "rxLlikSaveSize")
@@ -571,8 +628,16 @@ rxMemoryEstimate <- function(
   if (is.na(.est$freeRamBytes) || .est$freeRamBytes <= 0 || .est$effectiveSubs <= 0) {
     return(1L)
   }
-  .memPerSub <- as.numeric(.est$total) / max(1L, .est$effectiveSubs)
-  .avail <- .est$freeRamBytes * safetyFactor
+  # Per-THREAD allocations do not shrink when the chunk does: one subject at a
+  # time still needs the whole per-thread exponential cache and solver scratch.
+  # Dividing them by the subject count would understate the chunk, and would
+  # keep understating it however small the chunks got.  Take them off the top.
+  .fixedNames <- c("indLinExpCache", "indLinWork")
+  .fixed <- sum(vapply(.est[intersect(names(.est), .fixedNames)],
+                       as.numeric, numeric(1)))
+  .memPerSub <- (as.numeric(.est$total) - .fixed) / max(1L, .est$effectiveSubs)
+  .avail <- .est$freeRamBytes * safetyFactor - .fixed
+  if (.memPerSub <= 0 || .avail <= 0) return(1L)
   max(1L, as.integer(floor(.avail / .memPerSub)))
 }
 
@@ -613,6 +678,8 @@ print.rxMemoryEstimate <- function(x, ...) {
     ordId         = "ordId (subject ordering)",
     gInfusionRate = "gInfusionRate (per-thread infusion)",
     inds_global   = "inds_global (per-subject structs)",
+    indLinExpCache = "indLinExpCache (per-thread exponential cache)",
+    indLinWork    = "indLinWork (per-thread indLin scratch)",
     outputData    = "outputData (estimated returned data)"
   )
 

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -4159,7 +4159,8 @@ rxEtDispatchSolve.rxode2et <- function(x, ...) {
 #'         solving nor user Jacobian specification
 #'
 #' * `"indLin"` -- Solving through inductive linearization.  The rxode2 dll
-#'         must be setup specially to use this solving routine.
+#'         must be setup specially to use this solving routine.  Supports
+#'         parallel thread-based solving and honors `cores`.
 #'
 #' * `"f78"` -- Runge-Kutta Fehlberg 78 solver using Boost's odeint library.
 #'

--- a/bench/indlin_thread_bench.R
+++ b/bench/indlin_thread_bench.R
@@ -1,0 +1,41 @@
+## rxode2#1216: method="indLin" solves subjects in parallel.
+## Two models: a linear matExp(), where each subject is cheap and the per-thread
+## exponential cache does most of the work, and a Michaelis-Menten forcing,
+## where the adaptive driver gives each subject real work to do.
+suppressMessages(library(rxode2))
+
+suppressMessages({
+  .lin <- rxode2(paste("matExp()", "cmt(depot)", "cmt(central)",
+                       "k_depot_central = ka", "k_central_output = ke",
+                       sep = "\n"))
+  .mm <- rxode2(rxToIndLin(paste0(
+    "d/dt(depot) = -ka*depot\n",
+    "d/dt(central) = ka*depot - vmax*(central/v)/(km + central/v)\n")))
+})
+
+.linPar <- c(ka = 1, ke = 0.2)
+.mmPar <- c(ka = 1, km = 0.5, vmax = 0.2, v = 1)
+
+nsub <- 1000
+.ev <- as.data.frame(et(amt = 100, cmt = "depot") |>
+                       et(seq(0, 48, by = 0.5)) |> et(id = seq_len(nsub)))
+
+.solve <- function(model, params, nc) {
+  suppressMessages(rxSolve(model, params = params, events = .ev,
+                           method = "indLin", cores = nc,
+                           returnType = "data.frame"))
+}
+
+for (.m in list(list(n = "linear matExp()", m = .lin, p = .linPar),
+                list(n = "Michaelis-Menten indLin()", m = .mm, p = .mmPar))) {
+  invisible(.solve(.m$m, .m$p, 1L))                    # warm up
+  cat(sprintf("=== %s, %d subjects ===\n", .m$n, nsub))
+  .base <- NA_real_
+  for (nc in c(1L, 2L, 4L, 8L)) {
+    ts <- vapply(1:3, function(i) system.time(.solve(.m$m, .m$p, nc))["elapsed"],
+                 numeric(1))
+    if (nc == 1L) .base <- median(ts)
+    cat(sprintf("  cores=%d  median=%.3fs  speedup=%.2fx  (%.3f %.3f %.3f)\n",
+                nc, median(ts), .base/median(ts), ts[1], ts[2], ts[3]))
+  }
+}

--- a/bench/indlin_thread_bench.R
+++ b/bench/indlin_thread_bench.R
@@ -26,6 +26,15 @@ nsub <- 1000
                            returnType = "data.frame"))
 }
 
+## Say up front whether this build threads indLin at all, so a flat table is
+## never mistaken for "it does not scale".  The exponential cache is per
+## thread, and these subjects share one operand, so `dadt` (exponentials
+## COMPUTED) is the number of cache slots that were touched.
+.slots <- sum(suppressMessages(rxSolve(.lin, params = .linPar, events = .ev,
+                                       method = "indLin", cores = 4L))$counts$dadt)
+cat(sprintf("indLin thread slots touched at cores=4: %d%s\n\n", .slots,
+            if (.slots > 1) "" else "  <-- NOT THREADED, timings below are meaningless"))
+
 for (.m in list(list(n = "linear matExp()", m = .lin, p = .linPar),
                 list(n = "Michaelis-Menten indLin()", m = .mm, p = .mmPar))) {
   invisible(.solve(.m$m, .m$p, 1L))                    # warm up

--- a/inst/include/rxode2_RcppExports.h
+++ b/inst/include/rxode2_RcppExports.h
@@ -1091,17 +1091,17 @@ namespace rxode2 {
         return Rcpp::as<RObject >(rcpp_result_gen);
     }
 
-    inline NumericVector rxMemoryComponents_(int neq, int stateSize, int nlhs, int npars, int neta, int neps, int ncov, int nsim, int cores, int nMtime, int extraCmt, int linB, int nLlik, int nIndSim, int numLinSens, int numLin, int nsub, double nallTotal, double maxAllTimes) {
-        typedef SEXP(*Ptr_rxMemoryComponents_)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
+    inline NumericVector rxMemoryComponents_(int neq, int stateSize, int nlhs, int npars, int neta, int neps, int ncov, int nsim, int cores, int nMtime, int extraCmt, int linB, int nLlik, int nIndSim, int numLinSens, int numLin, int nsub, double nallTotal, double maxAllTimes, int stiff, int doIndLin) {
+        typedef SEXP(*Ptr_rxMemoryComponents_)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
         static Ptr_rxMemoryComponents_ p_rxMemoryComponents_ = NULL;
         if (p_rxMemoryComponents_ == NULL) {
-            validateSignature("NumericVector(*rxMemoryComponents_)(int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,double,double)");
+            validateSignature("NumericVector(*rxMemoryComponents_)(int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,double,double,int,int)");
             p_rxMemoryComponents_ = (Ptr_rxMemoryComponents_)R_GetCCallable("rxode2", "_rxode2_rxMemoryComponents_");
         }
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_rxMemoryComponents_(Shield<SEXP>(Rcpp::wrap(neq)), Shield<SEXP>(Rcpp::wrap(stateSize)), Shield<SEXP>(Rcpp::wrap(nlhs)), Shield<SEXP>(Rcpp::wrap(npars)), Shield<SEXP>(Rcpp::wrap(neta)), Shield<SEXP>(Rcpp::wrap(neps)), Shield<SEXP>(Rcpp::wrap(ncov)), Shield<SEXP>(Rcpp::wrap(nsim)), Shield<SEXP>(Rcpp::wrap(cores)), Shield<SEXP>(Rcpp::wrap(nMtime)), Shield<SEXP>(Rcpp::wrap(extraCmt)), Shield<SEXP>(Rcpp::wrap(linB)), Shield<SEXP>(Rcpp::wrap(nLlik)), Shield<SEXP>(Rcpp::wrap(nIndSim)), Shield<SEXP>(Rcpp::wrap(numLinSens)), Shield<SEXP>(Rcpp::wrap(numLin)), Shield<SEXP>(Rcpp::wrap(nsub)), Shield<SEXP>(Rcpp::wrap(nallTotal)), Shield<SEXP>(Rcpp::wrap(maxAllTimes)));
+            rcpp_result_gen = p_rxMemoryComponents_(Shield<SEXP>(Rcpp::wrap(neq)), Shield<SEXP>(Rcpp::wrap(stateSize)), Shield<SEXP>(Rcpp::wrap(nlhs)), Shield<SEXP>(Rcpp::wrap(npars)), Shield<SEXP>(Rcpp::wrap(neta)), Shield<SEXP>(Rcpp::wrap(neps)), Shield<SEXP>(Rcpp::wrap(ncov)), Shield<SEXP>(Rcpp::wrap(nsim)), Shield<SEXP>(Rcpp::wrap(cores)), Shield<SEXP>(Rcpp::wrap(nMtime)), Shield<SEXP>(Rcpp::wrap(extraCmt)), Shield<SEXP>(Rcpp::wrap(linB)), Shield<SEXP>(Rcpp::wrap(nLlik)), Shield<SEXP>(Rcpp::wrap(nIndSim)), Shield<SEXP>(Rcpp::wrap(numLinSens)), Shield<SEXP>(Rcpp::wrap(numLin)), Shield<SEXP>(Rcpp::wrap(nsub)), Shield<SEXP>(Rcpp::wrap(nallTotal)), Shield<SEXP>(Rcpp::wrap(maxAllTimes)), Shield<SEXP>(Rcpp::wrap(stiff)), Shield<SEXP>(Rcpp::wrap(doIndLin)));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();

--- a/inst/include/rxode2dataErr.h
+++ b/inst/include/rxode2dataErr.h
@@ -27,6 +27,7 @@
 #define rxErrRate02           8388608
 #define rxErrIndLinConverge   16777216
 #define rxErrIndLinCode       33554432
+#define rxErrIndLinExcept     67108864
 
 #define rxErrNaTimeLag   1
 #define rxErrNaTimeRate  2

--- a/man/odeMethodToInt.Rd
+++ b/man/odeMethodToInt.Rd
@@ -39,7 +39,8 @@ solving, but allows user Jacobian specification.
 \item \code{"dop853"} -- DOP853 solver.  Does not support parallel thread-based
 solving nor user Jacobian specification
 \item \code{"indLin"} -- Solving through inductive linearization.  The rxode2 dll
-must be setup specially to use this solving routine.
+must be setup specially to use this solving routine.  Supports
+parallel thread-based solving and honors \code{cores}.
 \item \code{"f78"} -- Runge-Kutta Fehlberg 78 solver using Boost's odeint library.
 \item \code{"rk4"} -- Runge-Kutta 4 solver using Boost's odeint library.
 \item \code{"ck54"} -- Cash-Karp 5(4) solver using Boost's odeint library.

--- a/man/rxMemoryEstimate.Rd
+++ b/man/rxMemoryEstimate.Rd
@@ -23,7 +23,9 @@ rxMemoryEstimate(
   nLlik = 0L,
   nIndSim = NULL,
   numLinSens = 0L,
-  numLin = 0L
+  numLin = 0L,
+  stiff = NA_integer_,
+  doIndLin = 0L
 )
 }
 \arguments{
@@ -81,6 +83,18 @@ model.}
 linCmt).}
 
 \item{numLin}{Number of linear compartment terms (FOCEi + linCmt).}
+
+\item{stiff}{Solving method as an integer (\code{\link{odeMethodToInt}});
+only \code{3} (\code{"indLin"}) allocates anything extra.  Taken from
+\code{control} when given, and overridden to \code{3} for any
+\code{matExp()} model, since \code{rxSolve()} force-selects that method
+for one whatever the control says.}
+
+\item{doIndLin}{Which matrix-exponential driver runs: \code{0} not a
+\code{matExp()} model, \code{1} pure matrix exponential, \code{2} plus a
+state-free \code{indLin()} forcing, \code{3}/\code{4} true inductive
+linearization.  Taken from \code{model} when given.  These cost very
+different amounts, so it is worth getting right.}
 }
 \value{
 A named list of class \code{"rxMemoryEstimate"} whose

--- a/man/rxSolve.Rd
+++ b/man/rxSolve.Rd
@@ -342,7 +342,8 @@ solving, but allows user Jacobian specification.
 \item \code{"dop853"} -- DOP853 solver.  Does not support parallel thread-based
 solving nor user Jacobian specification
 \item \code{"indLin"} -- Solving through inductive linearization.  The rxode2 dll
-must be setup specially to use this solving routine.
+must be setup specially to use this solving routine.  Supports
+parallel thread-based solving and honors \code{cores}.
 \item \code{"f78"} -- Runge-Kutta Fehlberg 78 solver using Boost's odeint library.
 \item \code{"rk4"} -- Runge-Kutta 4 solver using Boost's odeint library.
 \item \code{"ck54"} -- Cash-Karp 5(4) solver using Boost's odeint library.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2220,8 +2220,8 @@ RcppExport SEXP _rxode2_rxSymInvCholEnvCalculate(SEXP objSEXP, SEXP whatSEXP, SE
     return rcpp_result_gen;
 }
 // rxMemoryComponents_
-NumericVector rxMemoryComponents_(int neq, int stateSize, int nlhs, int npars, int neta, int neps, int ncov, int nsim, int cores, int nMtime, int extraCmt, int linB, int nLlik, int nIndSim, int numLinSens, int numLin, int nsub, double nallTotal, double maxAllTimes);
-static SEXP _rxode2_rxMemoryComponents__try(SEXP neqSEXP, SEXP stateSizeSEXP, SEXP nlhsSEXP, SEXP nparsSEXP, SEXP netaSEXP, SEXP nepsSEXP, SEXP ncovSEXP, SEXP nsimSEXP, SEXP coresSEXP, SEXP nMtimeSEXP, SEXP extraCmtSEXP, SEXP linBSEXP, SEXP nLlikSEXP, SEXP nIndSimSEXP, SEXP numLinSensSEXP, SEXP numLinSEXP, SEXP nsubSEXP, SEXP nallTotalSEXP, SEXP maxAllTimesSEXP) {
+NumericVector rxMemoryComponents_(int neq, int stateSize, int nlhs, int npars, int neta, int neps, int ncov, int nsim, int cores, int nMtime, int extraCmt, int linB, int nLlik, int nIndSim, int numLinSens, int numLin, int nsub, double nallTotal, double maxAllTimes, int stiff, int doIndLin);
+static SEXP _rxode2_rxMemoryComponents__try(SEXP neqSEXP, SEXP stateSizeSEXP, SEXP nlhsSEXP, SEXP nparsSEXP, SEXP netaSEXP, SEXP nepsSEXP, SEXP ncovSEXP, SEXP nsimSEXP, SEXP coresSEXP, SEXP nMtimeSEXP, SEXP extraCmtSEXP, SEXP linBSEXP, SEXP nLlikSEXP, SEXP nIndSimSEXP, SEXP numLinSensSEXP, SEXP numLinSEXP, SEXP nsubSEXP, SEXP nallTotalSEXP, SEXP maxAllTimesSEXP, SEXP stiffSEXP, SEXP doIndLinSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< int >::type neq(neqSEXP);
@@ -2243,15 +2243,17 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type nsub(nsubSEXP);
     Rcpp::traits::input_parameter< double >::type nallTotal(nallTotalSEXP);
     Rcpp::traits::input_parameter< double >::type maxAllTimes(maxAllTimesSEXP);
-    rcpp_result_gen = Rcpp::wrap(rxMemoryComponents_(neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, maxAllTimes));
+    Rcpp::traits::input_parameter< int >::type stiff(stiffSEXP);
+    Rcpp::traits::input_parameter< int >::type doIndLin(doIndLinSEXP);
+    rcpp_result_gen = Rcpp::wrap(rxMemoryComponents_(neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, maxAllTimes, stiff, doIndLin));
     return rcpp_result_gen;
 END_RCPP_RETURN_ERROR
 }
-RcppExport SEXP _rxode2_rxMemoryComponents_(SEXP neqSEXP, SEXP stateSizeSEXP, SEXP nlhsSEXP, SEXP nparsSEXP, SEXP netaSEXP, SEXP nepsSEXP, SEXP ncovSEXP, SEXP nsimSEXP, SEXP coresSEXP, SEXP nMtimeSEXP, SEXP extraCmtSEXP, SEXP linBSEXP, SEXP nLlikSEXP, SEXP nIndSimSEXP, SEXP numLinSensSEXP, SEXP numLinSEXP, SEXP nsubSEXP, SEXP nallTotalSEXP, SEXP maxAllTimesSEXP) {
+RcppExport SEXP _rxode2_rxMemoryComponents_(SEXP neqSEXP, SEXP stateSizeSEXP, SEXP nlhsSEXP, SEXP nparsSEXP, SEXP netaSEXP, SEXP nepsSEXP, SEXP ncovSEXP, SEXP nsimSEXP, SEXP coresSEXP, SEXP nMtimeSEXP, SEXP extraCmtSEXP, SEXP linBSEXP, SEXP nLlikSEXP, SEXP nIndSimSEXP, SEXP numLinSensSEXP, SEXP numLinSEXP, SEXP nsubSEXP, SEXP nallTotalSEXP, SEXP maxAllTimesSEXP, SEXP stiffSEXP, SEXP doIndLinSEXP) {
     SEXP rcpp_result_gen;
     {
         Rcpp::RNGScope rcpp_rngScope_gen;
-        rcpp_result_gen = PROTECT(_rxode2_rxMemoryComponents__try(neqSEXP, stateSizeSEXP, nlhsSEXP, nparsSEXP, netaSEXP, nepsSEXP, ncovSEXP, nsimSEXP, coresSEXP, nMtimeSEXP, extraCmtSEXP, linBSEXP, nLlikSEXP, nIndSimSEXP, numLinSensSEXP, numLinSEXP, nsubSEXP, nallTotalSEXP, maxAllTimesSEXP));
+        rcpp_result_gen = PROTECT(_rxode2_rxMemoryComponents__try(neqSEXP, stateSizeSEXP, nlhsSEXP, nparsSEXP, netaSEXP, nepsSEXP, ncovSEXP, nsimSEXP, coresSEXP, nMtimeSEXP, extraCmtSEXP, linBSEXP, nLlikSEXP, nIndSimSEXP, numLinSensSEXP, numLinSEXP, nsubSEXP, nallTotalSEXP, maxAllTimesSEXP, stiffSEXP, doIndLinSEXP));
     }
     Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
     if (rcpp_isInterrupt_gen) {
@@ -3027,7 +3029,7 @@ static int _rxode2_RcppExport_validate(const char* sig) {
         signatures.insert("NumericVector(*rxInv)(SEXP)");
         signatures.insert("RObject(*rxSymInvChol)(RObject,Nullable<NumericVector>,std::string,int)");
         signatures.insert("RObject(*rxSymInvCholEnvCalculate)(List,std::string,Nullable<NumericVector>)");
-        signatures.insert("NumericVector(*rxMemoryComponents_)(int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,double,double)");
+        signatures.insert("NumericVector(*rxMemoryComponents_)(int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,double,double,int,int)");
         signatures.insert("SEXP(*rxSaveState_)()");
         signatures.insert("bool(*rxIsSerializeFile_)(SEXP)");
         signatures.insert("SEXP(*rxRestoreState_)(SEXP)");

--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -147,7 +147,6 @@ static inline void matrixExp(arma::mat& H, arma::mat& out, double t, int type,
   case 2: {
     int iflag=0;
     int m = H.n_rows;
-    // FIXME C++ implementation for threading.
     out = H;
     F77_CALL(matexprbs)(&order, &m, &t, out.memptr(), &iflag);
     // matexpRBS used to warn through the R API from inside the parallel
@@ -159,9 +158,17 @@ static inline void matrixExp(arma::mat& H, arma::mat& out, double t, int type,
     }
     break;
   }
-  default:
+  default: {
     H *= t;
-    out = arma::expmat(H);
+    // The bool form, not `out = arma::expmat(H)`: the one-argument overload
+    // throws on failure, and `ARMA_DONT_PRINT_ERRORS` suppresses the message,
+    // not the throw.  An exception leaving an omp region is std::terminate.
+    if (!arma::expmat(out, H)) {
+      RSprintf(_("matrix exponential failed\n"));
+      out.zeros();
+    }
+    break;
+  }
   }
 }
 
@@ -251,10 +258,32 @@ typedef struct {
 } indLinAutoState_t;
 static std::vector<indLinAutoState_t> __indLinAutoState;
 
+// This thread's slot in a pool of `n`, or -1 when it has none.
+//
+// `rx_get_thread()` CLAMPS to the last slot instead, which is right for the
+// pools it was written for -- two threads sharing a counter tears a number.
+// It is not right here: the exponential cache's write path calls
+// `std::vector::resize()` on a slot another thread may be `memcmp`-ing, which
+// is a use-after-free rather than a torn read.  A thread with no slot of its
+// own simply does not cache.  An external OpenMP driver (nlmixr2est) is
+// supposed to have configured `op->cores` to cover its team; this is what
+// happens when it has not.
+static inline int indLinOwnSlot(int n) {
+  if (n <= 0) return -1;
+#ifdef _OPENMP
+  int tn = getRxThreadId();
+  if (tn < 0) tn = omp_get_thread_num();
+  if (tn < 0) tn = 0;
+  return (tn < n) ? tn : -1;
+#else
+  return 0;
+#endif
+}
+
 static inline indLinAutoState_t *indLinAutoFor(int cSub) {
-  if (__indLinAutoState.empty()) return NULL;
-  indLinAutoState_t *a =
-    &__indLinAutoState[rx_get_thread((int)__indLinAutoState.size())];
+  const int tid = indLinOwnSlot((int)__indLinAutoState.size());
+  if (tid < 0) return NULL;   // every caller is NULL-safe: Picard, no ratchet
+  indLinAutoState_t *a = &__indLinAutoState[tid];
   if (a->cSub != cSub) {
     a->cSub = cSub;
     a->scheme = RX_INDLIN_ITER_PICARD;
@@ -290,6 +319,8 @@ static std::vector<indLinCounts_t> __indLinCounts;
 // at that point, and `rxIndLinSteps()` drains it along with the rest.
 static indLinCounts_t __indLinCountsSink;
 
+// `rx_get_thread`'s clamp, not `indLinOwnSlot`: sharing a slot here tears a
+// diagnostic count, and nothing on this path reallocates.
 static inline indLinCounts_t *indLinCountsHere(void) {
   if (__indLinCounts.empty()) return &__indLinCountsSink;
   return &__indLinCounts[rx_get_thread((int)__indLinCounts.size())];
@@ -300,6 +331,15 @@ extern "C" void ensureIndLinExpCache(int nCores) {
   // Force-miss switch: every lookup fails, so "is this a cache bug?" is one run
   // rather than a bisect.  Read here so it is live per solve.
   __indLinExpCacheOff = (getenv("RXODE2_INDLIN_NO_EXP_CACHE") != NULL);
+  // Cover `omp_get_max_threads()` as well as the cores this solve asked for,
+  // for the reason `ensureExtraDosing` gives: an external OpenMP driver can
+  // bring more threads than `op->cores`.  Without a slot each they fall back to
+  // computing uncached (indLinOwnSlot), which is correct but slow, so size for
+  // the common case and let the guard cover the rest.
+  {
+    int mx = omp_get_max_threads();
+    if (mx > nCores) nCores = mx;
+  }
   if ((int)__indLinExpCache.size() < nCores) {
     __indLinExpCache.resize(nCores);
   }
@@ -342,9 +382,9 @@ static inline void matrixExpCached(arma::mat& H, arma::mat& out, double t,
   const int n = (int) H.n_rows;
   const size_t n2 = (size_t) n * (size_t) n;
   expCache_t *c = NULL;
-  if (!__indLinExpCacheOff && !__indLinExpCache.empty() &&
-      n2 <= RX_INDLIN_EXPCACHE_MAXN2) {
-    c = &__indLinExpCache[rx_get_thread((int)__indLinExpCache.size())];
+  const int tid = indLinOwnSlot((int)__indLinExpCache.size());
+  if (!__indLinExpCacheOff && tid >= 0 && n2 <= RX_INDLIN_EXPCACHE_MAXN2) {
+    c = &__indLinExpCache[tid];
     for (int j = 0; j < RX_INDLIN_EXPCACHE_N; j++) {
       expCacheSlot_t &s = c->slot[j];
       if (s.n == n && memcmp(&s.t, &t, sizeof(double)) == 0 &&
@@ -2382,10 +2422,10 @@ static int indLinDriveAdaptive(int cSub, rx_solving_options *op, rx_solving_opti
 //'        inductive linearization
 //' @name rxIndLin_
 //' @noRd
-extern "C" int indLin(int cSub, rx_solving_options *op, rx_solving_options_ind *ind,
-                      double tp, double *yp_, double tf,
-		      double *InfusionRate_, int *on_,
-		      t_ME ME, t_IndF  IndF){
+static int indLinRun(int cSub, rx_solving_options *op, rx_solving_options_ind *ind,
+                     double tp, double *yp_, double tf,
+                     double *InfusionRate_, int *on_,
+                     t_ME ME, t_IndF  IndF){
   int neq = (ind != NULL) ? rxEffNeq(ind, op) : op->neq;
   // Use per-individual tolerance arrays when available (set by
   // _setIndPointersByThread + iniSubject), falling back to op->rtol2/atol2.
@@ -2537,6 +2577,25 @@ extern "C" int indLin(int cSub, rx_solving_options *op, rx_solving_options_ind *
   //   }
   // }
   return 1;
+}
+
+// The solve-side entry point.  Everything it reaches is written not to throw --
+// `RSprintf` instead of the R API, the bool forms of the Armadillo
+// decompositions, `ind->err` instead of an error -- but an Armadillo
+// allocation can still raise `std::bad_alloc`, and an exception leaving
+// `par_indLin`'s parallel region is `std::terminate`, i.e. a lost session
+// rather than a failed subject.  Turn anything that escapes into the
+// convergence-failure code the caller already NA-fills on.
+extern "C" int indLin(int cSub, rx_solving_options *op, rx_solving_options_ind *ind,
+                      double tp, double *yp_, double tf,
+                      double *InfusionRate_, int *on_,
+                      t_ME ME, t_IndF  IndF){
+  try {
+    return indLinRun(cSub, op, ind, tp, yp_, tf, InfusionRate_, on_, ME, IndF);
+  } catch (...) {
+    if (ind != NULL) ind->err |= rxErrIndLinCode;
+    return -1;
+  }
 }
 
 // Step dispositions for the last solve (or since the last read), as a named

--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -319,11 +319,14 @@ static std::vector<indLinCounts_t> __indLinCounts;
 // at that point, and `rxIndLinSteps()` drains it along with the rest.
 static indLinCounts_t __indLinCountsSink;
 
-// `rx_get_thread`'s clamp, not `indLinOwnSlot`: sharing a slot here tears a
-// diagnostic count, and nothing on this path reallocates.
+// NULL when this thread has no slot of its own, so a caller skips the count
+// rather than sharing one.  `rx_get_thread`'s clamp would put two threads on
+// one `long`, which loses counts AND is a data race; a thread without a slot is
+// already running uncached, so undercounting it is the honest outcome.
 static inline indLinCounts_t *indLinCountsHere(void) {
   if (__indLinCounts.empty()) return &__indLinCountsSink;
-  return &__indLinCounts[rx_get_thread((int)__indLinCounts.size())];
+  const int tid = indLinOwnSlot((int)__indLinCounts.size());
+  return (tid < 0) ? NULL : &__indLinCounts[tid];
 }
 
 // Sized before the parallel region, from rxData.cpp, alongside the other pools.
@@ -2096,7 +2099,14 @@ static int indLinTryStep(int cSub, rx_solving_options *op, rx_solving_options_in
 // boundary is still a boundary (which is what keeps time-varying covariate
 // sampling a refinement rather than a change).
 // The step-disposition counters live with the other per-thread pools, above.
-extern "C" void rxIndLinCountIter(int n) { indLinCountsHere()->iter += n; }
+// `indLinCountsHere()` returns NULL for a thread with no slot of its own, so
+// every bump below is guarded rather than shared.
+#define rxIndLinBump(FIELD, BY) do {                    \
+    indLinCounts_t *_c_ = indLinCountsHere();           \
+    if (_c_ != NULL) _c_->FIELD += (BY);                \
+  } while (0)
+
+extern "C" void rxIndLinCountIter(int n) { rxIndLinBump(iter, n); }
 
 // The extrapolation level an explicit `indLinRichardson` asks for.  `auto`
 // starts at the base order and earns its way up through indLinRaiseRich().
@@ -2242,7 +2252,7 @@ static inline void indLinAcceptStep(indLinProgress_t *pr, bool inSS, double hCap
   y0 = yTry;
   pr->t += pr->h;
   pr->nAccept++;
-  indLinCountsHere()->accept++;
+  rxIndLinBump(accept, 1);
   if ((pr->lastRejected || inSS) && fac > 1.0) fac = 1.0;
   pr->lastRejected = 0;
   pr->h *= fac;
@@ -2266,7 +2276,7 @@ static indLinAction_t indLinAttempt(int cSub, rx_solving_options *op,
                                     arma::vec &yScratch, arma::mat &richTab,
                                     int *retOut) {
   const double SAFE = 0.9, FACMIN = 0.1, FACMAX = 5.0;
-  indLinCountsHere()->attempt++;
+  rxIndLinBump(attempt, 1);
   if (++(pr->nAttempt) > op->mxstep) return RX_INDLIN_ACT_ABANDON;
   // Decide from the step the controller has settled on rather than by burning
   // the switch-over count first.
@@ -2282,7 +2292,7 @@ static indLinAction_t indLinAttempt(int cSub, rx_solving_options *op,
                                 InfusionRate_, on_, ME, IndF, u, yTry, w1,
                                 yScratch, richTab, &err, &ratio);
   if (ret == -2) {
-    indLinCountsHere()->cutConv++;
+    rxIndLinBump(cutConv, 1);
     indLinStiffGate(autoScheme, autoRich, autoSt, &(pr->scheme), &(pr->useRich));
     pr->h *= indLinCutFactor(ratio, FACMIN);
     pr->lastRejected = 1;
@@ -2294,7 +2304,7 @@ static indLinAction_t indLinAttempt(int cSub, rx_solving_options *op,
   }
   double fac = indLinStepFactor(err, expo, SAFE, FACMIN, FACMAX);
   if (err > 1.0) {
-    indLinCountsHere()->rejErr++;
+    rxIndLinBump(rejErr, 1);
     pr->h *= fac;
     pr->lastRejected = 1;
     return (pr->h < 1e-10*span) ? RX_INDLIN_ACT_ABANDON : RX_INDLIN_ACT_RETRY;
@@ -2584,8 +2594,14 @@ static int indLinRun(int cSub, rx_solving_options *op, rx_solving_options_ind *i
 // decompositions, `ind->err` instead of an error -- but an Armadillo
 // allocation can still raise `std::bad_alloc`, and an exception leaving
 // `par_indLin`'s parallel region is `std::terminate`, i.e. a lost session
-// rather than a failed subject.  Turn anything that escapes into the
-// convergence-failure code the caller already NA-fills on.
+// rather than a failed subject.  Turn anything that escapes into a failed
+// subject, under its own error code so the message names what happened.
+//
+// This does not hide an R error or a user interrupt: R signals those with
+// `longjmp` (a udf's R error reaches C through `Rf_error` at the end of
+// `_rxode2_evalUdfS`'s BEGIN_RCPP/END_RCPP), and a `longjmp` unwinds straight
+// past a `catch`.  A udf model is also classified `notThreadSafe`, so it never
+// runs under a team in the first place.
 extern "C" int indLin(int cSub, rx_solving_options *op, rx_solving_options_ind *ind,
                       double tp, double *yp_, double tf,
                       double *InfusionRate_, int *on_,
@@ -2593,7 +2609,7 @@ extern "C" int indLin(int cSub, rx_solving_options *op, rx_solving_options_ind *
   try {
     return indLinRun(cSub, op, ind, tp, yp_, tf, InfusionRate_, on_, ME, IndF);
   } catch (...) {
-    if (ind != NULL) ind->err |= rxErrIndLinCode;
+    if (ind != NULL) ind->err |= rxErrIndLinExcept;
     return -1;
   }
 }

--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -264,6 +264,37 @@ static inline indLinAutoState_t *indLinAutoFor(int cSub) {
   return a;
 }
 
+// -- Step-disposition diagnostics ---------------------------------------------
+//
+// `$counts` is full: slvr counts accepted steps and dadt/jac already carry the
+// exponentials computed and reused.  These answer a different question -- WHY a
+// step was retried.  A step cut because the fixed-point iteration would not
+// contract is one the error controller would have allowed, so this count is the
+// ceiling on what replacing that iteration can win; a step rejected on error is
+// not.  Read with `rxIndLinSteps()`, which sums the threads and resets.
+//
+// Per thread and summed at read, not atomics: every increment sits in the
+// innermost substep loop, where a contended atomic would cost more than the
+// step it counts.  Padded so two threads never share a cache line.
+typedef struct {
+  long attempt;
+  long accept;
+  long rejErr;    // rejected: local error estimate too large
+  long cutConv;   // cut: iteration did not converge (ret == -2)
+  long iter;      // total iteration passes over all substeps
+  char pad[64];
+} indLinCounts_t;
+static std::vector<indLinCounts_t> __indLinCounts;
+// `indLin()` is reachable before any solve has sized the pool; count into a
+// sink there rather than branching around every increment.  Nothing is threaded
+// at that point, and `rxIndLinSteps()` drains it along with the rest.
+static indLinCounts_t __indLinCountsSink;
+
+static inline indLinCounts_t *indLinCountsHere(void) {
+  if (__indLinCounts.empty()) return &__indLinCountsSink;
+  return &__indLinCounts[rx_get_thread((int)__indLinCounts.size())];
+}
+
 // Sized before the parallel region, from rxData.cpp, alongside the other pools.
 extern "C" void ensureIndLinExpCache(int nCores) {
   // Force-miss switch: every lookup fails, so "is this a cache bug?" is one run
@@ -274,6 +305,12 @@ extern "C" void ensureIndLinExpCache(int nCores) {
   }
   if ((int)__indLinAutoState.size() < nCores) {
     __indLinAutoState.resize(nCores);
+  }
+  // Grown but never zeroed here: the counts accumulate until `rxIndLinSteps()`
+  // reads them, which is across solves, and `rxSolveFree()` runs at the START
+  // of the next one.  `resize` value-initializes the new slots.
+  if ((int)__indLinCounts.size() < nCores) {
+    __indLinCounts.resize(nCores);
   }
   for (int i = 0; i < (int)__indLinAutoState.size(); i++) {
     __indLinAutoState[i].cSub = -1;      // nothing survives into another solve
@@ -292,6 +329,9 @@ extern "C" void ensureIndLinExpCache(int nCores) {
 extern "C" void freeIndLinExpCache(void) {
   __indLinExpCache.clear();
   __indLinAutoState.clear();
+  // `__indLinCounts` is deliberately NOT cleared: `rxSolveFree()` calls this at
+  // the START of the next solve, and the counts have to survive until
+  // `rxIndLinSteps()` reads them.  It is five longs per core.
 }
 
 // exp(H*t) into `out`, reusing an identical earlier exponential when there is
@@ -505,10 +545,6 @@ arma::vec phiv(double t, arma::mat& A, arma::vec& u,
   }
   }
 }
-
-
-bool expm_assign=false;
-SEXP expm_s;
 
 // P(h) = A^-1(exp(Ah) - I) = h*phi1(Ah), the operator the substep map applies
 // to the forcing.  Needed as a MATRIX only by the Newton iteration, which forms
@@ -2019,26 +2055,8 @@ static int indLinTryStep(int cSub, rx_solving_options *op, rx_solving_options_in
 // tuned `hmax` keeps at least the accuracy they had, and every old substep
 // boundary is still a boundary (which is what keeps time-varying covariate
 // sampling a refinement rather than a change).
-// -- Step-disposition diagnostics ---------------------------------------------
-//
-// `$counts` is full: slvr counts accepted steps and dadt/jac already carry the
-// exponentials computed and reused.  These answer a different question -- WHY a
-// step was retried.  A step cut because the fixed-point iteration would not
-// contract is one the error controller would have allowed, so this count is the
-// ceiling on what replacing that iteration can win; a step rejected on error is
-// not.  Read with `rxIndLinSteps()`, which also resets.
-//
-// Plain `long` rather than atomics: `par_indLin` is forced single-threaded
-// (`solveMethodThreadSafe`), and these are diagnostics, so a torn count under a
-// future threaded build would mislead but not corrupt.  Revisit if indLin ever
-// becomes reentrant.
-static long __indLinNAttempt = 0;
-static long __indLinNAccept  = 0;
-static long __indLinNRejErr  = 0;   // rejected: local error estimate too large
-static long __indLinNCutConv = 0;   // cut: iteration did not converge (ret == -2)
-static long __indLinNIter    = 0;   // total iteration passes over all substeps
-
-extern "C" void rxIndLinCountIter(int n) { __indLinNIter += n; }
+// The step-disposition counters live with the other per-thread pools, above.
+extern "C" void rxIndLinCountIter(int n) { indLinCountsHere()->iter += n; }
 
 // The extrapolation level an explicit `indLinRichardson` asks for.  `auto`
 // starts at the base order and earns its way up through indLinRaiseRich().
@@ -2184,7 +2202,7 @@ static inline void indLinAcceptStep(indLinProgress_t *pr, bool inSS, double hCap
   y0 = yTry;
   pr->t += pr->h;
   pr->nAccept++;
-  __indLinNAccept++;
+  indLinCountsHere()->accept++;
   if ((pr->lastRejected || inSS) && fac > 1.0) fac = 1.0;
   pr->lastRejected = 0;
   pr->h *= fac;
@@ -2208,7 +2226,7 @@ static indLinAction_t indLinAttempt(int cSub, rx_solving_options *op,
                                     arma::vec &yScratch, arma::mat &richTab,
                                     int *retOut) {
   const double SAFE = 0.9, FACMIN = 0.1, FACMAX = 5.0;
-  __indLinNAttempt++;
+  indLinCountsHere()->attempt++;
   if (++(pr->nAttempt) > op->mxstep) return RX_INDLIN_ACT_ABANDON;
   // Decide from the step the controller has settled on rather than by burning
   // the switch-over count first.
@@ -2224,7 +2242,7 @@ static indLinAction_t indLinAttempt(int cSub, rx_solving_options *op,
                                 InfusionRate_, on_, ME, IndF, u, yTry, w1,
                                 yScratch, richTab, &err, &ratio);
   if (ret == -2) {
-    __indLinNCutConv++;
+    indLinCountsHere()->cutConv++;
     indLinStiffGate(autoScheme, autoRich, autoSt, &(pr->scheme), &(pr->useRich));
     pr->h *= indLinCutFactor(ratio, FACMIN);
     pr->lastRejected = 1;
@@ -2236,7 +2254,7 @@ static indLinAction_t indLinAttempt(int cSub, rx_solving_options *op,
   }
   double fac = indLinStepFactor(err, expo, SAFE, FACMIN, FACMAX);
   if (err > 1.0) {
-    __indLinNRejErr++;
+    indLinCountsHere()->rejErr++;
     pr->h *= fac;
     pr->lastRejected = 1;
     return (pr->h < 1e-10*span) ? RX_INDLIN_ACT_ABANDON : RX_INDLIN_ACT_RETRY;
@@ -2530,18 +2548,30 @@ extern "C" SEXP _rxode2_rxIndLinSteps(void) {
   rxProtect rx_protect;
   SEXP ret = rx_protect.protect(Rf_allocVector(REALSXP, 5));
   SEXP nm  = rx_protect.protect(Rf_allocVector(STRSXP, 5));
-  REAL(ret)[0] = (double) __indLinNAttempt;
-  REAL(ret)[1] = (double) __indLinNAccept;
-  REAL(ret)[2] = (double) __indLinNRejErr;
-  REAL(ret)[3] = (double) __indLinNCutConv;
-  REAL(ret)[4] = (double) __indLinNIter;
+  // Summed over the threads that did the work, plus the pre-solve sink; this
+  // runs on the R thread with no solve in flight, so a plain read is enough.
+  indLinCounts_t tot = __indLinCountsSink;
+  for (int i = 0; i < (int)__indLinCounts.size(); i++) {
+    tot.attempt += __indLinCounts[i].attempt;
+    tot.accept  += __indLinCounts[i].accept;
+    tot.rejErr  += __indLinCounts[i].rejErr;
+    tot.cutConv += __indLinCounts[i].cutConv;
+    tot.iter    += __indLinCounts[i].iter;
+  }
+  REAL(ret)[0] = (double) tot.attempt;
+  REAL(ret)[1] = (double) tot.accept;
+  REAL(ret)[2] = (double) tot.rejErr;
+  REAL(ret)[3] = (double) tot.cutConv;
+  REAL(ret)[4] = (double) tot.iter;
   SET_STRING_ELT(nm, 0, Rf_mkChar("attempt"));
   SET_STRING_ELT(nm, 1, Rf_mkChar("accept"));
   SET_STRING_ELT(nm, 2, Rf_mkChar("rejErr"));
   SET_STRING_ELT(nm, 3, Rf_mkChar("cutConv"));
   SET_STRING_ELT(nm, 4, Rf_mkChar("iter"));
   Rf_setAttrib(ret, R_NamesSymbol, nm);
-  __indLinNAttempt = __indLinNAccept = __indLinNRejErr = 0;
-  __indLinNCutConv = __indLinNIter = 0;
+  __indLinCountsSink = indLinCounts_t();
+  for (int i = 0; i < (int)__indLinCounts.size(); i++) {
+    __indLinCounts[i] = indLinCounts_t();
+  }
   return ret;
 }

--- a/src/init.c
+++ b/src/init.c
@@ -784,7 +784,7 @@ SEXP _rxode2_mexpit(SEXP p);
 SEXP _rxode2_dmexpit(SEXP p);
 SEXP _rxode2_mlogit_f(SEXP x, SEXP p);
 SEXP _rxode2_mlogit_j(SEXP x);
-SEXP _rxode2_rxMemoryComponents_(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
+SEXP _rxode2_rxMemoryComponents_(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
 SEXP _rxode2_rxRamBytes_(void);
 SEXP _rxode2_rxSolveSetCurObj_(SEXP);
 
@@ -974,7 +974,7 @@ void R_init_rxode2(DllInfo *info){
     {"_rxSetSeed", (DL_FUNC) _rxode2_rxSetSeed, 1},
     {"_rxode2_rxordSelect", (DL_FUNC) _rxode2_rxordSelect, 2},
     {"_rxode2_rxErf", (DL_FUNC) &_rxode2_rxErf, 1},
-    {"_rxode2_rxMemoryComponents_", (DL_FUNC) &_rxode2_rxMemoryComponents_, 19},
+    {"_rxode2_rxMemoryComponents_", (DL_FUNC) &_rxode2_rxMemoryComponents_, 21},
     {"_rxode2_rxRamBytes_", (DL_FUNC) &_rxode2_rxRamBytes_, 0},
     {"_rxode2_rxSaveState_", (DL_FUNC) _rxode2_rxSaveState_, 0},
     {"_rxode2_rxIsSerializeFile_", (DL_FUNC) _rxode2_rxIsSerializeFile_, 1},

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -289,6 +289,9 @@ extern "C" void printErr(int err, int id){
   if (err & rxErrIndLinCode){
     RSprintf("  Unsupported inductive linearization code; the model's 'indLin' descriptor does not match the solver\n");
   }
+  if (err & rxErrIndLinExcept){
+    RSprintf("  Inductive linearization failed with an unhandled exception (most likely out of memory)\n");
+  }
 }
 
 rx_solving_options op_global;
@@ -4261,7 +4264,19 @@ extern "C" void ind_indLin0(rx_solve *rx, rx_solving_options *op, int solveid,
 
 extern "C" void ind_indLin(rx_solve *rx,
                            int solveid, t_update_inis u_inis){
+  // `ind_solve` reaches this, and an external driver (nlmixr2est's FOCEi) calls
+  // that from its OWN thread team -- where `assignFuns()` would have every
+  // thread hit `R_GetCCallable` and, on a miss, write the model's global
+  // function pointers.  No other `ind_*` driver binds here at all; they rely on
+  // the caller having done it during setup.  Keep the bind for the serial call
+  // and skip it under a team.  `getRxThreadId() >= 0` is the external driver's
+  // own signal, and is what `omp_in_parallel()` cannot see: rxode2's statically
+  // linked libgomp does not know about another DLL's team.
+#ifdef _OPENMP
+  if (getRxThreadId() < 0 && !omp_in_parallel()) assignFuns();
+#else
   assignFuns();
+#endif
   rx_solving_options *op = &op_global;
   ind_indLin0(rx, op, solveid, u_inis);
 }

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -4106,10 +4106,13 @@ updateSolve(rx_solving_options_ind *ind, rx_solving_options *op, int *neq,
 
 //================================================================================
 // Inductive linearization routines
+// The caller binds the model functions: `par_indLin` once before its parallel
+// region, `ind_indLin` for the per-individual entry.  `assignFuns` reaches
+// `R_GetCCallable` and writes the generated DLL's global function pointers, so
+// it must not run per subject inside the loop -- no other `ind_*` driver does.
 extern "C" void ind_indLin0(rx_solve *rx, rx_solving_options *op, int solveid,
                             t_update_inis u_inis) {
   clock_t t0 = clock();
-  assignFuns();
   int i;
   int neq[2];
   neq[1] = solveid;
@@ -4292,7 +4295,10 @@ extern "C" void par_indLin(rx_solve *rx){
     localAbort = abort;
     if (localAbort == 0){
       setSeedEng1(seed0 + solveid - 1);
-      ind_indLin(rx, solveid, update_inis);
+      // `ind_indLin0` rather than the `ind_indLin` wrapper: the wrapper binds
+      // the model functions, which `assignFuns()` above already did once for
+      // the whole team.
+      ind_indLin0(rx, op, solveid, update_inis);
       if (displayProgress){
 #pragma omp critical
         cur++;

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -5587,9 +5587,13 @@ SEXP rxSolveFromRaw_(const RObject &obj, const RObject &rawObj,
 }
 extern "C" int solveMethodThreadSafe(rx_solving_options* op) {
   int stiff = op->stiff;
-  /* lsoda (1), indLin (3), lsode (106), and bdf (107) use non-reentrant
-   * Fortran COMMON blocks and must run single-threaded. */
-  return stiff != 1 && stiff != 3 && stiff != 106 && stiff != 107;
+  /* lsoda (1), lsode (106), and bdf (107) use non-reentrant Fortran COMMON
+   * blocks and must run single-threaded.  indLin (3) was on this list by
+   * association and is not one of them: its default backend (matexp_MH09) is
+   * plain C with a stack workspace, its one Fortran backend (matexpRBS) uses
+   * automatic arrays with no SAVE/COMMON, and its caches are already per
+   * thread (src/expm.cpp). */
+  return stiff != 1 && stiff != 106 && stiff != 107;
 }
 
 
@@ -6014,8 +6018,10 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
       if (op->cores == 0) {
         switch (thread) {
         case threadSafeRepNumThread:
-          // Thread safe, but possibly not reproducible
-          if (op->cores > 1) {
+          // Thread safe, but possibly not reproducible.  Never for indLin (3):
+          // swapping it for liblsodaR would silently change the solver rather
+          // than how it is threaded.
+          if (op->cores > 1 && op->stiff != 3) {
             op->stiff = method = 4;
           }
           rxSolveDat->throttle = false;
@@ -6043,7 +6049,7 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
       } else {
         switch (thread) {
         case threadSafeRepNumThread:
-          if (op->cores > 1) {
+          if (op->cores > 1 && op->stiff != 3) {
             op->stiff = method = 4;
           }
           break;

--- a/src/rxMemoryComponents.cpp
+++ b/src/rxMemoryComponents.cpp
@@ -38,6 +38,12 @@ using namespace Rcpp;
 //' @param nsub      Number of subjects.
 //' @param nallTotal Total events across all subjects (sum of obs + doses).
 //' @param maxAllTimes Maximum events for any single subject.
+//' @param stiff     The solving method (\code{op$stiff}); only 3
+//'   (\code{"indLin"}) allocates anything extra here.
+//' @param doIndLin  Which matrix-exponential driver runs: 0 not a
+//'   \code{matExp()} model, 1 pure matrix exponential, 2 plus a state-free
+//'   \code{indLin()} forcing, 3/4 true inductive linearization (the adaptive,
+//'   iterating driver).  These cost very different amounts.
 //' @return Named numeric vector; each element is bytes for that allocation.
 //'   Also includes \code{sizeofInd} (bytes per \code{rx_solving_options_ind}
 //'   struct) and \code{rxLlikSaveSize} (the compile-time constant).
@@ -62,7 +68,9 @@ NumericVector rxMemoryComponents_(
   int    numLin,
   int    nsub,
   double nallTotal,
-  double maxAllTimes)
+  double maxAllTimes,
+  int    stiff,
+  int    doIndLin)
 {
   rx_mem_layout _mem;
   rxFillMemLayout(
@@ -99,6 +107,51 @@ NumericVector rxMemoryComponents_(
   double b_gInfRate    = (double)cores * (neq + extraCmt) * sizeof(double);
   double b_inds        = (double)nsub  * sizeof(rx_solving_options_ind);
 
+  /* -- method="indLin" (src/expm.cpp) ---------------------------------------
+   *
+   * Unlike everything above, these scale with CORES and not with subjects: the
+   * exponential cache and the solver's Armadillo scratch are per thread, and a
+   * subject is solved start to finish on one thread.  `.rxOomChunkSize()` has
+   * to hold them out of its per-subject division for that reason.
+   *
+   * `m` is the dimension of the matrix actually exponentiated, which is NOT
+   * `neq`: `meOnly()` augments by one row per compartment carrying a nonzero
+   * forcing, and the iterating schemes augment further (exprb2 neq+1, exprb32
+   * neq+3, and the `indLinPmat()` phi fallback neq*(p+1), up to 3*neq).  Take
+   * the worst case each driver can reach, since the estimate exists to answer
+   * "will this fit", and an estimate that is too low is the useless kind.
+   */
+  double b_indLinCache = 0.0;
+  double b_indLinWork  = 0.0;
+  if (stiff == 3 && doIndLin > 0) {
+    const double dneq = (double) neq;
+    double m;
+    switch (doIndLin) {
+    case 1:  m = dneq + 1.0;  break;   /* pure matExp: augmented while infusing */
+    case 2:  m = 2.0 * dneq;  break;   /* + a forcing that may fill every row   */
+    default: m = 3.0 * dneq;  break;   /* iterating: the indLinPmat p=2 fallback */
+    }
+    /* The cache holds RX_INDLIN_EXPCACHE_N slots per thread, each a key and a
+     * value of m*m doubles -- but caching is SKIPPED above
+     * RX_INDLIN_EXPCACHE_MAXN2, so past that only the empty slots cost
+     * anything.  Both constants live in src/expm.cpp. */
+    const double slots  = 16.0;                     /* RX_INDLIN_EXPCACHE_N     */
+    const double maxN2  = 16384.0;                  /* RX_INDLIN_EXPCACHE_MAXN2 */
+    const double m2     = m * m;
+    const double perSlot = (m2 <= maxN2) ? 2.0 * m2 * sizeof(double) : 0.0;
+    /* An empty slot is still two std::vector headers plus the key fields. */
+    const double slotHdr = 2.0 * 24.0 + 2.0 * sizeof(double);
+    b_indLinCache = (double)cores * slots * (perSlot + slotHdr);
+    /* Scratch live at once in one thread.  The fixed-grid drivers (1/2) only
+     * ever hold meOnly()'s rate matrix and its augmented exponential; the
+     * iterating ones additionally hold the Jacobian, P(h), its inverse, the
+     * ramp and the Richardson table. */
+    const double sq = (doIndLin <= 2) ? (dneq*dneq + 2.0*m2)
+                                      : (12.0*dneq*dneq + 2.0*m2);
+    const double vec = (doIndLin <= 2) ? (4.0*dneq) : (25.0*dneq);
+    b_indLinWork = (double)cores * (sq + vec) * sizeof(double);
+  }
+
   NumericVector out = NumericVector::create(
     Named("gsolve")        = (double)_mem.gsolve_total * sizeof(double),
     Named("gsolve_n0")     = (double)_mem.n0           * sizeof(double),
@@ -113,6 +166,8 @@ NumericVector rxMemoryComponents_(
     Named("ordId")         = b_ordId,
     Named("gInfusionRate") = b_gInfRate,
     Named("inds_global")   = b_inds,
+    Named("indLinExpCache")= b_indLinCache,
+    Named("indLinWork")    = b_indLinWork,
     Named("sizeofInd")    = (double)sizeof(rx_solving_options_ind),
     Named("rxLlikSaveSize")= (double)rxLlikSaveSize);
 

--- a/tests/testthat/test-ind-lin.R
+++ b/tests/testthat/test-ind-lin.R
@@ -1843,4 +1843,154 @@ d/dt(blood)     = a*intestine - b*blood
              subset(evid == 1L & time == 24)),
       1L)
   })
+
+  # --- parallel population solving (rxode2#1216) -------------------------------
+  # indLin was pinned to one core by solveMethodThreadSafe(), which listed it
+  # with the Fortran COMMON-block solvers.  Subjects are independent and every
+  # cache in expm.cpp is per thread, so how many threads produced an answer must
+  # not be visible in it -- these compare at `tolerance = 0`, not approximately.
+  #
+  # Every one of these passes fixed `params` on purpose.  rxPreGenEta() draws
+  # per thread and hands them out with `schedule(static)`, so an `omega` model's
+  # etas ARE a function of the core count -- for every method, not just this one.
+  # Adding `omega`/`nSub` here would be comparing different draws.
+
+  .indLinCoresEq <- function(model, params, events, ..., cores = c(2L, 4L)) {
+    .one <- suppressMessages(rxSolve(model, params = params, events = events,
+                                     method = "indLin", cores = 1L, ...))
+    for (.nc in cores) {
+      expect_equal(as.data.frame(suppressMessages(
+        rxSolve(model, params = params, events = events, method = "indLin",
+                cores = .nc, ...))),
+        as.data.frame(.one), tolerance = 0)
+    }
+    invisible(.one)
+  }
+
+  # A pure matExp() model (no forcing) and one whose forcing is state free are
+  # different drivers from .mmMe's state-dependent one, so all three are here.
+  .parMe <- suppressMessages(rxode2(paste("matExp()", "cmt(depot)", "cmt(central)",
+                                          "k_depot_central = ka",
+                                          "k_central_output = ke", sep = "\n")))
+  .parMeF <- suppressMessages(rxode2(paste("matExp()", "cmt(central)",
+                                           "k_central_output = ke",
+                                           "indLin(central) <- kin", sep = "\n")))
+  .parEv <- as.data.frame(et(amt = 100, cmt = "depot") |>
+                            et(seq(0, 24, by = 1)) |> et(id = 1:40))
+
+  test_that("a pure matExp() population is unchanged by the core count", {
+    .indLinCoresEq(.parMe, c(ka = 1, ke = 0.2), .parEv, hmax = 0.5)
+  })
+
+  test_that("a state-free indLin() forcing is unchanged by the core count", {
+    .indLinCoresEq(.parMeF, c(ke = 0.2, kin = 1),
+                   as.data.frame(et(amt = 10, cmt = "central") |>
+                                   et(seq(0, 24, by = 1)) |> et(id = 1:40)),
+                   hmax = 0.5)
+  })
+
+  test_that("each indLin iteration scheme is unchanged by the core count", {
+    .e <- as.data.frame(et(amt = 3) |> et(c(0.5, 1, 2, 4, 8, 16, 30)) |>
+                          et(id = 1:40))
+    for (.it in c("picard", "newton", "exprb", "exprb32", "auto")) {
+      .indLinCoresEq(.mmMe, .mmPar, .e, atol = 1e-10, rtol = 1e-10,
+                     indLinIteration = .it)
+    }
+    # "auto" for both is the case that carries per-thread state ACROSS substeps
+    # of a subject -- __indLinAutoState's earned scheme and Richardson level --
+    # so it is the one a shared auto-state would show up in.
+    .indLinCoresEq(.mmMe, .mmPar, .e, atol = 1e-10, rtol = 1e-10,
+                   indLinIteration = "auto", indLinRichardson = "auto")
+    # Both forcing-Jacobian sources: symbolic goes through the generated
+    # calc_jac (which does _setThreadInd), fd calls IndF 2n times per step.
+    for (.j in c("symbolic", "fd")) {
+      .indLinCoresEq(.mmMe, .mmPar, .e, atol = 1e-10, rtol = 1e-10,
+                     indLinIteration = "newton", indLinJac = .j)
+    }
+  })
+
+  test_that("each matrix-exponential backend is unchanged by the core count", {
+    # Includes the Fortran expokit backend (2): it uses automatic arrays with
+    # no SAVE/COMMON, which is what makes it safe to run threaded.
+    .e <- as.data.frame(et(amt = 3) |> et(c(0.5, 1, 2, 4, 8, 16, 30)) |>
+                          et(id = 1:40))
+    for (.ty in 1:4) {
+      .indLinCoresEq(.mmMe, .mmPar, .e, atol = 1e-8, rtol = 1e-8,
+                     indLinMatExpType = .ty)
+    }
+  })
+
+  test_that("infusions, addl dosing and steady state survive threading", {
+    .obs <- seq(0, 48, by = 2)
+    .indLinCoresEq(.mmMe, .mmPar,
+                   as.data.frame(et(amt = 3, rate = 1) |> et(.obs) |> et(id = 1:40)),
+                   atol = 1e-10, rtol = 1e-10)
+    .indLinCoresEq(.mmMe, .mmPar,
+                   as.data.frame(et(amt = 3, ii = 12, addl = 3) |> et(.obs) |>
+                                   et(id = 1:40)),
+                   atol = 1e-10, rtol = 1e-10)
+    # Steady state on the linear model: the Michaelis-Menten one does not
+    # converge under ss=1 at any tolerance, which is a property of inductive
+    # linearization on that model and has nothing to do with threading.
+    .indLinCoresEq(.parMe, c(ka = 1, ke = 0.2),
+                   as.data.frame(et(amt = 100, cmt = "depot", ii = 12, ss = 1) |>
+                                   et(.obs) |> et(id = 1:40)),
+                   atol = 1e-10, rtol = 1e-10)
+  })
+
+  test_that("the step-disposition counters sum across threads", {
+    # Five plain `long`s would tear here; per-thread slots summed at read give
+    # the same totals whatever produced them.
+    .e <- as.data.frame(et(amt = 3) |> et(c(0.5, 1, 2, 4, 8, 16, 30)) |>
+                          et(id = 1:40))
+    .steps <- function(nc) {
+      invisible(.Call("_rxode2_rxIndLinSteps", PACKAGE = "rxode2"))  # read to reset
+      invisible(suppressMessages(rxSolve(.mmMe, params = .mmPar, events = .e,
+                                         method = "indLin", atol = 1e-8,
+                                         rtol = 1e-8, cores = nc)))
+      .Call("_rxode2_rxIndLinSteps", PACKAGE = "rxode2")
+    }
+    .one <- .steps(1L)
+    expect_gt(.one[["attempt"]], 0)
+    expect_equal(.steps(4L), .one)
+  })
+
+  test_that("indLin really does use the cores it is given", {
+    # Not a timing test: the exponential cache is per thread, so a population of
+    # identical subjects computes its one exponential once per thread that ran
+    # and reuses it after that.  `dadt` counts exponentials computed, so it
+    # bounds the number of cache slots that were touched.  `<= cores` is the
+    # invariant (a slot index past the pool would break it); `> 1` is the proof
+    # that more than one thread ran, and is why this needs enough subjects that
+    # the dynamic schedule cannot hand them all to one thread.
+    skip_if(rxCores() < 4L)
+    .ev <- as.data.frame(et(amt = 100, cmt = "depot") |> et(seq(0, 24, by = 1)) |>
+                           et(id = 1:200))
+    .nSlot <- function(nc) {
+      sum(suppressMessages(rxSolve(.parMe, params = c(ka = 1, ke = 0.2),
+                                   events = .ev, method = "indLin",
+                                   hmax = 0.5, cores = nc))$counts$dadt)
+    }
+    expect_equal(.nSlot(1L), 1)
+    expect_lte(.nSlot(4L), 4)
+    expect_gt(.nSlot(4L), 1)
+  })
+
+  test_that("a model the parser called not thread safe still gets one core", {
+    # Dropping indLin from solveMethodThreadSafe() hands it to the normal
+    # thread-flag switch; it must not hand it more than the model allows.  A
+    # user-defined R function is the ordinary way to earn that classification --
+    # calling back into R from a worker is what the flag exists for.
+    udfKin <- function(x) 1.0
+    .m <- suppressMessages(rxode2(paste("matExp()", "cmt(central)",
+                                        "k_central_output = ke",
+                                        "indLin(central) <- udfKin(t)",
+                                        sep = "\n")))
+    expect_equal(rxModelVars(.m)$flags[["thread"]], 0L)
+    expect_warning(rxSolve(.m, params = c(ke = 0.2),
+                           events = as.data.frame(et(amt = 10, cmt = "central") |>
+                                                    et(0:5) |> et(id = 1:8)),
+                           method = "indLin", cores = 4L),
+                   "not thread safe")
+  })
 })

--- a/tests/testthat/test-rxMemoryEstimate.R
+++ b/tests/testthat/test-rxMemoryEstimate.R
@@ -398,4 +398,98 @@ rxTest({
     expect_equal(as.numeric(.fromFile$gall_times), as.numeric(.fromBundle$gall_times))
     expect_equal(as.numeric(.fromFile$gall_times), as.numeric(.fromSolve$gall_times))
   })
+
+  # --- method="indLin" ---------------------------------------------------------
+  # What a matExp() model costs depends on which of the four drivers it runs:
+  # a pure matrix exponential holds one rate matrix, while true inductive
+  # linearization iterates and carries a Jacobian, P(h) and its inverse too.
+  # Both are per THREAD, so they grew with rxode2#1216 making indLin parallel.
+
+  .memOde <- suppressMessages(rxode2(paste0(
+    "d/dt(depot) = -ka*depot\nd/dt(central) = ka*depot - ke*central\n")))
+  .memPure <- suppressMessages(rxode2(paste("matExp()", "cmt(depot)", "cmt(central)",
+                                            "k_depot_central = ka",
+                                            "k_central_output = ke", sep = "\n")))
+  .memFree <- suppressMessages(rxode2(paste("matExp()", "cmt(depot)", "cmt(central)",
+                                            "k_depot_central = ka",
+                                            "k_central_output = ke",
+                                            "indLin(central) <- kin", sep = "\n")))
+  .memIl <- suppressMessages(rxode2(rxToIndLin(paste0(
+    "d/dt(depot) = -ka*depot\n",
+    "d/dt(central) = ka*depot - vmax*(central/v)/(km + central/v)\n"))))
+  .memEv <- as.data.frame(et(amt = 100, cmt = "depot") |> et(seq(0, 24, by = 1)) |>
+                            et(id = 1:100))
+
+  test_that(".rxMemDoIndLin names the driver the model will run", {
+    expect_equal(.rxMemDoIndLin(rxModelVars(.memOde)), 0L)   # not a matExp model
+    expect_equal(.rxMemDoIndLin(rxModelVars(.memPure)), 1L)  # pure matrix exponential
+    expect_equal(.rxMemDoIndLin(rxModelVars(.memFree)), 2L)  # + state-free forcing
+    expect_equal(.rxMemDoIndLin(rxModelVars(.memIl)), 4L)    # inductive linearization
+  })
+
+  test_that("an ODE model is charged nothing for indLin", {
+    .e <- rxMemoryEstimate(.memEv, model = .memOde,
+                           control = rxControl(cores = 4L, method = "liblsoda"))
+    expect_equal(as.numeric(.e$indLinExpCache), 0)
+    expect_equal(as.numeric(.e$indLinWork), 0)
+  })
+
+  test_that("a matExp() model is charged even when the control says otherwise", {
+    # rxSolve() force-selects method 3 for any matExp() model, so the control
+    # cannot veto the allocation.
+    .e <- rxMemoryEstimate(.memEv, model = .memPure,
+                           control = rxControl(cores = 4L, method = "liblsoda"))
+    expect_gt(as.numeric(.e$indLinExpCache), 0)
+    expect_gt(as.numeric(.e$indLinWork), 0)
+  })
+
+  test_that("the indLin estimate grows with the driver's augmented dimension", {
+    .est <- function(m) {
+      rxMemoryEstimate(.memEv, model = m, control = rxControl(cores = 4L))
+    }
+    .pure <- .est(.memPure)
+    .free <- .est(.memFree)
+    # The forcing can be nonzero in every compartment, so meOnly() augments
+    # further than a bolus does.
+    expect_gt(as.numeric(.free$indLinExpCache), as.numeric(.pure$indLinExpCache))
+    # The iterating driver holds far more scratch than the fixed grid.
+    expect_gt(as.numeric(.est(.memIl)$indLinWork), as.numeric(.pure$indLinWork))
+  })
+
+  test_that("the indLin estimate is per thread, not per subject", {
+    .cache <- function(nc) {
+      as.numeric(rxMemoryEstimate(.memEv, model = .memIl,
+                                  control = rxControl(cores = nc))$indLinExpCache)
+    }
+    expect_equal(.cache(4L), 4 * .cache(1L))
+    expect_equal(.cache(8L), 8 * .cache(1L))
+  })
+
+  test_that("indLin components are included in the total", {
+    .e <- rxMemoryEstimate(.memEv, model = .memIl, control = rxControl(cores = 4L))
+    .meta <- c("total", "sizeofInd", "rxLlikSaveSize", "ramBytes", "freeRamBytes",
+               "effectiveSubs")
+    .comps <- .e[!names(.e) %in% .meta]
+    expect_true("indLinExpCache" %in% names(.comps))
+    expect_true("indLinWork" %in% names(.comps))
+    expect_equal(as.numeric(.e$total),
+                 sum(vapply(.comps, as.numeric, numeric(1))))
+  })
+
+  test_that("the exponential cache stops being charged once it stops caching", {
+    # matrixExpCached() skips the cache above RX_INDLIN_EXPCACHE_MAXN2 (a
+    # 128-row operand), so the estimate has to fall off the same cliff rather
+    # than growing without bound.  The iterating driver reaches it at 3*neq.
+    .cache <- function(neq, doIndLin) {
+      unname(rxMemoryComponents_(
+        neq = neq, stateSize = neq, nlhs = 0L, npars = neq, neta = 0L, neps = 0L,
+        ncov = 0L, nsim = 1L, cores = 4L, nMtime = 0L, extraCmt = 0L, linB = 0L,
+        nLlik = 0L, nIndSim = 0L, numLinSens = 0L, numLin = 0L, nsub = 10L,
+        nallTotal = 100, maxAllTimes = 10, stiff = 3L,
+        doIndLin = doIndLin)[["indLinExpCache"]])
+    }
+    expect_gt(.cache(42L, 3L), .cache(10L, 3L))   # 3*42 = 126, still cached
+    expect_lt(.cache(43L, 3L), .cache(42L, 3L))   # 3*43 = 129, over the cap
+    expect_lt(.cache(128L, 1L), .cache(127L, 1L)) # pure matExp: neq+1
+  })
 })


### PR DESCRIPTION
Closes #1216.

`method="indLin"` was pinned to a single core by `solveMethodThreadSafe()`
(`src/rxData.cpp`), which listed it with the Fortran COMMON-block solvers:

```c
/* lsoda (1), indLin (3), lsode (106), and bdf (107) use non-reentrant
 * Fortran COMMON blocks and must run single-threaded. */
```

That reason was not true for indLin.  Its default backend
(`indLinMatExpType="Al-Mohy"`) never reaches Fortran -- it is `matexp_MH09()`
in `src/matexp_HM98.c`, written with a stack workspace, a `malloc` fallback and
an explicit "never longjmp from a worker thread" contract.  The one Fortran
backend it can reach (`matexpRBS`, `src/matexp.f`) uses automatic arrays with
no `SAVE` and no `COMMON`.  Meanwhile `par_indLin()` already contained a
correct `#pragma omp parallel for num_threads(cores) schedule(dynamic,1)`, and
`src/expm.cpp` already carried per-thread pools -- all of it dead, because
`op->cores` was forced to 1 before any of it ran.

## What actually blocked it

1. **`assignFuns()` ran per subject inside the parallel loop.**  `ind_indLin0()`
   and the `ind_indLin()` wrapper each called it, and `par_indLin`'s loop body
   went through the wrapper.  It reaches `R_GetCCallable` and, on a miss, writes
   the generated model's ~200 global function pointers.  No other `ind_*` driver
   does this.  `par_indLin` now calls `ind_indLin0` directly.
2. **Five file-scope `static long` step counters**, incremented from inside the
   solver.  Now one cache-line-padded slot per thread, sized alongside the
   exponential cache and summed (and reset) when `rxIndLinSteps()` reads them --
   so no atomic sits in the innermost substep loop.
3. **The gate itself**, plus a guard so the `threadSafeRepNumThread` branch can
   never swap indLin for liblsodaR: that would change the solver rather than how
   it is threaded, and a `matExp()` model's `dydt` is a stub, so the swap would
   have integrated an empty RHS.
4. **Dead globals** `expm_assign` and an unprotected file-scope `SEXP expm_s`.

## Fail-safe under threads

Three hazards that only mattered once more than one thread could run:

* `arma::expmat(H)` (one argument) **throws** on failure, and
  `ARMA_DONT_PRINT_ERRORS` suppresses the message, not the throw -- an exception
  leaving an OpenMP region is `std::terminate`.  Uses the bool form now, the way
  the expokit backend already reports its `iflag`.
* `indLin()` is a thin `try/catch` over `indLinRun()`, mapping anything that
  escapes (e.g. `std::bad_alloc`) to a failed subject under its own
  `rxErrIndLinExcept` code.  It does **not** hide an R error or a user
  interrupt: R signals those with `longjmp`, which unwinds past a `catch`.
* The exponential cache and the scheme/Richardson state pick their slot with a
  new `indLinOwnSlot()` that returns -1 rather than clamping.  Clamping is right
  for a counter, but the cache's write path `resize()`s a `std::vector` another
  thread may be `memcmp`-ing.  A thread with no slot of its own simply does not
  cache.  The pool is also sized to cover `omp_get_max_threads()`, as the
  extra-dosing pools are.

`ind_indLin()` no longer binds the model functions when it is driven from a
thread team.  `ind_solve()` reaches it, and an external driver (nlmixr2est's
FOCEi) calls that from its own team.  The gate is `getRxThreadId() >= 0`, not
`omp_in_parallel()` -- rxode2's statically linked libgomp cannot see another
DLL's team, which is the same reason `rx_get_thread()` exists.

## Results

Bit-identical (`tolerance = 0`) to the single-core answer for every driver
(pure `matExp()`, a state-free `indLin()` forcing, the adaptive state-dependent
one), every iteration scheme, both forcing-Jacobian sources, all four
matrix-exponential backends including the Fortran expokit, and infusion / addl /
steady-state dosing.  `rxIndLinSteps()` returns identical totals at 1 and 4
cores.

Scaling, 1000 subjects, `-O3` (`bench/indlin_thread_bench.R`):

| model | cores=1 | 2 | 4 | 8 |
|---|---|---|---|---|
| Michaelis-Menten `indLin()` | 3.244s | 2.186s (1.48x) | 1.522s (2.13x) | 1.108s (2.93x) |
| linear `matExp()` | 0.627s | 0.570s | 0.618s | 0.572s (1.10x) |

The linear model does not scale, and that is the honest result rather than a
bug: with one cached exponential per thread the per-subject solve is nearly
free, so wall time is the serial assembly of the ~97k-row output.  Parallelism
pays where the adaptive driver has real per-subject work.

Single-core is also faster, from hoisting `assignFuns()`.  Same model, 200
subjects, identical `slvr=59600 dadt=14200 jac=1182200`:

| build | cores=1 |
|---|---|
| rxode2 5.1.7 as installed | 0.855s |
| this branch | 0.558s |

## Tests

`tests/testthat/test-ind-lin.R` gains cores-invariance tests for each of the
above, a check that the step counters sum to the same totals whatever produced
them, a check that a model the parser calls not thread safe still drops to one
core, and -- since a population of identical subjects computes its one
exponential once per per-thread cache -- an assertion on `counts$dadt` that is
how the tests know more than one thread ran.  Every comparison passes fixed
`params` on purpose: `rxPreGenEta()` draws per thread, so an `omega` model's
etas are a function of the core count for every method.

The existing test *"the cache is per thread and does not change the answer"*
was vacuous before this change (all three core counts were forced to 1) and is
now real.  `helper-methods.R` carries `"indLin"` in `.methods0`, so the whole
nmtest dosing/event/steady-state matrix now exercises it multi-core.

`ind-lin` 338 pass; the method matrix (`par-solve`, `nmtest`, `cov`,
`mexp-nonmem`, `evid-push`, `modelargs`, `serialize`, `print`) 2242 pass; 0
failures.

## Not addressed here

The `threadSafeRepNumThread` branch swaps *any* method for liblsodaR when
`cores > 1`.  indLin is guarded above, but the same swap still applies to
`dop853` and the rest.  It is currently unreachable -- the only
`tb.thread = threadSafeRepNumThread` is commented out in `src/parseFuns.h` --
so nothing is broken today, but it is worth a separate issue.
