### PR TITLE
Fix rx->sensH reading the wrong control index (#1276)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -571,6 +571,15 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
 
 ### Sensitivities
 
+- `linCmtSensH` (the fixed finite-difference step used by the `forwardH`/
+  `centralH`/`forward3H`/`endpoint5H` `linCmtSensType` options) is now read
+  from its own control slot instead of `linCmtSensType`'s.  `rx->sensH` was
+  populated from the `linCmtSensType` control index a second time, so a fixed-
+  step `linCmt()` sensitivity used the integer sensType code itself as its
+  step size (e.g. `10.0` for `forwardH`) instead of the intended default of
+  `1e-4`, wildly distorting those finite-difference sensitivities (harmless
+  for the AD sensitivity types, which never read `sensH`) (#1276).
+
 - `rxode2()` now refuses to build a model that calls `linCmtB(which1 = -3)`
   (the dose-time sensitivity) while its `linCmt()` compartments carry more
   than one distinct modeled `alag()` -- e.g. `alag(depot)` driven by one

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -707,6 +707,10 @@ rxSolveFromRaw_ <- function(obj, rawObj, solveState, rxControl, specParams, extr
     .Call(`_rxode2_rxSolveFromRaw_`, obj, rawObj, solveState, rxControl, specParams, extraArgs, params, events, inits)
 }
 
+rxLinCmtSensDebug_ <- function() {
+    .Call(`_rxode2_rxLinCmtSensDebug_`)
+}
+
 rxSolve_ <- function(obj, rxControl, specParams, extraArgs, params, events, inits, setupOnly) {
     .Call(`_rxode2_rxSolve_`, obj, rxControl, specParams, extraArgs, params, events, inits, setupOnly)
 }

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -5664,3 +5664,15 @@ rxUiDeparse.rxControl <- function(object, var) {
   }, character(1), USE.NAMES=FALSE)
   str2lang(paste(var, " <- rxControl(", paste(.retD, collapse=","),")"))
 }
+
+#' Test-only accessor for the linCmt() sensitivity control values
+#'
+#' Returns `sensType`/`sensH` as they landed in the C-level `rx_solve` struct
+#' after the last solve, so a test can confirm `linCmtSensH` was read from its
+#' own `rxControl` slot instead of `linCmtSensType`'s (nlmixr2/rxode2#1276).
+#'
+#' @return A list with `sensType` and `sensH`
+#' @noRd
+.rxLinCmtSensDebug <- function() {
+  rxLinCmtSensDebug_()
+}

--- a/inst/include/rxode2_RcppExports.h
+++ b/inst/include/rxode2_RcppExports.h
@@ -505,6 +505,27 @@ namespace rxode2 {
         return Rcpp::as<SEXP >(rcpp_result_gen);
     }
 
+    inline List rxLinCmtSensDebug_() {
+        typedef SEXP(*Ptr_rxLinCmtSensDebug_)();
+        static Ptr_rxLinCmtSensDebug_ p_rxLinCmtSensDebug_ = NULL;
+        if (p_rxLinCmtSensDebug_ == NULL) {
+            validateSignature("List(*rxLinCmtSensDebug_)()");
+            p_rxLinCmtSensDebug_ = (Ptr_rxLinCmtSensDebug_)R_GetCCallable("rxode2", "_rxode2_rxLinCmtSensDebug_");
+        }
+        RObject rcpp_result_gen;
+        {
+            RNGScope RCPP_rngScope_gen;
+            rcpp_result_gen = p_rxLinCmtSensDebug_();
+        }
+        if (rcpp_result_gen.inherits("interrupted-error"))
+            throw Rcpp::internal::InterruptedException();
+        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))
+            throw Rcpp::LongjumpException(rcpp_result_gen);
+        if (rcpp_result_gen.inherits("try-error"))
+            throw Rcpp::exception(Rcpp::as<std::string>(rcpp_result_gen).c_str());
+        return Rcpp::as<List >(rcpp_result_gen);
+    }
+
     inline SEXP rxSolve_(const RObject& obj, const List& rxControl, const Nullable<CharacterVector>& specParams, const Nullable<List>& extraArgs, const RObject& params, const RObject& events, const RObject& inits, const int setupOnly) {
         typedef SEXP(*Ptr_rxSolve_)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
         static Ptr_rxSolve_ p_rxSolve_ = NULL;

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1246,6 +1246,39 @@ RcppExport SEXP _rxode2_rxSolveFromRaw_(SEXP objSEXP, SEXP rawObjSEXP, SEXP solv
     UNPROTECT(1);
     return rcpp_result_gen;
 }
+// rxLinCmtSensDebug_
+List rxLinCmtSensDebug_();
+static SEXP _rxode2_rxLinCmtSensDebug__try() {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    rcpp_result_gen = Rcpp::wrap(rxLinCmtSensDebug_());
+    return rcpp_result_gen;
+END_RCPP_RETURN_ERROR
+}
+RcppExport SEXP _rxode2_rxLinCmtSensDebug_() {
+    SEXP rcpp_result_gen;
+    {
+        Rcpp::RNGScope rcpp_rngScope_gen;
+        rcpp_result_gen = PROTECT(_rxode2_rxLinCmtSensDebug__try());
+    }
+    Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
+    if (rcpp_isInterrupt_gen) {
+        UNPROTECT(1);
+        Rf_onintr();
+    }
+    bool rcpp_isLongjump_gen = Rcpp::internal::isLongjumpSentinel(rcpp_result_gen);
+    if (rcpp_isLongjump_gen) {
+        Rcpp::internal::resumeJump(rcpp_result_gen);
+    }
+    Rboolean rcpp_isError_gen = Rf_inherits(rcpp_result_gen, "try-error");
+    if (rcpp_isError_gen) {
+        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
+        UNPROTECT(1);
+        (Rf_error)("%s", CHAR(rcpp_msgSEXP_gen));
+    }
+    UNPROTECT(1);
+    return rcpp_result_gen;
+}
 // rxSolve_
 SEXP rxSolve_(const RObject& obj, const List& rxControl, const Nullable<CharacterVector>& specParams, const Nullable<List>& extraArgs, const RObject& params, const RObject& events, const RObject& inits, const int setupOnly);
 static SEXP _rxode2_rxSolve__try(SEXP objSEXP, SEXP rxControlSEXP, SEXP specParamsSEXP, SEXP extraArgsSEXP, SEXP paramsSEXP, SEXP eventsSEXP, SEXP initsSEXP, SEXP setupOnlySEXP) {
@@ -3001,6 +3034,7 @@ static int _rxode2_RcppExport_validate(const char* sig) {
         signatures.insert("LogicalVector(*rxSolveFree)()");
         signatures.insert("LogicalVector(*rxSolveSetup)()");
         signatures.insert("SEXP(*rxSolveFromRaw_)(const RObject&,const RObject&,const RObject&,const List&,const Nullable<CharacterVector>&,const Nullable<List>&,const RObject&,const RObject&,const RObject&)");
+        signatures.insert("List(*rxLinCmtSensDebug_)()");
         signatures.insert("SEXP(*rxSolve_)(const RObject&,const List&,const Nullable<CharacterVector>&,const Nullable<List>&,const RObject&,const RObject&,const RObject&,const int)");
         signatures.insert("CharacterVector(*rxSolveDollarNames)(RObject)");
         signatures.insert("RObject(*rxSolveGet)(RObject,RObject,LogicalVector)");
@@ -3067,6 +3101,7 @@ RcppExport SEXP _rxode2_RcppExport_registerCCallable() {
     R_RegisterCCallable("rxode2", "_rxode2_rxSolveFree", (DL_FUNC)_rxode2_rxSolveFree_try);
     R_RegisterCCallable("rxode2", "_rxode2_rxSolveSetup", (DL_FUNC)_rxode2_rxSolveSetup_try);
     R_RegisterCCallable("rxode2", "_rxode2_rxSolveFromRaw_", (DL_FUNC)_rxode2_rxSolveFromRaw__try);
+    R_RegisterCCallable("rxode2", "_rxode2_rxLinCmtSensDebug_", (DL_FUNC)_rxode2_rxLinCmtSensDebug__try);
     R_RegisterCCallable("rxode2", "_rxode2_rxSolve_", (DL_FUNC)_rxode2_rxSolve__try);
     R_RegisterCCallable("rxode2", "_rxode2_rxSolveDollarNames", (DL_FUNC)_rxode2_rxSolveDollarNames_try);
     R_RegisterCCallable("rxode2", "_rxode2_rxSolveGet", (DL_FUNC)_rxode2_rxSolveGet_try);

--- a/src/init.c
+++ b/src/init.c
@@ -320,6 +320,7 @@ double gamma_p_inva(double a, double p);
 
 int compareFactorVal(int val, const char *factor, const char *value);
 int compareFactorInt(int val, const char *factor, int value);
+SEXP _rxode2_rxLinCmtSensDebug_(void);
 SEXP _rxode2_rxSolve_(SEXP, SEXP, SEXP, SEXP, SEXP,
                       SEXP, SEXP, SEXP);
 SEXP _rxode2_rxSolveFromRaw_(SEXP, SEXP, SEXP, SEXP, SEXP,
@@ -1020,6 +1021,7 @@ void R_init_rxode2(DllInfo *info){
     {"_linCmtParse", (DL_FUNC) _linCmtParse, 3},
     {"_rxode2_linCmtGen", (DL_FUNC) _rxode2_linCmtGen, 4},
     {"_rxode2_rpp_", (DL_FUNC) _rxode2_rpp_, 7},
+    {"_rxode2_rxLinCmtSensDebug_", (DL_FUNC) &_rxode2_rxLinCmtSensDebug_, 0},
     {"_rxode2_rxSolve_", (DL_FUNC) _rxode2_rxSolve_, 8},
     {"getRxThreads_R", (DL_FUNC) getRxThreads_R, 1},
     {"setRxthreads", (DL_FUNC) setRxthreads, 3},

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -6098,6 +6098,14 @@ extern "C" int solveMethodThreadSafe(rx_solving_options* op) {
   return stiff != 1 && stiff != 106 && stiff != 107;
 }
 
+// Test-only accessor for the linCmt() finite-difference control values that
+// land in the global rx_solve struct (nlmixr2/rxode2#1276): rx->sensType and
+// rx->sensH must come from their own, distinct rxControl slots.
+// [[Rcpp::export]]
+List rxLinCmtSensDebug_() {
+  rx_solve *rx = getRxSolve_();
+  return List::create(_["sensType"]=rx->sensType, _["sensH"]=rx->sensH);
+}
 
 // [[Rcpp::export]]
 SEXP rxSolve_(const RObject &obj, const List &rxControl,
@@ -6261,7 +6269,7 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
     rx->simflg  = INTEGER(rxSolveDat->mv[RxMv_flags])[RxMvFlag_simflg];
     rx->ndiff   =  INTEGER(rxSolveDat->mv[RxMv_flags])[RxMvFlag_ndiff];
     rx->sensType= asInt(rxControl[Rxc_linCmtSensType], "linCmtSensType");
-    rx->sensH   = asDouble(rxControl[Rxc_linCmtSensType], "linCmtSensH");
+    rx->sensH   = asDouble(rxControl[Rxc_linCmtSensH], "linCmtSensH");
     rx->sumType = asInt(rxControl[Rxc_sumType], "sumType");
     rx->prodType = asInt(rxControl[Rxc_prodType], "prodType");
     rx->maxwhile = asInt(rxControl[Rxc_maxwhile], "maxwhile");

--- a/tests/testthat/test-lincmt-sensH-1276.R
+++ b/tests/testthat/test-lincmt-sensH-1276.R
@@ -1,0 +1,49 @@
+rxTest({
+
+  ## rx->sensH (the fixed finite-difference step for the forwardH/centralH/
+  ## forward3H/endpoint5H linCmtSensType options) was populated by re-reading
+  ## the linCmtSensType control slot instead of its own linCmtSensH slot, so a
+  ## fixed-step linCmt() sensitivity used the integer sensType code itself as
+  ## its step size (e.g. 10.0 for forwardH) instead of the requested step
+  ## (nlmixr2/rxode2#1276).  `.rxLinCmtSensDebug()` reads back rx->sensType and
+  ## rx->sensH from the global rx_solve struct after a solve, which is the
+  ## only way to observe rx->sensH directly: it is consumed exclusively by
+  ## nlmixr2est's FOCEi `ind_solve()` C entry point (via `setupLinH()`), which
+  ## nothing in rxode2 itself calls, so no ordinary rxSolve() output differs
+  ## with or without the fix.
+
+  rx <- rxode2({
+    ka <- 0.5
+    cl <- 0.1
+    v <- 20
+    Cp <- linCmt()
+  })
+  ev <- eventTable() |> add.dosing(dose = 100) |> add.sampling(seq(0.5, 8, by = 0.5))
+
+  test_that("linCmtSensH lands in rx->sensH, not rx->sensType's value (#1276)", {
+
+    invisible(rxSolve(rx, ev, linCmtSensType = "forwardH", linCmtSensH = 0.0055))
+    .d <- .rxLinCmtSensDebug()
+    expect_equal(.d$sensType, 10)
+    expect_equal(.d$sensH, 0.0055)
+
+    invisible(rxSolve(rx, ev, linCmtSensType = "centralH", linCmtSensH = 0.02))
+    .d <- .rxLinCmtSensDebug()
+    expect_equal(.d$sensType, 20)
+    expect_equal(.d$sensH, 0.02)
+
+    ## default linCmtSensH is 1e-4; must not silently pick up sensType's code
+    invisible(rxSolve(rx, ev, linCmtSensType = "forward3H"))
+    .d <- .rxLinCmtSensDebug()
+    expect_equal(.d$sensType, 40)
+    expect_equal(.d$sensH, 1e-4)
+
+    ## AD never reads sensH, but it is still populated correctly from control
+    invisible(rxSolve(rx, ev, linCmtSensType = "AD"))
+    .d <- .rxLinCmtSensDebug()
+    expect_equal(.d$sensType, 3)
+    expect_equal(.d$sensH, 1e-4)
+
+  })
+
+})


### PR DESCRIPTION
## Summary

- `rx->sensH` (the fixed finite-difference step used by the `forwardH`/`centralH`/`forward3H`/`endpoint5H` `linCmtSensType` options) was populated by re-reading the `linCmtSensType` control slot (`Rxc_linCmtSensType`) instead of its own `linCmtSensH` slot (`Rxc_linCmtSensH`). A fixed-step `linCmt()` sensitivity therefore used the integer sensType code itself as its step size (e.g. `10.0` for `forwardH`) instead of the intended default of `1e-4`. Harmless for the AD sensitivity types, which never read `sensH`.
- One-line fix in `src/rxData.cpp`'s `rxSolve_()`.
- Adds a test-only accessor (`.rxLinCmtSensDebug()` / `rxLinCmtSensDebug_()`) that reads `rx->sensType`/`rx->sensH` back out of the global `rx_solve` struct after a solve. This is needed because `rx->sensH` is consumed only inside `setupLinH()` (`src/par_solve.cpp`), which is called exclusively from `ind_solve()` -- an entry point exposed via `inst/include/rxode2ptr.h`'s function-pointer table for downstream packages (e.g. nlmixr2est's FOCEi C++ code). Nothing inside rxode2 itself calls `ind_solve()`, so no ordinary `rxSolve()` R-level call exercises the affected code path, and no existing test's *output* would differ with or without this fix.
- New regression test `tests/testthat/test-lincmt-sensH-1276.R` verifies `sensH` is read distinctly from `sensType` across several `linCmtSensType` options; confirmed to fail before the fix and pass after.

Closes nlmixr2/rxode2#1276.

## Review

Reviewed with Antigravity (Gemini) in two passes: an initial full review (found one pre-existing, out-of-scope concurrency note in `setupLinH()`'s `sensType==100` auto-AD downgrade -- confirmed via `git diff` that `src/par_solve.cpp` is untouched by this PR) and a follow-up pass scoped strictly to the changed/added lines, which reported no issues.

## Test plan

- [x] `devtools::load_all()` builds cleanly
- [x] New test file passes with the fix, and was confirmed to fail (with the exact reported symptom, `sensH == sensType`'s numeric code) when the one-line fix is reverted
- [x] `tests/testthat/test-lincmt-solve.R` (1614 assertions), `test-lincmt-solve-sens.R` (4586), `test-lincmt-parse.R`/`test-lincmt-modelvars.R` (45) all still pass