### PR TITLE
Let ini() piping set a prior distribution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -171,6 +171,25 @@
   `rxRemoveUiPrep()` in `.onUnload()`.  See the [solve-time hooks
   article](https://nlmixr2.github.io/rxode2/articles/rxode2-solve-hooks.html).
 
+## New features
+
+- A prior distribution can now be set by piping, not only written in the
+  `ini({})` block (#1254):
+
+```r
+mod |> ini(prior(tka) ~ dnorm(0, 10))
+mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
+```
+
+  Piping a prior replaces whatever was on that parameter, the way piping a
+  label or an estimate does.  The line is validated by `lotri` in the
+  context of the real parameters rather than by a second implementation
+  here, so a piped prior is checked exactly like one written in the block.
+
+  Note the normal prior shorthand keeps its piping meaning: `mod |>
+  ini(tka ~ 4)` still changes the initial estimate, as it always has.  Use
+  the explicit `prior()` form to set a prior by piping.
+
 ## Bug fixes
 
 ### Initial conditions data frame

--- a/R/piping-ini.R
+++ b/R/piping-ini.R
@@ -385,6 +385,72 @@
   assign("iniDf", .ini, envir=rxui)
   invisible()
 }
+#' Is this a `prior(name) ~ dist(...)` piping line?
+#'
+#' @param expr expression to test
+#' @return TRUE when this sets a prior distribution
+#' @noRd
+#' @author Matthew L. Fidler
+.isIniPriorLine <- function(expr) {
+  is.call(expr) && length(expr) == 3L &&
+    identical(expr[[1]], quote(`~`)) &&
+    is.call(expr[[2]]) && identical(expr[[2]][[1]], quote(`prior`))
+}
+
+#' This handles the prior() piping calls
+#'
+#' The line is validated by `lotri` rather than here: the whole `ini`
+#' is turned back into a `lotri({})` block, the prior line is appended,
+#' and the block is re-evaluated.  That way the prior is checked against
+#' the real parameters -- their names, bounds and covariance blocks --
+#' by the same code that checks a prior written in the block to begin
+#' with, instead of a second implementation that could disagree with it.
+#'
+#' @param expr expression for prior() in `ini()` piping
+#' @param rxui rxode2 ui function
+#' @param envir evaluation environment
+#' @return nothing, called for side effects
+#' @noRd
+#' @author Matthew L. Fidler
+.iniHandlePrior <- function(expr, rxui, envir) {
+  .ini <- rxui$iniDf
+  ## piping replaces, the way it does for a label or an estimate, so the
+  ## prior already on these parameters is cleared before the block is
+  ## rebuilt; otherwise lotri would see two priors on one parameter
+  if (any(names(.ini) == "prior")) {
+    .tgt <- vapply(as.list(expr[[2]])[-1],
+                   function(y) paste(deparse(y), collapse=""), character(1),
+                   USE.NAMES=FALSE)
+    ## `om.eta.cl` names the omega element of `eta.cl`
+    .tgt <- unique(c(.tgt, sub("^om[.]", "", .tgt)))
+    .ini$prior[.ini$name %in% .tgt] <- NA_character_
+  }
+  .lotriExpr <- lotri::lotriDataFrameToLotriExpression(.ini, useIni=FALSE)
+  .body <- .lotriExpr[[2]]
+  .body[[length(.body) + 1L]] <- expr
+  .lotriExpr[[2]] <- .body
+  .env <- new.env(parent=envir)
+  assign("lotri", lotri::lotri, envir=.env)
+  .new <- try(eval(.lotriExpr, envir=.env), silent=TRUE)
+  if (inherits(.new, "try-error")) {
+    stop("cannot set the prior '", paste(deparse(expr), collapse=" "), "': ",
+         trimws(attr(.new, "condition")$message), call.=FALSE)
+  }
+  .newDf <- as.data.frame(.new)
+  if (!any(names(.newDf) == "prior")) {
+    stop("the installed 'lotri' does not support prior distributions",
+         call.=FALSE)
+  }
+  if (!any(names(.ini) == "prior")) {
+    .ini$prior <- rep(NA_character_, nrow(.ini))
+  }
+  ## only the prior column comes back; `err` and anything else rxode2
+  ## keeps on the iniDf is not lotri's to know about
+  .ini$prior <- .newDf$prior[match(.ini$name, .newDf$name)]
+  assign("iniDf", .ini, envir=rxui)
+  invisible()
+}
+
 #' This handles the backTransform() piping calls
 #'
 #' @param expr expression for backTransform() in `ini()` piping
@@ -671,7 +737,11 @@
   } else if (.matchesLangTemplate(expr, str2lang("unfix(.name)"))) {
     expr <- as.call(list(quote(`<-`), expr[[2]], quote(`unfix`)))
   }
-  if (.matchesLangTemplate(expr, str2lang(".name <- label(.)"))) {
+  if (.isIniPriorLine(expr)) {
+    ## checked before the `~` handling below, which would otherwise take
+    ## `prior(tka) ~ dnorm(0, 10)` for a matrix or a type switch
+    .iniHandlePrior(expr=expr, rxui=rxui, envir=envir)
+  } else if (.matchesLangTemplate(expr, str2lang(".name <- label(.)"))) {
     .iniHandleLabel(expr=expr, rxui=rxui, envir=envir)
   } else if (.matchesLangTemplate(expr, str2lang(".name <- backTransform(.)"))) {
     .iniHandleBackTransform(expr=expr, rxui=rxui, envir=envir)

--- a/tests/testthat/test-ini-prior-piping.R
+++ b/tests/testthat/test-ini-prior-piping.R
@@ -1,0 +1,98 @@
+rxTest({
+
+  ## A prior can be written in an `ini({})` block; it has to be settable
+  ## by piping onto an existing model too, the way a label or an
+  ## estimate is.
+
+  .hasPriors <- function() {
+    exists("lotriPriorDists", envir=asNamespace("lotri"), inherits=FALSE)
+  }
+
+  .mod <- function() {
+    f <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        eta.cl + eta.v ~ c(0.3,
+                           0.01, 0.1)
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(tcl + eta.cl)
+        v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    }
+    f()
+  }
+
+  test_that("a prior can be piped onto a population parameter", {
+    skip_if_not(.hasPriors())
+    .u <- ini(.mod(), prior(tka) ~ dnorm(0, 10))
+    expect_equal(.u$iniDf$prior[.u$iniDf$name == "tka"], "dnorm(0, 10)")
+    ## and nothing else gained one
+    expect_equal(sum(!is.na(.u$iniDf$prior)), 1L)
+  })
+
+  test_that("a prior can be piped onto a covariance block", {
+    skip_if_not(.hasPriors())
+    .u <- ini(.mod(), prior(eta.cl, eta.v) ~ invWishart(4))
+    ## stored on the first diagonal of the block
+    expect_equal(.u$iniDf$prior[.u$iniDf$name == "eta.cl"], "invWishart(4)")
+    ## and it prints back naming the whole block
+    expect_true(any(grepl("prior(eta.cl, eta.v) ~ invWishart(4)",
+                          deparse(.u$iniFun), fixed=TRUE)))
+  })
+
+  test_that("piping a prior replaces the one that was there", {
+    skip_if_not(.hasPriors())
+    .u <- ini(.mod(), prior(tka) ~ dnorm(0, 10))
+    .u2 <- ini(.u, prior(tka) ~ dnorm(0, 5))
+    expect_equal(.u2$iniDf$prior[.u2$iniDf$name == "tka"], "dnorm(0, 5)")
+
+    ## a block prior replaces too, and leaves the others alone
+    .u3 <- ini(.u2, prior(eta.cl, eta.v) ~ invWishart(4))
+    .u4 <- ini(.u3, prior(eta.cl, eta.v) ~ invWishart(6))
+    expect_equal(.u4$iniDf$prior[.u4$iniDf$name == "eta.cl"], "invWishart(6)")
+    expect_equal(.u4$iniDf$prior[.u4$iniDf$name == "tka"], "dnorm(0, 5)")
+  })
+
+  test_that("the om. spelling pipes onto the omega element", {
+    skip_if_not(.hasPriors())
+    .u <- ini(.mod(), prior(om.eta.cl) ~ dnorm(0, 0.1))
+    expect_equal(.u$iniDf$prior[.u$iniDf$name == "eta.cl"], "dnorm(0, 0.1)")
+  })
+
+  test_that("a piped prior is validated the same as one in the block", {
+    skip_if_not(.hasPriors())
+    .u <- .mod()
+    ## a parameter that is not in the model
+    expect_error(ini(.u, prior(nope) ~ dnorm(0, 1)))
+    ## a distribution that does not exist
+    expect_error(ini(.u, prior(tka) ~ dnorml(0, 1)))
+    ## a covariance matrix prior on a population parameter
+    expect_error(ini(.u, prior(tka) ~ invWishart(4)),
+                 "covariance matrix")
+    ## a correlation prior needs a block of more than one
+    expect_error(ini(.u, prior(eta.cl) ~ lkjCorr(2)),
+                 "more than one parameter")
+  })
+
+  test_that("a piped prior survives printing and re-parsing", {
+    skip_if_not(.hasPriors())
+    .u <- ini(.mod(), prior(tka) ~ dnorm(0, 10))
+    .u <- ini(.u, prior(eta.cl, eta.v) ~ invWishart(4))
+
+    .txt <- paste(deparse(.u$iniFun), collapse=" ")
+    expect_true(grepl("prior(tka) ~ dnorm(0, 10)", .txt, fixed=TRUE))
+    expect_true(grepl("prior(eta.cl, eta.v) ~ invWishart(4)", .txt, fixed=TRUE))
+
+    ## what is printed parses back to the same priors
+    .again <- eval(.u$iniFun)
+    expect_equal(as.data.frame(.again)$prior[c(1, 5)],
+                 c("dnorm(0, 10)", "invWishart(4)"))
+  })
+
+})


### PR DESCRIPTION
Fixes #1254.

A prior could be written in an `ini({})` block but not piped onto an existing
model, so there was no way to add one to a model you already had.

```r
mod |> ini(prior(tka) ~ dnorm(0, 10))
mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
mod |> ini(prior(om.eta.cl) ~ dnorm(0, 0.1))
```

## Validated by lotri, not a second implementation

The line is not checked here.  The whole `ini` is turned back into a
`lotri({})` block, the prior line is appended, and the block is re-evaluated.
The prior is therefore checked against the real parameters — their names,
bounds and covariance blocks — by the same code that checks a prior written
in the block to begin with, instead of a parallel implementation that could
drift from it:

```
> mod |> ini(prior(tka) ~ invWishart(4))
Error: cannot set the prior 'prior(tka) ~ invWishart(4)': prior 'invWishart'
  applies to a covariance matrix, but 'tka' is a population estimate

> mod |> ini(prior(eta.cl) ~ lkjCorr(2))
Error: ... prior 'lkjCorr' is a correlation matrix prior, so 'eta.cl' needs
  to be a block of more than one parameter
```

Only the `prior` column is lifted back onto the `iniDf`; `err` and the rest
are not lotri's to know about.

## Piping replaces

Like a label or an estimate, piping a prior replaces what was there.  The
prior on the named parameters is cleared before the block is rebuilt —
without that, lotri sees the old prior and the new one and refuses with "more
than one prior given". Verified for a scalar, a block, and that unrelated
priors are left alone.

## One asymmetry, deliberately kept

The normal prior shorthand keeps its piping meaning: `mod |> ini(tka ~ 4)`
still **changes the initial estimate**, as it always has, rather than setting
a `dnorm(0, 2)` prior the way `tka ~ 4` does inside an `ini({})` block.
Changing that would silently repurpose existing piping code, so the explicit
`prior()` form is the way to set a prior by piping.  Noted in NEWS.

## Testing

`tests/testthat/test-ini-prior-piping.R` — piping onto a population
parameter, onto a covariance block, the `om.` spelling, replacement of an
existing prior, the four validation failures above, and that a piped prior
prints in `$iniFun` and parses back to the same priors.

818 assertions pass across the new file plus `test-piping-ini.R`,
`test-ui-piping.R` and `test-ini-prior-column.R`.
