### PR TITLE
Refuse linCmtB(which1 = -3) when linCmt() compartments lag differently

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -558,6 +558,15 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
 
 ### Sensitivities
 
+- `rxode2()` now refuses to build a model that calls `linCmtB(which1 = -3)`
+  (the dose-time sensitivity) while its `linCmt()` compartments carry more
+  than one distinct modeled `alag()` -- e.g. `alag(depot)` driven by one
+  parameter and `alag(central)` by another.  `which1 = -3` is the derivative
+  wrt ONE delay applied to every dose feeding the linear system; such a model
+  previously solved and silently returned that single-delay answer instead of
+  the true per-compartment sensitivity, which the entry point cannot compute
+  (#1237).
+
 - `linCmtB()` gained a dose-time (moving boundary) sensitivity, `which1 = -3`:
   the derivative of a `linCmt()` model with respect to a delay applied to every
   dose feeding it, which is what a modeled `alag()` on its dosed compartment

--- a/R/eventSens.R
+++ b/R/eventSens.R
@@ -474,6 +474,135 @@
   .df[!duplicated(.df[c("state", "param")]), , drop = FALSE]
 }
 
+#' Recursively collect calls to a named function inside an expression
+#'
+#' @param expr An R language object (call, symbol, or literal).
+#' @param fname Function name to match (e.g. `"linCmtB"`).
+#' @return list of matching call objects (possibly empty).
+#' @noRd
+.rxFindNamedCalls <- function(expr, fname) {
+  if (!is.call(expr)) return(list())
+  .out <- if (identical(as.character(expr[[1]])[1], fname)) list(expr) else list()
+  for (.a in as.list(expr)[-1]) .out <- c(.out, .rxFindNamedCalls(.a, fname))
+  .out
+}
+
+#' Constants assigned to plain names by a normalized model's own lines
+#'
+#' `linCmtB()`'s mode selectors (`which1`/`which2`) are always literal in
+#' every generated or hand-written call this package has seen, but nothing in
+#' the grammar enforces that -- a model could stash `-3` in a variable first.
+#' `rxNorm()` output is one assignment per line in evaluation order, so a
+#' plain `name=<number>;` line is a genuine scalar constant for every later
+#' line; fold those in so `.rxLinCmtDoseTimeSensUsed()` still recognizes the
+#' selector.
+#'
+#' @param norm Character vector, one normalized model line per element.
+#' @return An environment (parent `baseenv()`) with one binding per constant.
+#' @noRd
+.rxLinCmtConstEnv <- function(norm) {
+  .env <- new.env(parent = baseenv())
+  .re <- "^([A-Za-z._][A-Za-z0-9._]*)=(-?[0-9]+(\\.[0-9]+)?)L?;$"
+  for (.line in grep(.re, norm, value = TRUE)) {
+    assign(sub(.re, "\\1", .line), as.numeric(sub(.re, "\\2", .line)), envir = .env)
+  }
+  .env
+}
+
+#' Does the model call `linCmtB(which1 = -3)` (the dose-time sensitivity)?
+#'
+#' `which1` is the 6th argument to `linCmtB()`
+#' (`rx__PTR__, t, linCmt, ncmt, oral0, which1, which2, trans, ...`); only a
+#' (possibly indirect, via `.rxLinCmtConstEnv()`) `-3` there triggers
+#' `linCmtBdoseTime()` (`src/linCmt.cpp`).
+#'
+#' @param mv Model vars (or normalized model text, one line per element).
+#' @return `TRUE`/`FALSE`.
+#' @noRd
+.rxLinCmtDoseTimeSensUsed <- function(mv) {
+  .norm <- strsplit(rxNorm(mv), "\n", fixed = TRUE)[[1]]
+  .lines <- grep("linCmtB(", .norm, fixed = TRUE, value = TRUE)
+  if (length(.lines) == 0L) return(FALSE)
+  .constEnv <- .rxLinCmtConstEnv(.norm)
+  for (.line in .lines) {
+    .rhs <- sub("^[^=]*=(.*);$", "\\1", .line)
+    .expr <- tryCatch(str2lang(.rhs), error = function(e) NULL)
+    if (is.null(.expr)) next
+    for (.call in .rxFindNamedCalls(.expr, "linCmtB")) {
+      .args <- as.list(.call)[-1]
+      if (length(.args) < 6L) next
+      .which1 <- tryCatch(eval(.args[[6]], envir = .constEnv),
+                          error = function(e) NA_real_)
+      if (isTRUE(.which1 == -3)) return(TRUE)
+    }
+  }
+  FALSE
+}
+
+#' The modeled `alag()` expression on each linCmt() physical compartment
+#'
+#' @param mv Model vars.
+#' @return Named character vector (alag expression text, named by linCmt
+#'   compartment); `NULL` when no linCmt() compartment carries a modeled
+#'   `alag()`.
+#' @noRd
+.rxLinCmtDoseTimeLagExprs <- function(mv) {
+  .linPhys <- grep("^rx__sens_", .rxLinCmt(mv), value = TRUE, invert = TRUE)
+  if (length(.linPhys) == 0L) return(NULL)
+  .norm <- strsplit(rxNorm(mv), "\n", fixed = TRUE)[[1]]
+  .re <- "^alag\\(([^)]+)\\)=(.*);$"
+  .lines <- grep(.re, .norm, value = TRUE)
+  if (length(.lines) == 0L) return(NULL)
+  .cmt <- sub(.re, "\\1", .lines)
+  .expr <- sub(.re, "\\2", .lines)
+  .keep <- .cmt %in% .linPhys
+  if (!any(.keep)) return(NULL)
+  stats::setNames(.expr[.keep], .cmt[.keep])
+}
+
+#' Refuse `linCmtB(which1 = -3)` when it cannot give a correct answer
+#'
+#' `linCmtB(which1 = -3)` is the derivative wrt ONE delay applied to every dose
+#' feeding the linear system (see the header comment on `linCmtB` in
+#' `src/linCmt.cpp`); it silently returns the single-delay answer for a model
+#' that lags its linCmt() compartments differently instead of the true
+#' per-compartment sensitivity (nlmixr2/rxode2#1237).  Error instead of
+#' solving when the model both uses `which1 = -3` and carries more than one
+#' distinct `alag()` expression across its linCmt() compartments.
+#'
+#' This is a static, text-level check: it does not know which compartments
+#' actually receive doses (that is event-table, not model, information), so a
+#' model with one modeled `alag()` that ALSO doses an unlagged (implicit
+#' delay-0) linCmt() compartment still passes -- that was already the
+#' documented requirement before this guard existed and remains a gap only
+#' the full per-compartment fix (shared with #1236) closes.
+#'
+#' A single compartment's `alag()` may be assigned conditionally (different
+#' text per `if`/`else` branch) without violating the shared-delay
+#' assumption by itself -- only more than one linCmt() compartment carrying
+#' different `alag()` expressions is the violation this refuses.  So this
+#' requires BOTH more than one distinct compartment carrying a modeled
+#' `alag()` AND more than one distinct expression across them; branches of
+#' one compartment's own conditional alag() do not by themselves trigger it.
+#'
+#' @param mv Model vars.
+#' @return invisibly `NULL`; called for the `stop()` side effect.
+#' @noRd
+.rxLinCmtDoseTimeSensCheck <- function(mv) {
+  if (!.rxLinCmtDoseTimeSensUsed(mv)) return(invisible(NULL))
+  .lag <- .rxLinCmtDoseTimeLagExprs(mv)
+  if (length(.lag) == 0L) return(invisible(NULL))
+  .cmts <- unique(names(.lag))
+  if (length(.cmts) < 2L || length(unique(unname(.lag))) < 2L) {
+    return(invisible(NULL))
+  }
+  stop("'linCmtB(which1 = -3)' (the dose-time sensitivity) assumes every ",
+       "dose feeding the linear system shares one alag(); this model lags ",
+       "linCmt() compartment(s) '", paste(.cmts, collapse = "', '"),
+       "' differently ('", paste(unique(unname(.lag)), collapse = "' vs '"),
+       "'), which it cannot represent -- see nlmixr2/rxode2#1237", call. = FALSE)
+}
+
 #' Free symbols of a dosing expression in symengine (SE-mangled) names
 #'
 #' `map$sensParams` are SE-mangled names (e.g. `ETA_3_`); `all.vars()` of the

--- a/R/rxode2.R
+++ b/R/rxode2.R
@@ -483,6 +483,11 @@ rxode2 <- # nolint
                 "sensitivities will be incorrect -- rename them", call. = FALSE)
       }
     }
+    ## linCmtB(which1 = -3) (the dose-time sensitivity, nlmixr2/rxode2#1119)
+    ## assumes every dose feeding the linear system shares one alag(); refuse
+    ## rather than silently return the single-delay answer for a model that
+    ## lags its linCmt() compartments differently (nlmixr2/rxode2#1237).
+    .rxLinCmtDoseTimeSensCheck(.env$.mv)
     .indLinSens <- length(.env$.mv$indLin) > 0L &&
       length(.env$.mv$sens) > 0L
     if (.indLinSens) {

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -539,8 +539,12 @@ static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
  *  with d(alag)/dp to get the sensitivity wrt a model parameter.  This
  *  requires that EVERY dose reaching the linear system carries the same
  *  `alag()`; it is not the per-compartment derivative of a model that lags
- *  its compartments differently.  An individual with any infusion gets
- *  `NA_REAL` -- see linCmtHasInfusion().
+ *  its compartments differently (nlmixr2/rxode2#1237).  A model that would
+ *  violate this -- calling `linCmtB(which1 = -3)` while its linCmt()
+ *  compartments carry more than one distinct `alag()` expression -- is
+ *  refused at build time by `.rxLinCmtDoseTimeSensCheck()` (R/eventSens.R)
+ *  rather than silently given the single-delay answer.  An individual with
+ *  any infusion gets `NA_REAL` -- see linCmtHasInfusion().
  *
  *  The parameter order is as follows:
  *

--- a/tests/testthat/test-lincmt-dose-time-sens-guard.R
+++ b/tests/testthat/test-lincmt-dose-time-sens-guard.R
@@ -1,0 +1,108 @@
+rxTest({
+  # linCmtB(which1 = -3) (the dose-time / moving-boundary sensitivity) assumes
+  # every dose feeding the linear system shares one alag() -- see the header
+  # comment on linCmtB in src/linCmt.cpp.  A model that lags more than one
+  # linCmt() compartment differently violates that assumption and would get a
+  # silently wrong answer instead of an error (nlmixr2/rxode2#1237); rxode2()
+  # refuses to build such a model instead.
+
+  test_that("linCmtB(-3) with distinct alag() on 2 linCmt compartments errors", {
+    expect_error(
+      rxode2({
+        cl <- exp(tcl); v <- exp(tv); ka <- exp(tka)
+        lag1 <- 2 * exp(eta1); lag2 <- 1 * exp(eta2)
+        alag(depot) <- lag1
+        alag(central) <- lag2
+        cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+        dcp <- lag1 * linCmtB(rx__PTR__, t, 2, 1, 1, -3, -3, 1, cl, v, 0, 0, 0, 0, ka)
+      }),
+      "1237"
+    )
+  })
+
+  test_that("linCmtB(-3) with the SAME alag() shared by 2 linCmt compartments is allowed", {
+    expect_no_error(
+      rxode2({
+        cl <- exp(tcl); v <- exp(tv); ka <- exp(tka)
+        lag <- 2 * exp(eta1)
+        alag(depot) <- lag
+        alag(central) <- lag
+        cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+        dcp <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -3, -3, 1, cl, v, 0, 0, 0, 0, ka)
+      })
+    )
+  })
+
+  test_that("distinct alag() on 2 linCmt compartments without which1=-3 is allowed", {
+    expect_no_error(
+      rxode2({
+        cl <- exp(tcl); v <- exp(tv); ka <- exp(tka)
+        lag1 <- 2 * exp(eta1); lag2 <- 1 * exp(eta2)
+        alag(depot) <- lag1
+        alag(central) <- lag2
+        cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+      })
+    )
+  })
+
+  test_that("which1=-3 with a single lagged linCmt compartment is allowed", {
+    expect_no_error(
+      rxode2({
+        cl <- exp(tcl); v <- exp(tv); ka <- exp(tka)
+        lag <- 2 * exp(eta1)
+        alag(depot) <- lag
+        cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+        dcp <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -3, -3, 1, cl, v, 0, 0, 0, 0, ka)
+      })
+    )
+  })
+
+  test_that("which1=-3 with no modeled alag() at all is allowed", {
+    expect_no_error(
+      rxode2({
+        cl <- exp(tcl); v <- exp(tv); ka <- exp(tka)
+        cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+        dcp <- linCmtB(rx__PTR__, t, 2, 1, 1, -3, -3, 1, cl, v, 0, 0, 0, 0, ka)
+      })
+    )
+  })
+
+  test_that("which1=-3 reached indirectly through a constant variable still errors", {
+    # linCmtB()'s which1/which2 selectors are always written as literals in
+    # every call this package generates or that its tests write by hand, but
+    # nothing in the grammar enforces that -- confirm the guard still catches
+    # `w <- -3; ... linCmtB(..., w, w, ...)`.
+    expect_error(
+      rxode2({
+        cl <- exp(tcl); v <- exp(tv); ka <- exp(tka)
+        lag1 <- 2; lag2 <- 3
+        alag(depot) <- lag1
+        alag(central) <- lag2
+        w <- -3
+        cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+        dcp <- linCmtB(rx__PTR__, t, 2, 1, 1, w, w, 1, cl, v, 0, 0, 0, 0, ka)
+      }),
+      "1237"
+    )
+  })
+
+  test_that("a conditionally re-assigned alag() on ONE compartment is allowed", {
+    # alag(central) taking a different expression per if/else branch does not
+    # violate the shared-delay assumption by itself -- there is still only one
+    # lagged compartment. Only a MISMATCH ACROSS compartments is the
+    # violation.
+    expect_no_error(
+      rxode2({
+        cl <- exp(tcl); v <- exp(tv)
+        lag1 <- 2; lag2 <- 3
+        if (wt > 70) {
+          alag(central) <- lag1
+        } else {
+          alag(central) <- lag2
+        }
+        cp <- linCmtB(rx__PTR__, t, 1, 1, 0, -1, -1, 1, cl, v, 0, 0, 0, 0, 0)
+        dcp <- linCmtB(rx__PTR__, t, 1, 1, 0, -3, -3, 1, cl, v, 0, 0, 0, 0, 0)
+      })
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #1237.

`linCmtB(which1 = -3)` (the dose-time / moving-boundary sensitivity added in #1235) is the derivative of a `linCmt()` model wrt ONE delay applied to every dose feeding the linear system -- valid only when every dosed `linCmt()` compartment shares the same `alag()`. A model that lags two `linCmt()` compartments differently (e.g. `alag(depot)` and `alag(central)` driven by distinct parameters) previously built and solved silently to the wrong, single-delay answer instead of erroring.

The full architectural fix -- per-compartment sensitivity vectors carried through the `linCmt` solve (extending `numLinSens`, the `linCmtFlg`/`.rxLinCmt()`/`op->linOffset` plumbing, `saveJac`/`restoreJac`) -- is a much larger change explicitly shared with #1236 and is not attempted here. Instead this implements the "meanwhile" guard the issue itself scoped out: refuse to build the offending model instead of silently returning a wrong answer.

* `rxode2()` now detects, at build time, when a model calls `linCmtB()` with a (possibly indirect, via simple constant folding) literal `which1 = -3` while its `linCmt()` compartments carry more than one distinct `alag()` expression, and raises a clear error instead of compiling.
* A single compartment's `alag()` assigned conditionally (different text per `if`/`else` branch) does not by itself trip the guard -- only a mismatch *across* compartments does.
* Updated the `linCmtB` header comment in `src/linCmt.cpp` to point at the new guard.

This underwent an independent review pass (Antigravity/Gemini) that surfaced two real gaps, both fixed and covered by new tests: a `which1` value reached indirectly through a constant variable, and a false positive on a single compartment's conditionally-reassigned `alag()`.

## Test plan

- [x] New test file `tests/testthat/test-lincmt-dose-time-sens-guard.R` (7 tests): errors on distinct `alag()` across two `linCmt()` compartments, allows a shared `alag()`, allows distinct `alag()`s when `which1 = -3` is never used, allows a single lagged compartment, allows no modeled `alag()` at all, still errors when `which1` is reached indirectly through a constant, and allows a single compartment's conditionally-reassigned `alag()`.
- [x] Existing `tests/testthat/test-lincmt-dose-time-sens.R` (20 tests, unmodified) still pass.
- [x] Full `lincmt`/`event-sensitivities`/`prior-density` filtered suite (6730 tests) passes after merging latest `main`.
- [x] Full repository test suite (~39k tests) passes (aside from an unrelated, intentionally-failing demo test).