### PR TITLE
Expand linCmt() based on the model, not the last parse (#1227)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -281,6 +281,15 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
   with `could not find function ".badBuild"` or reports a previous model's
   compiler output.
 
+- Re-compiling a `linCmt()` model from its own `rxModelVars()` no longer
+  fails with `implicit declaration of function 'linCmt'`.  Whether to expand
+  `linCmt()` was read from a parser global that only an actual parse
+  refreshes, and `rxGetModel()` returns model variables it is handed without
+  re-parsing them, so the expansion was skipped -- or run on a model that had
+  no `linCmt()` -- depending on what happened to be parsed last.  The model
+  itself is asked now, so `rxode2(rxModelVars(ui))` builds and the result no
+  longer depends on build order (#1227).
+
 - `rxLastCompile()` now prints its section rules -- `cli::rule()` was called
   but its result was never messaged -- and takes `what=` to choose which
   sections are messaged (`rxLastCompile("stderr")` for the compiler error

--- a/R/rxLinCmt.R
+++ b/R/rxLinCmt.R
@@ -35,22 +35,31 @@ findLhs <- function(x) {
 #' handed around as model variables has to be asked directly; otherwise
 #' the flag describes whatever was parsed last (nlmixr2/rxode2#1227).
 #'
-#' @param model anything `rxNorm()` accepts
+#' The model's own `flags` answer instead: `linCmtFlg` is nonzero for
+#' every linear compartment model (the parser always adds a central
+#' compartment), and `ncmt` is only ever filled in by parsing an
+#' already-expanded `linCmtA()`/`linCmtB()` call -- so a nonzero
+#' `linCmtFlg` with `ncmt` still zero is exactly `tb.linCmt == 1`.
 #'
-#' @return `TRUE` when the normalized model text still contains a
-#'   `linCmt()` that has not been expanded to `linCmtA()`/`linCmtB()`
+#' @param model anything `rxModelVars()` accepts; pass model variables
+#'   where they are already at hand, since anything else is parsed
+#'
+#' @return `TRUE` when the model contains a `linCmt()` that has not been
+#'   expanded to `linCmtA()`/`linCmtB()`
 #'
 #' @noRd
 #' @author Matthew L. Fidler
 .rxHasUnexpandedLinCmt <- function(model) {
-  .txt <- try(rxNorm(model), silent = TRUE)
-  if (inherits(.txt, "try-error") || !is.character(.txt) ||
-        length(.txt) == 0L || anyNA(.txt)) {
+  .mv <- try(rxModelVars(model), silent = TRUE)
+  if (inherits(.mv, "try-error")) {
     return(FALSE)
   }
-  .txt <- paste(.txt, collapse = "\n")
-  # `linCmtA(`/`linCmtB(` are the expanded forms and must not match
-  any(regexpr("(^|[^[:alnum:]._])linCmt[[:space:]]*\\(", .txt) != -1L)
+  .flags <- .mv$flags
+  if (!is.numeric(.flags) ||
+        !all(c("ncmt", "linCmtFlg") %in% names(.flags))) {
+    return(FALSE)
+  }
+  .flags[["linCmtFlg"]] != 0L && .flags[["ncmt"]] == 0L
 }
 
 #' Get the linear compartment model true function

--- a/R/rxLinCmt.R
+++ b/R/rxLinCmt.R
@@ -37,9 +37,11 @@ findLhs <- function(x) {
 #'
 #' The model's own `flags` answer instead: `linCmtFlg` is nonzero for
 #' every linear compartment model (the parser always adds a central
-#' compartment), and `ncmt` is only ever filled in by parsing an
-#' already-expanded `linCmtA()`/`linCmtB()` call -- so a nonzero
-#' `linCmtFlg` with `ncmt` still zero is exactly `tb.linCmt == 1`.
+#' compartment), while `ncmt` and `linCmt` (`tb.linCmtN`) are written
+#' only by parsing an already-expanded `linCmtA()`/`linCmtB()` call --
+#' so a nonzero `linCmtFlg` with both still at the values the parse
+#' reset them to is `tb.linCmt == 1`.  Both are checked because either
+#' one alone can be the argument an expanded call passes.
 #'
 #' @param model anything `rxModelVars()` accepts; pass model variables
 #'   where they are already at hand, since anything else is parsed
@@ -56,10 +58,11 @@ findLhs <- function(x) {
   }
   .flags <- .mv$flags
   if (!is.numeric(.flags) ||
-        !all(c("ncmt", "linCmtFlg") %in% names(.flags))) {
+        !all(c("ncmt", "linCmt", "linCmtFlg") %in% names(.flags))) {
     return(FALSE)
   }
-  .flags[["linCmtFlg"]] != 0L && .flags[["ncmt"]] == 0L
+  .flags[["linCmtFlg"]] != 0L && .flags[["ncmt"]] == 0L &&
+    .flags[["linCmt"]] == -100L
 }
 
 #' Get the linear compartment model true function

--- a/R/rxLinCmt.R
+++ b/R/rxLinCmt.R
@@ -56,10 +56,19 @@ findLhs <- function(x) {
   if (inherits(.mv, "try-error")) {
     return(FALSE)
   }
+  .need <- c("ncmt", "linCmt", "linCmtFlg")
   .flags <- .mv$flags
-  if (!is.numeric(.flags) ||
-        !all(c("ncmt", "linCmt", "linCmtFlg") %in% names(.flags))) {
-    return(FALSE)
+  if (!is.numeric(.flags) || !all(.need %in% names(.flags))) {
+    # model variables too old (or too damaged) to carry the flags: a parse
+    # always produces them, and the normalized text round-trips exactly
+    .mv <- try(rxModelVars(setNames(rxNorm(.mv), NULL)), silent = TRUE)
+    if (inherits(.mv, "try-error")) {
+      return(FALSE)
+    }
+    .flags <- .mv$flags
+    if (!is.numeric(.flags) || !all(.need %in% names(.flags))) {
+      return(FALSE)
+    }
   }
   .flags[["linCmtFlg"]] != 0L && .flags[["ncmt"]] == 0L &&
     .flags[["linCmt"]] == -100L

--- a/R/rxLinCmt.R
+++ b/R/rxLinCmt.R
@@ -28,6 +28,31 @@ findLhs <- function(x) {
   }
 }
 
+#' Does this model still carry an unexpanded `linCmt()`?
+#'
+#' The parser records `linCmt()` in a parser-global flag
+#' (`_rxode2_isLinCmt`) that only an actual parse refreshes, so a model
+#' handed around as model variables has to be asked directly; otherwise
+#' the flag describes whatever was parsed last (nlmixr2/rxode2#1227).
+#'
+#' @param model anything `rxNorm()` accepts
+#'
+#' @return `TRUE` when the normalized model text still contains a
+#'   `linCmt()` that has not been expanded to `linCmtA()`/`linCmtB()`
+#'
+#' @noRd
+#' @author Matthew L. Fidler
+.rxHasUnexpandedLinCmt <- function(model) {
+  .txt <- try(rxNorm(model), silent = TRUE)
+  if (inherits(.txt, "try-error") || !is.character(.txt) ||
+        length(.txt) == 0L || anyNA(.txt)) {
+    return(FALSE)
+  }
+  .txt <- paste(.txt, collapse = "\n")
+  # `linCmtA(`/`linCmtB(` are the expanded forms and must not match
+  any(regexpr("(^|[^[:alnum:]._])linCmt[[:space:]]*\\(", .txt) != -1L)
+}
+
 #' Get the linear compartment model true function
 #'
 #' @inheritParams rxode2
@@ -37,7 +62,7 @@ findLhs <- function(x) {
 rxGetLin <- function(model, linCmtSens = c("linCmtA", "linCmtB"),
                      verbose = FALSE) {
   .mv <- rxGetModel(model) # nolint
-  if (.Call(`_rxode2_isLinCmt`) == 1L) { # nolint
+  if (.rxHasUnexpandedLinCmt(.mv)) {
     .vars <- c(.mv$params, .mv$lhs, .mv$slhs)
     .Call(
       `_rxode2_linCmtGen`, # nolint

--- a/R/rxode2.R
+++ b/R/rxode2.R
@@ -440,7 +440,11 @@ rxode2 <- # nolint
     ## rxToIndLin() would leave a rewritten matrix-exponential model as the last
     ## parse.
     .env$.mv <- rxGetModel(model, collapseModel = collapseModel, indLin = FALSE)
-    .isLinCmt <- .Call(`_rxode2_isLinCmt`) == 1L
+    ## Ask the model, not the parser global: the flag is sticky across parses and
+    ## `rxGetModel()` does not re-parse model variables it is handed, so reading
+    ## it here both missed a real linCmt() model and claimed one that was not
+    ## (nlmixr2/rxode2#1227).
+    .isLinCmt <- .rxHasUnexpandedLinCmt(.env$.mv)
     if (.eventSensNeedsJac && !.isLinCmt && !isTRUE(calcJac)) {
       calcJac <- TRUE
     }
@@ -888,6 +892,17 @@ rxGetModel <- function(model, calcSens = NULL, calcJac = NULL, collapseModel = N
   ## that never fully compiled) makes an unrelated plain model hash differently
   ## depending on build order.
   assignInMyNamespace(".indLinInfo", list())
+  ## Model variables are returned below WITHOUT re-parsing, so the parser-global
+  ## linCmt() state -- both `_rxode2_isLinCmt` and the text `linCmtGen()`
+  ## rewrites -- would still describe whatever was parsed last.  Model variables
+  ## that still carry an unexpanded `linCmt()` then never got expanded, and
+  ## `linCmt()` reached the C code generator verbatim (nlmixr2/rxode2#1227).
+  ## Re-parse from the normalized text so the parse state matches the model in
+  ## hand; already-expanded (`linCmtA()`/`linCmtB()`) models short-circuit as
+  ## before.
+  if (inherits(model, "rxModelVars") && .rxHasUnexpandedLinCmt(model)) {
+    model <- setNames(rxNorm(model), NULL)
+  }
   .ret <- rxModelVars(model)
   if (!is.null(calcSens)) {
     .calcSens <- TRUE

--- a/tests/testthat/test-lincmt-modelvars.R
+++ b/tests/testthat/test-lincmt-modelvars.R
@@ -110,6 +110,11 @@ rxTest({
     .cmt <- rxModelVars("d/dt(linCmt)=1;\nlinCmt(0)=0;\n")
     expect_false(rxode2:::.rxHasUnexpandedLinCmt(.cmt))
     expect_equal(rxState(rxode2(.cmt)), "linCmt")
+
+    # an expanded call is expanded however few compartments it declares
+    .lin0 <- rxModelVars(paste0("cp=linCmtA(rx__PTR__, t, 0, 0, 0, -1, 2, ",
+                                "k, v, 0.0, 0.0, 0.0, 0.0, 0.0);\n"))
+    expect_false(rxode2:::.rxHasUnexpandedLinCmt(.lin0))
   })
 
   test_that("re-parsing model variables keeps the ini and state layout", {
@@ -122,6 +127,14 @@ rxTest({
     expect_equal(rxInits(.m)[["v"]], 10)
     expect_equal(rxInits(.m)[["kin"]], 1)
     expect_equal(rxState(.mv), rxState(.m))
+    # the re-parse has to be an identity, or it would move the compile
+    # cache key of every model that goes through it
+    .mv2 <- rxModelVars(setNames(rxNorm(.mv), NULL))
+    expect_equal(.mv2$md5[["parsed_md5"]], .mv$md5[["parsed_md5"]])
+    for (.n in c("params", "lhs", "state", "ini", "dvid", "alag", "slhs",
+                 "interp", "strAssign", "udf", "stateOrd", "lhsOrd", "flags")) {
+      expect_equal(.mv2[[.n]], .mv[[.n]], info = .n)
+    }
   })
 
   test_that("rxGetLin() expands model variables it is handed", {

--- a/tests/testthat/test-lincmt-modelvars.R
+++ b/tests/testthat/test-lincmt-modelvars.R
@@ -137,6 +137,20 @@ rxTest({
     }
   })
 
+  test_that("model variables that do not carry the flags still expand", {
+    .mv <- rxModelVars("k=0.1;\nv=10;\ncp=linCmt();\n")
+    names(.mv$flags) <- NULL
+    expect_true(rxode2:::.rxHasUnexpandedLinCmt(.mv))
+    expect_true(.isExpanded(rxode2(.mv)))
+
+    .mv$flags <- NULL
+    expect_true(rxode2:::.rxHasUnexpandedLinCmt(.mv))
+
+    .ode <- rxModelVars("a=1;\nd/dt(b)=a;\n")
+    .ode$flags <- NULL
+    expect_false(rxode2:::.rxHasUnexpandedLinCmt(.ode))
+  })
+
   test_that("rxGetLin() expands model variables it is handed", {
     .mv <- rxModelVars(rxode2({
       k <- 0.1

--- a/tests/testthat/test-lincmt-modelvars.R
+++ b/tests/testthat/test-lincmt-modelvars.R
@@ -100,6 +100,30 @@ rxTest({
     expect_true(.isExpanded(rxode2(.lin)))
   })
 
+  test_that("'linCmt' that is not a linCmt() call is left alone", {
+    # neither of these sets the parser's linCmt flag, so neither may be
+    # treated as a linCmt() model
+    .str <- rxModelVars('printf("linCmt()");\nd/dt(b)=1;\n')
+    expect_false(rxode2:::.rxHasUnexpandedLinCmt(.str))
+    expect_equal(rxState(rxode2(.str)), "b")
+
+    .cmt <- rxModelVars("d/dt(linCmt)=1;\nlinCmt(0)=0;\n")
+    expect_false(rxode2:::.rxHasUnexpandedLinCmt(.cmt))
+    expect_equal(rxState(rxode2(.cmt)), "linCmt")
+  })
+
+  test_that("re-parsing model variables keeps the ini and state layout", {
+    .mv <- rxModelVars(paste("k=0.1;", "v=10;", "cp=linCmt();",
+                             "kin=1;", "d/dt(eff)=kin-kin*eff*cp;",
+                             "eff(0)=1;", sep = "\n"))
+    .m <- rxode2(.mv)
+    expect_equal(rxInits(.m)[["eff"]], 1)
+    expect_equal(rxInits(.m)[["k"]], 0.1)
+    expect_equal(rxInits(.m)[["v"]], 10)
+    expect_equal(rxInits(.m)[["kin"]], 1)
+    expect_equal(rxState(.mv), rxState(.m))
+  })
+
   test_that("rxGetLin() expands model variables it is handed", {
     .mv <- rxModelVars(rxode2({
       k <- 0.1

--- a/tests/testthat/test-lincmt-modelvars.R
+++ b/tests/testthat/test-lincmt-modelvars.R
@@ -93,11 +93,20 @@ rxTest({
     # a plain ODE model handed in as model variables must not be treated as a
     # linCmt() model just because a linCmt() model was parsed just before it
     invisible(rxGetModel(rxNorm(.lin)))
-    expect_equal(rxState(rxode2(.ode)), "b")
+    .b <- rxode2(.ode)
+    expect_equal(rxState(.b), "b")
+    expect_equal(rxModelVars(.b)$flags[["linCmtFlg"]], 0L)
 
-    # ... and a linCmt() model must expand even when the last parse was not one
+    # ... and a linCmt() model must expand even when the last parse was not one.
+    # Assert what the model IS, not only that no linCmt() is left: the model the
+    # expansion rewrites comes from parser state, so a wrong one would also have
+    # no linCmt() in it.
     invisible(rxGetModel(rxNorm(.ode)))
-    expect_true(.isExpanded(rxode2(.lin)))
+    .l <- rxode2(.lin)
+    expect_true(.isExpanded(.l))
+    expect_equal(rxState(.l), "central")
+    expect_equal(rxModelVars(.l)$flags[["ncmt"]], 1L)
+    expect_false("b" %in% rxState(.l))
   })
 
   test_that("'linCmt' that is not a linCmt() call is left alone", {

--- a/tests/testthat/test-lincmt-modelvars.R
+++ b/tests/testthat/test-lincmt-modelvars.R
@@ -1,0 +1,112 @@
+rxTest({
+  # nlmixr2/rxode2#1227: rxode2() decided whether to expand linCmt() from a
+  # sticky parser global instead of from the model it was handed, so
+  # re-compiling a linCmt() model from its own rxModelVars() emitted linCmt()
+  # verbatim into the generated C.
+
+  .isExpanded <- function(model) {
+    !any(regexpr("(^|[^[:alnum:]._])linCmt[[:space:]]*\\(",
+                 rxNorm(rxModelVars(model))) != -1L)
+  }
+
+  test_that("a linCmt() model recompiles from its own model variables", {
+    f <- function() {
+      ini({
+        tk <- -1
+        tv <- 3
+        a <- 0.7
+      })
+      model({
+        k <- exp(tk)
+        v <- exp(tv)
+        cp <- linCmt()
+        cp ~ add(a)
+      })
+    }
+    .mv <- rxModelVars(f())
+    expect_false(.isExpanded(.mv))
+
+    .m <- rxode2(.mv)
+    expect_true(.isExpanded(.m))
+    expect_equal(rxModelVars(.m)$flags[["ncmt"]], 1L)
+
+    .s <- rxSolve(.m, et(amt = 100) %>% et(0:3),
+                  params = c(tk = -1, tv = 3))
+    expect_true(all(is.finite(.s$cp)))
+  })
+
+  test_that("the cl/v/ka parameterization recompiles too", {
+    f <- function() {
+      ini({
+        tcl <- 1
+        tv <- 3
+        tka <- 0.5
+        a <- 0.7
+      })
+      model({
+        cl <- exp(tcl)
+        v <- exp(tv)
+        ka <- exp(tka)
+        cp <- linCmt()
+        cp ~ add(a)
+      })
+    }
+    .m <- rxode2(rxModelVars(f()))
+    expect_true(.isExpanded(.m))
+    expect_equal(rxModelVars(.m)$flags[["ncmt"]], 1L)
+    expect_equal(rxModelVars(.m)$flags[["ka"]], 1L)
+  })
+
+  test_that("linCmt() mixed with ODE states recompiles", {
+    f <- function() {
+      ini({
+        tk <- -1
+        tv <- 3
+        tkin <- 0.1
+        a <- 0.7
+      })
+      model({
+        k <- exp(tk)
+        v <- exp(tv)
+        kin <- exp(tkin)
+        cp <- linCmt()
+        d/dt(eff) <- kin - kin * eff * cp
+        eff ~ add(a)
+      })
+    }
+    .m <- rxode2(rxModelVars(f()))
+    expect_true(.isExpanded(.m))
+    expect_true("eff" %in% rxState(.m))
+    .s <- rxSolve(.m, et(amt = 100) %>% et(0:3),
+                  params = c(tk = -1, tv = 3, tkin = 0.1))
+    expect_true(all(is.finite(.s$eff)))
+  })
+
+  test_that("the expansion does not depend on what was parsed last", {
+    .lin <- rxModelVars(rxode2({
+      k <- 0.1
+      v <- 10
+      cp <- linCmt()
+    }))
+    .ode <- rxModelVars("a=1;\nd/dt(b)=a;")
+
+    # a plain ODE model handed in as model variables must not be treated as a
+    # linCmt() model just because a linCmt() model was parsed just before it
+    invisible(rxGetModel(rxNorm(.lin)))
+    expect_equal(rxState(rxode2(.ode)), "b")
+
+    # ... and a linCmt() model must expand even when the last parse was not one
+    invisible(rxGetModel(rxNorm(.ode)))
+    expect_true(.isExpanded(rxode2(.lin)))
+  })
+
+  test_that("rxGetLin() expands model variables it is handed", {
+    .mv <- rxModelVars(rxode2({
+      k <- 0.1
+      v <- 10
+      cp <- linCmt()
+    }))
+    invisible(rxGetModel("a=1;\nd/dt(b)=a;"))
+    expect_true(.isExpanded(rxGetLin(.mv)))
+  })
+})

--- a/tests/testthat/test-lincmt-modelvars.R
+++ b/tests/testthat/test-lincmt-modelvars.R
@@ -3,6 +3,7 @@ rxTest({
   # sticky parser global instead of from the model it was handed, so
   # re-compiling a linCmt() model from its own rxModelVars() emitted linCmt()
   # verbatim into the generated C.
+  .rx <- loadNamespace("rxode2")
 
   .isExpanded <- function(model) {
     !any(regexpr("(^|[^[:alnum:]._])linCmt[[:space:]]*\\(",
@@ -30,7 +31,7 @@ rxTest({
     expect_true(.isExpanded(.m))
     expect_equal(rxModelVars(.m)$flags[["ncmt"]], 1L)
 
-    .s <- rxSolve(.m, et(amt = 100) %>% et(0:3),
+    .s <- rxSolve(.m, et(amt = 100) |> et(0:3),
                   params = c(tk = -1, tv = 3))
     expect_true(all(is.finite(.s$cp)))
   })
@@ -77,7 +78,7 @@ rxTest({
     .m <- rxode2(rxModelVars(f()))
     expect_true(.isExpanded(.m))
     expect_true("eff" %in% rxState(.m))
-    .s <- rxSolve(.m, et(amt = 100) %>% et(0:3),
+    .s <- rxSolve(.m, et(amt = 100) |> et(0:3),
                   params = c(tk = -1, tv = 3, tkin = 0.1))
     expect_true(all(is.finite(.s$eff)))
   })
@@ -113,17 +114,17 @@ rxTest({
     # neither of these sets the parser's linCmt flag, so neither may be
     # treated as a linCmt() model
     .str <- rxModelVars('printf("linCmt()");\nd/dt(b)=1;\n')
-    expect_false(rxode2:::.rxHasUnexpandedLinCmt(.str))
+    expect_false(.rx$.rxHasUnexpandedLinCmt(.str))
     expect_equal(rxState(rxode2(.str)), "b")
 
     .cmt <- rxModelVars("d/dt(linCmt)=1;\nlinCmt(0)=0;\n")
-    expect_false(rxode2:::.rxHasUnexpandedLinCmt(.cmt))
+    expect_false(.rx$.rxHasUnexpandedLinCmt(.cmt))
     expect_equal(rxState(rxode2(.cmt)), "linCmt")
 
     # an expanded call is expanded however few compartments it declares
     .lin0 <- rxModelVars(paste0("cp=linCmtA(rx__PTR__, t, 0, 0, 0, -1, 2, ",
                                 "k, v, 0.0, 0.0, 0.0, 0.0, 0.0);\n"))
-    expect_false(rxode2:::.rxHasUnexpandedLinCmt(.lin0))
+    expect_false(.rx$.rxHasUnexpandedLinCmt(.lin0))
   })
 
   test_that("re-parsing model variables keeps the ini and state layout", {
@@ -149,15 +150,15 @@ rxTest({
   test_that("model variables that do not carry the flags still expand", {
     .mv <- rxModelVars("k=0.1;\nv=10;\ncp=linCmt();\n")
     names(.mv$flags) <- NULL
-    expect_true(rxode2:::.rxHasUnexpandedLinCmt(.mv))
+    expect_true(.rx$.rxHasUnexpandedLinCmt(.mv))
     expect_true(.isExpanded(rxode2(.mv)))
 
     .mv$flags <- NULL
-    expect_true(rxode2:::.rxHasUnexpandedLinCmt(.mv))
+    expect_true(.rx$.rxHasUnexpandedLinCmt(.mv))
 
     .ode <- rxModelVars("a=1;\nd/dt(b)=a;\n")
     .ode$flags <- NULL
-    expect_false(rxode2:::.rxHasUnexpandedLinCmt(.ode))
+    expect_false(.rx$.rxHasUnexpandedLinCmt(.ode))
   })
 
   test_that("rxGetLin() expands model variables it is handed", {


### PR DESCRIPTION
Closes #1227.

## The bug

`rxode2()` decided whether to run the `linCmt()` expansion from the
parser-global `_rxode2_isLinCmt` (`tb.linCmt`) instead of from the model it
was handed.  `rxGetModel()` returns an `rxModelVars` without re-parsing it, so
the flag described whatever was parsed last -- and `linCmtGen()`, which
rewrites the text the parser still holds, was pointed at the wrong model.

`rxode2(rxModelVars(ui))` therefore emitted `linCmt()` verbatim into the
generated C (`implicit declaration of function 'linCmt'`), and because the flag
is sticky the failure was order dependent: the same call succeeded if some other
`linCmt()` model happened to be parsed first.  This broke every
`linCmt()`-translated model in `nonmem2rx`, which round-trips through
`rxModelVars()` in `rxUiGet.simulationModelIwres()`.

## The fix

Ask the model, not the parser.

* `.rxHasUnexpandedLinCmt()` reads the model's own parsed `flags`:
  `linCmtFlg != 0 && ncmt == 0 && linCmt == -100`.  `linCmtFlg` is nonzero for
  every linear compartment model (`parseLinCmtApplyCmts.h` always adds a central
  compartment), while `tb.ncmt` and `tb.linCmtN` are written only by
  `handleFunctionLinCmt()` -- i.e. only by parsing an already-expanded
  `linCmtA()`/`linCmtB()` -- and all three are reset per parse.  So the test is
  exactly `tb.linCmt == 1`.  Model variables with no usable `flags` fall back to
  re-parsing the normalized text rather than giving up.
* `rxGetModel()` re-parses an `rxModelVars` that still carries an unexpanded
  `linCmt()`, so `linCmtGen()` rewrites the model in hand rather than the
  previous parse.  Already-expanded models short-circuit exactly as before.
* `rxode2()` and `rxGetLin()` gate on the model instead of the global.

The re-parse is an identity: `rxModelVars(rxNorm(mv))` has the same
`parsed_md5` and the same `params`/`lhs`/`state`/`ini`/`dvid`/`alag`/`slhs`/
`interp`/`strAssign`/`udf`/`stateOrd`/`lhsOrd`/`flags`, so no compile cache key
moves and nothing is lost.  `rxCompile.rxModelVars()` already relies on the same
round trip.  A test asserts it.

## Tests

`tests/testthat/test-lincmt-modelvars.R` (45 assertions), covering: recompiling
from `rxModelVars()` for the `k`/`v`, `cl`/`v`/`ka` and mixed ODE+`linCmt()`
cases; both directions of the order dependence; the round trip being an
identity; model variables with stripped flags; and the near misses that must
*not* be treated as a `linCmt()` model -- `printf("linCmt()")`, a compartment
named `linCmt`, and an expanded `linCmtA()` that declares zero compartments.

Full suite at this HEAD: `[ FAIL 0 | WARN 33 | SKIP 2 | PASS 38985 ]`.

Reviewed with Antigravity (Gemini) over five rounds, ending with no findings;
three of its findings were real and are fixed by the follow-up commits here.
