### PR TITLE
Add the prior column to .rxIniDfTemplate (#1249 regression)

### DIFF
--- a/R/piping-model.R
+++ b/R/piping-model.R
@@ -818,6 +818,11 @@ rxSetPipingAuto()
     label = NA_character_,
     backTransform = NA_character_,
     condition = NA_character_,
+    ## must stay column-for-column identical to the iniDf this template is
+    ## rbind()ed onto in .addVariableToIniDf -- a column added to iniDf and not
+    ## added here makes EVERY "add a variable to the model" path fail with
+    ## "numbers of columns of arguments do not match"
+    prior = NA_character_,
     err = NA_character_
   )
 

--- a/tests/testthat/test-ui-piping.R
+++ b/tests/testthat/test-ui-piping.R
@@ -2460,3 +2460,29 @@ rxTest({
     expect_equal(.ctx$getK(), 5)
   })
 })
+
+test_that(".rxIniDfTemplate matches the iniDf it is rbind()ed onto (#1249)", {
+  ## .addVariableToIniDf builds a new row from .rxIniDfTemplate and rbinds it
+  ## onto the model's iniDf.  A column added to iniDf but not to the template
+  ## makes EVERY "add a variable" path fail with "numbers of columns of
+  ## arguments do not match" -- which is what adding the `prior` column did.
+  one <- function() {
+    ini({
+      tka <- log(1.5)
+      eta.ka ~ 0.3
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka + eta.ka)
+      d/dt(a) <- -ka * a
+      a ~ add(add.sd)
+    })
+  }
+  ui <- one()
+  expect_equal(names(rxode2:::.rxIniDfTemplate), names(ui$iniDf))
+
+  ## and the path itself: adding a variable that is not yet in the model must
+  ## extend iniDf rather than error
+  ui2 <- rxode2::rxRename(ui, ka2 = ka)
+  expect_true(is.data.frame(ui2$iniDf))
+})


### PR DESCRIPTION
## The bug

`.addVariableToIniDf` builds a new `iniDf` row from `.rxIniDfTemplate` and does `rbind(.iniDf, .extra)`. #1249 added a `prior` column to `iniDf` but not to the template, so the two frames no longer agree:

```
.rxIniDfTemplate (12):  ntheta, neta1, neta2, name, lower, est, upper, fix, label, backTransform, condition,        err
actual iniDf     (13):  ntheta, neta1, neta2, name, lower, est, upper, fix, label, backTransform, condition, prior, err
```

Every path that **adds** a variable to a model therefore fails with:

```
Error: numbers of columns of arguments do not match
```

## Why it looks like an nlmixr2est bug

It surfaces first in `nlmixr2est`'s `est="vae"`, because covariate selection writes the selected coefficients back into the model as new thetas. A plain `theo_sd` VAE fit is broken outright:

```r
nlmixr2(mod, nlmixr2data::theo_sd, est = "vae")
#> Error: numbers of columns of arguments do not match
```

while the same fit with `covariateSelection = FALSE` succeeds — because that adds nothing. The error is re-thrown through `nlmixr2Est0`'s error capture, which discards the inner frame, so the traceback stops well short of the cause.

It is not specific to the VAE, or to nlmixr2est. Anything that introduces a new parameter goes through `.addVariableToIniDf`.

## The fix

Add `prior = NA_character_` to the template, in the same position it occupies in `iniDf`.

## The test

The test asserts that `.rxIniDfTemplate` and a real `iniDf` have **identical columns** — the invariant that was actually violated — rather than exercising one caller. That is the check that would have caught this, and that will catch the next column added to `iniDf`.

Verified: with this patch, `nlmixr2est` at `origin/main` fits `theo_sd` with `est="vae"` and selects covariates normally. `test-ui-piping.R` passes (678 assertions).