### PR TITLE
Simulate omega uncertainty under a chunked solve

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -199,16 +199,21 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
 
 ## Bug fixes
 
-- A chunked solve (`rxSolve(file=, chunkSize=)`) with `nStud > 1` and an
-  `omega` is now an error rather than a result with the between study
-  variability silently missing (#1252).  The pre-draw is `nStud = 1` and
-  omega is stripped from what each chunk is forwarded, so such a solve
-  returned plausible looking output simulated entirely from the point
-  estimate omega, with nothing to signal that the uncertainty had been
-  dropped.  Carrying the draws through the chunking is a larger change and
-  is tracked in #1252; until then the combination is refused instead of
-  answered wrongly.  `nStud = 1`, a chunked solve without `omega`, and an
-  unchunked `nStud > 1` solve are all unaffected.
+- A chunked solve (`rxSolve(file=`/`chunkSize=`)) with `nStud > 1` now
+  simulates the omega uncertainty it was asked for.  It previously returned a
+  plausible looking result drawn entirely from the point estimate omega, with
+  the between study variability silently gone (#1252).
+
+  The draw is made once in the parent, so every chunk shares the same per
+  study omegas -- drawing per chunk would put subjects in different chunks
+  into different studies.  `$omegaList`/`$sigmaList` are reported on a chunked
+  solve as they are on a plain one.
+
+  This changes existing chunked results with `nStud > 1`; they were wrong
+  before.  Note that reproducing a chunked solve exactly needs both seeds
+  pinned, `set.seed()` as well as `rxSetSeed()`, because the omega draw runs
+  on R's RNG while the etas run on rxode2's.
+
 - The `lkj`/`separation` omega strategy no longer hangs on a simulated
   standard deviation it cannot use (#1255).  `cvPost()` retried a
   non-finite draw with no bound, but the failure is often not random: with

--- a/R/prior-sim.R
+++ b/R/prior-sim.R
@@ -354,7 +354,7 @@
   ## drawn from at all.
   if (!is.null(ctl$file) || !is.null(ctl$chunkSize)) {
     stop("prior simulation does not yet support a chunked solve ('file=' or ",
-         "'chunkSize='); see rxode2 issue #1252",
+         "'chunkSize='); see rxode2 issue #1263",
          call.=FALSE)
   }
   invisible()

--- a/R/rxOom.R
+++ b/R/rxOom.R
@@ -82,6 +82,18 @@ rxMemSummary.rxEtFile <- function(x, ...) {
   .rxMemSummarizeDat(.dat)
 }
 
+# The per study omega/sigma draws are written by the C++ side into the shared
+# `.rxModels` environment rather than returned, so a chunked solve has to read
+# them in the parent -- the only process that ran the draw.  Missing is normal
+# (no draw was made), so this returns NULL rather than erroring.
+.rxOomDrawnList <- function(what) {
+  .e <- .rxModels
+  if (!is.environment(.e) || !exists(what, envir=.e, inherits=FALSE)) return(NULL)
+  .l <- get(what, envir=.e, inherits=FALSE)
+  if (is.null(.l) || length(.l) == 0L) return(NULL)
+  .l
+}
+
 # -- Main OOM solve loop -------------------------------------------------------
 
 .rxSolveOom <- function(object, params, events, inits, .ctl, .envir = parent.frame()) {
@@ -148,23 +160,31 @@ rxMemSummary.rxEtFile <- function(x, ...) {
   # rxSolve_ calls seedEng(op->cores) BEFORE rxSimThetaOmega, advancing rxSeed
   # by 2*ncores.  We replicate that here with rxSeedEng() so our standalone
   # rxSimThetaOmega sees the same effective seed as the internal call in rxSolve_.
-  # A chunked solve cannot draw omega uncertainty: the pre-draw below is
-  # `nStud = 1L`, and omega is stripped from what each chunk is forwarded,
-  # so `nStud > 1` would return a plausible looking result simulated
-  # entirely from the point estimate omega with the between study
-  # variability silently gone.  Refuse it rather than answer wrongly.
-  # Supporting it needs the pre-draw, the by-subject chunk slicing and the
-  # `$omegaList` plumbing reworked together; that is nlmixr2/rxode2#1252.
-  if (!is.null(.ctl$omega) && !is.null(.ctl$nStud) &&
-        length(.ctl$nStud) == 1L && !is.na(.ctl$nStud) && .ctl$nStud > 1L) {
-    stop("a chunked solve ('file='/'chunkSize=') cannot simulate omega uncertainty; ",
-         "with 'nStud' > 1 the between subject variability would be drawn from the ",
-         "point estimate omega and the between study variability dropped without warning ",
-         "(see nlmixr2/rxode2#1252).  Solve with 'nStud=1', or without chunking.",
-         call.=FALSE)
+  # The pre-draw covers every study as well as every subject, so `nStud > 1`
+  # draws its omega uncertainty here once rather than in each chunk -- which
+  # is what makes it right: a per-chunk draw would give each chunk its own
+  # study omegas, so subjects in different chunks would not share a study.
+  .nStud <- if (!is.null(.ctl$nStud) && length(.ctl$nStud) == 1L &&
+                  !is.na(.ctl$nStud) && .ctl$nStud > 1L) {
+    as.integer(.ctl$nStud)
+  } else {
+    1L
   }
 
   .preDrawnParams <- NULL
+  .preDrawnOmegaL <- NULL
+  .preDrawnSigmaL <- NULL
+
+  # The pre-draw is study major: all `nSub` subjects of study 1, then of study
+  # 2, and so on -- the same layout `rxSimThetaOmega()` gives the unchunked
+  # solve.  A chunk holds a contiguous run of SUBJECTS, so its rows are one
+  # stride per study rather than one contiguous block.  Taking the contiguous
+  # block instead would hand the later chunks another study's etas.
+  .preDrawnSlice <- function(.first, .n) {
+    as.integer(vapply(seq_len(.nStud) - 1L,
+                      function(.s) .s * .nSub + seq.int(.first, length.out=.n),
+                      double(.n)))
+  }
   if (!is.null(.ctl$omega)) {
     .ncores <- if (!is.null(.ctl$cores) && .ctl$cores > 0L) {
       as.integer(.ctl$cores)
@@ -184,8 +204,20 @@ rxMemSummary.rxEtFile <- function(x, ...) {
       omegaXform      = if (!is.null(.ctl$omegaXform))  .ctl$omegaXform  else 1L,
       nSub            = .nSub,
       nCoresRV        = 1L,
-      nStud           = 1L
+      nStud           = .nStud,
+      # `dfSub` is what turns the omega uncertainty draw on, so the pre-draw
+      # has to carry it or `nStud > 1` would still come back with every study
+      # sharing the point estimate omega
+      dfSub           = if (!is.null(.ctl$dfSub)) .ctl$dfSub else 0,
+      simVariability  = if (!is.null(.ctl$simVariability)) .ctl$simVariability else NA
     )
+    # The drawn per study omegas live in the shared `.rxModels` environment that
+    # the C++ side writes.  They are read here, in the parent, because that is
+    # the only process that ran the draw -- a chunk never sees them, so without
+    # this `$omegaList`/`$sigmaList` would come back empty on a chunked solve
+    # while a plain one reports them.
+    .preDrawnOmegaL <- .rxOomDrawnList(".omegaL")
+    .preDrawnSigmaL <- .rxOomDrawnList(".sigmaL")
     # Strip omega from forwarded args -- etas are now baked into per-chunk params
     .fwdCtlArgs$omega           <- NULL
     .fwdCtlArgs$omegaDf         <- NULL
@@ -262,7 +294,7 @@ rxMemSummary.rxEtFile <- function(x, ...) {
       .chunkEvList[[.i]] <- .extractChunkEvents(.chunkList[[.i]])
       .nThis <- length(.chunkList[[.i]])
       .chunkParamsList[[.i]] <- if (!is.null(.preDrawnParams)) {
-        .preDrawnParams[(.cumSub + 1L):(.cumSub + .nThis), , drop = FALSE]
+        .preDrawnParams[.preDrawnSlice(.cumSub + 1L, .nThis), , drop = FALSE]
       } else {
         params
       }
@@ -385,7 +417,7 @@ rxMemSummary.rxEtFile <- function(x, ...) {
       .nThis    <- length(.chunkIds)
       .chunkEvents <- .extractChunkEvents(.chunkIds)
       .chunkParams <- if (!is.null(.preDrawnParams)) {
-        .preDrawnParams[(.cumSub + 1L):(.cumSub + .nThis), , drop = FALSE]
+        .preDrawnParams[.preDrawnSlice(.cumSub + 1L, .nThis), , drop = FALSE]
       } else {
         rxSetSeed(as.integer(
           (as.double(.baseSeed) + as.double(.cumSub)) %% .Machine$integer.max
@@ -411,6 +443,12 @@ rxMemSummary.rxEtFile <- function(x, ...) {
   }
   # Drop param chunks that failed to write (NA); keep only valid files.
   .manifest$paramChunks <- .paramFiles[!is.na(.paramFiles)]
+
+  # `$omegaList`/`$sigmaList` are what tell a user the between study
+  # variability was actually simulated, so a chunked solve has to report them
+  # like a plain one does
+  .manifest$omegaList <- .preDrawnOmegaL
+  .manifest$sigmaList <- .preDrawnSigmaL
 
   saveRDS(.manifest, paste0(.prefix, "_manifest.rds"))
   .rxSolveOomFromManifest(.manifest)
@@ -485,16 +523,28 @@ rxMemSummary.rxEtFile <- function(x, ...) {
 .rxOomParams <- function(manifest) {
   .pc <- manifest$paramChunks
   .pq <- .rxOomParquetFiles(.pc)
-  if (length(.pq) > 0L) {
-    if (.rxOomHasDuckdb()) {
-      return(.rxOomDuckQuery(.pq, "SELECT * FROM {tbl}"))
-    }
-    if (.rxOomHasArrow()) {
-      return(do.call(rbind, lapply(.pq, function(.f)
-        as.data.frame(arrow::read_parquet(.f)))))
-    }
+  .ret <- if (length(.pq) > 0L && .rxOomHasDuckdb()) {
+    .rxOomDuckQuery(.pq, "SELECT * FROM {tbl}")
+  } else if (length(.pq) > 0L && .rxOomHasArrow()) {
+    do.call(rbind, lapply(.pq, function(.f) as.data.frame(arrow::read_parquet(.f))))
+  } else {
+    do.call(rbind, lapply(.pc, readRDS))
   }
-  do.call(rbind, lapply(.pc, readRDS))
+  .rxOomOrderParams(.ret)
+}
+
+# Chunks are concatenated in chunk order, which is subject major: chunk 1 holds
+# its subjects across every study, then chunk 2 does.  An unchunked solve
+# reports the parameter table study major instead, so ordering here is what
+# keeps `$params` the same table either way -- the rows are already identical.
+.rxOomOrderParams <- function(pars) {
+  if (is.null(pars) || !is.data.frame(pars) || nrow(pars) == 0L) return(pars)
+  if (!all(c("sim.id", "id") %in% names(pars))) return(pars)
+  .o <- order(pars[["sim.id"]], pars[["id"]])
+  if (identical(.o, seq_len(nrow(pars)))) return(pars)
+  .ret <- pars[.o, , drop = FALSE]
+  rownames(.ret) <- NULL
+  .ret
 }
 
 .rxOomInits <- function(manifest) manifest$inits
@@ -678,6 +728,14 @@ head.rxSolveOom <- function(x, n = 6L, ...) {
   }
   if (name %in% c("inits", "init")) {
     return(.rxOomInits(.m))
+  }
+  ## the per study draws come off the manifest rather than the chunk files:
+  ## they are one matrix per study, not a column to read back out of the rows
+  if (name == "omegaList") {
+    return(.m$omegaList)
+  }
+  if (name == "sigmaList") {
+    return(.m$sigmaList)
   }
   .pq <- .rxOomParquetFiles(.m$chunks)
   if (length(.pq) > 0L && .rxOomHasDuckdb()) {

--- a/tests/testthat/test-oom.R
+++ b/tests/testthat/test-oom.R
@@ -543,14 +543,13 @@ test_that("rxSolveOom supports lazy dplyr queries through a DuckDB connection", 
 
 rxTest({
 
-  test_that("a chunked solve refuses to simulate omega uncertainty", {
+  test_that("a chunked solve simulates omega uncertainty like an unchunked one", {
     skip_on_cran()
 
-    ## #1252: the pre-draw is nStud=1 and omega is stripped from what each
-    ## chunk is forwarded, so `nStud > 1` returned a plausible looking
-    ## result simulated entirely from the point estimate omega, with the
-    ## between study variability gone and nothing to signal it.  It is a
-    ## clear error until the chunking can carry the draws.
+    ## #1252: the pre-draw used to be nStud=1 and omega was stripped from
+    ## what each chunk is forwarded, so `nStud > 1` returned a plausible
+    ## looking result simulated entirely from the point estimate omega,
+    ## with the between study variability gone and nothing to signal it.
     .m <- rxode2({
       ka <- exp(tka + eta.ka)
       cl <- exp(tcl + eta.cl)
@@ -561,23 +560,94 @@ rxTest({
     .om <- lotri::lotri(eta.ka + eta.cl ~ c(0.1, 0.01, 0.1))
     .p <- c(tka=0.45, tcl=1, tv=3.45)
 
-    expect_error(
-      rxSolve(.m, .ev, params=.p, omega=.om, nStud=3,
-              file=tempfile(fileext=".parquet"), chunkSize=2),
-      "nStud")
+    .solve <- function(...) {
+      ## the omega draw runs on R's RNG while the etas run on rxode2's, so
+      ## both have to be pinned for a chunked and an unchunked solve to be
+      ## comparable at all
+      set.seed(42)
+      rxSetSeed(1234)
+      rxSolve(.m, .ev, params=.p, omega=.om, nStud=3, dfSub=10, ...)
+    }
+    .key <- function(d) d[order(d$sim.id, d$id, d$time), ]
 
-    ## the combinations that do work are untouched
-    expect_error(
-      rxSolve(.m, .ev, params=.p, omega=.om, nStud=1,
-              file=tempfile(fileext=".parquet"), chunkSize=2),
-      NA)
-    expect_error(
-      rxSolve(.m, .ev, params=c(.p, eta.ka=0.1, eta.cl=0.1),
-              file=tempfile(fileext=".parquet"), chunkSize=2),
-      NA)
-    ## and an unchunked solve still simulates all the studies
-    .r <- rxSolve(.m, .ev, params=.p, omega=.om, nStud=3)
-    expect_equal(length(unique(.r$sim)), 3L)
+    .full  <- .solve()
+    .chunk <- .solve(file=tempfile(fileext=".parquet"), chunkSize=2)
+
+    ## the whole point: the chunked solve is the unchunked solve
+    expect_equal(.key(as.data.frame(.chunk))$cp,
+                 .key(as.data.frame(.full))$cp,
+                 tolerance=1e-8)
+
+    ## and the drawn omegas are reported, not just used
+    expect_equal(length(.chunk$omegaList), 3L)
+    expect_equal(.chunk$omegaList, .full$omegaList)
+
+    ## there really is between study variability to have gotten right
+    expect_false(isTRUE(all.equal(.full$omegaList[[1]], .full$omegaList[[2]])))
+
+    ## every study reached the output
+    expect_equal(length(unique(as.data.frame(.chunk)$sim.id)), 3L)
+  })
+
+  test_that("chunk boundaries do not shift which study a subject belongs to", {
+    skip_on_cran()
+
+    ## the pre-draw is study major, so a chunk's rows are one stride per
+    ## study rather than a contiguous block -- slicing it contiguously would
+    ## hand the later chunks another study's etas, which shows up as the
+    ## answer depending on the chunk size
+    .m <- rxode2({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      cp <- linCmt()
+    })
+    .ev <- et(et(amt=100, id=1:6), seq(0, 24, by=8))
+    .om <- lotri::lotri(eta.ka + eta.cl ~ c(0.1, 0.01, 0.1))
+    .p <- c(tka=0.45, tcl=1, tv=3.45)
+
+    .solve <- function(...) {
+      set.seed(42)
+      rxSetSeed(1234)
+      rxSolve(.m, .ev, params=.p, omega=.om, nStud=3, dfSub=10, ...)
+    }
+    .key <- function(d) d[order(d$sim.id, d$id, d$time), ]
+
+    .ref <- .key(as.data.frame(.solve()))
+    for (.cs in c(1L, 2L, 3L, 6L)) {
+      .got <- .key(as.data.frame(
+        .solve(file=tempfile(fileext=".parquet"), chunkSize=.cs)))
+      expect_equal(.got$cp, .ref$cp, tolerance=1e-8)
+    }
+  })
+
+  test_that("a chunked solve reports its parameters study major", {
+    skip_on_cran()
+
+    ## chunks are concatenated subject major, so `$params` has to be put
+    ## back in the order an unchunked solve reports
+    .m <- rxode2({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      cp <- linCmt()
+    })
+    .ev <- et(et(amt=100, id=1:6), seq(0, 24, by=8))
+    .om <- lotri::lotri(eta.ka + eta.cl ~ c(0.1, 0.01, 0.1))
+    .p <- c(tka=0.45, tcl=1, tv=3.45)
+
+    set.seed(42); rxSetSeed(1234)
+    .full <- rxSolve(.m, .ev, params=.p, omega=.om, nStud=3, dfSub=10)
+    set.seed(42); rxSetSeed(1234)
+    .chunk <- rxSolve(.m, .ev, params=.p, omega=.om, nStud=3, dfSub=10,
+                      file=tempfile(fileext=".parquet"), chunkSize=2)
+
+    .cp <- .chunk$params
+    expect_equal(nrow(.cp), nrow(.full$params))
+    expect_equal(as.integer(.cp$sim.id), as.integer(.full$params$sim.id))
+    expect_equal(as.integer(as.character(.cp$id)),
+                 as.integer(as.character(.full$params$id)))
+    expect_equal(.cp$eta.ka, .full$params$eta.ka, tolerance=1e-8)
   })
 
 })


### PR DESCRIPTION
Closes #1252. Supersedes the guard added in #1261.

A chunked solve with `nStud > 1` returned a plausible looking result drawn entirely from the point estimate omega — the pre-draw was `nStud = 1` and omega was stripped from what each chunk was forwarded, so nothing drew the between study variability and nothing signalled it. #1261 made that a clear error; this makes it work.

## What changed

Three things, all in `R/rxOom.R`:

**The draw happens once, in the parent.** The pre-draw now carries `nStud` and `dfSub`. Drawing per chunk would run, but it would be wrong: each chunk would get its own study omegas, so subjects in different chunks would no longer belong to the same study.

**The per-chunk slice is one stride per study.** The pre-draw is study major, so a chunk — which holds a contiguous run of *subjects* — needs `(s-1)*nSub + S` for each study `s`, not a contiguous block. Slicing contiguously hands the later chunks another study's etas, and the symptom is the answer depending on the chunk size. There is a test that varies `chunkSize` from 1 to `nSub` against a fixed reference for exactly this.

**`$omegaList`/`$sigmaList` are reported.** The draws are written by the C++ side into the shared `.rxModels` environment rather than returned, so they are read in the parent — the only process that ran the draw — and carried on the manifest. `$params` is also put back in study-major order, since chunks concatenate subject major.

## Verification

Against an unchunked solve, not against expectations:

| case | solve output | omegaList |
|---|---|---|
| nStud=3, chunk=3, dfSub=10 | identical | identical |
| nStud=3, chunk=8 (single chunk) | identical | identical |
| nStud=4, chunk=2, dfSub=20 | identical | identical |
| nStud=2, chunk=5, no dfSub | identical | identical |
| nStud=1, chunk=3 (regression) | identical | identical |

Full `test-oom.R` passes; the test asserting the old refusal is replaced by three positive ones. `test-prior-sim-spec` and `test-prior-sim-nwpri` also green.

## Two things found and deliberately not fixed here

**Reproducing a chunked solve needs both seeds pinned** — `set.seed()` as well as `rxSetSeed()` — because the omega draw runs on R's RNG while the etas run on rxode2's. This is not new and not caused by chunking: an *unchunked* `nStud > 1` solve is equally irreproducible from `rxSetSeed()` alone. My first comparison failed for this reason and looked like a bug in the fix. Now called out in NEWS.

**A `thetaMat` with a chunked solve errors outright**, at any `nStud`, because the pre-draw hands each chunk a params data frame while `thetaMat` is still forwarded. Pre-existing, filed as #1263, and it is why prior simulation still refuses a chunked solve — that guard now points at #1263 rather than #1252.

NEWS carries a `## Bug fixes` entry noting this **changes existing chunked results** with `nStud > 1`; they were wrong before. The superseded entry describing the #1261 guard is removed.