### PR TITLE
Require lotri 1.0.5, which is where the prior column lands

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -112,7 +112,7 @@ Imports:
     checkmate,
     ggplot2 (>= 3.4.0),
     inline,
-    lotri (>= 1.0.4),
+    lotri (>= 1.0.5),
     memoise,
     methods,
     mirai,

--- a/NEWS.md
+++ b/NEWS.md
@@ -123,14 +123,14 @@
 
 ### Initial conditions data frame
 
-- The `iniDf` now tolerates the `prior` column that newer versions of `lotri`
-  add for prior distributions (#1248).  `testIniDf()`/`assertIniDf()` used to
+- The `iniDf` now tolerates the `prior` column that `lotri` 1.0.5 adds for
+  prior distributions (#1248).  `testIniDf()`/`assertIniDf()` used to
   reject every model built with such a `lotri`, and the ini rows that are
   constructed by hand internally (adding a covariance between two etas,
   promoting a parameter, `linMod()`) hard-coded the column list and so failed
   to `rbind()` with "numbers of columns of arguments do not match".  These now
-  match whatever columns the `iniDf` actually has, so rxode2 works both with
-  `lotri` versions that have the column and with versions that do not.
+  match whatever columns the `iniDf` actually has, so an `iniDf` without the
+  column still works.
 
 ### Parsing
 

--- a/R/assert.R
+++ b/R/assert.R
@@ -311,9 +311,9 @@ assertRxUiNormal <- function(ui, extra="", .var.name=.vname(ui)) {
 
 #' The 'Stan' name of a prior distribution, or NA
 #'
-#' Looked up dynamically so that this still works with a 'lotri' that
-#' predates `lotriPriorDists()` (in which case there cannot be any
-#' priors to look up anyway).
+#' Looked up dynamically rather than with a hard `lotri::` reference, so
+#' that an `iniDf` carrying a prior can still be classified even if it
+#' came from somewhere other than the installed 'lotri'.
 #'
 #' @param name canonical distribution name as stored in the `prior` column
 #' @return the 'Stan' spelling, or `NA_character_` when it is not known
@@ -369,8 +369,8 @@ assertRxUiNormal <- function(ui, extra="", .var.name=.vname(ui)) {
 #'   columns `name`, `prior` (the prior as written, ie `"invWishart(4)"`),
 #'   `neta1`/`neta2` (`NA` for a population parameter) and `lower`/`upper`
 #'   from the parameter, which is what gives a truncated prior its bounds.
-#'   Zero rows when the model has no priors, including when the installed
-#'   'lotri' predates prior support.
+#'   Zero rows when the model has no priors, and also when the `iniDf` has
+#'   no `prior` column at all.
 #'
 #' @family Assertions
 #' @author Matthew L. Fidler

--- a/man/rxUiPriors.Rd
+++ b/man/rxUiPriors.Rd
@@ -14,8 +14,8 @@ data frame of the parameters that carry a prior, with the
 columns \code{name}, \code{prior} (the prior as written, ie \code{"invWishart(4)"}),
 \code{neta1}/\code{neta2} (\code{NA} for a population parameter) and \code{lower}/\code{upper}
 from the parameter, which is what gives a truncated prior its bounds.
-Zero rows when the model has no priors, including when the installed
-'lotri' predates prior support.
+Zero rows when the model has no priors, and also when the \code{iniDf} has
+no \code{prior} column at all.
 }
 \description{
 This is the accessor an estimation method uses to \emph{implement} priors,

--- a/tests/testthat/test-ini-prior-column.R
+++ b/tests/testthat/test-ini-prior-column.R
@@ -2,11 +2,11 @@ rxTest({
 
   .rxode2 <- loadNamespace("rxode2")
 
-  ## Newer 'lotri' adds a `prior` column to the ini data frame for prior
-  ## distributions.  rxode2 has to work with an `iniDf` that has it and
-  ## with one that does not, since which one you get depends on the
-  ## installed version of 'lotri'.  These tests construct both shapes by
-  ## hand so they do not depend on that version.
+  ## 'lotri' 1.0.5 adds a `prior` column to the ini data frame for prior
+  ## distributions.  Nothing here assumes the column is present: an
+  ## `iniDf` built by hand, or one from an object saved before it
+  ## existed, does not have it.  These tests construct both shapes by
+  ## hand so they hold either way.
 
   .iniDfNoPrior <- function() {
     data.frame(ntheta=c(1L, NA_integer_),


### PR DESCRIPTION
Follow-up to #1249, which is already merged.

The prior support landed in **lotri 1.0.5** rather than a later version, so
that is the floor rxode2 should declare:

```
-    lotri (>= 1.0.4),
+    lotri (>= 1.0.5),
```

`LinkingTo` is untouched, since none of the prior handling uses the lotri C
API — `_lotriEstDf` is internal to lotri and the `prior` column is read at the
R level.

Nothing in #1249 ever tested a lotri version number: the distribution lookup
asks whether `lotriPriorDists()` exists, and the column handling asks whether
`prior` is in the frame. So only the wording needed updating — it now names
1.0.5, and describes an `iniDf` that has no `prior` column (one built by hand,
or from an object saved before it existed) rather than talking about older
lotri releases, which no longer makes sense once 1.0.5 is required.

Verified against lotri 1.0.5 built from its `main`: 733 assertions across the
prior, ini-column, piping and ini-lotri tests.
