### PR TITLE
abs(): exact derivative (dabs) instead of the smoothed-indicator chain

### DIFF
--- a/R/symengine.R
+++ b/R/symengine.R
@@ -36,7 +36,11 @@ regIfOrElse <- rex::rex(or(regIf, regElse))
 
 .SEsingle <- list(
   "rxNot" = c("(!(", "))"),
-  "loggamma" = c("lgamma(", ")")
+  "loggamma" = c("lgamma(", ")"),
+  ## abs stays symbolic as abs0() between rxToSE() and rxFromSE() (so its
+  ## EXACT derivative table entry .rxD$abs0 -> dabs() drives the chain
+  ## rule); on the way out it is written abs(), which every backend has
+  "abs0" = c("abs(", ")")
 )
 
 .rxSEdouble <- list(
@@ -2012,7 +2016,15 @@ rxToSE <- function(x, envir = NULL, progress = FALSE,
                identical(x[[1]], quote(`abs0`))) {
     if (length(x) != 2) stop("abs only takes 1 argument", call.=FALSE)
     .r <- .rxToSE(x[[2]], envir = envir)
-    return(paste0("(2.0*(", .r, ")*rxGt(", .r, ",0.0)-(", .r, "))"))
+    ## Keep abs symbolic as abs0() so its EXACT derivative table entry
+    ## (.rxD$abs0 -> dabs(), the sign function) drives the chain rule.
+    ## The old rewrite 2*x*rxGt(x,0) - x had the right VALUE, but its
+    ## derivative went through rxGt's tanh-SMOOTHED step (a deliberate
+    ## nascent-delta for genuine if/else discontinuities), so d|x|/dx came
+    ## out sign(x) + 2*k*x*(1 - tanh(k*x)^2) -- e.g. a sensitivity column
+    ## scaled x1.42 at x = 0.1 (nlmixr2/nlmixr2est#952).  abs is
+    ## continuous; its a.e.-exact derivative is what every consumer wants.
+    return(paste0("abs0(", .r, ")"))
   } else if (identical(x[[1]], quote(`d4GELU`))) {
     return(.rxToSEd4GELU(x, envir = envir, progress = progress, isEnv=isEnv))
   } else if (identical(x[[1]], quote(`d4softplus`))) {

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -478,7 +478,11 @@ rxTest({
 
     .s <- rxS("rx_pred_ = abs(a)")
     .d <- eval(parse(text = "assign(\".d\", with(.s, D(rx_pred_, a)), envir = .s)"))
-    expect_equal(rxFromSE(.d), "-1+2*a*(5-5*tanh(10*(a-0))^2)+2*(a>0)")
+    # abs is continuous: its derivative is the EXACT sign (dabs), not a
+    # smoothed step -- the old indicator rewrite made d|x|/dx come out
+    # sign(x) + 2*k*x*(1 - tanh(k x)^2), scaling sensitivity columns by a
+    # theta-dependent factor (nlmixr2/nlmixr2est#952)
+    expect_equal(rxFromSE(.d), "dabs(a)")
   })
 
   # Test factor expansion by `rxSplitPlusQ'
@@ -696,9 +700,13 @@ rxTest({
   })
 
   test_that("abs tests", {
-    expect_equal(rxToSE("abs(a)"), "(2.0*(a)*rxGt(a,0.0)-(a))")
-    expect_equal(rxToSE("fabs(a)"), "(2.0*(a)*rxGt(a,0.0)-(a))")
-    expect_equal(rxToSE("abs0(a)"), "(2.0*(a)*rxGt(a,0.0)-(a))")
+    # abs stays symbolic (abs0) so the exact derivative table drives the
+    # chain rule; the value renders back as abs()
+    expect_equal(rxToSE("abs(a)"), "abs0(a)")
+    expect_equal(rxToSE("fabs(a)"), "abs0(a)")
+    expect_equal(rxToSE("abs0(a)"), "abs0(a)")
+    expect_equal(rxFromSE("abs0(a)"), "abs(a)")
+    expect_equal(rxFromSE("Derivative(abs0(a), a)"), "dabs(a)")
   })
 
   test_that("parsing errors", {


### PR DESCRIPTION
Companion to nlmixr2/nlmixr2est#952 (the IOV magnitude theta sensitivity scaled by a theta-dependent factor), fixing the root cause in rxode2 so **every** model using `abs()` gets an exact derivative.

## The bug

`rxToSE()` rewrote `abs(x)` into the indicator form `2*x*rxGt(x,0) - x`. The value is exact, but the derivative routes through `rxGt`'s tanh-smoothed step — a deliberate nascent-delta for genuine if/else discontinuities — so `d|x|/dx` came out `sign(x) + 2*k*x*(1 - tanh(k*x)^2)`: a sensitivity column scaled ×1.42 at x = 0.1, ×1.14 at 0.2, ×1.005 at 0.4 (exactly the factors measured in nlmixr2est#952). abs is continuous — the smoothing belongs to real discontinuities, not to it.

## The fix (uses machinery that already existed)

- `abs`/`fabs`/`abs0` stay symbolic as `abs0()` between the translators, so the **existing** exact derivative table entry (`.rxD$abs0 → dabs()`, the sign helper already in `rxode2.h` and the parser whitelist) drives the chain rule — the `abs → dabs → dabs2 → 0` chain the code comments always described.
- `.SEsingle` gains the missing `abs0 → abs()` output spelling (a bare `abs0()` node could never previously reach `rxFromSE()`, per the documented intent that abs0 exists only between the translators).
- The smoothed comparison derivatives themselves are untouched.

## Verification

- `rxFromSE(D(abs(a), a))` → `dabs(a)`; analytic/FD ratio 1.00000000 at x ∈ {−0.3, 0.1, 0.2, 0.4}.
- End-to-end through a compiled nlmixr2est θ-sensitivity model with `abs()` on a non-mu theta: FD gate holds at ~1e-9 on both sides of zero.
- dsl goldens updated (with a new `Derivative(abs0) → dabs` lock-in); dsl + symengine/locally-constant/backward/activation/mu/eventSens/sens suites: **2,313 passing, 0 failed**.

Note: nlmixr2est#952's own fix (the IOV hook emitting `sqrt(theta^2)`) is complementary and stays — it additionally avoids the non-differentiable point at zero for that use; this PR makes `abs()` correct everywhere else.