### PR TITLE
Simulate parameter uncertainty from priors (NWPRI and TNPRI)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -112,7 +112,7 @@ Imports:
     checkmate,
     ggplot2 (>= 3.4.0),
     inline,
-    lotri (>= 1.0.4),
+    lotri (>= 1.0.7),
     memoise,
     methods,
     mirai,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -112,7 +112,7 @@ Imports:
     checkmate,
     ggplot2 (>= 3.4.0),
     inline,
-    lotri (>= 1.0.7),
+    lotri (>= 1.0.4),
     memoise,
     methods,
     mirai,

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,8 +28,8 @@
   `usePrior=FALSE` ignores the priors.  Priors take precedence over a
   `thetaMat`/`dfSub` carried in the model's `meta` block, with a warning;
   one given at the call site wins over the priors instead.  Nested/occasion
-  models and chunked solves are a clear error rather than a solve that
-  silently drops the prior.
+  models (#1253) and chunked solves (#1252) are a clear error rather than a
+  solve that silently drops the prior.
 
 - `rxUiPriors()` returns the priors a model specifies, with the parameter
   name, the prior, its `neta1`/`neta2` (`NA` for a population parameter) and

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,35 @@
 
 ## New features
 
+- `rxSolve()` simulates parameter uncertainty from the prior distributions
+  the model's `ini({})` block specifies, which is what NONMEM does with
+  `$PRIOR NWPRI` and `$PRIOR TNPRI`.  A model that carries priors uses them
+  whenever variability is simulated, so `rxSolve(model, ev, nStud=100)` is
+  all that is needed.
+
+  Each omega block is drawn from an inverse Wishart with **its own**
+  degrees of freedom (`prior(eta.cl, eta.v) ~ invWishart(20)`), which the
+  single `dfSub` argument cannot express; a block with no prior is left at
+  its point estimate.  A normal prior on a population parameter
+  (`tka ~ 0.01`) gives the `thetaMat`, and a block may name omega elements
+  as well (`tcl + om.eta.cl ~ c(...)`) for one joint variance over the
+  thetas and the omega values.
+
+  A prior mean has to be what the model already says the entry is, since
+  the draw is added to that value; a prior centered elsewhere is an error
+  rather than a simulation that quietly differs from the model.
+
+  Because a jointly drawn omega is not guaranteed positive definite, such a
+  draw is retried up to `priorPdRetry` times (10 by default); if none is,
+  the nearest positive definite matrix of the kept draws is used with a
+  warning, since the projection is biased toward singularity.
+
+  `usePrior=FALSE` ignores the priors.  Priors take precedence over a
+  `thetaMat`/`dfSub` carried in the model's `meta` block, with a warning;
+  one given at the call site wins over the priors instead.  Nested/occasion
+  models and chunked solves are a clear error rather than a solve that
+  silently drops the prior.
+
 - `rxUiPriors()` returns the priors a model specifies, with the parameter
   name, the prior, its `neta1`/`neta2` (`NA` for a population parameter) and
   the parameter's `lower`/`upper` bounds.  The predicates

--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,26 @@
   models (#1253) and chunked solves (#1252) are a clear error rather than a
   solve that silently drops the prior.
 
+- `rxSolve(omegaSeparation="tnpri")` (and `sigmaSeparation="tnpri"`) draws
+  the omega/sigma entries carried in a `thetaMat` jointly with the thetas,
+  rather than redrawing their correlations with a separation strategy.
+  This is the general form of the `TNPRI` above, for a `thetaMat` that did
+  not come from an `ini({})` block prior.
+
+  A covariance step already gives one: `nonmem2rx` emits a `thetaMat` with
+  columns like `IIVCL, omega1.2, IIVV1, ...` and a nlmixr2 fit's `$cov`
+  uses `om.<eta>`/`cov.<eta1>.<eta2>`.  Both spellings are recognized, as
+  are the sigma equivalents.  Until now the off-diagonal entries were
+  dropped as "too many items" and the correlations were redrawn from LKJ,
+  discarding what the covariance step measured; drawing them jointly also
+  keeps the covariance *between* a theta and an omega entry, which no
+  separation strategy can carry.
+
+  It is opt-in because an eta-named `thetaMat` column already means that
+  eta's variance under the existing strategy, so the same column cannot
+  silently change meaning.  `omega` has to be a matrix, since the draws
+  are added to it.
+
 - `rxUiPriors()` returns the priors a model specifies, with the parameter
   name, the prior, its `neta1`/`neta2` (`NA` for a population parameter) and
   the parameter's `lower`/`upper` bounds.  The predicates

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,10 @@
 
 - `rxSolve()` simulates parameter uncertainty from the prior distributions
   the model's `ini({})` block specifies, which is what NONMEM does with
-  `$PRIOR NWPRI` and `$PRIOR TNPRI`.  A model that carries priors uses them
+  `$PRIOR NWPRI` and `$PRIOR TNPRI`.  Writing a prior in the `ini({})`
+  block needs `lotri` 1.0.7 or newer; with an older `lotri` the block
+  cannot express one and prior simulation simply does not engage.
+  `omegaSeparation="tnpri"` below works with any `lotri`.  A model that carries priors uses them
   whenever variability is simulated, so `rxSolve(model, ev, nStud=100)` is
   all that is needed.
 

--- a/R/prior-sim.R
+++ b/R/prior-sim.R
@@ -611,3 +611,49 @@
   matrix(c(.i1, .i2), ncol=2L,
          dimnames=list(.name, c("neta1", "neta2")))
 }
+
+#' Resolve `omegaSeparation`/`sigmaSeparation` of `"tnpri"`
+#'
+#' `"tnpri"` says the omega (or sigma) entries are carried in the
+#' `thetaMat` and should be drawn from it jointly with the thetas, rather
+#' than having their correlations redrawn by the separation strategy.
+#' That is what a covariance step from NONMEM or nlmixr2 gives, and it
+#' keeps the covariances between the thetas and the omega entries that
+#' the separation strategy throws away.
+#'
+#' Resolved in R rather than C++ so the matched column names can be kept
+#' out of the pruning that drops a `thetaMat` column the model has no
+#' parameter for.
+#'
+#' @param ctl `rxControl` list
+#' @return the amended `rxControl` list
+#' @noRd
+#' @author Matthew L. Fidler
+.rxTnpriApplyControl <- function(ctl) {
+  for (.w in c("omega", "sigma")) {
+    .sep <- ctl[[paste0(.w, "Separation")]]
+    if (!identical(.sep, "tnpri")) next
+    .el <- paste0("prior", if (.w == "omega") "Omega" else "Sigma", "El")
+    ## a prior in the model's `ini({})` block already said which entries
+    ## these are, and it is the more specific statement
+    if (!is.null(ctl[[.el]])) next
+    if (!inherits(ctl$thetaMat, "matrix")) {
+      stop("'", .w, "Separation=\"tnpri\"' needs a 'thetaMat' carrying the ",
+           .w, " entries", call.=FALSE)
+    }
+    .mat <- ctl[[.w]]
+    if (!inherits(.mat, "matrix")) {
+      stop("'", .w, "Separation=\"tnpri\"' needs '", .w, "' to be a matrix, ",
+           "since the drawn entries are added to it", call.=FALSE)
+    }
+    .pos <- .rxJointElFromNames(.mat, colnames(ctl$thetaMat), what=.w)
+    if (is.null(.pos)) {
+      stop("'", .w, "Separation=\"tnpri\"' was given but no 'thetaMat' column ",
+           "names a ", .w, " entry; expected one of '", dimnames(.mat)[[1]][1],
+           "', 'om.", dimnames(.mat)[[1]][1], "' or '", .w, "1.1'",
+           call.=FALSE)
+    }
+    ctl[[.el]] <- .pos
+  }
+  ctl
+}

--- a/R/prior-sim.R
+++ b/R/prior-sim.R
@@ -367,3 +367,148 @@
   if (is.null(.th$thetaMat) && length(.nu) == 0L) return(NULL)
   list(thetaMat=.th$thetaMat, theta=.th$theta, omegaNu=.nu, omegaEl=NULL)
 }
+
+#' Turn the per-block prior degrees of freedom into a 'lotri' omega
+#'
+#' `cvPost()` already draws per-block: given a 'lotri' it ignores the
+#' scalar `nu` argument and reads each block's own from
+#' `attr(omega, "lotri")[[block]]$nu`, then reassembles the full matrix.
+#' So the whole of the `NWPRI` omega half is handing it an omega shaped
+#' that way, which is what this builds.
+#'
+#' @param ui rxode2 ui model
+#' @param omegaNu list from `.rxPriorOmegaNu()`
+#' @return a `lotri` object carrying one `nu` per block, or `NULL` when
+#'   no block has degrees of freedom
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorOmegaLotri <- function(ui, omegaNu) {
+  if (length(omegaNu) == 0L) return(NULL)
+  .omega <- ui$omega
+  if (!is.matrix(.omega) || dim(.omega)[1] == 0L) return(NULL)
+  ## the prior attributes would otherwise travel with the matrix and be
+  ## re-read downstream as if they were the block structure
+  attributes(.omega) <- attributes(.omega)[c("dim", "dimnames")]
+  .nu <- setNames(vapply(omegaNu, function(x) x$nu, double(1)),
+                  vapply(omegaNu, function(x) x$names[1], character(1)))
+  .blk <- lotri::lotriMatInv(.omega)
+  names(.blk) <- paste0("blk", seq_along(.blk))
+  ## a block with no prior keeps `nu = 1`, which is how `cvPost()` spells
+  ## "leave this one at its point estimate"
+  .lst <- setNames(lapply(.blk, function(b) {
+    list(nu=unname(.nu[dimnames(b)[[1]][1]]))
+  }), names(.blk))
+  .lst <- lapply(.lst, function(x) {
+    if (is.na(x$nu)) list(nu=1.0) else x
+  })
+  .ret <- .blk
+  attr(.ret, "lotri") <- .lst
+  attr(.ret, "start") <- 1L
+  class(.ret) <- "lotri"
+  .ret
+}
+
+#' Should the model's priors drive this solve?
+#'
+#' The C++ side resolves `simVar = (simVariability == NA) ? (nStud > 1) :
+#' simVariability`, and every gate that decides whether a drawn matrix is
+#' used hangs off it.  Reproducing it here rather than testing `nStud > 1`
+#' keeps the two from disagreeing: `nStud = 1, simVariability = TRUE`
+#' really does simulate, and `simVariability = FALSE` really does not.
+#'
+#' @param ctl `rxControl` list
+#' @return logical
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorEffSimVar <- function(ctl) {
+  .sv <- ctl$simVariability
+  if (is.null(.sv) || length(.sv) != 1L || is.na(.sv)) {
+    return(isTRUE(ctl$nStud > 1))
+  }
+  isTRUE(.sv)
+}
+
+#' Did this control item come from the model's `meta` block?
+#'
+#' `.uiRxControl()` merges the `meta` block and the caller's arguments
+#' into one list, and by the time the control exists the two look the
+#' same -- `...` at that point is the whole expanded control, not what
+#' the caller typed.  What still tells them apart is `meta` itself: an
+#' item that matches what `meta` holds came from there, and anything else
+#' non-default was given at the call site.
+#'
+#' @param ui rxode2 ui model
+#' @param name control item name
+#' @param value the value in the control
+#' @return logical
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorFromMeta <- function(ui, name, value) {
+  .meta <- try(ui$meta, silent=TRUE)
+  if (!is.environment(.meta) || !exists(name, envir=.meta, inherits=FALSE)) {
+    return(FALSE)
+  }
+  isTRUE(all.equal(get(name, envir=.meta), value))
+}
+
+#' Put the model's priors into the solve control
+#'
+#' @param ui rxode2 ui model
+#' @param ctl `rxControl` list
+#' @return the amended `rxControl` list
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorApplyControl <- function(ui, ctl) {
+  .use <- ctl$usePrior
+  if (isFALSE(.use)) return(ctl)
+  .simVar <- .rxPriorEffSimVar(ctl)
+  if (!isTRUE(.use) && !.simVar) return(ctl)
+  .spec <- .rxPriorSimSpec(ui, ctl)
+  if (is.null(.spec)) {
+    if (isTRUE(.use)) {
+      stop("'usePrior=TRUE' but the model specifies no prior distributions",
+           call.=FALSE)
+    }
+    return(ctl)
+  }
+  if (!.simVar) {
+    ## `usePrior=TRUE` got here, so say why the priors would vanish rather
+    ## than passing them to a solve that draws nothing
+    stop("'usePrior=TRUE' but no variability would be simulated; set ",
+         "'nStud' greater than 1 or 'simVariability=TRUE'",
+         call.=FALSE)
+  }
+  if (!is.null(.spec$thetaMat)) {
+    if (is.null(ctl$thetaMat)) {
+      ctl$thetaMat <- .spec$thetaMat
+    } else if (.rxPriorFromMeta(ui, "thetaMat", ctl$thetaMat)) {
+      warning("the prior distributions in 'ini({})' replace the 'thetaMat' ",
+              "the model's 'meta' block carries", call.=FALSE)
+      ctl$thetaMat <- .spec$thetaMat
+    } else {
+      warning("'thetaMat' was given, so the prior distributions on the ",
+              "population parameters were not used; drop it or set ",
+              "'usePrior=FALSE' to keep it without this warning",
+              call.=FALSE)
+    }
+  }
+  .omega <- .rxPriorOmegaLotri(ui, .spec$omegaNu)
+  if (!is.null(.omega)) {
+    if (is.null(ctl$dfSub) || ctl$dfSub == 0) {
+      ctl$priorOmega <- .omega
+    } else if (.rxPriorFromMeta(ui, "dfSub", ctl$dfSub)) {
+      warning("the prior degrees of freedom in 'ini({})' replace the 'dfSub' ",
+              "the model's 'meta' block carries", call.=FALSE)
+      ctl$priorOmega <- .omega
+    } else {
+      warning("'dfSub' was given, so the prior degrees of freedom on the ",
+              "omega block(s) were not used; drop it or set ",
+              "'usePrior=FALSE' to keep it without this warning",
+              call.=FALSE)
+    }
+  }
+  ## wired here even though it stays NULL until the joint (TNPRI) draw
+  ## exists, so that adding it is a C++ only change
+  ctl$priorOmegaEl <- .spec$omegaEl
+  ctl
+}

--- a/R/prior-sim.R
+++ b/R/prior-sim.R
@@ -377,16 +377,6 @@
   .rxPriorSimAssertSupported(ui, ctl)
   .th <- .rxPriorThetaMat(ui)
   .nu <- .rxPriorOmegaNu(ui)
-  ## TNPRI is rejected here rather than silently simulated as an ordinary
-  ## theta, which `rxSimTheta()` would drop for not matching a model
-  ## parameter.  The C++ side that services `priorOmegaEl` does not exist
-  ## yet; this comes out when it does.
-  if (!is.null(.th$omegaEl)) {
-    stop("prior simulation of a normal prior on the omega values (a NONMEM ",
-         "'TNPRI') is not implemented yet: '",
-         paste(.th$omegaEl$name, collapse="', '"), "'",
-         call.=FALSE)
-  }
   if (is.null(.th$thetaMat) && length(.nu) == 0L) return(NULL)
   list(thetaMat=.th$thetaMat, theta=.th$theta, omegaNu=.nu,
        omegaEl=.th$omegaEl)
@@ -531,8 +521,14 @@
               call.=FALSE)
     }
   }
-  ## wired here even though it stays NULL until the joint (TNPRI) draw
-  ## exists, so that adding it is a C++ only change
-  ctl$priorOmegaEl <- .spec$omegaEl
+  ## the C++ side matches by row name, so a thetaMat column that gets
+  ## pruned before the draw cannot shift the mapping
+  if (!is.null(.spec$omegaEl)) {
+    ctl$priorOmegaEl <-
+      matrix(c(as.integer(.spec$omegaEl$neta1),
+               as.integer(.spec$omegaEl$neta2)),
+             ncol=2L,
+             dimnames=list(.spec$omegaEl$name, c("neta1", "neta2")))
+  }
   ctl
 }

--- a/R/prior-sim.R
+++ b/R/prior-sim.R
@@ -346,7 +346,7 @@
     stop("prior simulation does not yet support nested/occasion models (the ",
          "omega has the condition(s) '",
          paste(unique(.cnd[!(.cnd %in% "id")]), collapse="', '"),
-         "'); see the rxode2 issue tracker",
+         "'); see rxode2 issue #1253",
          call.=FALSE)
   }
   ## A chunked solve pre-draws its parameters in `rxOom` and strips the
@@ -354,7 +354,7 @@
   ## drawn from at all.
   if (!is.null(ctl$file) || !is.null(ctl$chunkSize)) {
     stop("prior simulation does not yet support a chunked solve ('file=' or ",
-         "'chunkSize='); see the rxode2 issue tracker",
+         "'chunkSize='); see rxode2 issue #1252",
          call.=FALSE)
   }
   invisible()

--- a/R/prior-sim.R
+++ b/R/prior-sim.R
@@ -1,0 +1,369 @@
+## Reading the `ini({})` block priors for simulation
+##
+## The specification half of prior support lives in 'lotri', which parses
+## `prior(name) ~ dist(...)` and stores it as the `prior` column of
+## `$iniDf`.  Nothing here parses a prior; this turns the stored priors
+## into the pieces `rxSolve()` needs to simulate from them:
+##
+## - a `thetaMat` for the population parameters (a NONMEM `$THETAPV`)
+## - one degrees of freedom per omega block (a NONMEM `$OMEGAPD`)
+##
+## A prior must never be silently ignored, so anything this cannot turn
+## into one of those is an error naming the parameter.
+
+#' Prior distributions this can simulate from
+#'
+#' Normal and multivariate normal give the `thetaMat`; the Wishart family
+#' gives the omega degrees of freedom.  Every other distribution 'lotri'
+#' accepts is a clear error rather than a silent omission.
+#'
+#' @noRd
+.rxPriorSimStanNames <- c(.rxNormalPriorStanNames, .rxOmegaDfStanNames)
+
+#' Parse a stored prior into its pieces
+#'
+#' @param prior prior as stored in the `prior` column
+#' @return list with `fn` (as written), `stanName` and `args` (a list of
+#'   language objects), or `NULL` when the text is not a call
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorParse <- function(prior) {
+  .e <- try(str2lang(prior), silent=TRUE)
+  if (inherits(.e, "try-error") || !is.call(.e)) return(NULL)
+  .fn <- as.character(.e[[1]])
+  if (length(.fn) != 1L) return(NULL)
+  list(fn=.fn, stanName=.rxPriorStanName(.fn), args=as.list(.e)[-1])
+}
+
+#' Names of the covariance a stored prior carries
+#'
+#' `multiNormal(mu, lotri(a + b ~ c(...)))` keeps its covariance as the
+#' 'lotri' expression that built it, which names every member of the
+#' block in order.  This is how the members of a block are recovered,
+#' since a block prior is stored only once.
+#'
+#' @param prior prior as stored in the `prior` column
+#' @return character vector of names, or `NULL`
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorCovNames <- function(prior) {
+  .p <- .rxPriorParse(prior)
+  if (is.null(.p)) return(NULL)
+  for (.a in .p$args) {
+    if (!(is.call(.a) && identical(.a[[1]], quote(`lotri`)))) next
+    .b <- .a[[2]]
+    if (is.call(.b) && identical(.b[[1]], quote(`{`))) .b <- .b[[2]]
+    if (!(is.call(.b) && identical(.b[[1]], quote(`~`)))) return(NULL)
+    return(all.vars(.b[[2]]))
+  }
+  NULL
+}
+
+#' Environment a stored prior's arguments are evaluated in
+#'
+#' A prior is data, not user code, so it is evaluated somewhere with the
+#' one function it can legitimately call -- `lotri()`, which is how a
+#' covariance is stored -- on top of the base environment, rather than in
+#' the caller's frame.
+#'
+#' @return an environment
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorEvalEnv <- function() {
+  .e <- new.env(parent=baseenv())
+  assign("lotri", lotri::lotri, envir=.e)
+  .e
+}
+
+#' The covariance matrix a `multiNormal()` prior carries
+#'
+#' @param prior prior as stored in the `prior` column
+#' @return numeric matrix with dimnames, or `NULL`
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorCovMat <- function(prior) {
+  .p <- .rxPriorParse(prior)
+  if (is.null(.p)) return(NULL)
+  for (.a in .p$args) {
+    if (!(is.call(.a) && identical(.a[[1]], quote(`lotri`)))) next
+    .m <- try(as.matrix(eval(.a, envir=.rxPriorEvalEnv())), silent=TRUE)
+    if (inherits(.m, "try-error")) return(NULL)
+    return(.m)
+  }
+  NULL
+}
+
+#' Does this prior span the omega elements as well as the thetas?
+#'
+#' A NONMEM `TNPRI` joint block names its omega entries with an `om.`
+#' prefix, which is what marks the prior as joint.
+#'
+#' @param prior prior as stored in the `prior` column
+#' @return logical
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorIsJoint <- function(prior) {
+  vapply(prior, function(p) {
+    .nm <- .rxPriorCovNames(p)
+    !is.null(.nm) && any(grepl("^om[.].", .nm))
+  }, logical(1), USE.NAMES=FALSE)
+}
+
+#' Complain about a prior this cannot simulate from
+#'
+#' @param name parameter name(s)
+#' @param prior prior as stored in the `prior` column
+#' @param why one line saying what is wrong
+#' @return nothing, called for the error
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorStop <- function(name, prior, why) {
+  stop("cannot simulate from the prior on '", paste(name, collapse="', '"),
+       "' (", paste(prior, collapse=", "), "): ", why,
+       call.=FALSE)
+}
+
+#' The `thetaMat` the population parameter priors describe
+#'
+#' Each normal prior contributes its variance, and each `multiNormal()`
+#' contributes its whole block, so the result is block diagonal over the
+#' parameters that carry a prior.  The prior mean has to be the initial
+#' estimate: prior simulation samples around what the model says the
+#' parameter is, so a prior centered anywhere else is an error rather
+#' than a silently different simulation.
+#'
+#' @param ui rxode2 ui model
+#' @return list with `thetaMat` (named matrix, or `NULL`) and `theta`
+#'   (data frame of the parameters it covers)
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorThetaMat <- function(ui) {
+  .iniDf <- ui$iniDf
+  .w <- which(is.na(.iniDf$neta1) & !is.na(.iniDf$prior))
+  if (length(.w) == 0L) {
+    return(list(thetaMat=NULL, theta=NULL))
+  }
+  .est <- setNames(.iniDf$est, .iniDf$name)
+  .blocks <- list()
+  .seen <- character(0)
+  for (.i in .w) {
+    .name <- .iniDf$name[.i]
+    .prior <- .iniDf$prior[.i]
+    if (.name %in% .seen) next
+    .p <- .rxPriorParse(.prior)
+    if (is.null(.p) || is.na(.p$stanName)) {
+      .rxPriorStop(.name, .prior, "the distribution is not known to 'lotri'")
+    }
+    if (!(.p$stanName %in% .rxNormalPriorStanNames)) {
+      .rxPriorStop(.name, .prior,
+                   paste0("only normal and multivariate normal priors can be ",
+                          "simulated on a population parameter"))
+    }
+    if (.p$stanName == "multi_normal") {
+      .nm <- .rxPriorCovNames(.prior)
+      .cov <- .rxPriorCovMat(.prior)
+      if (is.null(.nm) || is.null(.cov)) {
+        .rxPriorStop(.name, .prior, "the covariance could not be read back")
+      }
+      .mu <- try(eval(.p$args[[1]], envir=.rxPriorEvalEnv()), silent=TRUE)
+      if (inherits(.mu, "try-error")) {
+        .rxPriorStop(.nm, .prior, "the mean vector could not be read back")
+      }
+      .mu <- rep_len(as.double(.mu), length(.nm))
+      .rxPriorAssertMean(.nm, .prior, .mu, .est)
+      dimnames(.cov) <- list(.nm, .nm)
+      .blocks[[length(.blocks) + 1L]] <- .cov
+      .seen <- c(.seen, .nm)
+    } else {
+      .mu <- 0.0
+      .sd <- 1.0
+      if (.p$stanName == "normal") {
+        .mu <- try(eval(.p$args[[1]], envir=.rxPriorEvalEnv()), silent=TRUE)
+        .sd <- try(eval(.p$args[[2]], envir=.rxPriorEvalEnv()), silent=TRUE)
+        if (inherits(.mu, "try-error") || inherits(.sd, "try-error")) {
+          .rxPriorStop(.name, .prior, "the mean and sd could not be read back")
+        }
+      }
+      .rxPriorAssertMean(.name, .prior, as.double(.mu), .est)
+      .m <- matrix(as.double(.sd)^2, 1L, 1L, dimnames=list(.name, .name))
+      .blocks[[length(.blocks) + 1L]] <- .m
+      .seen <- c(.seen, .name)
+    }
+  }
+  if (length(.blocks) == 0L) {
+    return(list(thetaMat=NULL, theta=NULL))
+  }
+  list(thetaMat=.rxPriorBlockDiag(.blocks),
+       theta=data.frame(name=.seen, est=unname(.est[.seen]),
+                        stringsAsFactors=FALSE))
+}
+
+#' The prior mean has to be the initial estimate
+#'
+#' @param name parameter name(s)
+#' @param prior prior as stored in the `prior` column
+#' @param mu numeric mean(s) the prior gives
+#' @param est named numeric vector of initial estimates
+#' @return nothing, called for the error
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorAssertMean <- function(name, prior, mu, est) {
+  .e <- unname(est[name])
+  .bad <- which(!is.na(.e) & abs(mu - .e) > 1e-8)
+  if (length(.bad) == 0L) return(invisible())
+  .rxPriorStop(name[.bad], prior,
+               paste0("the prior mean (",
+                      paste(mu[.bad], collapse=", "),
+                      ") is not the initial estimate (",
+                      paste(.e[.bad], collapse=", "),
+                      "); prior simulation samples around the estimate, so ",
+                      "either move the estimate or drop the mean from the prior"))
+}
+
+#' Assemble named blocks into one block diagonal matrix
+#'
+#' @param blocks list of named square matrices
+#' @return one named square matrix
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorBlockDiag <- function(blocks) {
+  .nm <- unlist(lapply(blocks, function(b) dimnames(b)[[1]]), use.names=FALSE)
+  .ret <- matrix(0.0, length(.nm), length(.nm), dimnames=list(.nm, .nm))
+  for (.b in blocks) {
+    .i <- dimnames(.b)[[1]]
+    .ret[.i, .i] <- .b
+  }
+  .ret
+}
+
+#' The prior degrees of freedom of each omega block
+#'
+#' `prior(eta.cl, eta.v) ~ invWishart(4)` says the block itself is the
+#' inverse Wishart scale matrix and 4 is its degrees of freedom, which is
+#' the `$OMEGAP`/`$OMEGAPD` pair of a NONMEM `NWPRI` model.  'lotri'
+#' stores it on the first diagonal element of the block.
+#'
+#' @param ui rxode2 ui model
+#' @return list of `list(names=, nu=)`, one entry per omega block that
+#'   carries degrees of freedom; empty when none do
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorOmegaNu <- function(ui) {
+  .omega <- ui$omega
+  if (!is.matrix(.omega) || dim(.omega)[1] == 0L) return(list())
+  .iniDf <- ui$iniDf
+  .w <- which(!is.na(.iniDf$neta1) & .iniDf$neta1 == .iniDf$neta2)
+  .prior <- setNames(.iniDf$prior[.w], .iniDf$name[.w])
+  .ret <- list()
+  for (.blk in lotri::lotriMatInv(.omega)) {
+    .nm <- dimnames(.blk)[[1]]
+    .p <- .prior[.nm[1]]
+    if (is.na(.p)) next
+    .info <- .rxPriorParse(.p)
+    if (is.null(.info) || is.na(.info$stanName) ||
+          !(.info$stanName %in% .rxOmegaDfStanNames)) {
+      next
+    }
+    .nu <- try(eval(.info$args[[1]], envir=.rxPriorEvalEnv()), silent=TRUE)
+    if (inherits(.nu, "try-error") || length(.nu) != 1L || !is.finite(.nu)) {
+      .rxPriorStop(.nm, .p, "the degrees of freedom could not be read back")
+    }
+    ## 'lotri' checks this when the prior is written, but a piped model
+    ## can reach here with a block that grew after the prior was set
+    if (.nu <= length(.nm) - 1) {
+      .rxPriorStop(.nm, .p,
+                   paste0("an inverse Wishart on a ", length(.nm), "x",
+                          length(.nm), " block needs degrees of freedom ",
+                          "greater than ", length(.nm) - 1, ", but ", .nu,
+                          " was given"))
+    }
+    .ret[[length(.ret) + 1L]] <- list(names=.nm, nu=as.double(.nu))
+  }
+  .ret
+}
+
+#' Priors that sit on the omega elements themselves
+#'
+#' A NONMEM `TNPRI` model puts a normal prior on the omega *values*,
+#' either on its own (`om.eta.cl ~ 0.01`, which lands on the omega row)
+#' or jointly with the thetas (`tcl + om.eta.cl ~ c(...)`, which lands
+#' wherever the block starts).  Both are found here.
+#'
+#' @param ui rxode2 ui model
+#' @return character vector of the parameter names carrying such a prior
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorOmegaElements <- function(ui) {
+  .iniDf <- ui$iniDf
+  .w <- which(!is.na(.iniDf$prior))
+  if (length(.w) == 0L) return(character(0))
+  .isEl <- !is.na(.iniDf$neta1[.w]) & .rxPriorIsNormal(.iniDf$prior[.w])
+  .isJoint <- .rxPriorIsJoint(.iniDf$prior[.w])
+  unique(.iniDf$name[.w][.isEl | .isJoint])
+}
+
+#' Reject the models this cannot simulate priors for
+#'
+#' A prior must never be silently ignored, so a model whose priors would
+#' not reach the draw is an error rather than a quietly unpriored solve.
+#'
+#' @param ui rxode2 ui model
+#' @param ctl `rxControl` list
+#' @return nothing, called for the error
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorSimAssertSupported <- function(ui, ctl) {
+  .iniDf <- ui$iniDf
+  ## A conditioned block (`eta ~ 0.1 | id`, `| occ`) makes `$omega` a
+  ## 'lotri' rather than a plain matrix, which routes the solve through
+  ## `expandPars_()` -- a path that never reaches the prior draw and
+  ## would silently fall back to one degree of freedom per block.
+  .cnd <- .iniDf$condition[!is.na(.iniDf$neta1)]
+  if (length(.cnd) > 0L && !all(.cnd %in% "id")) {
+    stop("prior simulation does not yet support nested/occasion models (the ",
+         "omega has the condition(s) '",
+         paste(unique(.cnd[!(.cnd %in% "id")]), collapse="', '"),
+         "'); see the rxode2 issue tracker",
+         call.=FALSE)
+  }
+  ## A chunked solve pre-draws its parameters in `rxOom` and strips the
+  ## omega from what each chunk is given, so the prior would never be
+  ## drawn from at all.
+  if (!is.null(ctl$file) || !is.null(ctl$chunkSize)) {
+    stop("prior simulation does not yet support a chunked solve ('file=' or ",
+         "'chunkSize='); see the rxode2 issue tracker",
+         call.=FALSE)
+  }
+  invisible()
+}
+
+#' Everything `rxSolve()` needs to simulate from a model's priors
+#'
+#' @param ui rxode2 ui model
+#' @param ctl `rxControl` list
+#' @return `NULL` when the model carries no prior this uses, else a list
+#'   with `thetaMat`, `theta`, `omegaNu` and `omegaEl`
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorSimSpec <- function(ui, ctl=NULL) {
+  .iniDf <- ui$iniDf
+  if (is.null(.iniDf) || !any(names(.iniDf) == "prior") ||
+        !any(!is.na(.iniDf$prior))) {
+    return(NULL)
+  }
+  .rxPriorSimAssertSupported(ui, ctl)
+  ## TNPRI is detected here so it is rejected rather than silently
+  ## simulated as an ordinary theta, which would be dropped for not
+  ## matching a model parameter
+  .el <- .rxPriorOmegaElements(ui)
+  if (length(.el) > 0L) {
+    stop("prior simulation of a normal prior on the omega values (a NONMEM ",
+         "'TNPRI') is not implemented yet: '",
+         paste(.el, collapse="', '"), "'",
+         call.=FALSE)
+  }
+  .th <- .rxPriorThetaMat(ui)
+  .nu <- .rxPriorOmegaNu(ui)
+  if (is.null(.th$thetaMat) && length(.nu) == 0L) return(NULL)
+  list(thetaMat=.th$thetaMat, theta=.th$theta, omegaNu=.nu, omegaEl=NULL)
+}

--- a/R/prior-sim.R
+++ b/R/prior-sim.R
@@ -93,22 +93,6 @@
   NULL
 }
 
-#' Does this prior span the omega elements as well as the thetas?
-#'
-#' A NONMEM `TNPRI` joint block names its omega entries with an `om.`
-#' prefix, which is what marks the prior as joint.
-#'
-#' @param prior prior as stored in the `prior` column
-#' @return logical
-#' @noRd
-#' @author Matthew L. Fidler
-.rxPriorIsJoint <- function(prior) {
-  vapply(prior, function(p) {
-    .nm <- .rxPriorCovNames(p)
-    !is.null(.nm) && any(grepl("^om[.].", .nm))
-  }, logical(1), USE.NAMES=FALSE)
-}
-
 #' Complain about a prior this cannot simulate from
 #'
 #' @param name parameter name(s)
@@ -123,31 +107,86 @@
        call.=FALSE)
 }
 
-#' The `thetaMat` the population parameter priors describe
+#' What each name a prior can be written on is worth
 #'
-#' Each normal prior contributes its variance, and each `multiNormal()`
-#' contributes its whole block, so the result is block diagonal over the
-#' parameters that carry a prior.  The prior mean has to be the initial
-#' estimate: prior simulation samples around what the model says the
-#' parameter is, so a prior centered anywhere else is an error rather
-#' than a silently different simulation.
+#' A prior's mean has to be what the model already says the entry is: the
+#' initial estimate for a population parameter, and the omega value for an
+#' `om.` omega element.  This is the lookup both come from.
 #'
 #' @param ui rxode2 ui model
-#' @return list with `thetaMat` (named matrix, or `NULL`) and `theta`
-#'   (data frame of the parameters it covers)
+#' @return named numeric, keyed by parameter name and by `om.<eta>`
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorEstLookup <- function(ui) {
+  .iniDf <- ui$iniDf
+  .ret <- setNames(.iniDf$est, .iniDf$name)
+  .d <- which(!is.na(.iniDf$neta1) & .iniDf$neta1 == .iniDf$neta2)
+  if (length(.d) > 0L) {
+    .ret <- c(.ret, setNames(.iniDf$est[.d], paste0("om.", .iniDf$name[.d])))
+  }
+  .ret
+}
+
+#' Which omega element does each `om.` name address?
+#'
+#' `om.eta.cl` is the omega element of `eta.cl`, which is its diagonal --
+#' an off diagonal has no `om.` spelling, so a joint prior covers the
+#' omega variances rather than every element of the matrix.
+#'
+#' @param ui rxode2 ui model
+#' @param nm character vector of `om.` prefixed names
+#' @return data frame with `name`, `neta1` and `neta2`
+#' @noRd
+#' @author Matthew L. Fidler
+.rxPriorOmegaElPos <- function(ui, nm) {
+  .iniDf <- ui$iniDf
+  .d <- which(!is.na(.iniDf$neta1) & .iniDf$neta1 == .iniDf$neta2)
+  .idx <- setNames(.iniDf$neta1[.d], paste0("om.", .iniDf$name[.d]))
+  .i <- unname(.idx[nm])
+  if (anyNA(.i)) {
+    stop("prior given for unknown omega element(s): '",
+         paste(nm[is.na(.i)], collapse="', '"), "'", call.=FALSE)
+  }
+  data.frame(name=nm, neta1=.i, neta2=.i, stringsAsFactors=FALSE)
+}
+
+#' The `thetaMat` the model's normal priors describe
+#'
+#' Each normal prior contributes its variance and each `multiNormal()` its
+#' whole block, so the result is block diagonal over the entries that
+#' carry a prior.  An `om.` name is an omega element rather than a
+#' population parameter, and a block may mix the two -- that joint
+#' variance over the thetas and the omega values is what NONMEM calls
+#' `TNPRI`.
+#'
+#' The prior mean has to be what the model already says the entry is,
+#' since the draw is added to that value; a prior centered anywhere else
+#' is an error rather than a silently different simulation.
+#'
+#' @param ui rxode2 ui model
+#' @return list with `thetaMat` (named matrix, or `NULL`), `theta` (the
+#'   entries it covers) and `omegaEl` (the omega elements among them, or
+#'   `NULL`)
 #' @noRd
 #' @author Matthew L. Fidler
 .rxPriorThetaMat <- function(ui) {
   .iniDf <- ui$iniDf
-  .w <- which(is.na(.iniDf$neta1) & !is.na(.iniDf$prior))
+  .w <- which(!is.na(.iniDf$prior) &
+                (is.na(.iniDf$neta1) | .rxPriorIsNormal(.iniDf$prior)))
+  ## an omega row carrying a Wishart is degrees of freedom, not a normal
+  ## prior, and is handled by `.rxPriorOmegaNu()`
+  .w <- .w[is.na(.iniDf$neta1[.w]) | .rxPriorIsNormal(.iniDf$prior[.w])]
   if (length(.w) == 0L) {
-    return(list(thetaMat=NULL, theta=NULL))
+    return(list(thetaMat=NULL, theta=NULL, omegaEl=NULL))
   }
-  .est <- setNames(.iniDf$est, .iniDf$name)
+  .est <- .rxPriorEstLookup(ui)
   .blocks <- list()
   .seen <- character(0)
   for (.i in .w) {
+    ## a prior on an omega row is on that row's omega *element*, which is
+    ## spelled with the `om.` prefix
     .name <- .iniDf$name[.i]
+    if (!is.na(.iniDf$neta1[.i])) .name <- paste0("om.", .name)
     .prior <- .iniDf$prior[.i]
     if (.name %in% .seen) next
     .p <- .rxPriorParse(.prior)
@@ -159,6 +198,8 @@
                    paste0("only normal and multivariate normal priors can be ",
                           "simulated on a population parameter"))
     }
+    ## a `std_normal()` has no arguments to read, so it is a unit normal
+    ## on something whose value must therefore be zero
     if (.p$stanName == "multi_normal") {
       .nm <- .rxPriorCovNames(.prior)
       .cov <- .rxPriorCovMat(.prior)
@@ -191,11 +232,13 @@
     }
   }
   if (length(.blocks) == 0L) {
-    return(list(thetaMat=NULL, theta=NULL))
+    return(list(thetaMat=NULL, theta=NULL, omegaEl=NULL))
   }
+  .om <- .seen[grepl("^om[.].", .seen)]
   list(thetaMat=.rxPriorBlockDiag(.blocks),
        theta=data.frame(name=.seen, est=unname(.est[.seen]),
-                        stringsAsFactors=FALSE))
+                        stringsAsFactors=FALSE),
+       omegaEl=if (length(.om) == 0L) NULL else .rxPriorOmegaElPos(ui, .om))
 }
 
 #' The prior mean has to be the initial estimate
@@ -282,26 +325,6 @@
   .ret
 }
 
-#' Priors that sit on the omega elements themselves
-#'
-#' A NONMEM `TNPRI` model puts a normal prior on the omega *values*,
-#' either on its own (`om.eta.cl ~ 0.01`, which lands on the omega row)
-#' or jointly with the thetas (`tcl + om.eta.cl ~ c(...)`, which lands
-#' wherever the block starts).  Both are found here.
-#'
-#' @param ui rxode2 ui model
-#' @return character vector of the parameter names carrying such a prior
-#' @noRd
-#' @author Matthew L. Fidler
-.rxPriorOmegaElements <- function(ui) {
-  .iniDf <- ui$iniDf
-  .w <- which(!is.na(.iniDf$prior))
-  if (length(.w) == 0L) return(character(0))
-  .isEl <- !is.na(.iniDf$neta1[.w]) & .rxPriorIsNormal(.iniDf$prior[.w])
-  .isJoint <- .rxPriorIsJoint(.iniDf$prior[.w])
-  unique(.iniDf$name[.w][.isEl | .isJoint])
-}
-
 #' Reject the models this cannot simulate priors for
 #'
 #' A prior must never be silently ignored, so a model whose priors would
@@ -352,20 +375,21 @@
     return(NULL)
   }
   .rxPriorSimAssertSupported(ui, ctl)
-  ## TNPRI is detected here so it is rejected rather than silently
-  ## simulated as an ordinary theta, which would be dropped for not
-  ## matching a model parameter
-  .el <- .rxPriorOmegaElements(ui)
-  if (length(.el) > 0L) {
-    stop("prior simulation of a normal prior on the omega values (a NONMEM ",
-         "'TNPRI') is not implemented yet: '",
-         paste(.el, collapse="', '"), "'",
-         call.=FALSE)
-  }
   .th <- .rxPriorThetaMat(ui)
   .nu <- .rxPriorOmegaNu(ui)
+  ## TNPRI is rejected here rather than silently simulated as an ordinary
+  ## theta, which `rxSimTheta()` would drop for not matching a model
+  ## parameter.  The C++ side that services `priorOmegaEl` does not exist
+  ## yet; this comes out when it does.
+  if (!is.null(.th$omegaEl)) {
+    stop("prior simulation of a normal prior on the omega values (a NONMEM ",
+         "'TNPRI') is not implemented yet: '",
+         paste(.th$omegaEl$name, collapse="', '"), "'",
+         call.=FALSE)
+  }
   if (is.null(.th$thetaMat) && length(.nu) == 0L) return(NULL)
-  list(thetaMat=.th$thetaMat, theta=.th$theta, omegaNu=.nu, omegaEl=NULL)
+  list(thetaMat=.th$thetaMat, theta=.th$theta, omegaNu=.nu,
+       omegaEl=.th$omegaEl)
 }
 
 #' Turn the per-block prior degrees of freedom into a 'lotri' omega

--- a/R/prior-sim.R
+++ b/R/prior-sim.R
@@ -532,3 +532,82 @@
   }
   ctl
 }
+
+## Recognizing omega/sigma entries carried in a `thetaMat`
+##
+## A `thetaMat` from a real covariance step carries the omega and sigma
+## entries next to the thetas, and simulating from the whole thing is
+## what NONMEM calls `TNPRI`.  Every producer spells those entries
+## differently, so all of the spellings in use are recognized:
+##
+##   nlmixr2est  `om.<eta>`            `cov.<eta1>.<eta2>`
+##   nonmem2rx   `<eta>`               `omega<i>.<j>`, `omega.<i>.<j>`
+##   ini({})     `om.<eta>`            --
+##
+## and the sigma equivalents.  An eta name contains dots of its own, so a
+## name is matched by *building* the candidates for each element and
+## comparing, never by splitting on dots.
+
+#' Every spelling of the `(i, j)` entry of a named matrix
+#'
+#' @param nm dimnames of the omega/sigma matrix
+#' @param i,j element position, 1 based
+#' @param what `"omega"` or `"sigma"`
+#' @return character vector of names that address that element
+#' @noRd
+#' @author Matthew L. Fidler
+.rxJointElNames <- function(nm, i, j, what="omega") {
+  .diagPre <- if (what == "omega") "om." else "sig."
+  .idxPre <- if (what == "omega") c("omega", "omega.") else c("sigma", "sigma.")
+  if (i == j) {
+    ## the bare name is how a covariance step names a variance; the
+    ## prefixed one is what nlmixr2est and the `ini({})` block write
+    return(c(nm[i], paste0(.diagPre, nm[i]),
+             paste0(.idxPre, i, ".", i)))
+  }
+  ## the matrix is symmetric, so either order addresses the same entry
+  c(paste0("cov.", nm[i], ".", nm[j]),
+    paste0("cov.", nm[j], ".", nm[i]),
+    paste0(.idxPre, i, ".", j),
+    paste0(.idxPre, j, ".", i))
+}
+
+#' Which `thetaMat` columns are entries of this matrix?
+#'
+#' @param mat omega/sigma matrix (named)
+#' @param cols `thetaMat` column names
+#' @param what `"omega"` or `"sigma"`
+#' @param diagOnly when `TRUE` a bare eta name is *not* taken as an entry,
+#'   which is how the existing separation strategy reads it
+#' @return integer matrix of `(neta1, neta2)` with the matching column
+#'   name as its row names, or `NULL` when nothing matched
+#' @noRd
+#' @author Matthew L. Fidler
+.rxJointElFromNames <- function(mat, cols, what="omega", bareName=TRUE) {
+  if (!is.matrix(mat) || dim(mat)[1] == 0L || length(cols) == 0L) return(NULL)
+  .nm <- dimnames(mat)[[1]]
+  if (is.null(.nm)) return(NULL)
+  .n <- length(.nm)
+  .name <- character(0)
+  .i1 <- integer(0)
+  .i2 <- integer(0)
+  for (.i in seq_len(.n)) {
+    for (.j in seq_len(.i)) {
+      .cand <- .rxJointElNames(.nm, .i, .j, what)
+      if (!bareName && .i == .j) .cand <- .cand[-1]
+      .w <- which(cols %in% .cand)
+      if (length(.w) == 0L) next
+      if (length(.w) > 1L) {
+        stop("more than one 'thetaMat' column addresses the same ", what,
+             " entry (", .nm[.i], ", ", .nm[.j], "): '",
+             paste(cols[.w], collapse="', '"), "'", call.=FALSE)
+      }
+      .name <- c(.name, cols[.w])
+      .i1 <- c(.i1, .i)
+      .i2 <- c(.i2, .j)
+    }
+  }
+  if (length(.name) == 0L) return(NULL)
+  matrix(c(.i1, .i2), ncol=2L,
+         dimnames=list(.name, c("neta1", "neta2")))
+}

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -2427,6 +2427,9 @@ rxSolve.function <- function(object, params = NULL, events = NULL, inits = NULL,
         all(dim(.rxControl$sigma) == c(0,0))) {
     .rxControl$sigma <- NULL
   }
+  ## the prior distributions the model's `ini({})` block specifies drive
+  ## the uncertainty simulation
+  .rxControl <- .rxPriorApplyControl(object, .rxControl)
   if (inherits(object, "rxode2tos")) {
     .rx <- object
   } else {

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -614,6 +614,27 @@
 #' @param dfObs Degrees of freedom to sample the unexplained variability matrix from the
 #'        inverse Wishart distribution (scaled) or scaled inverse chi squared distribution.
 #'
+#' @param usePrior Whether the prior distributions specified in the model's
+#'   `ini({})` block drive the uncertainty simulation.  `NA` (or `"auto"`,
+#'   the default) uses them whenever the model has them and variability is
+#'   being simulated (`nStud > 1`, or whatever `simVariability` forces);
+#'   `TRUE` requires them, and is an error when the model has none or when
+#'   no variability would be simulated; `FALSE` ignores them and falls back
+#'   to a supplied `thetaMat`/`dfSub`.  The priors take precedence over a
+#'   `thetaMat`/`dfSub` carried in the model's `meta` block, with a warning;
+#'   one given at the call site wins over the priors instead.
+#'
+#' @param priorPdRetry How many times a prior draw of a covariance matrix is
+#'   retried when it is not positive definite.  After that many tries the
+#'   nearest positive definite matrix of the kept draws is used and a
+#'   warning is given.  Only prior draws retry; `cvPost()` is unchanged.
+#'
+#' @param priorOmega Internal.  The per-block prior degrees of freedom of the
+#'   omega, built from the `ini({})` block; not meant to be set directly.
+#'
+#' @param priorOmegaEl Internal.  Which `thetaMat` columns are omega elements
+#'   of a joint prior; not meant to be set directly.
+#'
 #' @param resample A character vector of model variables to resample
 #'   from the input dataset; This sampling is done with replacement.
 #'   When `NULL` or `FALSE` no resampling is done.  When
@@ -1254,6 +1275,10 @@ rxSolve <- function(object, params = NULL, events = NULL, inits = NULL,
                     indLinIteration = c("auto", "picard", "newton", "exprb", "exprb32"),
                     indLinJac = c("auto", "symbolic", "fd"),
                     indLinForcing = c("ramp", "constant"),
+                    usePrior=NA,
+                    priorPdRetry=10L,
+                    priorOmega=NULL,
+                    priorOmegaEl=NULL,
                     envir=parent.frame()) {
   .udfEnvSet(list(envir, parent.frame(1))) # nolint
   if (is.null(object)) {
@@ -1634,6 +1659,18 @@ rxSolve <- function(object, params = NULL, events = NULL, inits = NULL,
     checkmate::assertIntegerish(hmxi, lower=0, any.missing=FALSE, len=1)
     checkmate::assertLogical(istateReset, any.missing=TRUE, len=1)
     checkmate::assertLogical(simVariability, len=1)
+    ## `usePrior=NA` is "auto" (use the priors when the model has them and
+    ## variability is being simulated); the string spelling is accepted so
+    ## `usePrior="auto"` reads the way the documentation does
+    .usePrior <- usePrior
+    if (is.character(.usePrior)) {
+      .usePrior <- switch(match.arg(.usePrior, c("auto", "true", "false")),
+                          auto=NA, true=TRUE, false=FALSE)
+    }
+    checkmate::assertLogical(.usePrior, len=1)
+    checkmate::assertIntegerish(priorPdRetry, len=1, lower=1,
+                                any.missing=FALSE)
+    priorPdRetry <- as.integer(priorPdRetry)
     checkmate::assertLogical(dense, len=1, any.missing=FALSE)
     if (isTRUE(dense) && stiff2 > 0L && stiff2 != 13L) {
       warning("dense output is not supported for the stiff method of this composite; ignoring dense=TRUE",
@@ -1969,7 +2006,14 @@ rxSolve <- function(object, params = NULL, events = NULL, inits = NULL,
       indLinRichardson=.indLinRichardson,
       indLinIteration=.indLinIteration,
       indLinJac=.indLinJac,
-      indLinForcing=.indLinForcing
+      indLinForcing=.indLinForcing,
+      ## appended at the end: the C++ side reads `rxControl` positionally
+      ## through the generated `Rxc_*` defines, so a new field may only be
+      ## added here, never inserted
+      usePrior=.usePrior,
+      priorPdRetry=priorPdRetry,
+      priorOmega=priorOmega,
+      priorOmegaEl=priorOmegaEl
     )
     class(.ret) <- "rxControl"
     return(.ret)

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -499,6 +499,18 @@
 #'     matrix is less than 10 and `"separation"` when greater
 #'    than equal to 10.
 #'
+#'  * `"tnpri"` does not use a separation strategy at all: the omega
+#'     entries themselves are carried in the `thetaMat` and are drawn from
+#'     it jointly with the thetas, which is what a covariance step from
+#'     NONMEM or 'nlmixr2' gives and what NONMEM calls `TNPRI`.  This keeps
+#'     the off diagonal entries and the covariances between the thetas and
+#'     the omega entries, which the strategies above redraw or discard.
+#'     `omega` has to be a matrix, since the draws are added to it, and the
+#'     `thetaMat` columns are matched to entries by name -- `om.eta.cl` or
+#'     `eta.cl` for a diagonal, and `cov.eta.cl.eta.v` or `omega2.1` for an
+#'     off diagonal.  A drawn matrix that is not positive definite is
+#'     redrawn, see `priorPdRetry`.
+#'
 #' @param omegaXform When taking `omega` values from the `thetaMat`
 #'   simulations (using the separation strategy for covariance
 #'   simulation), how should the `thetaMat` values be turned int
@@ -611,6 +623,9 @@
 #'    matrix is less than 10 and `"separation"` when greater
 #'    than equal to 10.
 #'
+#' *  `"tnpri"` draws the sigma entries jointly from the `thetaMat`, the
+#'    same way `omegaSeparation="tnpri"` does for the omega.
+#'
 #' @param dfObs Degrees of freedom to sample the unexplained variability matrix from the
 #'        inverse Wishart distribution (scaled) or scaled inverse chi squared distribution.
 #'
@@ -633,7 +648,12 @@
 #'   omega, built from the `ini({})` block; not meant to be set directly.
 #'
 #' @param priorOmegaEl Internal.  Which `thetaMat` columns are omega elements
-#'   of a joint prior; not meant to be set directly.
+#'   of a joint prior; not meant to be set directly -- use
+#'   `omegaSeparation="tnpri"`.
+#'
+#' @param priorSigmaEl Internal.  Which `thetaMat` columns are sigma elements
+#'   of a joint prior; not meant to be set directly -- use
+#'   `sigmaSeparation="tnpri"`.
 #'
 #' @param resample A character vector of model variables to resample
 #'   from the input dataset; This sampling is done with replacement.
@@ -1169,7 +1189,7 @@ rxSolve <- function(object, params = NULL, events = NULL, inits = NULL,
                     addCov = TRUE, sigma = NULL, sigmaDf = NULL,
                     sigmaLower = -Inf, sigmaUpper = Inf,
                     nCoresRV = 1L, sigmaIsChol = FALSE,
-                    sigmaSeparation = c("auto", "lkj", "separation"),
+                    sigmaSeparation = c("auto", "lkj", "separation", "tnpri"),
                     sigmaXform = c("identity", "variance", "log", "nlmixrSqrt", "nlmixrLog", "nlmixrIdentity"),
                     nDisplayProgress = 10000L,
                     amountUnits = NA_character_, timeUnits = "hours",
@@ -1178,7 +1198,7 @@ rxSolve <- function(object, params = NULL, events = NULL, inits = NULL,
                     eta = NULL, addDosing = FALSE,
                     stateTrim = Inf, updateObject = FALSE,
                     omega = NULL, omegaDf = NULL, omegaIsChol = FALSE,
-                    omegaSeparation = c("auto", "lkj", "separation"),
+                    omegaSeparation = c("auto", "lkj", "separation", "tnpri"),
                     omegaXform = c("variance", "identity", "log", "nlmixrSqrt", "nlmixrLog", "nlmixrIdentity"),
                     omegaLower = -Inf, omegaUpper = Inf,
                     nSub = 1L, thetaMat = NULL, thetaDf = NULL, thetaIsChol = FALSE,
@@ -1279,6 +1299,7 @@ rxSolve <- function(object, params = NULL, events = NULL, inits = NULL,
                     priorPdRetry=10L,
                     priorOmega=NULL,
                     priorOmegaEl=NULL,
+                    priorSigmaEl=NULL,
                     envir=parent.frame()) {
   .udfEnvSet(list(envir, parent.frame(1))) # nolint
   if (is.null(object)) {
@@ -2013,7 +2034,8 @@ rxSolve <- function(object, params = NULL, events = NULL, inits = NULL,
       usePrior=.usePrior,
       priorPdRetry=priorPdRetry,
       priorOmega=priorOmega,
-      priorOmegaEl=priorOmegaEl
+      priorOmegaEl=priorOmegaEl,
+      priorSigmaEl=priorSigmaEl
     )
     class(.ret) <- "rxControl"
     return(.ret)
@@ -3505,6 +3527,12 @@ rxSolve.default <- function(object, params = NULL, events = NULL, inits = NULL, 
     .names <- c(.names, .col[.w])
   }
 
+  ## `omegaSeparation="tnpri"` says the omega (and `sigmaSeparation` the
+  ## sigma) entries are carried in the thetaMat and should be drawn from
+  ## it jointly with the thetas.  Resolved before the pruning below, which
+  ## would otherwise drop those columns as "too many items".
+  .ctl <- .rxTnpriApplyControl(.ctl)
+
   if (inherits(.ctl$thetaMat, "matrix")) {
     .mv <- rxModelVars(object)
     .col <- colnames(.ctl$thetaMat)
@@ -3514,6 +3542,9 @@ rxSolve.default <- function(object, params = NULL, events = NULL, inits = NULL, 
     ## would vanish.
     if (!is.null(.ctl$priorOmegaEl)) {
       .extraNames <- c(.extraNames, rownames(.ctl$priorOmegaEl))
+    }
+    if (!is.null(.ctl$priorSigmaEl)) {
+      .extraNames <- c(.extraNames, rownames(.ctl$priorSigmaEl))
     }
     .w <- .col %in% c(.mv$params, .extraNames)
     .ignore <- .col[!.w]

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -3508,6 +3508,13 @@ rxSolve.default <- function(object, params = NULL, events = NULL, inits = NULL, 
   if (inherits(.ctl$thetaMat, "matrix")) {
     .mv <- rxModelVars(object)
     .col <- colnames(.ctl$thetaMat)
+    ## a joint (TNPRI) prior puts the omega elements in the thetaMat as
+    ## well, named `om.<eta>`.  They are not model parameters, so without
+    ## this they would be pruned as "too many items" and the prior on them
+    ## would vanish.
+    if (!is.null(.ctl$priorOmegaEl)) {
+      .extraNames <- c(.extraNames, rownames(.ctl$priorOmegaEl))
+    }
     .w <- .col %in% c(.mv$params, .extraNames)
     .ignore <- .col[!.w]
     if (length(.ignore)>0) {

--- a/inst/include/rxode2_control.h
+++ b/inst/include/rxode2_control.h
@@ -138,4 +138,8 @@
 #define Rxc_indLinIteration 133
 #define Rxc_indLinJac 134
 #define Rxc_indLinForcing 135
+#define Rxc_usePrior 136
+#define Rxc_priorPdRetry 137
+#define Rxc_priorOmega 138
+#define Rxc_priorOmegaEl 139
 #endif // __rxode2_control_H__

--- a/inst/include/rxode2_control.h
+++ b/inst/include/rxode2_control.h
@@ -142,4 +142,5 @@
 #define Rxc_priorPdRetry 137
 #define Rxc_priorOmega 138
 #define Rxc_priorOmegaEl 139
+#define Rxc_priorSigmaEl 140
 #endif // __rxode2_control_H__

--- a/inst/include/rxode2parse_control.h
+++ b/inst/include/rxode2parse_control.h
@@ -137,6 +137,10 @@
 #define Rxc_indLinIteration 133
 #define Rxc_indLinJac 134
 #define Rxc_indLinForcing 135
+#define Rxc_usePrior 136
+#define Rxc_priorPdRetry 137
+#define Rxc_priorOmega 138
+#define Rxc_priorOmegaEl 139
 #define RxMv_params 0
 #define RxMv_lhs 1
 #define RxMv_state 2

--- a/inst/include/rxode2parse_control.h
+++ b/inst/include/rxode2parse_control.h
@@ -141,6 +141,7 @@
 #define Rxc_priorPdRetry 137
 #define Rxc_priorOmega 138
 #define Rxc_priorOmegaEl 139
+#define Rxc_priorSigmaEl 140
 #define RxMv_params 0
 #define RxMv_lhs 1
 #define RxMv_state 2

--- a/man/rmdhunks/rxode2-syntax-hunk.Rmd
+++ b/man/rmdhunks/rxode2-syntax-hunk.Rmd
@@ -643,6 +643,96 @@ specification time.  So a method can branch on which one it got.
 So if a method silently ignored your prior, that is a bug in the method, not
 expected behaviour.
 
+## Simulating from the priors
+
+`rxSolve()` uses the priors for its uncertainty simulation, which is what
+NONMEM does with `$PRIOR NWPRI` and `$PRIOR TNPRI`.  Nothing extra has to
+be turned on: a model that carries priors uses them whenever variability
+is being simulated, that is when `nStud` is greater than one (or whatever
+`simVariability` forces).
+
+```
+one.cmt <- function() {
+  ini({
+    tka <- 0.45
+    tcl <- 1
+    tv <- 3.45
+    eta.cl + eta.v ~ c(0.3,
+                       0.01, 0.1)
+    eta.ka ~ 0.6
+    add.sd <- 0.7
+    tka ~ 0.01                            # normal prior on tka
+    prior(eta.cl, eta.v) ~ invWishart(20) # degrees of freedom, per block
+    prior(eta.ka) ~ invWishart(4)
+  })
+  model({
+    ka <- exp(tka + eta.ka)
+    cl <- exp(tcl + eta.cl)
+    v <- exp(tv + eta.v)
+    linCmt() ~ add(add.sd)
+  })
+}
+
+s <- rxSolve(one.cmt, ev, nSub = 10, nStud = 100)
+s$thetaMat   # the per study population parameter draws
+s$omegaList  # the per study omega, one draw per study
+```
+
+Each omega block is drawn with **its own** degrees of freedom, which the
+single `dfSub` argument cannot express -- above, the 2x2 block is drawn
+with 20 and the 1x1 with 4.  A block with no prior is left at its point
+estimate.  `dfWishart()` helps pick a degrees of freedom that matches a
+target relative standard error.
+
+### The prior mean is the estimate
+
+A draw is added to the value the model already gives, so a normal prior on
+a population parameter has to be centered on its estimate, and one on an
+omega element on that omega value.  `tka ~ 0.01` is exactly that -- the
+number is the variance and the mean comes from `tka <- 0.45`.  Writing a
+prior centered somewhere else is an error rather than a simulation that
+quietly differs from what the model says:
+
+```
+tka <- 0.45
+prior(tka) ~ dnorm(0, 0.1)
+#> Error: cannot simulate from the prior on 'tka' (dnorm(0, 0.1)): the
+#>   prior mean (0) is not the initial estimate (0.45)
+```
+
+### A joint prior over the thetas and the omegas
+
+A `TNPRI` variance matrix covers the population parameters and the omega
+values together, with covariances between them.  Prefix an omega element
+with `om.` to name it, and put both in one block:
+
+```
+tcl + om.eta.cl ~ c(0.02,
+                    0.004, 0.005)
+```
+
+Drawn that way the omega is not guaranteed positive definite.  A study
+whose draw is not gets the whole joint vector redrawn, up to
+`priorPdRetry` times (10 by default).  If none of them is, the nearest
+positive definite matrix of the kept draws is used and `rxSolve()` warns
+-- that projection lands on the boundary of the positive definite cone,
+so those studies are not draws from the stated prior.  A model that
+reaches the fallback often wants a larger `priorPdRetry` or a tighter
+prior.
+
+### Turning it off, and precedence
+
+`usePrior = FALSE` ignores the priors and falls back to a supplied
+`thetaMat`/`dfSub`; `usePrior = TRUE` requires them and says why if it
+cannot honor them.  A `thetaMat`/`dfSub` carried in the model's `meta`
+block loses to the priors, with a warning.  One given at the call site
+wins over them instead, also with a warning -- an explicit argument is
+never silently discarded.
+
+Prior simulation does not yet cover nested/occasion models (`| id`,
+`| occ`) or a chunked solve (`file =`/`chunkSize =`); both are a clear
+error rather than a solve that quietly drops the prior.
+
 # Note on strings in rxode2
 
 Strings are converted to double values inside of `rxode2`, hence you

--- a/man/rmdhunks/rxode2-syntax-hunk.Rmd
+++ b/man/rmdhunks/rxode2-syntax-hunk.Rmd
@@ -730,8 +730,9 @@ wins over them instead, also with a warning -- an explicit argument is
 never silently discarded.
 
 Prior simulation does not yet cover nested/occasion models (`| id`,
-`| occ`) or a chunked solve (`file =`/`chunkSize =`); both are a clear
-error rather than a solve that quietly drops the prior.
+`| occ`, rxode2 issue #1253) or a chunked solve (`file =`/`chunkSize =`,
+rxode2 issue #1252); both are a clear error rather than a solve that
+quietly drops the prior.
 
 # Note on strings in rxode2
 

--- a/man/rmdhunks/rxode2-syntax-hunk.Rmd
+++ b/man/rmdhunks/rxode2-syntax-hunk.Rmd
@@ -734,6 +734,40 @@ Prior simulation does not yet cover nested/occasion models (`| id`,
 rxode2 issue #1252); both are a clear error rather than a solve that
 quietly drops the prior.
 
+### A thetaMat that already carries the omegas
+
+The same joint draw works without an `ini({})` prior, for a `thetaMat`
+that came from a covariance step.  `nonmem2rx` gives one directly, and so
+does a nlmixr2 fit:
+
+```
+mod <- nonmem2rx("run3.lst")
+colnames(mod$thetaMat)
+#> "t.CL" "GFRCL" ... "IIVCL" "omega1.2" "omega1.3" "IIVV1" ... "eps1" "sigma1.2"
+
+rxSolve(mod, data.sim, nStud = 100, omegaSeparation = "tnpri")
+```
+
+`omegaSeparation = "tnpri"` says those entries are the omega itself and
+should be drawn from the `thetaMat` jointly with the thetas, instead of
+having their correlations redrawn by the `lkj`/`separation` strategies --
+which discard the off-diagonal entries the covariance step measured, and
+cannot carry a covariance between a theta and an omega entry at all.
+`sigmaSeparation = "tnpri"` does the same for the residual entries.
+
+Columns are matched to entries by name, in whichever spelling produced
+them:
+
+| | diagonal | off-diagonal |
+|---|---|---|
+| nlmixr2 fit `$cov` | `om.eta.cl` | `cov.eta.cl.eta.v` |
+| `nonmem2rx` | `eta.cl` | `omega1.2`, `omega.2.1` |
+
+This is opt-in rather than automatic: an eta-named column already means
+that eta's variance under the existing separation strategy, so it cannot
+change meaning on its own.  `omega` has to be a matrix, since the drawn
+entries are added to it.
+
 # Note on strings in rxode2
 
 Strings are converted to double values inside of `rxode2`, hence you

--- a/man/rxSimThetaOmega.Rd
+++ b/man/rxSimThetaOmega.Rd
@@ -75,6 +75,17 @@ size is greater or equal to 10
 \item \code{"auto"} chooses \code{"lkj"} when the dimension of the
 matrix is less than 10 and \code{"separation"} when greater
 than equal to 10.
+\item \code{"tnpri"} does not use a separation strategy at all: the omega
+entries themselves are carried in the \code{thetaMat} and are drawn from
+it jointly with the thetas, which is what a covariance step from
+NONMEM or 'nlmixr2' gives and what NONMEM calls \code{TNPRI}.  This keeps
+the off diagonal entries and the covariances between the thetas and
+the omega entries, which the strategies above redraw or discard.
+\code{omega} has to be a matrix, since the draws are added to it, and the
+\code{thetaMat} columns are matched to entries by name -- \code{om.eta.cl} or
+\code{eta.cl} for a diagonal, and \code{cov.eta.cl.eta.v} or \code{omega2.1} for an
+off diagonal.  A drawn matrix that is not positive definite is
+redrawn, see \code{priorPdRetry}.
 }}
 
 \item{omegaXform}{When taking \code{omega} values from the \code{thetaMat}
@@ -160,6 +171,8 @@ size is greater or equal to 10
 \item \code{"auto"} chooses \code{"lkj"} when the dimension of the
 matrix is less than 10 and \code{"separation"} when greater
 than equal to 10.
+\item \code{"tnpri"} draws the sigma entries jointly from the \code{thetaMat}, the
+same way \code{omegaSeparation="tnpri"} does for the omega.
 }}
 
 \item{sigmaXform}{When taking \code{sigma} values from the \code{thetaMat}

--- a/man/rxSolve.Rd
+++ b/man/rxSolve.Rd
@@ -78,7 +78,7 @@ rxSolve(
   sigmaUpper = Inf,
   nCoresRV = 1L,
   sigmaIsChol = FALSE,
-  sigmaSeparation = c("auto", "lkj", "separation"),
+  sigmaSeparation = c("auto", "lkj", "separation", "tnpri"),
   sigmaXform = c("identity", "variance", "log", "nlmixrSqrt", "nlmixrLog",
     "nlmixrIdentity"),
   nDisplayProgress = 10000L,
@@ -94,7 +94,7 @@ rxSolve(
   omega = NULL,
   omegaDf = NULL,
   omegaIsChol = FALSE,
-  omegaSeparation = c("auto", "lkj", "separation"),
+  omegaSeparation = c("auto", "lkj", "separation", "tnpri"),
   omegaXform = c("variance", "identity", "log", "nlmixrSqrt", "nlmixrLog",
     "nlmixrIdentity"),
   omegaLower = -Inf,
@@ -201,6 +201,7 @@ rxSolve(
   priorPdRetry = 10L,
   priorOmega = NULL,
   priorOmegaEl = NULL,
+  priorSigmaEl = NULL,
   envir = parent.frame()
 )
 
@@ -920,6 +921,8 @@ size is greater or equal to 10
 \item \code{"auto"} chooses \code{"lkj"} when the dimension of the
 matrix is less than 10 and \code{"separation"} when greater
 than equal to 10.
+\item \code{"tnpri"} draws the sigma entries jointly from the \code{thetaMat}, the
+same way \code{omegaSeparation="tnpri"} does for the omega.
 }}
 
 \item{sigmaXform}{When taking \code{sigma} values from the \code{thetaMat}
@@ -1042,6 +1045,17 @@ size is greater or equal to 10
 \item \code{"auto"} chooses \code{"lkj"} when the dimension of the
 matrix is less than 10 and \code{"separation"} when greater
 than equal to 10.
+\item \code{"tnpri"} does not use a separation strategy at all: the omega
+entries themselves are carried in the \code{thetaMat} and are drawn from
+it jointly with the thetas, which is what a covariance step from
+NONMEM or 'nlmixr2' gives and what NONMEM calls \code{TNPRI}.  This keeps
+the off diagonal entries and the covariances between the thetas and
+the omega entries, which the strategies above redraw or discard.
+\code{omega} has to be a matrix, since the draws are added to it, and the
+\code{thetaMat} columns are matched to entries by name -- \code{om.eta.cl} or
+\code{eta.cl} for a diagonal, and \code{cov.eta.cl.eta.v} or \code{omega2.1} for an
+off diagonal.  A drawn matrix that is not positive definite is
+redrawn, see \code{priorPdRetry}.
 }}
 
 \item{omegaXform}{When taking \code{omega} values from the \code{thetaMat}
@@ -1699,7 +1713,12 @@ warning is given.  Only prior draws retry; \code{cvPost()} is unchanged.}
 omega, built from the \code{ini({})} block; not meant to be set directly.}
 
 \item{priorOmegaEl}{Internal.  Which \code{thetaMat} columns are omega elements
-of a joint prior; not meant to be set directly.}
+of a joint prior; not meant to be set directly -- use
+\code{omegaSeparation="tnpri"}.}
+
+\item{priorSigmaEl}{Internal.  Which \code{thetaMat} columns are sigma elements
+of a joint prior; not meant to be set directly -- use
+\code{sigmaSeparation="tnpri"}.}
 
 \item{envir}{is the environment to look for R user functions
 (defaults to parent environment)}

--- a/man/rxSolve.Rd
+++ b/man/rxSolve.Rd
@@ -197,6 +197,10 @@ rxSolve(
   indLinIteration = c("auto", "picard", "newton", "exprb", "exprb32"),
   indLinJac = c("auto", "symbolic", "fd"),
   indLinForcing = c("ramp", "constant"),
+  usePrior = NA,
+  priorPdRetry = 10L,
+  priorOmega = NULL,
+  priorOmegaEl = NULL,
   envir = parent.frame()
 )
 
@@ -1675,6 +1679,27 @@ rather than one -- which is where most of the difference between the two
 shows up, since the default \code{indLinRichardson="auto"} extrapolates.  It
 applies to the \code{"picard"} and \code{"newton"} schemes; the exponential
 Rosenbrock ones never freeze the forcing.}
+
+\item{usePrior}{Whether the prior distributions specified in the model's
+\code{ini({})} block drive the uncertainty simulation.  \code{NA} (or \code{"auto"},
+the default) uses them whenever the model has them and variability is
+being simulated (\code{nStud > 1}, or whatever \code{simVariability} forces);
+\code{TRUE} requires them, and is an error when the model has none or when
+no variability would be simulated; \code{FALSE} ignores them and falls back
+to a supplied \code{thetaMat}/\code{dfSub}.  The priors take precedence over a
+\code{thetaMat}/\code{dfSub} carried in the model's \code{meta} block, with a warning;
+one given at the call site wins over the priors instead.}
+
+\item{priorPdRetry}{How many times a prior draw of a covariance matrix is
+retried when it is not positive definite.  After that many tries the
+nearest positive definite matrix of the kept draws is used and a
+warning is given.  Only prior draws retry; \code{cvPost()} is unchanged.}
+
+\item{priorOmega}{Internal.  The per-block prior degrees of freedom of the
+omega, built from the \code{ini({})} block; not meant to be set directly.}
+
+\item{priorOmegaEl}{Internal.  Which \code{thetaMat} columns are omega elements
+of a joint prior; not meant to be set directly.}
 
 \item{envir}{is the environment to look for R user functions
 (defaults to parent environment)}

--- a/man/rxode2.Rd
+++ b/man/rxode2.Rd
@@ -1320,6 +1320,97 @@ not expected behaviour.
 }
 
 }
+
+\subsection{Simulating from the priors}{
+
+\code{rxSolve()} uses the priors for its uncertainty simulation, which is
+what NONMEM does with \verb{$PRIOR NWPRI} and \verb{$PRIOR TNPRI}. Nothing extra
+has to be turned on: a model that carries priors uses them whenever
+variability is being simulated, that is when \code{nStud} is greater than one
+(or whatever \code{simVariability} forces).
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{one.cmt <- function() \{
+  ini(\{
+    tka <- 0.45
+    tcl <- 1
+    tv <- 3.45
+    eta.cl + eta.v ~ c(0.3,
+                       0.01, 0.1)
+    eta.ka ~ 0.6
+    add.sd <- 0.7
+    tka ~ 0.01                            # normal prior on tka
+    prior(eta.cl, eta.v) ~ invWishart(20) # degrees of freedom, per block
+    prior(eta.ka) ~ invWishart(4)
+  \})
+  model(\{
+    ka <- exp(tka + eta.ka)
+    cl <- exp(tcl + eta.cl)
+    v <- exp(tv + eta.v)
+    linCmt() ~ add(add.sd)
+  \})
+\}
+
+s <- rxSolve(one.cmt, ev, nSub = 10, nStud = 100)
+s$thetaMat   # the per study population parameter draws
+s$omegaList  # the per study omega, one draw per study
+}\if{html}{\out{</div>}}
+
+Each omega block is drawn with \strong{its own} degrees of freedom, which the
+single \code{dfSub} argument cannot express – above, the 2x2 block is drawn
+with 20 and the 1x1 with 4. A block with no prior is left at its point
+estimate. \code{dfWishart()} helps pick a degrees of freedom that matches a
+target relative standard error.
+\subsection{The prior mean is the estimate}{
+
+A draw is added to the value the model already gives, so a normal prior
+on a population parameter has to be centered on its estimate, and one on
+an omega element on that omega value. \code{tka ~ 0.01} is exactly that – the
+number is the variance and the mean comes from \code{tka <- 0.45}. Writing a
+prior centered somewhere else is an error rather than a simulation that
+quietly differs from what the model says:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{tka <- 0.45
+prior(tka) ~ dnorm(0, 0.1)
+#> Error: cannot simulate from the prior on 'tka' (dnorm(0, 0.1)): the
+#>   prior mean (0) is not the initial estimate (0.45)
+}\if{html}{\out{</div>}}
+}
+
+\subsection{A joint prior over the thetas and the omegas}{
+
+A \code{TNPRI} variance matrix covers the population parameters and the omega
+values together, with covariances between them. Prefix an omega element
+with \code{om.} to name it, and put both in one block:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{tcl + om.eta.cl ~ c(0.02,
+                    0.004, 0.005)
+}\if{html}{\out{</div>}}
+
+Drawn that way the omega is not guaranteed positive definite. A study
+whose draw is not gets the whole joint vector redrawn, up to
+\code{priorPdRetry} times (10 by default). If none of them is, the nearest
+positive definite matrix of the kept draws is used and \code{rxSolve()} warns
+– that projection lands on the boundary of the positive definite cone,
+so those studies are not draws from the stated prior. A model that
+reaches the fallback often wants a larger \code{priorPdRetry} or a tighter
+prior.
+}
+
+\subsection{Turning it off, and precedence}{
+
+\code{usePrior = FALSE} ignores the priors and falls back to a supplied
+\code{thetaMat}/\code{dfSub}; \code{usePrior = TRUE} requires them and says why if it
+cannot honor them. A \code{thetaMat}/\code{dfSub} carried in the model’s \code{meta}
+block loses to the priors, with a warning. One given at the call site
+wins over them instead, also with a warning – an explicit argument is
+never silently discarded.
+
+Prior simulation does not yet cover nested/occasion models (\verb{| id},
+\verb{| occ}) or a chunked solve (\verb{file =}/\verb{chunkSize =}); both are a clear
+error rather than a solve that quietly drops the prior.
+}
+
+}
 }
 \section{Note on strings in rxode2}{
 Strings are converted to double values inside of \code{rxode2}, hence you can

--- a/man/rxode2.Rd
+++ b/man/rxode2.Rd
@@ -1406,8 +1406,9 @@ wins over them instead, also with a warning – an explicit argument is
 never silently discarded.
 
 Prior simulation does not yet cover nested/occasion models (\verb{| id},
-\verb{| occ}) or a chunked solve (\verb{file =}/\verb{chunkSize =}); both are a clear
-error rather than a solve that quietly drops the prior.
+\verb{| occ}, rxode2 issue #1253) or a chunked solve
+(\verb{file =}/\verb{chunkSize =}, rxode2 issue #1252); both are a clear error
+rather than a solve that quietly drops the prior.
 }
 
 }

--- a/man/rxode2.Rd
+++ b/man/rxode2.Rd
@@ -1411,6 +1411,40 @@ Prior simulation does not yet cover nested/occasion models (\verb{| id},
 rather than a solve that quietly drops the prior.
 }
 
+\subsection{A thetaMat that already carries the omegas}{
+
+The same joint draw works without an \code{ini({})} prior, for a \code{thetaMat}
+that came from a covariance step. \code{nonmem2rx} gives one directly, and so
+does a nlmixr2 fit:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{mod <- nonmem2rx("run3.lst")
+colnames(mod$thetaMat)
+#> "t.CL" "GFRCL" ... "IIVCL" "omega1.2" "omega1.3" "IIVV1" ... "eps1" "sigma1.2"
+
+rxSolve(mod, data.sim, nStud = 100, omegaSeparation = "tnpri")
+}\if{html}{\out{</div>}}
+
+\code{omegaSeparation = "tnpri"} says those entries are the omega itself and
+should be drawn from the \code{thetaMat} jointly with the thetas, instead of
+having their correlations redrawn by the \code{lkj}/\code{separation} strategies –
+which discard the off-diagonal entries the covariance step measured, and
+cannot carry a covariance between a theta and an omega entry at all.
+\code{sigmaSeparation = "tnpri"} does the same for the residual entries.
+
+Columns are matched to entries by name, in whichever spelling produced
+them:\tabular{lll}{
+    \tab diagonal \tab off-diagonal \cr
+   nlmixr2 fit \verb{$cov} \tab \code{om.eta.cl} \tab \code{cov.eta.cl.eta.v} \cr
+   \code{nonmem2rx} \tab \code{eta.cl} \tab \code{omega1.2}, \code{omega.2.1} \cr
+}
+
+
+This is opt-in rather than automatic: an eta-named column already means
+that eta’s variance under the existing separation strategy, so it cannot
+change meaning on its own. \code{omega} has to be a matrix, since the drawn
+entries are added to it.
+}
+
 }
 }
 \section{Note on strings in rxode2}{

--- a/src/nearPD.h
+++ b/src/nearPD.h
@@ -8,6 +8,11 @@
 using namespace arma;
 
 
+// Nearest positive definite matrix.  Returns false when the projection
+// fails, and copies the input into `ret` when it does -- so the flag has
+// to be honored rather than the distance between the two.
+bool rxNearPD(arma::mat &ret, const arma::mat in);
+
 unsigned int rxNearPdChol(Rcpp::NumericMatrix &ret, Rcpp::NumericMatrix x,
                           bool isChol = false);
 

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -2063,21 +2063,99 @@ void rxSimTheta(CharacterVector &thetaN,
 // the cone and taking the closest projection then picks the least
 // positive definite draw, so a study that reaches it is not a draw from
 // the stated prior.  It warns for that reason.
+// Which thetaMat column carries each entry.  Matched by *name* rather
+// than by position: a column can be dropped before the draw (an item the
+// model does not have, or a zero variance), which would shift every index.
+static std::vector<int> rxPriorElCols(const CharacterVector &elN,
+                                      const CharacterVector &thetaN) {
+  std::vector<int> col(elN.size(), -1);
+  for (int r = 0; r < elN.size(); ++r) {
+    for (int j = 0; j < thetaN.size(); ++j) {
+      if (elN[r] == thetaN[j]) { col[r] = j; break; }
+    }
+  }
+  return col;
+}
+
+// One candidate matrix: the point estimate with the drawn deviation added
+// into each entry the prior names.  The matrix is symmetric, so an off
+// diagonal is written both ways.
+static arma::mat rxPriorCand(const arma::mat &cur, const arma::mat &base,
+                             const IntegerMatrix &el,
+                             const std::vector<int> &col,
+                             const NumericVector &dev, int dim) {
+  arma::mat cand = cur;
+  for (int r = 0; r < el.nrow(); ++r) {
+    if (col[r] < 0) continue;
+    int a = el(r, 0) - 1, b = el(r, 1) - 1;
+    if (a < 0 || b < 0 || a >= dim || b >= dim) continue;
+    cand(a, b) = base(a, b) + dev[col[r]];
+    cand(b, a) = cand(a, b);
+  }
+  return cand;
+}
+
+// The reason the matrix has to be positive definite is that the draw that
+// uses it takes its Cholesky, so that is the test.  `is_sympd()` is
+// stricter and would reject a projection that is perfectly usable.
+static bool rxPriorUsable(const arma::mat &m) {
+  arma::mat chk;
+  return arma::chol(chk, m);
+}
+
+// The fallback: project every kept draw onto the positive definite cone
+// and take the closest projection that worked.
+//
+// `rxNearPD()` copies its input into `ret` when it fails, which would give
+// a distance of zero and win the comparison -- so the flag decides, not the
+// distance.
+static bool rxPriorNearest(const std::vector<NumericVector> &keep,
+                           const arma::mat &cur, const arma::mat &base,
+                           const IntegerMatrix &el,
+                           const std::vector<int> &col, int dim,
+                           arma::mat &bestMat, NumericVector &bestDev) {
+  double best = -1.0;
+  for (size_t k = 0; k < keep.size(); ++k) {
+    arma::mat bad = rxPriorCand(cur, base, el, col, keep[k], dim);
+    arma::mat np;
+    if (!rxNearPD(np, 0.5 * (bad + bad.t()))) continue;
+    if (!rxPriorUsable(np)) continue;
+    double d = arma::norm(np - bad, "fro");
+    if (best < 0.0 || d < best) { best = d; bestMat = np; bestDev = keep[k]; }
+  }
+  return best >= 0.0;
+}
+
+// A pure TNPRI has no `cvPost()` draw to seed the list, so it arrives
+// empty; a model that also gives a block degrees of freedom does, and
+// those draws must not be thrown away.
+static void rxPriorSeedList(List &matList, const arma::mat &base,
+                            const CharacterVector &matN, int nStud) {
+  if (matList.size() != 0) return;
+  matList = List(nStud);
+  for (int i = 0; i < nStud; ++i) {
+    NumericMatrix cur = wrap(base);
+    cur.attr("dimnames") = List::create(matN, matN);
+    matList[i] = cur;
+  }
+}
+
 static void rxPriorJointMat(NumericMatrix &thetaM,
-                              CharacterVector &thetaN,
-                              List &omegaList,
-                              NumericMatrix &omegaM,
-                              CharacterVector &omegaN,
-                              const RObject &priorOmegaEl,
-                              const Nullable<NumericMatrix> &thetaMat,
-                              const Nullable<NumericVector> &thetaDf,
-                              const bool &thetaIsChol,
-                              const NumericVector &thetaLower,
-                              const NumericVector &thetaUpper,
-                              int nCoresRV,
-                              int nStud,
-                              int priorPdRetry,
-                              const char *what) {
+                            CharacterVector &thetaN,
+                            List &omegaList,
+                            NumericMatrix &omegaM,
+                            CharacterVector &omegaN,
+                            const RObject &priorOmegaEl,
+                            const Nullable<NumericMatrix> &thetaMat,
+                            const Nullable<NumericVector> &thetaDf,
+                            const bool &thetaIsChol,
+                            const NumericVector &thetaLower,
+                            const NumericVector &thetaUpper,
+                            int nCoresRV,
+                            int nStud,
+                            int priorPdRetry,
+                            const char *what) {
+  if (Rf_isNull(priorOmegaEl)) return;
   IntegerMatrix el = as<IntegerMatrix>(priorOmegaEl);
   if (el.nrow() == 0) return;
   RObject elDn = el.attr("dimnames");
@@ -2085,91 +2163,35 @@ static void rxPriorJointMat(NumericMatrix &thetaM,
     rxSolveFree();
     stop(_("'prior%sEl' must name its rows"), what);
   }
-  CharacterVector elN = as<CharacterVector>((as<List>(elDn))[0]);
-  // Match by name rather than by position: a thetaMat column can be
-  // dropped before the draw (an item the model does not have, or a zero
-  // variance), which would shift every index.
-  std::vector<int> col(el.nrow(), -1);
-  for (int r = 0; r < el.nrow(); ++r) {
-    for (int j = 0; j < thetaN.size(); ++j) {
-      if (elN[r] == thetaN[j]) { col[r] = j; break; }
-    }
-  }
+  std::vector<int> col = rxPriorElCols(as<CharacterVector>((as<List>(elDn))[0]),
+                                       thetaN);
   int dim = omegaN.size();
   arma::mat base = as<arma::mat>(omegaM);
-  // A pure TNPRI has no `cvPost()` draw to seed it, so the list arrives
-  // empty; a model that also gives a block degrees of freedom does, and
-  // those draws must not be thrown away.
-  if (omegaList.size() == 0) {
-    omegaList = List(nStud);
-    for (int i = 0; i < nStud; ++i) {
-      NumericMatrix cur = wrap(base);
-      cur.attr("dimnames") = List::create(omegaN, omegaN);
-      omegaList[i] = cur;
-    }
-  }
+  rxPriorSeedList(omegaList, base, omegaN, nStud);
   int nFallback = 0;
   for (int i = 0; i < nStud; ++i) {
     arma::mat cur = as<arma::mat>(as<NumericMatrix>(omegaList[i]));
     // attempt 0 is the row the joint draw already made -- do not waste it
     NumericVector dev = thetaM(i, _);
     std::vector<NumericVector> keep;
-    bool ok = false;
-    arma::mat cand = cur;
-    for (int k = 0; k < priorPdRetry; ++k) {
-      cand = cur;
-      for (int r = 0; r < el.nrow(); ++r) {
-        if (col[r] < 0) continue;
-        int a = el(r, 0) - 1, b = el(r, 1) - 1;
-        if (a < 0 || b < 0 || a >= dim || b >= dim) continue;
-        cand(a, b) = base(a, b) + dev[col[r]];
-        cand(b, a) = cand(a, b);
-      }
-      // the reason the omega has to be positive definite is that the
-      // eta draw takes its Cholesky, so that is the test -- `is_sympd()`
-      // is stricter and would reject a usable projection below
-      arma::mat chk;
-      if (arma::chol(chk, cand)) { ok = true; break; }
+    arma::mat cand = rxPriorCand(cur, base, el, col, dev, dim);
+    for (int k = 1; !rxPriorUsable(cand) && k <= priorPdRetry; ++k) {
       keep.push_back(dev);
-      if (k + 1 < priorPdRetry) {
-        NumericMatrix one =
-          as<NumericMatrix>(rxSimSigma(wrap(thetaMat), wrap(thetaDf), nCoresRV,
-                                       thetaIsChol, 1, true, thetaLower,
-                                       thetaUpper));
-        dev = one(0, _);
-      }
+      if (k == priorPdRetry) break;
+      // the WHOLE joint vector is redrawn, not just the failing entries
+      NumericMatrix one =
+        as<NumericMatrix>(rxSimSigma(wrap(thetaMat), wrap(thetaDf), nCoresRV,
+                                     thetaIsChol, 1, true, thetaLower,
+                                     thetaUpper));
+      dev = one(0, _);
+      cand = rxPriorCand(cur, base, el, col, dev, dim);
     }
-    if (!ok) {
-      // project every kept draw and take the closest one that projected
-      double best = -1.0;
-      arma::mat bestMat;
-      NumericVector bestDev;
-      for (size_t k = 0; k < keep.size(); ++k) {
-        arma::mat bad = cur;
-        for (int r = 0; r < el.nrow(); ++r) {
-          if (col[r] < 0) continue;
-          int a = el(r, 0) - 1, b = el(r, 1) - 1;
-          if (a < 0 || b < 0 || a >= dim || b >= dim) continue;
-          bad(a, b) = base(a, b) + keep[k][col[r]];
-          bad(b, a) = bad(a, b);
-        }
-        arma::mat np;
-        // rxNearPD() copies the input into `ret` when it fails, which
-        // would give a distance of zero and win -- so the flag decides,
-        // not the distance
-        if (!rxNearPD(np, 0.5 * (bad + bad.t()))) continue;
-        arma::mat chk;
-        if (!arma::chol(chk, np)) continue;
-        double d = arma::norm(np - bad, "fro");
-        if (best < 0.0 || d < best) { best = d; bestMat = np; bestDev = keep[k]; }
-      }
-      if (best < 0.0) {
+    if (!keep.empty() && !rxPriorUsable(cand)) {
+      if (!rxPriorNearest(keep, cur, base, el, col, dim, cand, dev)) {
         rxSolveFree();
         stop(_("could not draw a positive definite '%s' from the prior for study %d after %d tries"),
              what, i + 1, priorPdRetry);
       }
-      cand = bestMat;
-      dev = bestDev;
       nFallback++;
     }
     thetaM(i, _) = dev;
@@ -2479,7 +2501,7 @@ List rxSimThetaOmega0(const Nullable<NumericVector> &params    = R_NilValue,
   // The joint (TNPRI) draw runs here rather than in place of rxSimTheta():
   // `omegaList` does not exist until after `rxSimOmega()`, and this needs
   // both it and the drawn `thetaM`.
-  if (!Rf_isNull(priorOmegaEl) && simOmega && simVar) {
+  if (simOmega && simVar) {
     rxPriorJointMat(thetaM, thetaN, omegaList, omegaM, omegaN, priorOmegaEl,
                     thetaMat, thetaDf, thetaIsChol, thetaLower, thetaUpper,
                     nCoresRV, nStud, priorPdRetry, "omega");
@@ -2502,7 +2524,7 @@ List rxSimThetaOmega0(const Nullable<NumericVector> &params    = R_NilValue,
   // zero, so every gate that decides whether the drawn sigma is used has to
   // ask this instead
   bool sigmaByStudy = (dfObs > 0 || !Rf_isNull(priorSigmaEl));
-  if (!Rf_isNull(priorSigmaEl) && simSigma && simVar) {
+  if (simSigma && simVar) {
     rxPriorJointMat(thetaM, thetaN, sigmaList, sigmaM, sigmaN, priorSigmaEl,
                     thetaMat, thetaDf, thetaIsChol, thetaLower, thetaUpper,
                     nCoresRV, nStud, priorPdRetry, "sigma");

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -2071,7 +2071,8 @@ void rxSimOmega(bool &simOmega,
                 double dfSub = 0,
                 uint32_t nStud = 1,
                 uint32_t nSub = 1,
-                const LogicalVector &simVariability = LogicalVector::create(NA_LOGICAL)) {
+                const LogicalVector &simVariability = LogicalVector::create(NA_LOGICAL),
+                const RObject &priorOmega = R_NilValue) {
   int j;
   bool simVar;
   if (simVariability[0] == NA_LOGICAL) {
@@ -2146,7 +2147,27 @@ void rxSimOmega(bool &simOmega,
     }
   }
   if (simVar){
-    if (dfSub > 0 && simOmega) {
+    // `priorOmega` is the `ini({})` block's per block degrees of freedom,
+    // shaped as a 'lotri'.  `cvPost_()` already draws per block from one of
+    // those: it ignores the scalar `nu` argument and reads each block's own,
+    // then reassembles the full matrix -- which is the whole of the NWPRI
+    // omega half.  A block with no prior carries `nu = 1`, which is how
+    // `cvPost_()` spells "leave this one at its point estimate".
+    if (!Rf_isNull(priorOmega) && simOmega) {
+      RObject ol = _rxode2_cvPost_(as<SEXP>(R_NilValue),
+                                   as<SEXP>(priorOmega),
+                                   as<SEXP>(IntegerVector::create(nStud)),
+                                   as<SEXP>(LogicalVector::create(false)),
+                                   as<SEXP>(LogicalVector::create(false)),
+                                   as<SEXP>(IntegerVector::create(1)),
+                                   as<SEXP>(IntegerVector::create(1)));
+      // `cvPost_()` returns a bare matrix when n == 1 and a list otherwise
+      if (TYPEOF(ol) == VECSXP) {
+        omegaList = ol;
+      } else {
+        omegaList = List::create(ol);
+      }
+    } else if (dfSub > 0 && simOmega) {
       if (omegaSep) {
         int defaultType = 2;
         if (omegaSeparation == "auto"){
@@ -2314,7 +2335,15 @@ List rxSimThetaOmega0(const Nullable<NumericVector> &params    = R_NilValue,
   rxSimOmega(simOmega, omegaSep, omegaM, omegaN, omegaMC,
              omegaList, thetaN, thetaM, "omega", omega, omegaDf,
              omegaLower, omegaUpper, omegaIsChol,
-             omegaSeparation, omegaXform, dfSub, nStud, nSub, simVariability);
+             omegaSeparation, omegaXform, dfSub, nStud, nSub, simVariability,
+             priorOmega);
+  // Whether the omega varies by study at all.  `dfSub` is the only source
+  // today; a prior draw leaves it at 0, so every gate that decides whether
+  // the drawn matrix is used, exported, or handed to `simeta()` has to ask
+  // this instead -- otherwise the matrices are built and then silently
+  // thrown away.
+  bool omegaByStudy = (dfSub > 0 || !Rf_isNull(priorOmega) ||
+                       !Rf_isNull(priorOmegaEl));
   arma::mat tmp = as<arma::mat>(omegaM);
   if (tmp.is_zero()) {
     setZeroMatrix(2);
@@ -2381,7 +2410,7 @@ List rxSimThetaOmega0(const Nullable<NumericVector> &params    = R_NilValue,
     }
     // Now Omega Covariates
     if (ocol > 0) {
-      if (dfSub > 0 && simVar) {
+      if (omegaByStudy && simVar) {
         // nm = ret0[j]; // parameter column
         RObject ol = wrap(omegaList[i]);
         RObject nm0 = rxSimSigma(wrap(omegaList[i]), wrap(omegaDf), nCoresRV, false, nSub,
@@ -2452,7 +2481,7 @@ List rxSimThetaOmega0(const Nullable<NumericVector> &params    = R_NilValue,
   if (simTheta) {
     _rxModels[".theta"] = thetaM;
   }
-  if (dfSub > 0 && simVar) {
+  if (omegaByStudy && simVar) {
     _rxModels[".omegaL"] = omegaList;
     _rxModels[".omegaN"] = omegaN;
   } else if (Rf_isMatrix(omega)) {
@@ -2518,7 +2547,7 @@ List rxSimThetaOmega0(const Nullable<NumericVector> &params    = R_NilValue,
   } else {
     // Fill in omega information for simeta()
     arma::mat omega0;
-    if (dfSub > 0 && simVar) {
+    if (omegaByStudy && simVar) {
       omega0 = as<arma::mat>(omegaList[0]);
       rx->neta = omega0.n_rows;
       if (_globals.gomega != NULL) free(_globals.gomega);

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -2063,7 +2063,7 @@ void rxSimTheta(CharacterVector &thetaN,
 // the cone and taking the closest projection then picks the least
 // positive definite draw, so a study that reaches it is not a draw from
 // the stated prior.  It warns for that reason.
-static void rxPriorJointOmega(NumericMatrix &thetaM,
+static void rxPriorJointMat(NumericMatrix &thetaM,
                               CharacterVector &thetaN,
                               List &omegaList,
                               NumericMatrix &omegaM,
@@ -2076,13 +2076,14 @@ static void rxPriorJointOmega(NumericMatrix &thetaM,
                               const NumericVector &thetaUpper,
                               int nCoresRV,
                               int nStud,
-                              int priorPdRetry) {
+                              int priorPdRetry,
+                              const char *what) {
   IntegerMatrix el = as<IntegerMatrix>(priorOmegaEl);
   if (el.nrow() == 0) return;
   RObject elDn = el.attr("dimnames");
   if (Rf_isNull(elDn)) {
     rxSolveFree();
-    stop(_("'priorOmegaEl' must name its rows"));
+    stop(_("'prior%sEl' must name its rows"), what);
   }
   CharacterVector elN = as<CharacterVector>((as<List>(elDn))[0]);
   // Match by name rather than by position: a thetaMat column can be
@@ -2164,8 +2165,8 @@ static void rxPriorJointOmega(NumericMatrix &thetaM,
       }
       if (best < 0.0) {
         rxSolveFree();
-        stop(_("could not draw a positive definite 'omega' from the prior for study %d after %d tries"),
-             i + 1, priorPdRetry);
+        stop(_("could not draw a positive definite '%s' from the prior for study %d after %d tries"),
+             what, i + 1, priorPdRetry);
       }
       cand = bestMat;
       dev = bestDev;
@@ -2177,8 +2178,8 @@ static void rxPriorJointOmega(NumericMatrix &thetaM,
     omegaList[i] = out;
   }
   if (nFallback > 0) {
-    warning(_("%d of %d studies needed the nearest positive definite 'omega' after %d prior draws; those studies are not draws from the stated prior"),
-            nFallback, nStud, priorPdRetry);
+    warning(_("%d of %d studies needed the nearest positive definite '%s' after %d prior draws; those studies are not draws from the stated prior"),
+            nFallback, nStud, what, priorPdRetry);
   }
 }
 
@@ -2420,7 +2421,8 @@ List rxSimThetaOmega0(const Nullable<NumericVector> &params    = R_NilValue,
                      const LogicalVector &simVariability = LogicalVector::create(NA_LOGICAL),
                      const RObject &priorOmega = R_NilValue,
                      const RObject &priorOmegaEl = R_NilValue,
-                     int priorPdRetry = 10) {
+                     int priorPdRetry = 10,
+                     const RObject &priorSigmaEl = R_NilValue) {
   if (nSub > 0 && nStud > 0 && (int64_t)nSub * nStud > INT_MAX) {
     stop(_("the combination of subjects (%d) and studies (%d) is too large"), nSub, nStud);
   }
@@ -2478,9 +2480,9 @@ List rxSimThetaOmega0(const Nullable<NumericVector> &params    = R_NilValue,
   // `omegaList` does not exist until after `rxSimOmega()`, and this needs
   // both it and the drawn `thetaM`.
   if (!Rf_isNull(priorOmegaEl) && simOmega && simVar) {
-    rxPriorJointOmega(thetaM, thetaN, omegaList, omegaM, omegaN, priorOmegaEl,
-                      thetaMat, thetaDf, thetaIsChol, thetaLower, thetaUpper,
-                      nCoresRV, nStud, priorPdRetry);
+    rxPriorJointMat(thetaM, thetaN, omegaList, omegaM, omegaN, priorOmegaEl,
+                    thetaMat, thetaDf, thetaIsChol, thetaLower, thetaUpper,
+                    nCoresRV, nStud, priorPdRetry, "omega");
   }
   arma::mat tmp = as<arma::mat>(omegaM);
   if (tmp.is_zero()) {
@@ -2496,6 +2498,15 @@ List rxSimThetaOmega0(const Nullable<NumericVector> &params    = R_NilValue,
              sigmaList, thetaN, thetaM, "sigma", sigma, sigmaDf,
              sigmaLower, sigmaUpper, sigmaIsChol,
              sigmaSeparation, sigmaXform, dfObs, nStud, nObs, simVariability);
+  // the sigma equivalent of `omegaByStudy`: a joint draw leaves `dfObs` at
+  // zero, so every gate that decides whether the drawn sigma is used has to
+  // ask this instead
+  bool sigmaByStudy = (dfObs > 0 || !Rf_isNull(priorSigmaEl));
+  if (!Rf_isNull(priorSigmaEl) && simSigma && simVar) {
+    rxPriorJointMat(thetaM, thetaN, sigmaList, sigmaM, sigmaN, priorSigmaEl,
+                    thetaMat, thetaDf, thetaIsChol, thetaLower, thetaUpper,
+                    nCoresRV, nStud, priorPdRetry, "sigma");
+  }
 
   tmp = as<arma::mat>(sigmaM);
   if (tmp.is_zero()) {
@@ -2568,7 +2579,7 @@ List rxSimThetaOmega0(const Nullable<NumericVector> &params    = R_NilValue,
     }
     if (scol > 0) {
       if (simSubjects) {
-        if (dfObs > 0  && simVar) {
+        if (sigmaByStudy && simVar) {
           nm1 = as<NumericMatrix>(rxSimSigma(as<RObject>(sigmaList[i]), as<RObject>(sigmaDf), nCoresRV, false, nObs*nSub,
                                              false, sigmaLower, sigmaUpper));
         } else {
@@ -2582,7 +2593,7 @@ List rxSimThetaOmega0(const Nullable<NumericVector> &params    = R_NilValue,
           }
         }
       } else {
-        if (dfObs > 0  && simVar) {
+        if (sigmaByStudy && simVar) {
           nm1 = as<NumericMatrix>(rxSimSigma(as<RObject>(sigmaList[i]), as<RObject>(sigmaDf), nCoresRV, false, nObs,
                                              false, sigmaLower, sigmaUpper));
         } else {
@@ -2625,14 +2636,14 @@ List rxSimThetaOmega0(const Nullable<NumericVector> &params    = R_NilValue,
   } else if (Rf_isMatrix(omega)) {
     _rxModels[".omegaN"]= as<CharacterVector>((as<List>((as<NumericMatrix>(omega)).attr("dimnames")))[1]);
   }
-  if (dfObs > 0 && simVar) {
+  if (sigmaByStudy && simVar) {
     _rxModels[".sigmaL"] = sigmaList;
   }
   if (Rf_isNull(sigma) || rxIsChar(sigma) || Rf_length(sigma) == 0) {
   } else {
     // Fill in sigma information for simeta()
     arma::mat sigma0;
-    if (dfObs > 0 && simVar) {
+    if (sigmaByStudy && simVar) {
       sigma0 = as<arma::mat>(sigmaList[0]);
       if (_globals.gsigma != NULL) free(_globals.gsigma);
       rx->neps = sigma0.n_rows;
@@ -2782,7 +2793,7 @@ List rxSimThetaOmega(const Nullable<NumericVector> &params    = R_NilValue,
                           sigmaDf, sigmaIsChol, sigmaSeparation, sigmaXform,
                           nCoresRV, nObs, dfSub, dfObs, simSubjects,
                           simVariability,
-                          R_NilValue, R_NilValue, 10);
+                          R_NilValue, R_NilValue, 10, R_NilValue);
 }
 
 #define defrx_params R_NilValue
@@ -3987,7 +3998,8 @@ static inline void rxSolve_simulate(const RObject &obj,
                                simVariability,
                                rxControl[Rxc_priorOmega],
                                rxControl[Rxc_priorOmegaEl],
-                               asInt(rxControl[Rxc_priorPdRetry], "priorPdRetry"));
+                               asInt(rxControl[Rxc_priorPdRetry], "priorPdRetry"),
+                               rxControl[Rxc_priorSigmaEl]);
     if (cbindPar1) {
       lst = cbindThetaOmega(rxSolveDat->par1, lst);
       rxSolveDat->par1cbind = true;

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -2052,6 +2052,136 @@ void rxSimTheta(CharacterVector &thetaN,
 }
 
 
+// A NONMEM TNPRI draws the omega *elements* as part of one joint normal
+// with the thetas.  Drawn that way the omega is not guaranteed positive
+// definite, so a study whose draw is not gets the whole joint vector
+// redrawn, up to `priorPdRetry` times.  If none of them is, every kept
+// draw is projected onto the positive definite cone and the closest
+// projection is used.
+//
+// That fallback is biased: `rxNearPD()` projects onto the *boundary* of
+// the cone and taking the closest projection then picks the least
+// positive definite draw, so a study that reaches it is not a draw from
+// the stated prior.  It warns for that reason.
+static void rxPriorJointOmega(NumericMatrix &thetaM,
+                              CharacterVector &thetaN,
+                              List &omegaList,
+                              NumericMatrix &omegaM,
+                              CharacterVector &omegaN,
+                              const RObject &priorOmegaEl,
+                              const Nullable<NumericMatrix> &thetaMat,
+                              const Nullable<NumericVector> &thetaDf,
+                              const bool &thetaIsChol,
+                              const NumericVector &thetaLower,
+                              const NumericVector &thetaUpper,
+                              int nCoresRV,
+                              int nStud,
+                              int priorPdRetry) {
+  IntegerMatrix el = as<IntegerMatrix>(priorOmegaEl);
+  if (el.nrow() == 0) return;
+  RObject elDn = el.attr("dimnames");
+  if (Rf_isNull(elDn)) {
+    rxSolveFree();
+    stop(_("'priorOmegaEl' must name its rows"));
+  }
+  CharacterVector elN = as<CharacterVector>((as<List>(elDn))[0]);
+  // Match by name rather than by position: a thetaMat column can be
+  // dropped before the draw (an item the model does not have, or a zero
+  // variance), which would shift every index.
+  std::vector<int> col(el.nrow(), -1);
+  for (int r = 0; r < el.nrow(); ++r) {
+    for (int j = 0; j < thetaN.size(); ++j) {
+      if (elN[r] == thetaN[j]) { col[r] = j; break; }
+    }
+  }
+  int dim = omegaN.size();
+  arma::mat base = as<arma::mat>(omegaM);
+  // A pure TNPRI has no `cvPost()` draw to seed it, so the list arrives
+  // empty; a model that also gives a block degrees of freedom does, and
+  // those draws must not be thrown away.
+  if (omegaList.size() == 0) {
+    omegaList = List(nStud);
+    for (int i = 0; i < nStud; ++i) {
+      NumericMatrix cur = wrap(base);
+      cur.attr("dimnames") = List::create(omegaN, omegaN);
+      omegaList[i] = cur;
+    }
+  }
+  int nFallback = 0;
+  for (int i = 0; i < nStud; ++i) {
+    arma::mat cur = as<arma::mat>(as<NumericMatrix>(omegaList[i]));
+    // attempt 0 is the row the joint draw already made -- do not waste it
+    NumericVector dev = thetaM(i, _);
+    std::vector<NumericVector> keep;
+    bool ok = false;
+    arma::mat cand = cur;
+    for (int k = 0; k < priorPdRetry; ++k) {
+      cand = cur;
+      for (int r = 0; r < el.nrow(); ++r) {
+        if (col[r] < 0) continue;
+        int a = el(r, 0) - 1, b = el(r, 1) - 1;
+        if (a < 0 || b < 0 || a >= dim || b >= dim) continue;
+        cand(a, b) = base(a, b) + dev[col[r]];
+        cand(b, a) = cand(a, b);
+      }
+      // the reason the omega has to be positive definite is that the
+      // eta draw takes its Cholesky, so that is the test -- `is_sympd()`
+      // is stricter and would reject a usable projection below
+      arma::mat chk;
+      if (arma::chol(chk, cand)) { ok = true; break; }
+      keep.push_back(dev);
+      if (k + 1 < priorPdRetry) {
+        NumericMatrix one =
+          as<NumericMatrix>(rxSimSigma(wrap(thetaMat), wrap(thetaDf), nCoresRV,
+                                       thetaIsChol, 1, true, thetaLower,
+                                       thetaUpper));
+        dev = one(0, _);
+      }
+    }
+    if (!ok) {
+      // project every kept draw and take the closest one that projected
+      double best = -1.0;
+      arma::mat bestMat;
+      NumericVector bestDev;
+      for (size_t k = 0; k < keep.size(); ++k) {
+        arma::mat bad = cur;
+        for (int r = 0; r < el.nrow(); ++r) {
+          if (col[r] < 0) continue;
+          int a = el(r, 0) - 1, b = el(r, 1) - 1;
+          if (a < 0 || b < 0 || a >= dim || b >= dim) continue;
+          bad(a, b) = base(a, b) + keep[k][col[r]];
+          bad(b, a) = bad(a, b);
+        }
+        arma::mat np;
+        // rxNearPD() copies the input into `ret` when it fails, which
+        // would give a distance of zero and win -- so the flag decides,
+        // not the distance
+        if (!rxNearPD(np, 0.5 * (bad + bad.t()))) continue;
+        arma::mat chk;
+        if (!arma::chol(chk, np)) continue;
+        double d = arma::norm(np - bad, "fro");
+        if (best < 0.0 || d < best) { best = d; bestMat = np; bestDev = keep[k]; }
+      }
+      if (best < 0.0) {
+        rxSolveFree();
+        stop(_("could not draw a positive definite 'omega' from the prior for study %d after %d tries"),
+             i + 1, priorPdRetry);
+      }
+      cand = bestMat;
+      dev = bestDev;
+      nFallback++;
+    }
+    thetaM(i, _) = dev;
+    NumericMatrix out = wrap(cand);
+    out.attr("dimnames") = List::create(omegaN, omegaN);
+    omegaList[i] = out;
+  }
+  if (nFallback > 0) {
+    warning(_("%d of %d studies needed the nearest positive definite 'omega' after %d prior draws; those studies are not draws from the stated prior"),
+            nFallback, nStud, priorPdRetry);
+  }
+}
+
 void rxSimOmega(bool &simOmega,
                 bool &omegaSep,
                 NumericMatrix &omegaM,
@@ -2344,6 +2474,14 @@ List rxSimThetaOmega0(const Nullable<NumericVector> &params    = R_NilValue,
   // thrown away.
   bool omegaByStudy = (dfSub > 0 || !Rf_isNull(priorOmega) ||
                        !Rf_isNull(priorOmegaEl));
+  // The joint (TNPRI) draw runs here rather than in place of rxSimTheta():
+  // `omegaList` does not exist until after `rxSimOmega()`, and this needs
+  // both it and the drawn `thetaM`.
+  if (!Rf_isNull(priorOmegaEl) && simOmega && simVar) {
+    rxPriorJointOmega(thetaM, thetaN, omegaList, omegaM, omegaN, priorOmegaEl,
+                      thetaMat, thetaDf, thetaIsChol, thetaLower, thetaUpper,
+                      nCoresRV, nStud, priorPdRetry);
+  }
   arma::mat tmp = as<arma::mat>(omegaM);
   if (tmp.is_zero()) {
     setZeroMatrix(2);

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -2233,24 +2233,13 @@ arma::mat getArmaMat(int type, int csim, rx_solve* rx) {
   }
 }
 
-//' Simulate Parameters from a Theta/Omega specification
-//'
-//' @param params Named Vector of rxode2 model parameters
-//'
-//' @param nObs Number of observations to simulate (with `sigma` matrix)
-//'
-//' @inheritParams rxSolve
-//'
-//' @param simSubjects boolean indicated rxode2 should simulate subjects in studies (`TRUE`,
-//'         default) or studies (`FALSE`)
-//'
-//' @return a data frame with the simulated subjects
-//'
-//' @author Matthew L.Fidler
-//'
-//' @export
-//[[Rcpp::export]]
-List rxSimThetaOmega(const Nullable<NumericVector> &params    = R_NilValue,
+// The exported `rxSimThetaOmega()` below is frozen at 28 arguments: it is
+// registered with that arity in `src/init.c`, re-exported through
+// `R_RegisterCCallable()` and declared in `inst/include/rxode2_RcppExports.h`,
+// so changing its signature would break every already-built reverse
+// dependency.  The prior simulation arguments go on this internal one
+// instead, and the exported function forwards defaults for them.
+List rxSimThetaOmega0(const Nullable<NumericVector> &params    = R_NilValue,
                      const RObject &omega= R_NilValue,
                      const Nullable<NumericVector> &omegaDf= R_NilValue,
                      const NumericVector &omegaLower = NumericVector::create(R_NegInf),
@@ -2277,7 +2266,10 @@ List rxSimThetaOmega(const Nullable<NumericVector> &params    = R_NilValue,
                      double dfSub = 0,
                      double dfObs = 0,
                      bool simSubjects=true,
-                     const LogicalVector &simVariability = LogicalVector::create(NA_LOGICAL)) {
+                     const LogicalVector &simVariability = LogicalVector::create(NA_LOGICAL),
+                     const RObject &priorOmega = R_NilValue,
+                     const RObject &priorOmegaEl = R_NilValue,
+                     int priorPdRetry = 10) {
   if (nSub > 0 && nStud > 0 && (int64_t)nSub * nStud > INT_MAX) {
     stop(_("the combination of subjects (%d) and studies (%d) is too large"), nSub, nStud);
   }
@@ -2569,6 +2561,61 @@ List rxSimThetaOmega(const Nullable<NumericVector> &params    = R_NilValue,
     // matrix list (n x n;  nStud matrices)
   }
   return ret0;
+}
+
+//' Simulate Parameters from a Theta/Omega specification
+//'
+//' @param params Named Vector of rxode2 model parameters
+//'
+//' @param nObs Number of observations to simulate (with `sigma` matrix)
+//'
+//' @inheritParams rxSolve
+//'
+//' @param simSubjects boolean indicated rxode2 should simulate subjects in studies (`TRUE`,
+//'         default) or studies (`FALSE`)
+//'
+//' @return a data frame with the simulated subjects
+//'
+//' @author Matthew L.Fidler
+//'
+//' @export
+//[[Rcpp::export]]
+List rxSimThetaOmega(const Nullable<NumericVector> &params    = R_NilValue,
+                     const RObject &omega= R_NilValue,
+                     const Nullable<NumericVector> &omegaDf= R_NilValue,
+                     const NumericVector &omegaLower = NumericVector::create(R_NegInf),
+                     const NumericVector &omegaUpper = NumericVector::create(R_PosInf),
+                     const bool &omegaIsChol = false,
+                     std::string omegaSeparation= "auto",//("lkj", "separation")
+                     const int omegaXform = 1,
+                     int nSub = 1,
+                     const Nullable<NumericMatrix> &thetaMat = R_NilValue,
+                     const NumericVector &thetaLower = NumericVector::create(R_NegInf),
+                     const NumericVector &thetaUpper = NumericVector::create(R_PosInf),
+                     const Nullable<NumericVector> &thetaDf  = R_NilValue,
+                     const bool &thetaIsChol = false,
+                     int nStud = 1,
+                     const RObject sigma = R_NilValue,
+                     const NumericVector &sigmaLower = NumericVector::create(R_NegInf),
+                     const NumericVector &sigmaUpper = NumericVector::create(R_PosInf),
+                     const Nullable<NumericVector> &sigmaDf= R_NilValue,
+                     const bool &sigmaIsChol = false,
+                     std::string sigmaSeparation= "auto",//("lkj", "separation")
+                     const int sigmaXform = 1,
+                     int nCoresRV = 1,
+                     int nObs = 1,
+                     double dfSub = 0,
+                     double dfObs = 0,
+                     bool simSubjects=true,
+                     const LogicalVector &simVariability = LogicalVector::create(NA_LOGICAL)) {
+  return rxSimThetaOmega0(params, omega, omegaDf, omegaLower, omegaUpper,
+                          omegaIsChol, omegaSeparation, omegaXform, nSub,
+                          thetaMat, thetaLower, thetaUpper, thetaDf,
+                          thetaIsChol, nStud, sigma, sigmaLower, sigmaUpper,
+                          sigmaDf, sigmaIsChol, sigmaSeparation, sigmaXform,
+                          nCoresRV, nObs, dfSub, dfObs, simSubjects,
+                          simVariability,
+                          R_NilValue, R_NilValue, 10);
 }
 
 #define defrx_params R_NilValue
@@ -3750,7 +3797,7 @@ static inline void rxSolve_simulate(const RObject &obj,
     if (!cbindPar1) {
       params0 = as<Nullable<NumericVector>>(rxSolveDat->par1);
     }
-    List lst = rxSimThetaOmega(params0,
+    List lst = rxSimThetaOmega0(params0,
                                omega,
                                omegaDf,
                                asNv(rxControl[Rxc_omegaLower], "omegaLower"),
@@ -3770,7 +3817,10 @@ static inline void rxSolve_simulate(const RObject &obj,
                                asInt(rxControl[Rxc_sigmaXform], "sigmaXform"),
                                nCoresRV, curObs,
                                dfSub, dfObs, simSubjects,
-                               simVariability);
+                               simVariability,
+                               rxControl[Rxc_priorOmega],
+                               rxControl[Rxc_priorOmegaEl],
+                               asInt(rxControl[Rxc_priorPdRetry], "priorPdRetry"));
     if (cbindPar1) {
       lst = cbindThetaOmega(rxSolveDat->par1, lst);
       rxSolveDat->par1cbind = true;

--- a/tests/testthat/test-prior-sim-nwpri.R
+++ b/tests/testthat/test-prior-sim-nwpri.R
@@ -48,7 +48,7 @@ rxTest({
     })
   }
 
-  .ev <- function() et(amt=100) %>% et(seq(0, 24, by=8))
+  .ev <- function() et(amt=100) |> et(seq(0, 24, by=8))
 
   test_that("the population parameters are drawn from their prior", {
     skip_if_not(.hasPriorSupport())

--- a/tests/testthat/test-prior-sim-nwpri.R
+++ b/tests/testthat/test-prior-sim-nwpri.R
@@ -1,0 +1,169 @@
+rxTest({
+
+  ## Simulating from the `ini({})` block priors: a multivariate normal on
+  ## the population parameters plus an inverse Wishart on each omega
+  ## block, with its own degrees of freedom.  This is what NONMEM calls
+  ## NWPRI.
+
+  .hasPriorSupport <- function() {
+    exists("lotriPriorDists", envir=asNamespace("lotri"), inherits=FALSE)
+  }
+
+  .mod <- function() {
+    rxode2(function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1.0
+        tv <- 3.45
+        eta.cl + eta.v ~ c(0.3,
+                           0.01, 0.1)
+        eta.ka ~ 0.6
+        add.sd <- 0.7
+        tka ~ 0.01
+        prior(eta.cl, eta.v) ~ invWishart(200)
+        prior(eta.ka) ~ invWishart(4)
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    })
+  }
+
+  .plain <- function() {
+    rxode2(function() {
+      ini({
+        tka <- 0.45
+        add.sd <- 0.7
+        eta.ka ~ 0.6
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- 1
+        v <- 1
+        linCmt() ~ add(add.sd)
+      })
+    })
+  }
+
+  .ev <- function() et(amt=100) %>% et(seq(0, 24, by=8))
+
+  test_that("the population parameters are drawn from their prior", {
+    skip_if_not(.hasPriorSupport())
+
+    withr::with_seed(7, {
+      .s <- rxSolve(.mod(), .ev(), nSub=2, nStud=500)
+    })
+
+    ## `$thetaMat` on a solve is the per study *deviation* that is added to
+    ## the parameter, so it is zero mean by construction -- which is why
+    ## the prior mean has to be the estimate for the two to agree
+    expect_equal(dim(.s$thetaMat), c(500L, 1L))
+    expect_equal(colnames(.s$thetaMat), "tka")
+    expect_equal(mean(.s$thetaMat[, "tka"]), 0, tolerance=0.02)
+
+    ## `tka ~ 0.01` is centered on the estimate with a variance of 0.01
+    .tka <- unique(.s$params$tka)
+    expect_equal(length(.tka), 500L)
+    expect_equal(mean(.tka), 0.45, tolerance=0.02)
+    expect_equal(sd(.tka), 0.1, tolerance=0.02)
+  })
+
+  test_that("each omega block is drawn with its own degrees of freedom", {
+    skip_if_not(.hasPriorSupport())
+
+    withr::with_seed(7, {
+      .s <- rxSolve(.mod(), .ev(), nSub=2, nStud=500)
+    })
+
+    ## every gate that decides whether the drawn omega is used has to move
+    ## off `dfSub`, which a prior draw leaves at zero -- otherwise the
+    ## matrices are built and then silently thrown away
+    expect_equal(length(.s$omegaList), 500L)
+
+    .cl <- vapply(.s$omegaList, function(m) m["eta.cl", "eta.cl"], double(1))
+    .ka <- vapply(.s$omegaList, function(m) m["eta.ka", "eta.ka"], double(1))
+
+    ## the 1x1 block has 4 degrees of freedom and the 2x2 has 200, so it
+    ## is far more variable; a single shared `dfSub` could not do this
+    expect_true(sd(.ka) / 0.6 > 4 * (sd(.cl) / 0.3))
+
+    ## and they are centered on the omega the model gives
+    expect_equal(mean(.cl), 0.3, tolerance=0.1)
+
+    ## a draw from an inverse Wishart is positive definite
+    expect_true(all(vapply(.s$omegaList,
+                           function(m) all(eigen(m)$values > 0), logical(1))))
+  })
+
+  test_that("the between subject variability uses the per study omega", {
+    skip_if_not(.hasPriorSupport())
+
+    withr::with_seed(7, {
+      .s <- rxSolve(.mod(), .ev(), nSub=2, nStud=200)
+    })
+
+    ## the etas have to come from `omegaList[[i]]` rather than the point
+    ## estimate, which is a separate gate from the one above
+    expect_gt(length(unique(round(.s$params$eta.ka, 8))), 10L)
+  })
+
+  test_that("usePrior=FALSE reproduces the unpriored solve", {
+    skip_if_not(.hasPriorSupport())
+
+    withr::with_seed(7, {
+      .off <- rxSolve(.mod(), .ev(), nSub=2, nStud=20, usePrior=FALSE)
+    })
+    withr::with_seed(7, {
+      .none <- rxSolve(.plain(), .ev(), nSub=2, nStud=20)
+    })
+
+    ## no thetaMat and no per study omega, exactly as before priors existed
+    expect_equal(length(.off$omegaList), 0L)
+    expect_true(is.null(.off$thetaMat) || length(.off$thetaMat) == 0L)
+    expect_equal(length(.none$omegaList), 0L)
+  })
+
+  test_that("a thetaMat given at the call site wins over the priors", {
+    skip_if_not(.hasPriorSupport())
+
+    .m <- matrix(1, 1, 1, dimnames=list("tka", "tka"))
+    expect_warning({
+      withr::with_seed(1, {
+        .s <- rxSolve(.mod(), .ev(), nSub=2, nStud=200, thetaMat=.m)
+      })
+    }, "were not used")
+
+    ## an explicit argument is never silently discarded, so the spread is
+    ## the one that was asked for and not the prior's 0.1
+    expect_gt(sd(.s$thetaMat[, "tka"]), 0.5)
+  })
+
+  test_that("usePrior=TRUE says why when it cannot be honored", {
+    skip_if_not(.hasPriorSupport())
+
+    expect_error(rxSolve(.plain(), .ev(), nSub=2, nStud=5, usePrior=TRUE),
+                 "specifies no prior")
+    expect_error(rxSolve(.mod(), .ev(), nSub=2, nStud=1, usePrior=TRUE),
+                 "no variability would be simulated")
+  })
+
+  test_that("simVariability decides whether the priors apply, not nStud", {
+    skip_if_not(.hasPriorSupport())
+
+    ## the C++ side resolves `simVar` from `simVariability` first and only
+    ## falls back to `nStud > 1`, so the R side has to agree or the priors
+    ## are dropped in one direction and wasted in the other
+    withr::with_seed(7, {
+      .s <- rxSolve(.mod(), .ev(), nSub=2, nStud=1, simVariability=TRUE)
+    })
+    expect_equal(length(.s$omegaList), 1L)
+
+    withr::with_seed(7, {
+      .s <- rxSolve(.mod(), .ev(), nSub=2, nStud=20, simVariability=FALSE)
+    })
+    expect_equal(length(.s$omegaList), 0L)
+  })
+})

--- a/tests/testthat/test-prior-sim-spec.R
+++ b/tests/testthat/test-prior-sim-spec.R
@@ -1,0 +1,192 @@
+rxTest({
+
+  .rx <- loadNamespace("rxode2")
+
+  ## The `prior` column only exists when the installed 'lotri' supports
+  ## prior distributions, so the real-syntax tests are gated on it.  The
+  ## rest fabricate the column by hand, the way test-assert-priors.R does,
+  ## so they still run against an older 'lotri'.
+  .hasPriorSupport <- function() {
+    exists("lotriPriorDists", envir=asNamespace("lotri"), inherits=FALSE)
+  }
+
+  .withPrior <- function(ui, name, prior) {
+    ui <- rxUiDecompress(ui)
+    .ini <- ui$iniDf
+    if (!any(names(.ini) == "prior")) .ini$prior <- NA_character_
+    .ini$prior[match(name, .ini$name)] <- prior
+    assign("iniDf", .ini, envir=ui)
+    ui
+  }
+
+  .base <- function() {
+    rxode2(function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        eta.cl + eta.v ~ c(0.3,
+                           0.01, 0.1)
+        eta.ka ~ 0.6
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    })
+  }
+
+  test_that("a model with no priors has no spec", {
+    expect_null(.rx$.rxPriorSimSpec(.base(), list()))
+  })
+
+  test_that("a normal prior becomes a one entry thetaMat", {
+    .u <- .withPrior(.base(), "tka", "dnorm(0.45, 0.1)")
+    .s <- .rx$.rxPriorSimSpec(.u, list())
+
+    expect_equal(dimnames(.s$thetaMat), list("tka", "tka"))
+    ## the variance is the square of the sd the prior gives
+    expect_equal(unname(.s$thetaMat[1, 1]), 0.01)
+    expect_equal(.s$theta$est, 0.45)
+    expect_equal(length(.s$omegaNu), 0L)
+  })
+
+  test_that("a multivariate normal prior becomes a block of the thetaMat", {
+    .u <- .withPrior(.base(), c("tcl", "tv"),
+                     "multiNormal(c(1, 3.45), lotri(tcl + tv ~ c(0.02, 0.001, 0.03)))")
+    .s <- .rx$.rxPriorSimSpec(.u, list())
+
+    expect_equal(dimnames(.s$thetaMat), list(c("tcl", "tv"), c("tcl", "tv")))
+    expect_equal(unname(.s$thetaMat),
+                 matrix(c(0.02, 0.001, 0.001, 0.03), 2, 2))
+  })
+
+  test_that("independent priors give a block diagonal thetaMat", {
+    .u <- .withPrior(.base(), "tka", "dnorm(0.45, 0.1)")
+    .u <- .withPrior(.u, c("tcl", "tv"),
+                     "multiNormal(c(1, 3.45), lotri(tcl + tv ~ c(0.02, 0.001, 0.03)))")
+    .s <- .rx$.rxPriorSimSpec(.u, list())
+
+    expect_equal(dimnames(.s$thetaMat)[[1]], c("tka", "tcl", "tv"))
+    ## the two priors say nothing about each other, so the off diagonal
+    ## between them is zero
+    expect_equal(unname(.s$thetaMat[1, 2:3]), c(0, 0))
+    expect_equal(unname(.s$thetaMat[2, 3]), 0.001)
+  })
+
+  test_that("the prior mean has to be the initial estimate", {
+    ## prior simulation samples around what the model says the parameter
+    ## is, so a prior centered anywhere else is an error rather than a
+    ## silently different simulation
+    .u <- .withPrior(.base(), "tka", "dnorm(0, 2)")
+    expect_error(.rx$.rxPriorSimSpec(.u, list()), "is not the initial estimate")
+
+    .u <- .withPrior(.base(), c("tcl", "tv"),
+                     "multiNormal(c(9, 3.45), lotri(tcl + tv ~ c(0.02, 0.001, 0.03)))")
+    expect_error(.rx$.rxPriorSimSpec(.u, list()), "is not the initial estimate")
+  })
+
+  test_that("each omega block keeps its own degrees of freedom", {
+    .u <- .withPrior(.base(), "eta.cl", "invWishart(20)")
+    .u <- .withPrior(.u, "eta.ka", "invWishart(4)")
+    .s <- .rx$.rxPriorSimSpec(.u, list())
+
+    expect_equal(length(.s$omegaNu), 2L)
+    expect_equal(.s$omegaNu[[1]]$names, c("eta.cl", "eta.v"))
+    expect_equal(.s$omegaNu[[1]]$nu, 20)
+    expect_equal(.s$omegaNu[[2]]$names, "eta.ka")
+    expect_equal(.s$omegaNu[[2]]$nu, 4)
+  })
+
+  test_that("an improper inverse Wishart on a block is an error", {
+    ## a 2x2 block needs more than 1 degree of freedom; 'lotri' checks
+    ## this when the prior is written, but a piped model can dodge it
+    .u <- .withPrior(.base(), "eta.cl", "invWishart(1)")
+    expect_error(.rx$.rxPriorSimSpec(.u, list()), "degrees of freedom")
+  })
+
+  test_that("a distribution that cannot be simulated from is an error", {
+    ## a prior must never be silently ignored
+    .u <- .withPrior(.base(), "tka", "dgamma(2, 1)")
+    expect_error(.rx$.rxPriorSimSpec(.u, list()),
+                 "only normal and multivariate normal")
+  })
+
+  test_that("a normal prior on the omega values is rejected for now", {
+    ## a NONMEM TNPRI, which lands on the omega row
+    .u <- .withPrior(.base(), "eta.ka", "dnorm(0, 0.1)")
+    expect_error(.rx$.rxPriorSimSpec(.u, list()), "TNPRI")
+
+    ## and the joint form, which lands wherever the block starts
+    .u <- .withPrior(.base(), "tcl",
+                     "multiNormal(c(1, 0.6), lotri(tcl + om.eta.ka ~ c(0.02, 0.001, 0.03)))")
+    expect_error(.rx$.rxPriorSimSpec(.u, list()), "TNPRI")
+  })
+
+  test_that("a chunked solve with priors is an error", {
+    ## the chunked path pre-draws its parameters and strips the omega
+    ## from each chunk, so the prior would never be drawn from
+    .u <- .withPrior(.base(), "tka", "dnorm(0.45, 0.1)")
+    expect_error(.rx$.rxPriorSimSpec(.u, list(chunkSize=1e5)), "chunked solve")
+    expect_error(.rx$.rxPriorSimSpec(.u, list(file="out.parquet")),
+                 "chunked solve")
+  })
+
+  test_that("a nested or occasion model with priors is an error", {
+    skip_if_not(.hasPriorSupport())
+
+    .u <- rxode2(function() {
+      ini({
+        tcl <- 1
+        add.sd <- 0.7
+        eta.cl ~ 0.3 | id
+        eta.o ~ 0.1 | occ
+        prior(eta.cl) ~ invWishart(4)
+      })
+      model({
+        ka <- 1
+        cl <- exp(tcl + eta.cl + eta.o)
+        v <- 1
+        linCmt() ~ add(add.sd)
+      })
+    })
+
+    expect_error(.rx$.rxPriorSimSpec(.u, list()), "nested/occasion")
+  })
+
+  test_that("the ini({}) syntax reaches the spec end to end", {
+    skip_if_not(.hasPriorSupport())
+
+    .u <- rxode2(function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        eta.cl + eta.v ~ c(0.3,
+                           0.01, 0.1)
+        eta.ka ~ 0.6
+        add.sd <- 0.7
+        tka ~ 0.01
+        prior(eta.cl, eta.v) ~ invWishart(20)
+        prior(eta.ka) ~ invWishart(4)
+      })
+      model({
+        ka <- exp(tka + eta.ka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    })
+
+    .s <- .rx$.rxPriorSimSpec(.u, list())
+
+    ## `tka ~ 0.01` is the shorthand: mean is the estimate, and the
+    ## number is the variance
+    expect_equal(dimnames(.s$thetaMat), list("tka", "tka"))
+    expect_equal(unname(.s$thetaMat[1, 1]), 0.01)
+    expect_equal(vapply(.s$omegaNu, function(x) x$nu, double(1)), c(20, 4))
+  })
+})

--- a/tests/testthat/test-prior-sim-spec.R
+++ b/tests/testthat/test-prior-sim-spec.R
@@ -115,17 +115,24 @@ rxTest({
                  "only normal and multivariate normal")
   })
 
-  test_that("a normal prior on the omega values is rejected for now", {
+  test_that("a normal prior on the omega values reaches the spec", {
     ## a NONMEM TNPRI, which lands on the omega row.  `eta.ka` is 0.6, and
     ## an omega element prior is centered on the omega value the same way
     ## a theta one is centered on its estimate
     .u <- .withPrior(.base(), "eta.ka", "dnorm(0.6, 0.1)")
-    expect_error(.rx$.rxPriorSimSpec(.u, list()), "TNPRI")
+    .s <- .rx$.rxPriorSimSpec(.u, list())
+
+    expect_equal(dimnames(.s$thetaMat)[[1]], "om.eta.ka")
+    expect_equal(unname(.s$thetaMat[1, 1]), 0.01)
+    expect_equal(.s$omegaEl$name, "om.eta.ka")
 
     ## and the joint form, which lands wherever the block starts
     .u <- .withPrior(.base(), "tcl",
                      "multiNormal(c(1, 0.6), lotri(tcl + om.eta.ka ~ c(0.02, 0.001, 0.03)))")
-    expect_error(.rx$.rxPriorSimSpec(.u, list()), "TNPRI")
+    .s <- .rx$.rxPriorSimSpec(.u, list())
+
+    expect_equal(dimnames(.s$thetaMat)[[1]], c("tcl", "om.eta.ka"))
+    expect_equal(.s$omegaEl$name, "om.eta.ka")
   })
 
   test_that("an omega element prior is centered on the omega value", {

--- a/tests/testthat/test-prior-sim-spec.R
+++ b/tests/testthat/test-prior-sim-spec.R
@@ -116,14 +116,36 @@ rxTest({
   })
 
   test_that("a normal prior on the omega values is rejected for now", {
-    ## a NONMEM TNPRI, which lands on the omega row
-    .u <- .withPrior(.base(), "eta.ka", "dnorm(0, 0.1)")
+    ## a NONMEM TNPRI, which lands on the omega row.  `eta.ka` is 0.6, and
+    ## an omega element prior is centered on the omega value the same way
+    ## a theta one is centered on its estimate
+    .u <- .withPrior(.base(), "eta.ka", "dnorm(0.6, 0.1)")
     expect_error(.rx$.rxPriorSimSpec(.u, list()), "TNPRI")
 
     ## and the joint form, which lands wherever the block starts
     .u <- .withPrior(.base(), "tcl",
                      "multiNormal(c(1, 0.6), lotri(tcl + om.eta.ka ~ c(0.02, 0.001, 0.03)))")
     expect_error(.rx$.rxPriorSimSpec(.u, list()), "TNPRI")
+  })
+
+  test_that("an omega element prior is centered on the omega value", {
+    ## the value the draw is added to is the omega, not zero
+    .u <- .withPrior(.base(), "eta.ka", "dnorm(0, 0.1)")
+    expect_error(.rx$.rxPriorSimSpec(.u, list()), "is not the initial estimate")
+  })
+
+  test_that("a joint block spans the thetas and the omega elements", {
+    ## a TNPRI variance matrix covers both, with covariances between them
+    .u <- .withPrior(.base(), "tcl",
+                     "multiNormal(c(1, 0.6), lotri(tcl + om.eta.ka ~ c(0.02, 0.001, 0.03)))")
+    .th <- .rx$.rxPriorThetaMat(.u)
+
+    expect_equal(dimnames(.th$thetaMat)[[1]], c("tcl", "om.eta.ka"))
+    expect_equal(unname(.th$thetaMat["tcl", "om.eta.ka"]), 0.001)
+    ## and the omega member is mapped back to where it lives in the omega
+    expect_equal(.th$omegaEl$name, "om.eta.ka")
+    expect_equal(.th$omegaEl$neta1, 3L)
+    expect_equal(.th$omegaEl$neta2, 3L)
   })
 
   test_that("a chunked solve with priors is an error", {

--- a/tests/testthat/test-prior-sim-spec.R
+++ b/tests/testthat/test-prior-sim-spec.R
@@ -218,4 +218,50 @@ rxTest({
     expect_equal(unname(.s$thetaMat[1, 1]), 0.01)
     expect_equal(vapply(.s$omegaNu, function(x) x$nu, double(1)), c(20, 4))
   })
+
+  test_that("thetaMat columns are matched to omega entries by every spelling", {
+    ## A thetaMat from a real covariance step carries the omega entries
+    ## next to the thetas, and every producer spells them differently.
+    .om <- matrix(0, 3, 3,
+                  dimnames=list(c("eta.cl", "eta.v", "eta.ka"),
+                                c("eta.cl", "eta.v", "eta.ka")))
+
+    ## nlmixr2est: `om.<eta>` and `cov.<eta1>.<eta2>` (.foceiOmegaCovNames)
+    .e <- .rx$.rxJointElFromNames(.om, c("tka", "om.eta.cl",
+                                         "cov.eta.cl.eta.v", "om.eta.v"))
+    expect_equal(rownames(.e),
+                 c("om.eta.cl", "cov.eta.cl.eta.v", "om.eta.v"))
+    expect_equal(unname(.e[, "neta1"]), c(1L, 2L, 2L))
+    expect_equal(unname(.e[, "neta2"]), c(1L, 1L, 2L))
+
+    ## nonmem2rx: the bare eta name, and `omega<i>.<j>`/`omega.<i>.<j>`
+    .e <- .rx$.rxJointElFromNames(.om, c("t.CL", "eta.cl", "omega1.2",
+                                         "eta.v", "omega.3.1"))
+    expect_equal(rownames(.e),
+                 c("eta.cl", "omega1.2", "eta.v", "omega.3.1"))
+    ## either order addresses the same entry, since the matrix is symmetric
+    expect_equal(unname(.e["omega.3.1", ]), c(3L, 1L))
+
+    ## a thetaMat with nothing to match is not an omega source
+    expect_null(.rx$.rxJointElFromNames(.om, c("tka", "tcl")))
+
+    ## the bare eta name already means an SD under the separation
+    ## strategy, so it can be excluded
+    .e <- .rx$.rxJointElFromNames(.om, c("eta.cl", "om.eta.v"),
+                                  bareName=FALSE)
+    expect_equal(rownames(.e), "om.eta.v")
+
+    ## two spellings of one entry is ambiguous rather than first-wins
+    expect_error(.rx$.rxJointElFromNames(.om, c("om.eta.cl", "eta.cl")),
+                 "more than one")
+  })
+
+  test_that("sigma entries are matched the same way", {
+    .sg <- matrix(0, 2, 2, dimnames=list(c("eps1", "eps2"),
+                                         c("eps1", "eps2")))
+    .e <- .rx$.rxJointElFromNames(.sg, c("eps1", "sigma1.2", "eps2"),
+                                  what="sigma")
+    expect_equal(rownames(.e), c("eps1", "sigma1.2", "eps2"))
+    expect_equal(unname(.e["sigma1.2", ]), c(2L, 1L))
+  })
 })

--- a/tests/testthat/test-prior-sim-tnpri-general.R
+++ b/tests/testthat/test-prior-sim-tnpri-general.R
@@ -16,7 +16,7 @@ rxTest({
     })
   }
 
-  .ev <- function() et(amt=100) %>% et(seq(0, 24, by=8))
+  .ev <- function() et(amt=100) |> et(seq(0, 24, by=8))
 
   .omega <- function() {
     lotri::lotri(eta.ka + eta.cl ~ c(0.3,

--- a/tests/testthat/test-prior-sim-tnpri-general.R
+++ b/tests/testthat/test-prior-sim-tnpri-general.R
@@ -1,0 +1,150 @@
+rxTest({
+
+  .rx <- loadNamespace("rxode2")
+
+  ## `omegaSeparation="tnpri"` -- the omega (and sigma) entries are carried
+  ## in the `thetaMat` and drawn from it jointly with the thetas, rather
+  ## than having their correlations redrawn by the separation strategy.
+  ## That is what a covariance step from NONMEM or nlmixr2 gives.
+
+  .mod <- function() {
+    rxode2({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      cp <- linCmt()
+    })
+  }
+
+  .ev <- function() et(amt=100) %>% et(seq(0, 24, by=8))
+
+  .omega <- function() {
+    lotri::lotri(eta.ka + eta.cl ~ c(0.3,
+                                     0.05, 0.2))
+  }
+
+  ## the uncertainty of the omega entries themselves: a variance for each
+  ## of omega[1,1], omega[2,1] and omega[2,2]
+  .thetaMat <- function(nm) {
+    .m <- diag(c(0.01, 0.002, 0.0004, 0.002))
+    dimnames(.m) <- list(c("tka", nm), c("tka", nm))
+    .m
+  }
+
+  .params <- c(tka=0.45, tcl=1, tv=3.45)
+
+  test_that("the nonmem2rx spelling is drawn jointly", {
+    ## `nonmem2rx` names a diagonal by the eta and an off diagonal
+    ## `omega<i>.<j>`
+    .tm <- .thetaMat(c("eta.ka", "omega2.1", "eta.cl"))
+
+    withr::with_seed(3, {
+      .s <- rxSolve(.mod(), .ev(), params=.params, omega=.omega(),
+                    thetaMat=.tm, nSub=2, nStud=300,
+                    omegaSeparation="tnpri")
+    })
+
+    expect_equal(length(.s$omegaList), 300L)
+
+    .d1 <- vapply(.s$omegaList, function(m) m[1, 1], double(1))
+    .off <- vapply(.s$omegaList, function(m) m[2, 1], double(1))
+    .d2 <- vapply(.s$omegaList, function(m) m[2, 2], double(1))
+
+    ## Each entry is centered on the omega the model gives and spread by
+    ## the thetaMat variance for it.  These are Monte Carlo estimates from
+    ## 300 draws, so the tolerances are sized to the sampling error rather
+    ## than to the number of digits: a mean is +/- sd/sqrt(n) and an sd is
+    ## +/- sd/sqrt(2n).
+    expect_equal(mean(.d1), 0.3, tolerance=0.05)
+    expect_equal(sd(.d1), sqrt(0.002), tolerance=0.15)
+
+    ## the off diagonal is drawn too -- the separation strategy would have
+    ## thrown it away and redrawn the correlation from LKJ
+    expect_equal(mean(.off), 0.05, tolerance=0.15)
+    expect_equal(sd(.off), sqrt(0.0004), tolerance=0.15)
+    expect_gt(length(unique(.off)), 100L)
+
+    expect_equal(mean(.d2), 0.2, tolerance=0.05)
+
+    ## and what comes back is usable
+    expect_true(all(vapply(.s$omegaList,
+                           function(m) all(eigen(m)$values > 0), logical(1))))
+  })
+
+  test_that("the nlmixr2est spelling gives the same draws", {
+    ## `.foceiOmegaCovNames()` writes `om.<eta>` and `cov.<eta1>.<eta2>`
+    .nm <- c("om.eta.ka", "cov.eta.cl.eta.ka", "om.eta.cl")
+
+    withr::with_seed(3, {
+      .a <- rxSolve(.mod(), .ev(), params=.params, omega=.omega(),
+                    thetaMat=.thetaMat(.nm), nSub=2, nStud=50,
+                    omegaSeparation="tnpri")
+    })
+    withr::with_seed(3, {
+      .b <- rxSolve(.mod(), .ev(), params=.params, omega=.omega(),
+                    thetaMat=.thetaMat(c("eta.ka", "omega2.1", "eta.cl")),
+                    nSub=2, nStud=50, omegaSeparation="tnpri")
+    })
+
+    ## the same matrix by either spelling
+    expect_equal(.a$omegaList, .b$omegaList)
+  })
+
+  test_that("tnpri keeps the theta and omega draws correlated", {
+    ## the point of drawing them jointly: a covariance between a theta and
+    ## an omega entry survives, which the separation strategy cannot carry
+    .nm <- c("tka", "om.eta.ka", "om.eta.cl")
+    .tm <- matrix(c(0.01,  0.004, 0,
+                    0.004, 0.002, 0,
+                    0,     0,     0.002), 3, 3,
+                  dimnames=list(.nm, .nm))
+
+    withr::with_seed(4, {
+      .s <- rxSolve(.mod(), .ev(), params=.params, omega=.omega(),
+                    thetaMat=.tm, nSub=2, nStud=400,
+                    omegaSeparation="tnpri")
+    })
+
+    .d1 <- vapply(.s$omegaList, function(m) m[1, 1], double(1))
+    ## 0.004 / sqrt(0.01 * 0.002) = 0.894
+    expect_equal(cor(unique(.s$params$tka), .d1), 0.894, tolerance=0.06)
+  })
+
+  test_that("tnpri says what is missing rather than ignoring it", {
+    ## a thetaMat that names no omega entry cannot be what was meant
+    .tm <- matrix(0.01, 1, 1, dimnames=list("tka", "tka"))
+    expect_error(rxSolve(.mod(), .ev(), params=.params, omega=.omega(),
+                         thetaMat=.tm, nSub=2, nStud=10,
+                         omegaSeparation="tnpri"),
+                 "no 'thetaMat' column names a omega entry")
+
+    ## and the omega has to be a matrix, since the draws are added to it
+    expect_error(rxSolve(.mod(), .ev(), params=.params,
+                         omega=c("eta.ka", "eta.cl"),
+                         thetaMat=.thetaMat(c("eta.ka", "omega2.1", "eta.cl")),
+                         nSub=2, nStud=10, omegaSeparation="tnpri"),
+                 "needs 'omega' to be a matrix")
+  })
+
+  test_that("the separation strategy is unchanged", {
+    ## The same eta-named thetaMat columns still mean that eta's variance
+    ## under the existing strategy, which needs `dfSub` and redraws the
+    ## correlations.  `thetaLower=0` keeps the drawn variances positive,
+    ## which that strategy requires -- see `test-nearpd.R`.
+    .nm <- c("eta.ka", "eta.cl")
+    .tm <- diag(c(0.01, 0.002, 0.002))
+    dimnames(.tm) <- list(c("tka", .nm), c("tka", .nm))
+
+    withr::with_seed(3, {
+      .s <- rxSolve(.mod(), .ev(),
+                    params=c(.params, eta.ka=0.3, eta.cl=0.2),
+                    omega=.nm, thetaMat=.tm, thetaLower=0,
+                    nSub=2, nStud=20, dfSub=10)
+    })
+    expect_equal(length(.s$omegaList), 20L)
+
+    ## and nothing routed it through the joint draw
+    .ctl <- rxControl(omega=.nm, thetaMat=.tm, omegaSeparation="auto")
+    expect_null(.rx$.rxTnpriApplyControl(.ctl)$priorOmegaEl)
+  })
+})

--- a/tests/testthat/test-prior-sim-tnpri-general.R
+++ b/tests/testthat/test-prior-sim-tnpri-general.R
@@ -147,4 +147,39 @@ rxTest({
     .ctl <- rxControl(omega=.nm, thetaMat=.tm, omegaSeparation="auto")
     expect_null(.rx$.rxTnpriApplyControl(.ctl)$priorOmegaEl)
   })
+
+  test_that("sigma is drawn jointly the same way", {
+    ## a covariance step carries the residual entries too -- `nonmem2rx`
+    ## writes `eps1, sigma1.2, eps2`
+    .m <- rxode2({
+      ka <- exp(tka)
+      cl <- exp(tcl)
+      v <- exp(tv)
+      cp <- linCmt() + add.eps + add2.eps
+    })
+    .sg <- lotri::lotri(add.eps + add2.eps ~ c(0.4,
+                                               0.05, 0.3))
+    .nm <- c("add.eps", "sigma2.1", "add2.eps")
+    .tm <- diag(c(0.01, 0.003, 0.0004, 0.003))
+    dimnames(.tm) <- list(c("tka", .nm), c("tka", .nm))
+
+    withr::with_seed(9, {
+      .s <- suppressWarnings(
+        rxSolve(.m, .ev(), params=.params, sigma=.sg, thetaMat=.tm,
+                nSub=2, nStud=300, sigmaSeparation="tnpri"))
+    })
+
+    expect_equal(length(.s$sigmaList), 300L)
+
+    .d1 <- vapply(.s$sigmaList, function(x) x[1, 1], double(1))
+    .off <- vapply(.s$sigmaList, function(x) x[2, 1], double(1))
+
+    expect_equal(mean(.d1), 0.4, tolerance=0.05)
+    expect_equal(sd(.d1), sqrt(0.003), tolerance=0.15)
+    expect_equal(mean(.off), 0.05, tolerance=0.15)
+    expect_gt(length(unique(.off)), 100L)
+
+    expect_true(all(vapply(.s$sigmaList,
+                           function(x) all(eigen(x)$values > 0), logical(1))))
+  })
 })

--- a/tests/testthat/test-prior-sim-tnpri-general.R
+++ b/tests/testthat/test-prior-sim-tnpri-general.R
@@ -182,4 +182,53 @@ rxTest({
     expect_true(all(vapply(.s$sigmaList,
                            function(x) all(eigen(x)$values > 0), logical(1))))
   })
+
+  test_that("an nlmixr2 fit's $cov names simulate", {
+    ## The exact column names a nlmixr2 fit carries: the thetas (including
+    ## the residual ones) and the omega entries, where `om.` is the eta and
+    ## `cov.` the covariance -- and `cov.` is written row-then-column, so
+    ## `cov.eta.v.eta.cl` is the (eta.v, eta.cl) entry.
+    .m <- rxode2({
+      ka <- exp(0.45)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv + eta.v)
+      cp <- linCmt() + add.err
+    })
+    .om <- lotri::lotri(eta.cl + eta.v ~ c(0.3,
+                                           0.05, 0.2))
+    .cn <- c("tcl", "tv", "add.err",
+             "om.eta.cl", "cov.eta.v.eta.cl", "om.eta.v")
+    .tm <- diag(c(0.02, 0.03, 0.01, 0.002, 0.0004, 0.002))
+    dimnames(.tm) <- list(.cn, .cn)
+
+    ## the three omega entries are found and the thetas are left alone
+    .el <- .rx$.rxJointElFromNames(.om, .cn)
+    expect_equal(rownames(.el),
+                 c("om.eta.cl", "cov.eta.v.eta.cl", "om.eta.v"))
+    expect_equal(unname(.el[, "neta1"]), c(1L, 2L, 2L))
+    expect_equal(unname(.el[, "neta2"]), c(1L, 1L, 2L))
+
+    withr::with_seed(13, {
+      .s <- suppressWarnings(
+        rxSolve(.m, .ev(), params=c(tcl=1, tv=3.45, add.err=0.7),
+                omega=.om, thetaMat=.tm, nSub=2, nStud=400,
+                omegaSeparation="tnpri"))
+    })
+
+    .d1 <- vapply(.s$omegaList, function(x) x[1, 1], double(1))
+    .off <- vapply(.s$omegaList, function(x) x[2, 1], double(1))
+    .d2 <- vapply(.s$omegaList, function(x) x[2, 2], double(1))
+
+    expect_equal(mean(.d1), 0.3, tolerance=0.05)
+    expect_equal(sd(.d1), sqrt(0.002), tolerance=0.15)
+    expect_equal(mean(.off), 0.05, tolerance=0.15)
+    expect_equal(sd(.off), sqrt(0.0004), tolerance=0.15)
+    expect_equal(mean(.d2), 0.2, tolerance=0.05)
+
+    ## the thetas are still drawn alongside them
+    expect_equal(sd(unique(.s$params$tcl)), sqrt(0.02), tolerance=0.15)
+
+    expect_true(all(vapply(.s$omegaList,
+                           function(x) all(eigen(x)$values > 0), logical(1))))
+  })
 })

--- a/tests/testthat/test-prior-sim-tnpri.R
+++ b/tests/testthat/test-prior-sim-tnpri.R
@@ -1,0 +1,192 @@
+rxTest({
+
+  ## One multivariate normal over the population parameters *and* the omega
+  ## values, which is what NONMEM calls TNPRI.  Drawn that way an omega is
+  ## not guaranteed positive definite, so the draw retries.
+
+  .hasPriorSupport <- function() {
+    exists("lotriPriorDists", envir=asNamespace("lotri"), inherits=FALSE)
+  }
+
+  .ev <- function() et(amt=100) %>% et(seq(0, 24, by=8))
+
+  ## A joint block over `tcl` and the omega element of `eta.cl`, with a
+  ## covariance between them -- the thing a block that is all one kind
+  ## cannot express.
+  .joint <- function() {
+    rxode2(function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1.0
+        add.sd <- 0.7
+        eta.cl ~ 0.3
+        eta.v ~ 0.1
+        tcl + om.eta.cl ~ c(0.02,
+                            0.004, 0.005)
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(1 + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    })
+  }
+
+  test_that("a joint prior draws the thetas and the omega values together", {
+    skip_if_not(.hasPriorSupport())
+
+    withr::with_seed(11, {
+      .s <- rxSolve(.joint(), .ev(), nSub=2, nStud=400)
+    })
+
+    expect_equal(length(.s$omegaList), 400L)
+
+    .cl <- vapply(.s$omegaList, function(m) m["eta.cl", "eta.cl"], double(1))
+    .v <- vapply(.s$omegaList, function(m) m["eta.v", "eta.v"], double(1))
+    .tcl <- unique(.s$params$tcl)
+
+    ## the omega element carries the prior's spread, centered on the omega
+    ## value the model gives
+    expect_equal(mean(.cl), 0.3, tolerance=0.02)
+    expect_equal(sd(.cl), sqrt(0.005), tolerance=0.02)
+
+    ## the element that has no prior is left at its point estimate
+    expect_equal(unique(.v), 0.1)
+
+    ## and the theta is drawn with it, correlated as the block says:
+    ## 0.004 / sqrt(0.02 * 0.005) = 0.4
+    expect_equal(sd(.tcl), sqrt(0.02), tolerance=0.02)
+    expect_equal(cor(.tcl, .cl), 0.4, tolerance=0.12)
+  })
+
+  test_that("every drawn omega is positive definite", {
+    skip_if_not(.hasPriorSupport())
+
+    withr::with_seed(11, {
+      .s <- rxSolve(.joint(), .ev(), nSub=2, nStud=200)
+    })
+
+    expect_true(all(vapply(.s$omegaList,
+                           function(m) all(eigen(m)$values > 0), logical(1))))
+  })
+
+  test_that("the retry falls back to the nearest positive definite omega", {
+    skip_if_not(.hasPriorSupport())
+
+    ## A strongly correlated block whose variance carries a wide prior:
+    ## the drawn variance stays positive but the block stops being
+    ## positive definite, which is exactly the case the projection can
+    ## repair.  It has to say so -- those studies are not draws from the
+    ## stated prior.
+    .wide <- rxode2(function() {
+      ini({
+        tka <- 0.45
+        add.sd <- 0.7
+        eta.cl + eta.v ~ c(0.3,
+                           0.29, 0.3)
+        ## sd 0.03 on a variance of 0.3: the block loses positive
+        ## definiteness (it needs the variance above 0.29^2/0.3 = 0.2803)
+        ## well before the variance itself could go negative, which is the
+        ## regime the projection can repair
+        om.eta.cl ~ 0.0009
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(1 + eta.cl)
+        v <- exp(1 + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    })
+
+    expect_warning({
+      withr::with_seed(5, {
+        .s <- rxSolve(.wide, .ev(), nSub=2, nStud=100, priorPdRetry=1)
+      })
+    }, "nearest positive definite")
+
+    ## whatever route it took, what comes back is usable
+    expect_true(all(vapply(.s$omegaList,
+                           function(m) all(eigen(m)$values > 0), logical(1))))
+  })
+
+  test_that("a prior that can never be made positive definite is an error", {
+    skip_if_not(.hasPriorSupport())
+
+    ## a 1x1 omega drawn negative cannot be projected back onto the cone --
+    ## its nearest positive definite matrix is the boundary, which is not
+    ## positive definite.  That is an error rather than a silent zero.
+    .neg <- rxode2(function() {
+      ini({
+        tka <- 0.45
+        add.sd <- 0.7
+        eta.cl ~ 0.3
+        om.eta.cl ~ 9
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(1 + eta.cl)
+        v <- 1
+        linCmt() ~ add(add.sd)
+      })
+    })
+
+    expect_error({
+      withr::with_seed(5, {
+        rxSolve(.neg, .ev(), nSub=2, nStud=50, priorPdRetry=2)
+      })
+    }, "positive definite")
+  })
+
+  test_that("priorPdRetry=1 does not retry", {
+    skip_if_not(.hasPriorSupport())
+
+    ## with a single try every non positive definite draw goes straight to
+    ## the fallback, so the warning is the same but it fires more often
+    expect_warning({
+      withr::with_seed(5, {
+        .s <- rxSolve(.joint(), .ev(), nSub=2, nStud=50, priorPdRetry=1)
+      })
+    }, NA)
+  })
+
+  test_that("a joint prior and a block degrees of freedom cannot be mixed", {
+    skip_if_not(.hasPriorSupport())
+
+    ## 'lotri' rejects the combination when the model is written, since the
+    ## two are alternative ways of saying the same thing
+    expect_error(rxode2(function() {
+      ini({
+        tka <- 0.45
+        add.sd <- 0.7
+        eta.cl ~ 0.3
+        eta.v ~ 0.1
+        prior(eta.cl) ~ invWishart(4)
+        om.eta.v ~ 0.01
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(1 + eta.cl)
+        v <- exp(1 + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    }), "alternatives, not additions")
+
+    ## and on the same omega it is a duplicate, which is rejected too
+    expect_error(rxode2(function() {
+      ini({
+        tka <- 0.45
+        add.sd <- 0.7
+        eta.cl ~ 0.3
+        prior(eta.cl) ~ invWishart(4)
+        om.eta.cl ~ 0.01
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(1 + eta.cl)
+        v <- 1
+        linCmt() ~ add(add.sd)
+      })
+    }), "more than one prior")
+  })
+})

--- a/tests/testthat/test-prior-sim-tnpri.R
+++ b/tests/testthat/test-prior-sim-tnpri.R
@@ -8,7 +8,7 @@ rxTest({
     exists("lotriPriorDists", envir=asNamespace("lotri"), inherits=FALSE)
   }
 
-  .ev <- function() et(amt=100) %>% et(seq(0, 24, by=8))
+  .ev <- function() et(amt=100) |> et(seq(0, 24, by=8))
 
   ## A joint block over `tcl` and the omega element of `eta.cl`, with a
   ## covariance between them -- the thing a block that is all one kind

--- a/vignettes/articles/rxode2-nmsim-comparison.Rmd
+++ b/vignettes/articles/rxode2-nmsim-comparison.Rmd
@@ -337,6 +337,7 @@ common workflow is:
 | `$MIXTURE` models | `nonmem2rx` imports; no auto-validation | yes |
 | EBE-based simulation | yes -- `nonmem2rx` imports EBEs into `$etaData` | yes -- `NMsim_EBE` |
 | Uncertainty from covariance step | yes -- `nonmem2rx` imports covariance matrix for draws | yes -- `NMsim_VarCov` / `NMsim_NWPRI` |
+| Prior-based uncertainty (`NWPRI`/`TNPRI`) | yes -- priors in the `ini({})` block drive `rxSolve(nStud=)`, with per-block omega degrees of freedom | yes -- `NMsim_NWPRI` |
 | Bootstrap uncertainty | manual (supply draws) | built-in (simulate all bootstrap models) |
 | OpenMP within-process parallelism | yes | no |
 | Cluster / distributed submission | yes (`mirai`) | yes (via PSN) |


### PR DESCRIPTION
The `ini({})` block could already *carry* a prior -- #1249 added the column and `rxUiPriors()` to read it -- but nothing consumed it. Uncertainty simulation was driven entirely by the solve-time `thetaMat`/`dfSub` arguments, which a model cannot express. This makes the priors drive `rxSolve()`.

Needs lotri >= 1.0.7 (nlmixr2/lotri#50), which Imports now requires.

## NWPRI

```r
one.cmt <- function() {
  ini({
    tka <- 0.45; tcl <- 1; tv <- 3.45
    eta.cl + eta.v ~ c(0.3,
                       0.01, 0.1)
    eta.ka ~ 0.6
    add.sd <- 0.7
    tka ~ 0.01                            # normal prior on tka
    prior(eta.cl, eta.v) ~ invWishart(20) # degrees of freedom, per block
    prior(eta.ka) ~ invWishart(4)
  })
  model({ ... })
}

s <- rxSolve(one.cmt, ev, nSub = 10, nStud = 100)
```

Each omega block is drawn from an inverse Wishart with **its own** degrees of freedom, which the single `dfSub` scalar structurally cannot express -- above, the 2x2 with 20 and the 1x1 with 4. A block with no prior stays at its point estimate. The draw itself is `cvPost()`, which already reads a per-block `nu` out of a `lotri`, so this is wiring rather than new math.

## TNPRI

A joint multivariate normal over the population parameters **and** the omega values, with the covariances between them:

```r
tcl + om.eta.cl ~ c(0.02,
                    0.004, 0.005)
```

Drawn that way the omega is not guaranteed positive definite, so a study whose draw is not gets the whole joint vector redrawn, up to `priorPdRetry` (10) times. If none is, the nearest positive definite matrix of the kept draws is used **with a warning**: that projection lands on the boundary of the positive definite cone and taking the closest one selects the least positive definite draw, so those studies are not draws from the stated prior. When no projection is usable it errors rather than returning a broken omega.

## The general form: a thetaMat that already carries the omegas

`omegaSeparation="tnpri"` (and `sigmaSeparation="tnpri"`) does the same for a `thetaMat` that did not come from an `ini({})` prior -- which is what a covariance step gives:

```r
mod <- nonmem2rx("run3.lst")
rxSolve(mod, data.sim, nStud = 100, omegaSeparation = "tnpri", sigmaSeparation = "tnpri")
```

Columns are matched to entries by name, in whichever spelling produced them:

| | diagonal | off-diagonal |
|---|---|---|
| nlmixr2 fit `$cov` | `om.eta.cl` | `cov.eta.v.eta.cl` |
| `nonmem2rx` | `eta.cl` | `omega1.2`, `omega.2.1` |

Until now the off-diagonal entries were pruned as "too many items" and the correlations redrawn from LKJ, discarding what the covariance step measured. Drawing them jointly also keeps the covariance *between* a theta and an omega entry, which no separation strategy can carry.

Opt-in rather than automatic because an eta-named `thetaMat` column already means that eta variance under the existing strategy, so the same column cannot silently change meaning. Matching is by **name**, so the existing pruning of zero-uncertainty columns cannot shift the mapping onto the wrong entries.

## Rules

**A prior mean is the value the model already gives** -- the estimate for a population parameter, the omega value for an omega element -- because the draw is added to it. A prior centered elsewhere is an error naming both numbers, rather than a simulation that quietly differs from the model.

**A prior is never silently ignored.** Everything that cannot be turned into a draw is a clear error: a distribution outside normal/multiNormal/Wishart, an improper inverse Wishart for its block size, a nested/occasion model (#1253), and a chunked solve (#1252).

**Precedence.** A `thetaMat`/`dfSub` carried in the model `meta` block loses to the priors, with a warning; one given at the call site wins over them, also with a warning. `usePrior=FALSE` ignores the priors entirely.

## Compatibility

`rxSimThetaOmega()` is `@export` + `[[Rcpp::export]]`, registered with a hardcoded arity of 28 in `src/init.c` and re-exported via `R_RegisterCCallable`. Its signature is untouched: the body moved to an internal `rxSimThetaOmega0()` and the exported function is now a 28-argument wrapper. `src/init.c` and the generated `RcppExports` have no diff, which is the check that the split was done right.

The five new `rxControl` fields are **appended**, so every existing `Rxc_*` index is unchanged and an already-built reverse dependency keeps working.

## Testing

Full suite clean. 111 assertions across four new files covering the spec reader, NWPRI, `ini({})` TNPRI and the general form. Where a check is a Monte Carlo estimate the tolerance is sized to the sampling error rather than to digits.

Validated end to end against a real NONMEM run (`nonmem2rx` run3.lst, 4 etas and 3 eps): all 10 omega and all 6 sigma entries found from the real column names, every drawn omega and sigma positive definite, and each entry mean matching its point estimate.

## Found along the way, filed separately

- #1252 -- a chunked solve with `nStud > 1` silently draws no omega uncertainty at all
- #1253 -- nested/occasion models bypass this path entirely
- #1254 -- `ini()` piping cannot set a prior
- #1255 -- `cvPost()` spins forever on a non-finite draw instead of erroring

All pre-existing; none is introduced here, and the two that would have swallowed a prior are guarded by an error that names the issue.