### PR TITLE
Size the individual solve pool by nsim*nsub (fixes nlmixr2#412 'nothing to solve')

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -278,6 +278,14 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
 
 ## Bug fixes
 
+- A multi-subject `rxSolve()` with `nsim`/`nStud > 1` no longer sizes the
+  per-individual solve pool as `nsub` times the number of individual solves
+  it needs.  The over-allocation grew with the square of the number of
+  subjects, so a large study either ran out of memory or overflowed the size
+  to a negative number and stopped with `nothing to solve` -- which is what
+  made `nlmixr2est::addNpde()` and `vpcSim()` fail on a large fit
+  (nlmixr2/nlmixr2#412).  Results are unchanged.
+
 - A chunked solve (`rxSolve(file=`/`chunkSize=`)) with `nStud > 1` now
   simulates the omega uncertainty it was asked for.  It previously returned a
   plausible looking result drawn entirely from the point estimate omega, with

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -4253,7 +4253,9 @@ static inline void rxSolve_datSetupHmax(const RObject &obj, const List &rxContro
       // one solve per subject).  Multiplying nid by nPopPar over-allocated by a
       // factor of nsub: a large study then either exhausted memory or overflowed
       // `int` and reported "nothing to solve" (nlmixr2/nlmixr2#412).
-      if (rxSolveDat->nPopPar == 0) {
+      if (nid == 0 || rxSolveDat->nPopPar == 0) {
+        // both were 0 under the old expression too, so the ntot <= 0 guard
+        // below keeps firing exactly where it used to
         ntot = 0;
       } else if (nid > rxSolveDat->nPopPar) {
         ntot = nid;

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -4247,12 +4247,18 @@ static inline void rxSolve_datSetupHmax(const RObject &obj, const List &rxContro
           }
         }
       }
-      // if (nid == 0){
-      // } else
-      if (nid == rxSolveDat->nPopPar || rxSolveDat->nPopPar == 1){
+      // One `rx_solving_options_ind` is needed per individual SOLVE, that is
+      // `nsub*nsim`, which is `nPopPar` whenever the parameters were expanded
+      // per subject (`nPopPar == 1` is a single population set, i.e. nsim=1 and
+      // one solve per subject).  Multiplying nid by nPopPar over-allocated by a
+      // factor of nsub: a large study then either exhausted memory or overflowed
+      // `int` and reported "nothing to solve" (nlmixr2/nlmixr2#412).
+      if (rxSolveDat->nPopPar == 0) {
+        ntot = 0;
+      } else if (nid > rxSolveDat->nPopPar) {
         ntot = nid;
       } else {
-        ntot = nid*rxSolveDat->nPopPar;
+        ntot = rxSolveDat->nPopPar;
       }
     } else {
       if (rxSolveDat->nPopPar != 0) ntot = rxSolveDat->nPopPar;

--- a/tests/testthat/test-nsim-ind-alloc-412.R
+++ b/tests/testthat/test-nsim-ind-alloc-412.R
@@ -54,6 +54,28 @@ rxTest({
     }
   })
 
+  test_that("an explicit nStud sizes the pool the same way nsim does", {
+    m <- rxode2({
+      ka <- 1
+      cl <- 1
+      v <- 20
+      cp <- linCmt()
+      sim <- cp + eta.cl
+    })
+    .n <- 200L
+    .d <- data.frame(ID=rep(seq_len(.n), each=2L),
+                     TIME=rep(c(0, 4), .n),
+                     AMT=rep(c(100, 0), .n),
+                     EVID=rep(c(1L, 0L), .n))
+    .om <- lotri::lotri(eta.cl ~ 0.1)
+    sStud <- rxSolve(m, .d, omega=.om, nStud=3, returnType="data.frame")
+    sSim <- rxSolve(m, .d, omega=.om, nsim=3, returnType="data.frame")
+    expect_equal(nrow(sStud), .n * 3L)
+    expect_equal(nrow(sSim), nrow(sStud))
+    expect_equal(sort(unique(sStud$sim.id)), 1:3)
+    expect_true(all(is.finite(sStud$sim)))
+  })
+
   test_that("an empty data set still refuses to solve", {
     m <- rxode2({
       cl <- 1

--- a/tests/testthat/test-nsim-ind-alloc-412.R
+++ b/tests/testthat/test-nsim-ind-alloc-412.R
@@ -53,4 +53,16 @@ rxTest({
       expect_equal(s3$sim[s3$sim.id == .i], s1$sim)
     }
   })
+
+  test_that("an empty data set still refuses to solve", {
+    m <- rxode2({
+      cl <- 1
+      v <- 20
+      ka <- 1
+      cp <- linCmt()
+    })
+    .d <- data.frame(ID=integer(0), TIME=numeric(0), AMT=numeric(0),
+                     EVID=integer(0))
+    expect_error(rxSolve(m, .d))
+  })
 })

--- a/tests/testthat/test-nsim-ind-alloc-412.R
+++ b/tests/testthat/test-nsim-ind-alloc-412.R
@@ -1,0 +1,56 @@
+rxTest({
+  # rxSolve_datSetupHmax() sized the per-individual solve pool (inds_global)
+  # as nsub*nPopPar instead of the nsub*nsim (== nPopPar) it actually needs.
+  # For a large study that either exhausted memory or overflowed the int and
+  # reported "nothing to solve" -- which is what made addNpde()/vpcSim() fail
+  # on a real data set (nlmixr2/nlmixr2#412).  33000 subjects x nsim 2 puts
+  # the old size (33000 * 66000) past INT_MAX while the true pool is 66000.
+  test_that("a many-subject nsim solve does not over-size the individual pool", {
+    m <- rxode2({
+      ka <- 1
+      cl <- 1
+      v <- 20
+      cp <- linCmt()
+      sim <- cp + eta.cl
+    })
+    .n <- 33000L
+    .d <- data.frame(ID=rep(seq_len(.n), each=2L),
+                     TIME=rep(c(0, 4), .n),
+                     AMT=rep(c(100, 0), .n),
+                     EVID=rep(c(1L, 0L), .n))
+    s <- rxSolve(m, .d, omega=lotri::lotri(eta.cl ~ 0.1), nsim=2,
+                 returnType="data.frame")
+    expect_equal(nrow(s), 2L * .n)
+    expect_equal(sort(unique(s$sim.id)), 1:2)
+    expect_true(all(is.finite(s$sim)))
+  })
+
+  test_that("a params data.frame of nsub*nsim rows solves as nsim replicates", {
+    # exercises the nid != nPopPar branch that was over-sizing the pool
+    m <- rxode2({
+      cl <- exp(tcl)
+      v <- exp(tv)
+      ka <- exp(tka)
+      cp <- linCmt()
+      sim <- cp
+    })
+    .d <- data.frame(ID=rep(1:4, each=3L),
+                     TIME=rep(c(0, 1, 4), 4),
+                     AMT=rep(c(100, 0, 0), 4),
+                     EVID=rep(c(1L, 0L, 0L), 4))
+    .p1 <- data.frame(tka=seq(0.4, 0.7, length.out=4),
+                      tcl=1, tv=3.5)
+    .p3 <- do.call(rbind, lapply(1:3, function(.i) {
+      .p1$tcl <- 1 + 0.1 * .i
+      .p1
+    }))
+    s3 <- rxSolve(m, .p3, .d, returnType="data.frame")
+    expect_equal(sort(unique(s3$sim.id)), 1:3)
+    for (.i in 1:3) {
+      .p <- .p1
+      .p$tcl <- 1 + 0.1 * .i
+      s1 <- rxSolve(m, .p, .d, returnType="data.frame")
+      expect_equal(s3$sim[s3$sim.id == .i], s1$sim)
+    }
+  })
+})


### PR DESCRIPTION
## The report

nlmixr2/nlmixr2#412: `addNpde()` and `vpcSim()` on a two compartment
`linCmt()` FOCEi fit both stop with

```
Error in rxSolveSEXP(object, .ctl, .nms, .xtra, params, .eventsForSolve,  :
  nothing to solve
```

while everything else about the fit works.

## Root cause

`rxSolve_datSetupHmax()` (`src/rxData.cpp`) sizes the per-individual solve
pool (`inds_global`, via `rxOptionsIniEnsure()`):

```c
if (nid == nPopPar || nPopPar == 1) {
  ntot = nid;
} else {
  ntot = nid*nPopPar;   // <-- nsub times too many
}
```

A solve only ever needs one `rx_solving_options_ind` per individual solve,
which is `rx->nsub * rx->nsim`. That is exactly `nPopPar`: a few lines later
rxode2 itself derives `rx->nsim = nPopPar / rx->nsub` and requires `nPopPar`
to be a multiple of `nsub`, and `rxSerialize.cpp` allocates the same pool as
`nsub * rx->nsim`.

Multiplying by `nid` on top of that makes the pool grow with the *square* of
the number of subjects. With `nsim = 300` (the `vpcSim()`/`addNpde()`
default) on the reported linCmt model:

| subjects | pool asked for | outcome (before) |
|---|---|---|
| 12 (theo_sd) | 43,200 | works |
| 400 | 4.8e7 (47 GB) | works only because `calloc` is lazy |
| 1000 | 3.0e8 (297 GB) | `'R_Calloc' could not allocate memory (300000000 of 992 bytes)` |
| >= ~2700 | overflows `int` -> negative | **`nothing to solve`** (`if (ntot <= 0) stop(...)`) |

The `ntot <= 0` guard right below is what turns the overflow into the
reported message.

## Fix

Size the pool as the number of individual solves:

```c
if (nPopPar == 0) {
  ntot = 0;              // keep the existing 0-row-params guard
} else if (nid > nPopPar) {
  ntot = nid;
} else {
  ntot = nPopPar;
}
```

Results are unchanged -- only the allocation size differs. Verified byte
identical `sim` output before/after for the four parameter shapes that reach
this branch: `nsim` with multi-subject data, `nPopPar == 1`, `nSub` with
single-subject data (`simSubjects`), and a `params` data.frame of
`nsub * nsim` rows.

## Effect

The reproducer from the issue (2700 subjects, 2 compartment `linCmt()`,
`est = "focei"`):

```
before:  addNpde ERROR: nothing to solve
         vpcSim  ERROR: nothing to solve
after:   addNpde OK; NPDE range: -2.935 .. 2.935
         vpcSim  OK rows: 2430000
```

`rxSolve(..., nsim = 300)` on 2700 subjects now takes 2.3 s / 1.9 GB peak.

## Tests

`tests/testthat/test-nsim-ind-alloc-412.R`

- 33,000 subjects x `nsim = 2` puts the old size (`33000 * 66000`) past
  `INT_MAX` while the real pool is 66,000. Confirmed to fail with exactly
  `nothing to solve` on the unpatched build and to pass here (~1 s, ~140 MB).
- a `params` data.frame of `nsub * nsim` rows solves as `nsim` replicates,
  each matching the corresponding single-parameter-set solve -- this is the
  `nid != nPopPar` branch that changed.