### PR TITLE
Model builds survive leaked compiler environment variables (rstan::stan_model leak)

### DIFF
--- a/R/rxode-options.R
+++ b/R/rxode-options.R
@@ -31,8 +31,52 @@
   .Call(`_rxode2_rxode2Ptr`, PACKAGE = "rxode2")
 }
 
+#' Compiler-environment hygiene for model builds
+#'
+#' Some packages permanently leak build environment variables into the
+#' session -- notably `rstan::stan_model()` sets `PKG_CPPFLAGS` (with a
+#' forced C++ `-include`), `PKG_LIBS` and `USE_CXX17` and never restores
+#' them -- and `R CMD SHLIB` then applies them to rxode2's C model
+#' compiles, which die with "compilation terminated".  At load time
+#' rxode2 snapshots these variables; every model build swaps the
+#' snapshot in for the duration of the compile and restores the session
+#' values afterward, so rxode2 always compiles no matter what another
+#' package did to the build environment.
+#'
+#' (If rxode2 is loaded AFTER the leak has already happened the snapshot
+#' captures the leaked values; loading rxode2 before compiling Stan
+#' models -- the usual order -- captures the clean state.)
+#' @noRd
+.rxCompileEnvVars <- c("PKG_CPPFLAGS", "PKG_CXXFLAGS", "PKG_CFLAGS",
+                       "PKG_LIBS", "PKG_FFLAGS", "USE_CXX17", "USE_CXX14")
+.rxCompileEnvClean <- new.env(parent = emptyenv())
+
+#' Evaluate `expr` with the load-time (clean) compiler environment
+#' @noRd
+.rxWithCleanCompileEnv <- function(expr) {
+  .clean <- get0("snapshot", envir = .rxCompileEnvClean)
+  if (is.null(.clean)) return(force(expr))
+  .cur <- Sys.getenv(.rxCompileEnvVars, unset = NA_character_)
+  .set <- function(vals) {
+    for (.v in .rxCompileEnvVars) {
+      if (is.na(vals[[.v]])) {
+        Sys.unsetenv(.v)
+      } else {
+        do.call(Sys.setenv, stats::setNames(list(vals[[.v]]), .v))
+      }
+    }
+  }
+  .set(.clean)
+  on.exit(.set(.cur), add = TRUE)
+  force(expr)
+}
+
 ## nocov start
 .onLoad <- function(libname, pkgname) {
+  # snapshot the build environment BEFORE anything can leak into it (see
+  # .rxWithCleanCompileEnv)
+  assign("snapshot", Sys.getenv(.rxCompileEnvVars, unset = NA_character_),
+         envir = .rxCompileEnvClean)
   .ver <- .rxVersion
   .ver["version"] <- as.character(utils::packageVersion("rxode2"))
   assignInMyNamespace(".rxVersion", .ver)

--- a/R/rxode2.R
+++ b/R/rxode2.R
@@ -2255,9 +2255,14 @@ rxCompile.rxModelVars <- function(model, # Model
           on.exit(Sys.setenv("BINPREF" = .oldBinpref), add = TRUE)
         }
         rxode2::rxReq("sys")
-        .rxWithWd(.dir, {
+        # swap in the load-time (clean) compiler environment for the build:
+        # another package may have leaked PKG_CPPFLAGS/PKG_LIBS/USE_CXX17
+        # into the session (rstan::stan_model does, with a forced C++
+        # -include), which otherwise makes this C compile die with
+        # "compilation terminated"
+        .rxWithCleanCompileEnv(.rxWithWd(.dir, {
           .out <- sys::exec_internal(cmd = .cmd, args = .args, error = FALSE)
-        })
+        }))
         .stderr <- rawToChar(.out$stderr)
         .rxCompileEnv$lst <- list()
         if (!(all(.stderr == "") && length(.stderr) == 1)) {

--- a/tests/testthat/test-compile-env.R
+++ b/tests/testthat/test-compile-env.R
@@ -1,0 +1,33 @@
+test_that("model builds survive leaked compiler environment variables", {
+  skip_on_cran()
+  # rstan::stan_model permanently leaks PKG_CPPFLAGS (with a forced C++
+  # -include), PKG_LIBS and USE_CXX17 into the session; R CMD SHLIB then
+  # applies them to rxode2's C compile, which dies with "compilation
+  # terminated".  The load-time snapshot + per-build swap makes the build
+  # immune.  Simulate the leak with a forced include of a C++-only header
+  # and a bogus library.
+  .old <- Sys.getenv(c("PKG_CPPFLAGS", "PKG_LIBS", "USE_CXX17"),
+                     unset = NA_character_)
+  on.exit({
+    for (.v in names(.old)) {
+      if (is.na(.old[[.v]])) {
+        Sys.unsetenv(.v)
+      } else {
+        do.call(Sys.setenv, stats::setNames(list(.old[[.v]]), .v))
+      }
+    }
+  }, add = TRUE)
+  .hdr <- tempfile(fileext = ".hpp")
+  writeLines("template <typename T> struct rxLeakProbe { T x; };", .hdr)
+  Sys.setenv(PKG_CPPFLAGS = paste0("-include '", .hdr, "'"),
+             PKG_LIBS = "-lrxNoSuchLibrary",
+             USE_CXX17 = "1")
+  # a model text unique to this run so a cached DLL cannot mask the compile
+  .txt <- sprintf("d/dt(a) = -%s*a", format(stats::runif(1, 0.1, 0.2),
+                                            digits = 10))
+  .m <- rxode2(.txt)
+  expect_s3_class(.m, "rxode2")
+  # and the session's (leaked) values are untouched after the build --
+  # the swap is scoped to the compile only
+  expect_equal(Sys.getenv("PKG_LIBS"), "-lrxNoSuchLibrary")
+})


### PR DESCRIPTION
`rstan::stan_model()` permanently leaks `PKG_CPPFLAGS` (with a forced C++ `-include .../Eigen.hpp`), `PKG_LIBS` and `USE_CXX17` into the session.  `R CMD SHLIB` then applies them to rxode2's C model compiles, which die with `compilation terminated` — any session that compiles a Stan model and afterwards needs a new rxode2 model hits it (found while benchmarking nlmixr2/nlmixr2stan against native Stan; reproduces deterministically with `rstan::stan_model(...)` followed by any fresh `rxode2()` build).

Fix per the defensive design: `.onLoad` snapshots the build environment variables before anything can leak into them, and every model build swaps the snapshot in for the duration of the compile only, restoring the session's values afterward — rxode2 always compiles regardless of what a badly-behaved package did, and the swap is invisible outside the compile.  Documented caveat: if rxode2 loads after the leak already happened, the snapshot captures the leaked state (the usual load order captures clean).

Regression test: a simulated leak (forced include of a C++-only header + a bogus `PKG_LIBS`) no longer breaks a fresh model build, and the leaked session values are intact after it.

(nlmixr2stan also now restores these variables around its own `rstan::stan_model` call, so the leak is contained at both ends.)