### PR TITLE
Bound the cvPost() separation retry instead of spinning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -173,6 +173,16 @@
 
 ## Bug fixes
 
+- The `lkj`/`separation` omega strategy no longer hangs on a simulated
+  standard deviation it cannot use (#1255).  `cvPost()` retried a
+  non-finite draw with no bound, but the failure is often not random: with
+  the default `omegaXform = "variance"` the transform is a `sqrt()`, so a
+  **negative** simulated standard deviation gives `NaN` on every attempt
+  and the solve span at 100% CPU with no error, no warning and no way to
+  tell a hang from a slow solve.  The attempts are now bounded and the
+  error names the cause and points at `thetaLower = 0`.
+
+
 ### Initial conditions data frame
 
 - The `iniDf` now tolerates the `prior` column that `lotri` 1.0.5 adds for

--- a/src/cvPost.cpp
+++ b/src/cvPost.cpp
@@ -510,10 +510,21 @@ SEXP cvPost_(SEXP nuS, SEXP omegaS, SEXP nS, SEXP omegaIsCholS,
           }
           bool goodSolve = false;
           arma::mat reti;
+          // A non-finite draw can be a one-off, but it can also be
+          // deterministic: rcvC1() turns each value into a standard
+          // deviation with diagXformType, and the default "variance"
+          // transform is a sqrt(), so a negative simulated value gives
+          // NaN on every attempt.  Retrying forever spun at 100% CPU
+          // with no error and no way to tell a hang from a slow solve,
+          // so the attempts are bounded and the cause is named.
+          int tries = 0;
           while (!goodSolve) {
             reti = rcvC1(sd, nu, diagXformType, type-1, returnChol);
             if (reti.is_finite()) {
               goodSolve = true;
+            } else if (++tries >= 100) {
+              rxError(_("could not draw a finite covariance matrix for simulated standard deviation %d after %d tries; a negative simulated standard deviation cannot be transformed by the 'omegaXform' in use (constraining the draws with 'thetaLower=0' avoids this)"),
+                      (int)(i + 1), tries);
             }
           }
           RObject retc = wrap(reti);

--- a/tests/testthat/test-cvpost-separation-bound.R
+++ b/tests/testthat/test-cvpost-separation-bound.R
@@ -1,0 +1,57 @@
+rxTest({
+
+  ## The lkj/separation omega strategy used to retry a non-finite draw
+  ## forever.  With the default `omegaXform="variance"` the transform is
+  ## a sqrt(), so a negative simulated standard deviation gives NaN every
+  ## time and the solve hung at 100% CPU with no error and no warning --
+  ## indistinguishable from a slow solve.
+
+  .mod <- function() {
+    rxode2({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      cp <- linCmt()
+    })
+  }
+
+  .ev <- function() {
+    et(et(amt=100), seq(0, 24, by=8))
+  }
+
+  .thetaMat <- function() {
+    .nm <- c("tka", "eta.ka", "eta.cl")
+    .tm <- diag(c(0.01, 0.002, 0.002))
+    dimnames(.tm) <- list(.nm, .nm)
+    .tm
+  }
+
+  test_that("an unusable simulated sd errors rather than spinning", {
+    skip_on_cran()
+    .m <- .mod()
+    .p <- c(tka=0.45, tcl=1, tv=3.45, eta.ka=0.3, eta.cl=0.2)
+
+    ## Unconstrained draws are deviations, so roughly half are negative
+    ## and cannot be turned into a standard deviation.  This used to
+    ## hang; it now stops, and the message says why and what to do.
+    expect_error(
+      rxSolve(.m, .ev(), params=.p, omega=c("eta.ka", "eta.cl"),
+              thetaMat=.thetaMat(), nSub=2, nStud=20, dfSub=10),
+      "thetaLower")
+  })
+
+  test_that("constraining the draws still solves", {
+    skip_on_cran()
+    .m <- .mod()
+    .p <- c(tka=0.45, tcl=1, tv=3.45, eta.ka=0.3, eta.cl=0.2)
+
+    ## the same call with the draws constrained positive is the
+    ## supported way to do this, and is unaffected
+    expect_error(
+      rxSolve(.m, .ev(), params=.p, omega=c("eta.ka", "eta.cl"),
+              thetaMat=.thetaMat(), nSub=2, nStud=20, dfSub=10,
+              thetaLower=0),
+      NA)
+  })
+
+})


### PR DESCRIPTION
Fixes #1255.

The `lkj`/`separation` omega strategy retried a non-finite draw with no bound:

```cpp
while (!goodSolve) {
  reti = rcvC1(sd, nu, diagXformType, type-1, returnChol);
  if (reti.is_finite()) { goodSolve = true; }
}
```

## Why retrying could never work

The failure is usually **not** random.  `rcvC1()` turns each drawn value into
a standard deviation using `diagXformType`, and the default
`omegaXform = "variance"` is a `sqrt()` — so a **negative** drawn value gives
`NaN` on *every* attempt.  The draws come from `thetaMat` and are deviations,
so roughly half are negative, and the first negative one hung the solve at
100% CPU with no error, no warning, and nothing to distinguish it from a slow
solve.

So this is not a flaky-draw retry that needed a bigger budget; it is a
deterministic failure that a retry loop can never escape.

## The fix

Bound the attempts and say what happened:

```
Error: could not draw a finite covariance matrix for simulated standard
  deviation 1 after 100 tries; a negative simulated standard deviation cannot
  be transformed by the 'omegaXform' in use (constraining the draws with
  'thetaLower=0' avoids this)
```

Measured on the issue's own reproducer, with the package built from this
branch:

| call | before | after |
|---|---|---|
| without `thetaLower` | hangs forever | **errors in 0.02s** |
| with `thetaLower=0` | 0.29s | **0.01s, still solves** |

## Testing

`tests/testthat/test-cvpost-separation-bound.R` covers both: the
unconstrained call errors and names `thetaLower`, and the constrained call
still solves.

The issue notes why this went unnoticed — `test-nearpd.R:50-60` is the only
test exercising a character `omega`, and it passes `thetaLower=0`, so the
unconstrained path had no coverage at all.  It does now.  `test-nearpd.R`
still passes.
