### PR TITLE
fix: linCmtB(which1 = -3) now handles infusions (#1236)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -581,11 +581,12 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
   for the amount in that compartment; chain-rule it with `d(alag)/dp` for the
   sensitivity wrt a model parameter.  The system is linear and its whole input
   is delayed together, so the derivative is exactly `-dA/dt` -- it matches a
-  finite difference to round-off for bolus and steady-state-bolus regimens
-  across one to three compartments, IV and oral.  It reports `NA` for an
-  individual with an infusion (`dA/dt` needs the infusion rate, which is not
-  carried into the pass that computes the output) and requires that every dose
-  reaching the linear system share the same `alag()` (#1119).
+  finite difference to round-off for bolus, infusion, and steady-state-bolus
+  regimens across one to three compartments, IV and oral.  It reports `NA` for
+  a steady-state infusion (its amounts are established analytically, so the
+  infusion rate afterward is not well defined at that index -- #1236) and
+  requires that every dose reaching the linear system share the same
+  `alag()` (#1119).
 
 - A model that mixes `linCmt()` with `d/dt()` now expands its sensitivities
   once.  The `linCmt()` call has to be resolved before the sensitivity

--- a/inst/include/rxode2parseStruct.h
+++ b/inst/include/rxode2parseStruct.h
@@ -367,6 +367,20 @@ struct rx_solving_options_ind_s {
   double  delayT0;         /* initial time; history before this is the IC */
   double  delayMinT;       /* smallest delay duration seen; caps the step size */
   int     delayWarmed;     /* 1 once the RHS has been evaluated to learn delays */
+  // linCmtB(which1 = -3) (the dose-time/moving-boundary sensitivity, see
+  // src/linCmt.cpp) needs the infusion rate at output time, but
+  // ind->InfusionRate is only maintained while solving -- rxode2_df.cpp's
+  // output pass clears it (nlmixr2/rxode2#1236).  linCmtB() records the live
+  // rate here, once per output index, while it is actually being solved
+  // (mirroring how the amounts themselves are cached via getAdvan()/Alast);
+  // linCmtBdoseTime() reads it back on a re-query (the output pass, or any
+  // backward re-query of an already-solved index) instead of the
+  // (by-then-cleared) live rate.  Flat idx-major layout: idx*linCmtRateHistW
+  // + j, j in [0, linCmtRateHistW).  Kept after the solve (freed with the
+  // subject) so the output pass can still read it, like delayHist above.
+  double *linCmtRateHist;   /* flat idx-indexed rate history, or NULL when unused */
+  int     linCmtRateHistCap; /* capacity in idx slots */
+  int     linCmtRateHistW;   /* doubles per idx slot (op->numLin); realloc if changed */
   // Event ("jump") sensitivities: deferred moving-boundary jump for non-dosed
   // compartments.  At a modeled-lag dose the sensitivity of a compartment that
   // does NOT receive the bolus has a genuine jump discontinuity at the arrival

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -3,6 +3,9 @@
 #endif
 #define USE_FC_LEN_T
 #define STRICT_R_HEADERS
+#include <cstdlib>
+#include <cstring>
+#include <algorithm>
 #include "rxomp.h"
 #include "../inst/include/rxode2.h"
 #include "timsort.h"
@@ -29,25 +32,65 @@ extern t_update_inis update_inis;
 #define getLinRate ind->InfusionRate + op->linOffset
 #define isSameTime(xout, xp) (fabs((xout)-(xp)) <= 2.0*DBL_EPSILON*max2(fabs(xout),fabs(xp)))
 
-// Does this individual have any infusion (or steady-state infusion) dose?
+// Does this individual have a steady-state infusion (rate/dur) dose?
 //
 // The dose-time sensitivity (linCmtB which1 = -3) needs dA/dt, which includes
-// the infusion rate -- and `ind->InfusionRate` is only maintained while
-// SOLVING.  rxode2_df.cpp's output pass re-runs calc_lhs from the saved
-// amounts after iniSubject() has cleared the rates, so an infusion's
-// contribution would silently drop out of the reported value.  Report NA
-// instead of a wrong number; a bolus (including steady-state bolus) regimen is
-// exact.
-static inline int linCmtHasInfusion(rx_solving_options_ind *ind) {
-  if (ind->linSS == linCmtSsInf || ind->linSS == linCmtSsInf8) return 1;
+// the infusion rate.  A regular (non-SS) infusion's rate is recovered at
+// output time via the linCmtRateHist cache (see linCmtBRateSlot() /
+// linCmtBdoseTime() below, nlmixr2/rxode2#1236).  A steady-state infusion
+// establishes its amounts analytically (handleSSinf8()/solveSSinf(), setting
+// ind->linSS only transiently around that single call) and, for a one-shot
+// SS dose with no following schedule, deliberately leaves ind->InfusionRate
+// at 0 afterward -- the closed-form amount is exact but is not the limit of
+// an ongoing rate, so -dA/dt is not well defined by the cache at the SS
+// dose's own index; report NA there instead of a value that depends on
+// solve-order happenstance.  A steady-state BOLUS (linCmtSsBolus) never
+// touches InfusionRate and is unaffected -- it stays exact (see
+// test-lincmt-dose-time-sens.R).
+static inline int linCmtHasSsInfusion(rx_solving_options_ind *ind) {
   for (int i = 0; i < ind->ndoses; ++i) {
     int wh, cmt, wh100, whI, wh0;
     getWh(getEvid(ind, ind->idose[i]), &wh, &cmt, &wh100, &whI, &wh0);
-    if (whI != EVIDF_NORMAL && whI != EVIDF_REPLACE && whI != EVIDF_MULT) {
+    if ((wh0 == EVID0_SS0 || wh0 == EVID0_SS || wh0 == EVID0_SS20 ||
+         wh0 == EVID0_SS2 || wh0 == EVID0_SSINF) &&
+        whI != EVIDF_NORMAL && whI != EVIDF_REPLACE && whI != EVIDF_MULT) {
       return 1;
     }
   }
   return 0;
+}
+
+// Per-idx cache of the infusion rate feeding a linCmt() model, keyed the same
+// way as the amounts cached via getAdvan()/Alast: written once, while the
+// index is genuinely being solved (ind->InfusionRate live and correct), and
+// read back on any later re-query of that same index (the output pass in
+// rxode2_df.cpp, which clears ind->InfusionRate before recomputing lhs, or a
+// backward re-query within the same solve).  width is op->numLin, the size of
+// the rate vector linCmtBdoseTime()'s dAdt() expects.  linCmtB() writes this
+// for every genuinely-solved idx (whether or not the model actually has an
+// infusion -- it is simply 0 for a bolus-only regimen), so a re-query (grow =
+// 0) should always find it; NULL is a defensive fallback for an idx that
+// somehow was not, rather than a case expected to occur.
+static inline double *linCmtBRateSlot(rx_solving_options_ind *ind, int idx, int width, int grow) {
+  if (idx < 0 || width <= 0) return NULL;
+  if (ind->linCmtRateHistW != width) {
+    free(ind->linCmtRateHist);
+    ind->linCmtRateHist = NULL;
+    ind->linCmtRateHistCap = 0;
+    ind->linCmtRateHistW = width;
+  }
+  if (idx >= ind->linCmtRateHistCap) {
+    if (!grow) return NULL;
+    int newCap = ind->linCmtRateHistCap > 0 ? ind->linCmtRateHistCap : 64;
+    while (idx >= newCap) newCap *= 2;
+    double *np = (double*) realloc(ind->linCmtRateHist, (size_t)newCap * width * sizeof(double));
+    if (np == NULL) (Rf_error)("cannot allocate linCmt rate history");
+    memset(np + (size_t)ind->linCmtRateHistCap * width, 0,
+           (size_t)(newCap - ind->linCmtRateHistCap) * width * sizeof(double));
+    ind->linCmtRateHist = np;
+    ind->linCmtRateHistCap = newCap;
+  }
+  return ind->linCmtRateHist + (size_t)idx * width;
 }
 
 // Create linear compartment models for testing
@@ -462,10 +505,13 @@ extern "C" int linCmtZeroJac(int i) {
 //
 // `amt` holds the amounts at the requested time from the which1=-1/which2=-1
 // call the caller is required to have made, and the linear system's own
-// right-hand side gives d/dL exactly (see linCmtStan::dAdt()).  Returns
-// NA_REAL for a call that does not describe the model `lc` is set up for, for
-// an individual with an infusion (linCmtHasInfusion()), or for an out of range
-// `which2`.
+// right-hand side gives d/dL exactly (see linCmtStan::dAdt()).  `rate` is
+// either the live ind->InfusionRate slice (while genuinely solving) or the
+// linCmtBRateSlot() cache for that idx (a re-query, e.g. the output pass);
+// see the caller in linCmtB().  Returns NA_REAL for a call that does not
+// describe the model `lc` is set up for, when `rate` could not be recovered
+// (NULL -- see linCmtBRateSlot()), for a steady-state infusion
+// (linCmtHasSsInfusion()), or for an out of range `which2`.
 static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
                                      const Eigen::Matrix<double, Eigen::Dynamic, 1> &amt,
                                      rx_solving_options_ind *ind,
@@ -479,7 +525,8 @@ static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
       (int)amt.size() != ncmt + oral0) {
     return NA_REAL;
   }
-  if (linCmtHasInfusion(ind)) return NA_REAL;
+  if (rate == NULL) return NA_REAL;
+  if (linCmtHasSsInfusion(ind)) return NA_REAL;
   Eigen::Matrix<double, Eigen::Dynamic, 1> th(lc.getNpars());
   if (!linCmtFillTheta(th, ncmt, oral0, p1, v1, p2, p3, p4, p5, ka)) {
     return NA_REAL;
@@ -543,8 +590,10 @@ static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
  *  violate this -- calling `linCmtB(which1 = -3)` while its linCmt()
  *  compartments carry more than one distinct `alag()` expression -- is
  *  refused at build time by `.rxLinCmtDoseTimeSensCheck()` (R/eventSens.R)
- *  rather than silently given the single-delay answer.  An individual with
- *  any infusion gets `NA_REAL` -- see linCmtHasInfusion().
+ *  rather than silently given the single-delay answer.  A regular infusion's
+ *  rate is recovered at output time via the linCmtBRateSlot() per-idx cache
+ *  (nlmixr2/rxode2#1236); an individual with a steady-state infusion still
+ *  gets `NA_REAL` -- see linCmtHasSsInfusion().
  *
  *  The parameter order is as follows:
  *
@@ -633,7 +682,12 @@ extern "C" double linCmtB(rx_solve *rx, int id,
     } else if (which1 == -2 && which2 >= 0) {
       return Jg(which2);
     } else if (which1 == -3) {
-      return linCmtBdoseTime(lc, fx, ind, getLinRate, ncmt, oral0, which2,
+      // Mirrors the fx/J restore-vs-solve condition above (idx already
+      // solved -> a re-query, e.g. the output pass, where ind->InfusionRate
+      // has since been cleared/moved on; use the cached rate instead).
+      const double *rate = (!ind->doSS && ind->solvedIdx >= idx) ?
+        linCmtBRateSlot(ind, idx, op->numLin, 0) : getLinRate;
+      return linCmtBdoseTime(lc, fx, ind, rate, ncmt, oral0, which2,
                              trans, p1, v1, p2, p3, p4, p5, ka);
     }
   } else if (!lc.isSame(ncmt, oral0, trans, rx->ndiff)) {
@@ -687,6 +741,15 @@ extern "C" double linCmtB(rx_solve *rx, int id,
   double *asave = ind->linCmtSave;
   double *r = getLinRate;
   double *a;
+
+  // idx is genuinely being solved right now (not a re-query of an
+  // already-solved index, e.g. the output pass) -- ind->InfusionRate is live
+  // and correct, so cache it for linCmtBdoseTime() (which1 = -3) to read back
+  // on a later re-query, once ind->InfusionRate has been cleared/moved on.
+  if (op->numLin > 0 && (ind->doSS || ind->solvedIdx < idx)) {
+    double *rslot = linCmtBRateSlot(ind, idx, op->numLin, 1);
+    if (rslot != NULL) std::copy(r, r + op->numLin, rslot);
+  }
 
   if (ind->linCmtAlast == NULL) {
     a = getAdvan(ind->solvedIdx);

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -1888,6 +1888,12 @@ static void rxFreeInd(rx_solving_options_ind *ind) {
   ind->delayHistNeq = 0;
   ind->delayHistN = 0;
   ind->delayHistOn = 0;
+  // linCmtB(which1 = -3)'s output-time rate history (nlmixr2/rxode2#1236);
+  // kept after the solve for the same reason as delayHist above.
+  free(ind->linCmtRateHist);
+  ind->linCmtRateHist = NULL;
+  ind->linCmtRateHistCap = 0;
+  ind->linCmtRateHistW = 0;
 }
 
 extern "C" void gFree(){

--- a/tests/testthat/test-lincmt-dose-time-sens.R
+++ b/tests/testthat/test-lincmt-dose-time-sens.R
@@ -128,10 +128,97 @@ rxTest({
     expect_equal(s$dCentral / exp(.p[["tv"]]), .fdCol(m, e, "cp"), tolerance = 1e-5)
   })
 
-  test_that("linCmtB(-3) reports NA for an infusion rather than a wrong value", {
-    # dA/dt includes the infusion rate, and ind->InfusionRate is only
-    # maintained while solving -- the output pass recomputes the lhs from the
-    # saved amounts with the rates cleared.  Report NA instead (#1119).
+  test_that("linCmtB(-3) matches finite differences for an infusion (#1236)", {
+    # dA/dt includes the infusion rate; ind->InfusionRate is only maintained
+    # while solving, so the output pass (which recomputes the lhs from the
+    # saved amounts after clearing the rates) recovers it from the per-idx
+    # linCmtBRateSlot() cache written while genuinely solving instead.
+    .cases <- list(
+      list(
+        nm = "1cmt IV single infusion",
+        m = rxode2({
+          cl <- exp(tcl); v <- exp(tv); lag <- 2 * exp(eta_lag)
+          alag(central) <- lag
+          cp <- linCmtB(rx__PTR__, t, 1, 1, 0, -1, -1, 1, cl, v, 0, 0, 0, 0, 0)
+          dcp <- lag * linCmtB(rx__PTR__, t, 1, 1, 0, -3, -3, 1, cl, v, 0, 0, 0, 0, 0)
+        }),
+        e = eventTable() |> add.dosing(dose = 100, rate = 25, cmt = "central") |>
+          add.sampling(seq(0.1, 12, 0.25))
+      ),
+      list(
+        nm = "1cmt IV multiple infusions",
+        m = rxode2({
+          cl <- exp(tcl); v <- exp(tv); lag <- 2 * exp(eta_lag)
+          alag(central) <- lag
+          cp <- linCmtB(rx__PTR__, t, 1, 1, 0, -1, -1, 1, cl, v, 0, 0, 0, 0, 0)
+          dcp <- lag * linCmtB(rx__PTR__, t, 1, 1, 0, -3, -3, 1, cl, v, 0, 0, 0, 0, 0)
+        }),
+        e = eventTable() |>
+          add.dosing(dose = 100, rate = 25, nbr.doses = 4, dosing.interval = 6, cmt = "central") |>
+          add.sampling(seq(0.1, 30, 0.25))
+      ),
+      list(
+        nm = "1cmt IV infusion specified by duration",
+        m = rxode2({
+          cl <- exp(tcl); v <- exp(tv); lag <- 2 * exp(eta_lag)
+          alag(central) <- lag
+          cp <- linCmtB(rx__PTR__, t, 1, 1, 0, -1, -1, 1, cl, v, 0, 0, 0, 0, 0)
+          dcp <- lag * linCmtB(rx__PTR__, t, 1, 1, 0, -3, -3, 1, cl, v, 0, 0, 0, 0, 0)
+        }),
+        e = eventTable() |> add.dosing(dose = 100, dur = 4, cmt = "central") |>
+          add.sampling(seq(0.1, 12, 0.25))
+      ),
+      list(
+        nm = "1cmt oral infusion into depot",
+        m = rxode2({
+          cl <- exp(tcl); v <- exp(tv); ka <- exp(tka); lag <- 2 * exp(eta_lag)
+          alag(depot) <- lag
+          cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+          dcp <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -3, -3, 1, cl, v, 0, 0, 0, 0, ka)
+        }),
+        e = eventTable() |> add.dosing(dose = 100, rate = 10, cmt = "depot") |>
+          add.sampling(seq(0.1, 24, 0.25))
+      ),
+      list(
+        nm = "2cmt IV infusion into central (with peripheral)",
+        m = rxode2({
+          cl <- exp(tcl); v <- exp(tv); q <- exp(tq); v2 <- exp(tv2)
+          lag <- 2 * exp(eta_lag)
+          alag(central) <- lag
+          cp <- linCmtB(rx__PTR__, t, 2, 2, 0, -1, -1, 1, cl, v, q, v2, 0, 0, 0)
+          dcp <- lag * linCmtB(rx__PTR__, t, 2, 2, 0, -3, -3, 1, cl, v, q, v2, 0, 0, 0)
+        }),
+        e = eventTable() |> add.dosing(dose = 100, rate = 10, cmt = "central") |>
+          add.sampling(seq(0.1, 24, 0.25))
+      ),
+      list(
+        nm = "linCmt() mixed with an ODE compartment (numLin < neq), infusion",
+        m = rxode2({
+          cl <- exp(tcl); v <- exp(tv); lag <- 2 * exp(eta_lag); ke0 <- 0.5
+          alag(central) <- lag
+          cp <- linCmtB(rx__PTR__, t, 1, 1, 0, -1, -1, 1, cl, v, 0, 0, 0, 0, 0)
+          dcp <- lag * linCmtB(rx__PTR__, t, 1, 1, 0, -3, -3, 1, cl, v, 0, 0, 0, 0, 0)
+          d/dt(ce) <- (cp - ce) * ke0
+        }),
+        e = eventTable() |> add.dosing(dose = 100, rate = 25, cmt = "central") |>
+          add.sampling(seq(0.1, 12, 0.25))
+      )
+    )
+    for (.c in .cases) {
+      .s <- rxSolve(.c$m, .c$e, params = .p)
+      expect_false(any(is.na(.s$dcp)), info = .c$nm)
+      expect_true(max(abs(.s$dcp)) > 1e-3, info = .c$nm)  # not trivially zero
+      expect_equal(.s$dcp, .fdCol(.c$m, .c$e, "cp"),
+                   tolerance = 1e-5, info = .c$nm)
+    }
+  })
+
+  test_that("linCmtB(-3) matches finite differences for an infusion with method='dop853'", {
+    # The default (liblsoda/advan) and dop853 solve drivers walk ind->idx the
+    # same way for a linCmt()-only model (dense dop853 output, which does not,
+    # is disabled for any model with numLin > 0 -- see rxData.cpp), but
+    # exercise it explicitly since linCmtBRateSlot()'s cache is keyed on
+    # ind->idx/solvedIdx/doSS, common state every driver sets.
     m <- rxode2({
       cl <- exp(tcl); v <- exp(tv); lag <- 2 * exp(eta_lag)
       alag(central) <- lag
@@ -140,9 +227,40 @@ rxTest({
     })
     e <- eventTable() |> add.dosing(dose = 100, rate = 25, cmt = "central") |>
       add.sampling(seq(0.1, 12, 0.25))
-    s <- rxSolve(m, e, params = .p)
-    expect_true(all(is.na(s$dcp)))
-    expect_false(any(is.na(s$cp)))   # the model itself still solves
+    s <- rxSolve(m, e, params = .p, method = "dop853")
+    expect_false(any(is.na(s$dcp)))
+    h <- 1e-5
+    p1 <- .p; p1[["eta_lag"]] <- .p[["eta_lag"]] + h
+    p0 <- .p; p0[["eta_lag"]] <- .p[["eta_lag"]] - h
+    fd <- (rxSolve(m, e, params = p1, method = "dop853")$cp -
+             rxSolve(m, e, params = p0, method = "dop853")$cp) / (2 * h)
+    expect_equal(s$dcp, fd, tolerance = 1e-5)
+  })
+
+  test_that("linCmtB(-3) reports NA for a steady-state infusion", {
+    # A steady-state infusion establishes its amounts analytically
+    # (handleSSinf8()/solveSSinf()); ind->InfusionRate afterward reflects
+    # solve-order happenstance rather than a well-defined "rate at this
+    # index", so -dA/dt is not trustworthy there -- refused (#1236). A
+    # steady-state BOLUS is unaffected (never touches InfusionRate) and stays
+    # exact -- see the "1cmt IV steady-state bolus" case above.
+    m <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); lag <- 2 * exp(eta_lag)
+      alag(central) <- lag
+      cp <- linCmtB(rx__PTR__, t, 1, 1, 0, -1, -1, 1, cl, v, 0, 0, 0, 0, 0)
+      dcp <- lag * linCmtB(rx__PTR__, t, 1, 1, 0, -3, -3, 1, cl, v, 0, 0, 0, 0, 0)
+    })
+    .es <- list(
+      "periodic ss" = et(amt = 100, rate = 25, ii = 24, ss = 1, cmt = "central") |>
+        et(seq(0.1, 24, 0.25)),
+      "continuous ss" = et(amt = 0, rate = 25, ss = 1, cmt = "central") |>
+        et(seq(0.1, 24, 0.25))
+    )
+    for (.nm in names(.es)) {
+      s <- rxSolve(m, .es[[.nm]], params = .p)
+      expect_true(all(is.na(s$dcp)), info = .nm)
+      expect_false(any(is.na(s$cp)), info = .nm)   # the model itself still solves
+    }
   })
 
   test_that("linCmtB(-3) rejects a mismatched model shape", {


### PR DESCRIPTION
## Summary

Fixes #1236. `linCmtB(which1 = -3)` -- the dose-time (moving-boundary)
sensitivity added in #1235 -- previously returned `NA_REAL` for any individual
whose regimen contained an infusion, because the derivative needs `dA/dt`
(which includes the infusion rate), and `ind->InfusionRate` is only maintained
while solving. `rxode2_df.cpp`'s output pass recomputes `lhs` from the saved
amounts *after* `iniSubject()` clears the rates, so the rate read there was
always 0.

- `linCmtB()` now caches the live infusion rate per output index while it is
  genuinely solving that index, mirroring the existing `fx`/Jacobian `Alast`
  cache (`getAdvan(idx)`/`lc.restoreFx()`/`lc.restoreJac()`), keyed on the same
  `!ind->doSS && ind->solvedIdx >= idx` condition that already distinguishes a
  fresh solve from a re-query (e.g. the output pass).
- `linCmtBdoseTime()` reads that cache back on a re-query instead of the
  by-then-cleared live rate.
- A steady-state infusion still returns `NA_REAL`: it establishes its amounts
  analytically (`handleSSinf8()`/`solveSSinf()`), and for a one-shot SS dose
  with no following schedule the solver deliberately leaves `InfusionRate` at
  0 afterward -- the cache-based value there is well-defined but not
  physically meaningful (verified empirically: true steady state should give
  `-dA/dt = 0`, but reading the cache at that index gave a nonzero answer).
  Steady-state *bolus* never touches `InfusionRate` and was already exact.

Both correctness bugs an independent Antigravity/Gemini review raised (a
stale `ind->idx` sentinel during extra-dose injection; dense `dop853`
intra-segment observations) were checked against the actual code and do not
apply here: the extra-dose/`pushDosingEvent` path is reachable only from
inside the steady-state branch of `handle_evid`, which the new
`linCmtHasSsInfusion()` guard already refuses regardless of cache state; and
dense output is unconditionally disabled for any model with `numLin > 0`
(`rxData.cpp`), i.e. any model that could call `linCmtB()` at all. Both were
confirmed unreachable by tracing the call graph and by passing tests that
exercise the surrounding code paths (steady-state infusions, `method =
"dop853"`).

## Test plan

- [x] `tests/testthat/test-lincmt-dose-time-sens.R`: infusion regimens (single,
      multiple, duration-specified, oral-into-depot, IV-with-peripheral, mixed
      `linCmt()` + `d/dt()`, `method = "dop853"`) match a central finite
      difference to ~1e-10; steady-state infusions (periodic and continuous)
      still report `NA`.
- [x] `tests/testthat/test-lincmt-dose-time-sens-guard.R` (unaffected #1237
      guard) still passes.
- [x] `tests/testthat/test-lincmt-solve-sens.R`, `test-steady-state.R`,
      `test-event-sensitivities*.R`, `test-infusion-bolus.R`,
      `test-lincmt-*.R` all pass with no new failures.
- [x] Full clean rebuild (`rm -f src/*.o`, required since a shared header
      changed) with no new warnings from the changed files.
- [x] Reviewed with an independent Antigravity (Gemini) pass; findings
      triaged above.