### PR TITLE
fix: drop threadSafeRepNumThread's silent solver swap to liblsodaR

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -482,6 +482,13 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
   loaded, rather than losing the solve over a setting that version had no notion
   of.  What they can take is asked of the daemon itself, so a matching pool
   drops nothing.
+- `rxSolve()`'s thread-safety dispatch no longer has a code path that could
+  silently substitute `liblsodaR` for the solving method a user explicitly
+  requested. The path was reachable only once a currently-disabled model
+  classification was re-enabled, so it never fired in a release, but every
+  `par_*` solver already reseeds its RNG per subject as a pure function of
+  that subject's position, so the swap was never buying the reproducibility
+  it was meant to protect (#1240).
 - An event pushed by the model with `evid_()` (and the `bolus()`, `infuse()`,
   `replace()`, `multiply()`, `reset()`, `phantom()` and `obs()` helpers) now
   gives the same solution as the identical event written in the data, on every

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -6514,12 +6514,14 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
       if (op->cores == 0) {
         switch (thread) {
         case threadSafeRepNumThread:
-          // Thread safe, but possibly not reproducible.  Never for indLin (3):
-          // swapping it for liblsodaR would silently change the solver rather
-          // than how it is threaded.
-          if (op->cores > 1 && op->stiff != 3) {
-            op->stiff = method = 4;
-          }
+          // Every par_* solver seeds its RNG per-subject as
+          // seed0 + rx->ordId[solveid] - 1 immediately before solving that
+          // subject (see par_solve.cpp), so the result is already a pure
+          // function of solveid and does not depend on which thread picks up
+          // which subject or on scheduling order.  There is therefore nothing
+          // to gain by silently swapping the user's requested solver for
+          // liblsodaR here -- doing so previously changed the solver a user
+          // explicitly named without any message (issue #1240).
           rxSolveDat->throttle = false;
           break;
         case threadSafe:
@@ -6545,9 +6547,8 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
       } else {
         switch (thread) {
         case threadSafeRepNumThread:
-          if (op->cores > 1 && op->stiff != 3) {
-            op->stiff = method = 4;
-          }
+          // See the op->cores == 0 arm above: the RNG stream is already
+          // reproducible per solveid, so no solver swap is needed here either.
           break;
         case threadSafe:
           // Thread safe, and reproducible


### PR DESCRIPTION
## Summary

- Fixes #1240: `rxSolve()`'s thread-safety dispatch had a branch that, for
  a model classified `threadSafeRepNumThread` with `cores > 1`, silently
  overrode whatever solver the user requested (`op->stiff = method = 4`,
  i.e. `liblsodaR`) with no message.
- Removed the swap from both arms of the `op->cores == 0` / `op->cores > 0`
  switch in `src/rxData.cpp`. The rest of each case (setting
  `rxSolveDat->throttle`) is unchanged.
- Verified the RNG-reproducibility rationale in the branch's original
  comment ("Thread safe, but possibly not reproducible") no longer holds:
  every `par_*` solver (`par_dop`, `par_liblsoda`, `par_liblsodaR`, etc. in
  `src/par_solve.cpp`) already seeds its RNG per subject as
  `seed0 + rx->ordId[solveid] - 1` immediately before solving that subject
  -- a pure function of `solveid`, independent of thread scheduling. Confirmed
  empirically: `dop853` gives bit-identical output across core counts with a
  fixed seed both before and after this change.
- This branch is currently unreachable (nothing in the tree assigns the
  `threadSafeRepNumThread` classification -- the one assignment site in
  `src/parseFuns.h` is commented out), so this is a preventative fix for a
  latent landmine, not a behavior change in any released version.

## Review

Independently reviewed with Antigravity (`agy`, Gemini 3.1 Pro). It confirmed
the fix is correct and flagged that the old swap was worse than described in
the issue: solver-specific setup done earlier in `rxSolve_()` based on the
*original* requested method (e.g. adjoint array allocation for `rk4s`, dense
output for `useDense`) would have been left inconsistent with `liblsodaR`
actually being the solver that ran, once the classification is live. No
issues found after the fix.

## Test plan

- [x] `find src -name "*.so" -o -name "*.o" | xargs rm -f; NOT_CRAN=true Rscript -e "pkgload::load_all()"` builds cleanly
- [x] `NOT_CRAN=true Rscript -e "devtools::test(filter='parallel|thread|parsing|solve-methods')"` -- 353 passed, 0 failed
- [x] Manual check: `dop853` solve with a fixed seed gives identical output for `cores=1` vs `cores=4`