### PR TITLE
rxS(): build the symengine function symbols once at package build (#1283)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -110,6 +110,7 @@ Imports:
     backports,
     cli (>= 2.0.0),
     checkmate,
+    compiler,
     ggplot2 (>= 3.4.0),
     inline,
     lotri (>= 1.0.5),

--- a/NEWS.md
+++ b/NEWS.md
@@ -250,15 +250,17 @@
   `rxRemoveUiPrep()` in `.onUnload()`.  See the [solve-time hooks
   article](https://nlmixr2.github.io/rxode2/articles/rxode2-solve-hooks.html).
 
-- Building a symengine environment with `rxS()` is about twice as fast
-  (#1283).  The opaque function symbols it loads (`linCmtA()`, `delay()`,
-  `lag()`, the derivative helpers, ...) were built by splicing each name into a
-  fresh function body, so R created and byte-compiled about 250 new closures on
-  every call.  They now share one body, are built when the package itself is
-  built, and are reused by every symengine environment; a user function
-  registered at run time with `rxFun()` or `rxD()` is built the same way on
-  first use.  This speeds up every consumer that loads models into symengine
-  repeatedly, such as an nlmixr2 fit.
+- Building a symengine environment with `rxS()` no longer rebuilds its function
+  symbols on every call (#1283).  The opaque symbols it loads (`linCmtA()`,
+  `delay()`, `lag()`, the derivative helpers, ...) were made by splicing each
+  name into a fresh function body, so R created -- and byte-compiled -- about
+  250 new closures per call.  They now share one body, are built when the
+  package itself is built, and are reused by every symengine environment; a user
+  function registered at run time with `rxFun()` or `rxD()` is built the same
+  way on first use.  This removes a fixed per-call cost for every consumer that
+  loads models into symengine repeatedly, such as an nlmixr2 fit; the saving is
+  largest for small models and in a `pkgload::load_all()` session, where the
+  discarded closures were byte-compiled again on each call.
 
 ## Breaking changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -250,6 +250,16 @@
   `rxRemoveUiPrep()` in `.onUnload()`.  See the [solve-time hooks
   article](https://nlmixr2.github.io/rxode2/articles/rxode2-solve-hooks.html).
 
+- Building a symengine environment with `rxS()` is about twice as fast
+  (#1283).  The opaque function symbols it loads (`linCmtA()`, `delay()`,
+  `lag()`, the derivative helpers, ...) were built by splicing each name into a
+  fresh function body, so R created and byte-compiled about 250 new closures on
+  every call.  They now share one body, are built when the package itself is
+  built, and are reused by every symengine environment; a user function
+  registered at run time with `rxFun()` or `rxD()` is built the same way on
+  first use.  This speeds up every consumer that loads models into symengine
+  repeatedly, such as an nlmixr2 fit.
+
 ## Breaking changes
 
 - The exported `.iniHandleFixOrUnfix()` alias is removed (#1250).  It was an

--- a/R/symengine.R
+++ b/R/symengine.R
@@ -3227,7 +3227,7 @@ rxFromSE <- function(x, unknownDerivatives = c("forward", "central", "error"),
     if (length(.args) == 0) {
       .args <- NaN
     }
-    return(symengine::FunctionSymbol(name, .args))
+    symengine::FunctionSymbol(name, .args)
   }
 })
 

--- a/R/symengine.R
+++ b/R/symengine.R
@@ -3343,7 +3343,8 @@ rxS <- function(x, doConst = TRUE, promoteLinSens = FALSE, envir=parent.frame())
   # as emitted lhs and bound as symbols (not inlined or dead-code eliminated), so
   # the history function still references a defined variable in the output model
   .env$..laggedVars <- .rxCollectLaggedVars(.expr)
-  .ret <- .rxToSE(.expr, envir=.env)
+  # loads the model into .env by side effect; the returned text is not used
+  .rxToSE(.expr, envir=.env)
   class(.env) <- "rxS"
   return(.env)
 }

--- a/R/symengine.R
+++ b/R/symengine.R
@@ -349,6 +349,23 @@ regIfOrElse <- rex::rex(or(regIf, regElse))
   setdiff(names(.rxSEeq)[!is.na(.rxSEeq)], .rxSEnative)
 }
 
+## The build-time known function names loaded into every rxS() environment as
+## opaque FunctionSymbols; rxS() adds the run-time ones (user functions and user
+## derivative tables) to these.  Evaluated once when the package is built.
+.rxSEfunNames <- c(
+  "linCmtA", "linCmtB",
+  "rxEq", "rxNeq", "rxGeq", "rxLeq", "rxLt",
+  "rxGt", "rxAnd", "rxOr", "rxNot", "rxTBS", "rxTBSd", "rxTBSd2",
+  "rxTBSdL", "rxTBSdL2", "rxTBSdLx", "lag", "lead",
+  "lag0", "lead0", "diff0",
+  # every parser-known function symengine cannot handle itself -- the locally
+  # constant floor()/ceil()/round()/trunc()/sign() family, the special
+  # functions (bessel_*, gammaq, fmax2, logspace_add, ...) and the emitted
+  # derivative helpers (llikNormDmean, dSELU, ...).  Without this the
+  # assignment stores a non-Basic and the model is silently corrupted
+  .rxSEopaque(),
+  "delay", "rxDelayD", "rxDelayD2", "rxDelayD3", "rxTBSi")
+
 .rxOnly <- c(
   ## Now random number generators
   "rnorm" = NA,
@@ -3191,18 +3208,47 @@ rxFromSE <- function(x, unknownDerivatives = c("forward", "central", "error"),
   }
 }
 
-.rxFunction <- function(name) {
-  .f <- function(...) {
-    1
-  }
-  body(.f) <- bquote({
+## Cache of the opaque FunctionSymbol closures handed to rxS().  A closure
+## depends only on its name, so every symengine environment shares one closure
+## per name instead of rxS() building (and R's JIT byte-compiling) a fresh set of
+## ~250 of them on every call (#1283).
+.rxFunctionCache <- new.env(parent = emptyenv())
+
+## Every opaque FunctionSymbol closure shares one body, written once here and
+## byte-compiled when the package is built (the factory is compiled explicitly
+## because a closure made by an interpreted factory keeps an interpreted body).
+## The name is captured lexically rather than spliced into a fresh body with
+## bquote(), which is what made each of these a distinct, separately
+## JIT-compiled function at run time.
+.rxFunctionMake <- compiler::cmpfun(function(name) {
+  force(name)
+  function(...) {
     .args <- unlist(list(...))
     if (length(.args) == 0) {
       .args <- NaN
     }
-    return(symengine::FunctionSymbol(.(name), .args))
-  })
-  return(.f)
+    return(symengine::FunctionSymbol(name, .args))
+  }
+})
+
+## Every function rxode2 itself knows about is built HERE, when the package is
+## built, and restored from the lazy-load database, so no rxS() call -- not even
+## the first of a session -- creates or compiles them.  Names registered at run
+## time (rxFun()/rxD() user functions) are not known at build time and are built
+## on first use by .rxFunction() below.
+local({
+  for (.f in c(ls(.rxD), .rxSEfunNames)) {
+    assign(.f, .rxFunctionMake(.f), envir = .rxFunctionCache)
+  }
+})
+
+.rxFunction <- function(name) {
+  .f <- .rxFunctionCache[[name]]
+  if (is.null(.f)) {
+    .f <- .rxFunctionMake(name)
+    assign(name, .f, envir = .rxFunctionCache)
+  }
+  .f
 }
 
 #' Load a model into a symengine environment
@@ -3239,21 +3285,7 @@ rxS <- function(x, doConst = TRUE, promoteLinSens = FALSE, envir=parent.frame())
   .env$..lhs0 <- NULL
   .env$..doConst <- doConst
   .rxD <- rxode2parseD()
-  for (.f in c(
-    ls(.symengineFs()),
-    ls(.rxD), "linCmtA", "linCmtB",
-    "rxEq", "rxNeq", "rxGeq", "rxLeq", "rxLt",
-    "rxGt", "rxAnd", "rxOr", "rxNot", "rxTBS", "rxTBSd", "rxTBSd2",
-    "rxTBSdL", "rxTBSdL2", "rxTBSdLx", "lag", "lead",
-    "lag0", "lead0", "diff0",
-    # every parser-known function symengine cannot handle itself -- the locally
-    # constant floor()/ceil()/round()/trunc()/sign() family, the special
-    # functions (bessel_*, gammaq, fmax2, logspace_add, ...) and the emitted
-    # derivative helpers (llikNormDmean, dSELU, ...).  Without this the
-    # assignment stores a non-Basic and the model is silently corrupted
-    .rxSEopaque(),
-    "delay", "rxDelayD", "rxDelayD2", "rxDelayD3", "rxTBSi"
-  )) {
+  for (.f in c(ls(.symengineFs()), ls(.rxD), .rxSEfunNames)) {
     assign(.f, .rxFunction(.f), envir = .env)
   }
 

--- a/tests/testthat/test-rxs-function-cache.R
+++ b/tests/testthat/test-rxs-function-cache.R
@@ -4,21 +4,23 @@ rxTest({
   # used to splice each name into a fresh body with bquote(), so R re-created
   # and JIT byte-compiled ~250 of them on every call.
 
+  # both are internal to rxode2; resolve them once here rather than reaching
+  # into the rxode2 namespace at every use
+  .cache <- utils::getFromNamespace(".rxFunctionCache", "rxode2")
+  .rxFun <- utils::getFromNamespace(".rxFunction", "rxode2")
+
   test_that("the rxS() function closures are pre-built and shared", {
-    .cache <- rxode2:::.rxFunctionCache
     # built with the package, so they are there before any rxS() call
     expect_true(all(c("linCmtA", "linCmtB", "delay", "lag0", "rxTBS") %in%
                       ls(.cache)))
 
     # one closure per name, not one per rxS() call
-    expect_identical(rxode2:::.rxFunction("linCmtA"),
-                     rxode2:::.rxFunction("linCmtA"))
-    expect_identical(rxode2:::.rxFunction("linCmtA"), .cache[["linCmtA"]])
+    expect_identical(.rxFun("linCmtA"), .rxFun("linCmtA"))
+    expect_identical(.rxFun("linCmtA"), .cache[["linCmtA"]])
 
     # the name is captured lexically, so the body is the same object for every
     # function instead of a per-name expression that has to be compiled again
-    expect_identical(body(rxode2:::.rxFunction("linCmtA")),
-                     body(rxode2:::.rxFunction("delay")))
+    expect_identical(body(.rxFun("linCmtA")), body(.rxFun("delay")))
 
     # and rxS() hands out those same closures
     .s <- rxS(rxModelVars("d/dt(x) <- -k*x"))
@@ -35,7 +37,7 @@ rxTest({
           "double cacheUdf(double a, double b) { return a + b; }")
     expect_equal(.ddt("d/dt(x) <- -cacheUdf(a, b)*x"), "-x*cacheUdf(a, b)")
     # not known when the package was built, so it is built on first use
-    expect_true("cacheUdf" %in% ls(rxode2:::.rxFunctionCache))
+    expect_true("cacheUdf" %in% ls(.cache))
 
     # the closure only carries the name, so re-registering the same function
     # with a different number of arguments still translates
@@ -54,8 +56,7 @@ rxTest({
       function(a, b, c) "1"))
     expect_true("cacheUdf" %in% ls(rxode2parseD()))
     .s <- rxS(rxModelVars("d/dt(x) <- -cacheUdf(a, b, c)*x"))
-    expect_identical(mget("cacheUdf", envir = .s)[[1]],
-                     rxode2:::.rxFunctionCache[["cacheUdf"]])
+    expect_identical(mget("cacheUdf", envir = .s)[[1]], .cache[["cacheUdf"]])
     expect_equal(rxFromSE("Derivative(cacheUdf(a, b, c), a)"), "1")
   })
 })

--- a/tests/testthat/test-rxs-function-cache.R
+++ b/tests/testthat/test-rxs-function-cache.R
@@ -1,0 +1,48 @@
+rxTest({
+  # The opaque FunctionSymbol closures rxS() loads are built once when the
+  # package is built and shared by every symengine environment (#1283); rxS()
+  # used to splice each name into a fresh body with bquote(), so R re-created
+  # and JIT byte-compiled ~250 of them on every call.
+
+  test_that("the rxS() function closures are pre-built and shared", {
+    .cache <- rxode2:::.rxFunctionCache
+    # built with the package, so they are there before any rxS() call
+    expect_true(all(c("linCmtA", "linCmtB", "delay", "lag0", "rxTBS") %in%
+                      ls(.cache)))
+
+    # one closure per name, not one per rxS() call
+    expect_identical(rxode2:::.rxFunction("linCmtA"),
+                     rxode2:::.rxFunction("linCmtA"))
+    expect_identical(rxode2:::.rxFunction("linCmtA"), .cache[["linCmtA"]])
+
+    # the name is captured lexically, so the body is the same object for every
+    # function instead of a per-name expression that has to be compiled again
+    expect_identical(body(rxode2:::.rxFunction("linCmtA")),
+                     body(rxode2:::.rxFunction("delay")))
+
+    # and rxS() hands out those same closures
+    .s <- rxS(rxModelVars("d/dt(x) <- -k*x"))
+    expect_identical(mget("linCmtA", envir = .s)[[1]], .cache[["linCmtA"]])
+  })
+
+  test_that("user functions registered at run time are loaded into rxS()", {
+    on.exit(suppressWarnings(try(rxRmFun("cacheUdf"), silent = TRUE)),
+            add = TRUE)
+    .ddt <- function(mod) {
+      as.character(eval(quote(rx__d_dt_x__), envir = rxS(rxModelVars(mod))))
+    }
+    rxFun("cacheUdf", c("a", "b"),
+          "double cacheUdf(double a, double b) { return a + b; }")
+    expect_equal(.ddt("d/dt(x) <- -cacheUdf(a, b)*x"), "-x*cacheUdf(a, b)")
+    # not known when the package was built, so it is built on first use
+    expect_true("cacheUdf" %in% ls(rxode2:::.rxFunctionCache))
+
+    # the closure only carries the name, so re-registering the same function
+    # with a different number of arguments still translates
+    rxRmFun("cacheUdf")
+    rxFun("cacheUdf", c("a", "b", "c"),
+          "double cacheUdf(double a, double b, double c) { return a+b+c; }")
+    expect_equal(.ddt("d/dt(x) <- -cacheUdf(a, b, c)*x"),
+                 "-x*cacheUdf(a, b, c)")
+  })
+})

--- a/tests/testthat/test-rxs-function-cache.R
+++ b/tests/testthat/test-rxs-function-cache.R
@@ -44,5 +44,18 @@ rxTest({
           "double cacheUdf(double a, double b, double c) { return a+b+c; }")
     expect_equal(.ddt("d/dt(x) <- -cacheUdf(a, b, c)*x"),
                  "-x*cacheUdf(a, b, c)")
+
+    # a derivative table added with rxD() after the package was built is picked
+    # up by rxS() the same way -- it comes from ls(rxode2parseD()), not from the
+    # build-time name list
+    rxD("cacheUdf", list(
+      function(a, b, c) "1",
+      function(a, b, c) "1",
+      function(a, b, c) "1"))
+    expect_true("cacheUdf" %in% ls(rxode2parseD()))
+    .s <- rxS(rxModelVars("d/dt(x) <- -cacheUdf(a, b, c)*x"))
+    expect_identical(mget("cacheUdf", envir = .s)[[1]],
+                     rxode2:::.rxFunctionCache[["cacheUdf"]])
+    expect_equal(rxFromSE("Derivative(cacheUdf(a, b, c), a)"), "1")
   })
 })


### PR DESCRIPTION
Fixes #1283.

## What was happening

`rxS()` loads ~250 opaque `FunctionSymbol` closures (`linCmtA()`, `delay()`,
`lag()`, the `rxode2parseD()` derivative helpers, the `floor()`/`ceil()` locally
constant family, ...) into every symengine environment it builds. `.rxFunction()`
built each one by splicing its name into a **fresh** function body:

```r
.f <- function(...) { 1 }
body(.f) <- bquote({ ... symengine::FunctionSymbol(.(name), .args) })
```

So every `rxS()` call created ~250 new closures with ~250 *distinct* bodies,
which R then byte-compiled again -- the JIT's body cache never hit, because each
body carried a different spliced name constant. `bquote()` alone was ~42% of
`rxS()` in an Rprof of a small model.

## What changed

- One body, written once at package level, with the name captured lexically.
- The factory is byte-compiled explicitly (`compiler::cmpfun`) -- a closure made
  by an interpreted factory keeps an interpreted body, and the build-time loop
  below runs *before* the installer's byte-compile sweep.
- The closures for every function rxode2 itself knows about (`ls(.rxD)` plus the
  new `.rxSEfunNames` constant, which is the old inline list) are built by
  top-level code, i.e. **when the package is built**, and come back out of the
  lazy-load database. Nothing is created or compiled on the first `rxS()` of a
  session.
- Names that are not known at build time -- `rxFun()`/`rxD()` user functions and
  R user functions reached from `.rxToSE()` -- fall through to `.rxFunction()`,
  which builds from the same compiled factory and caches. The closure carries
  only the name (not the arity or the C code), so removing and re-registering a
  function with a different number of arguments still translates correctly.

Verified on a real install: all 182 build-time closures have bytecode bodies
sharing one object, and a closure built at run time shares that same object.

## Effect

This removes a *fixed* per-call cost, so the fraction depends on the model and
on the session. The issue's ~0.53 s figure is a `pkgload::load_all()` session,
where rxode2's own code is not byte-compiled and the discarded closures were
byte-compiled again on every call; installed, the JIT has much less to do.

| | before | after |
|---|---|---|
| installed, `rxS()` one compartment model | 0.040 s | 0.020 s |
| installed, `rxS()` 56 state sensitivity model | 0.522 s | 0.519 s (`.rxFunction` 3.1% -> 0) |
| installed, nlmixr2est `ui$foceiEtaS` (median of 6) | 0.274 s | 0.256 s |
| `load_all`, nlmixr2est `ui$foceiEtaS` (warm) | 0.42 s | 0.28 s |

The other component #1283 mentions, ~0.35 s of env `assign()`s, did not
reproduce in either session type: the three loops in `rxS()` measure ~5 ms
total (1.5 ms functions, 1.3 ms reserved, 2.3 ms the `.pars` loop). The rest of
a large build is the `.rxToSE()`/`rxFromSE()` walk, which is real work.

## Tests

New `tests/testthat/test-rxs-function-cache.R`: the base closures are present
before any `rxS()` call, `.rxFunction()` is stable and shared with what `rxS()`
hands out, the body is the same object across names (the actual root cause), and
the run-time path works for both `rxFun()` (including re-registration with a
different arity) and a derivative table added later with `rxD()`.

`dsl|sens3|lag|udf|derived` 2311 pass / 0 fail; `fun` + the new file 130 pass /
0 fail. The full suite is left to CI. Reviewed independently by Antigravity
(Gemini 3.1 Pro) over two passes.