### PR TITLE
Allow a marginal prior on an omega covariance (off-diagonal) element

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -141,8 +141,6 @@ Description: Facilities for running simulations from ordinary
     'CVODE' sources and headers are released under the BSD-3-Clause license.
     The information is available in the inst/COPYRIGHTS.
 BugReports: https://github.com/nlmixr2/rxode2/issues/
-Remotes:
-    nlmixr2/lotri@offdiag-cov-prior
 NeedsCompilation: yes
 VignetteBuilder: knitr
 License: GPL (>= 3)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -141,6 +141,8 @@ Description: Facilities for running simulations from ordinary
     'CVODE' sources and headers are released under the BSD-3-Clause license.
     The information is available in the inst/COPYRIGHTS.
 BugReports: https://github.com/nlmixr2/rxode2/issues/
+Remotes:
+    nlmixr2/lotri@offdiag-cov-prior
 NeedsCompilation: yes
 VignetteBuilder: knitr
 License: GPL (>= 3)

--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,23 @@
   `rxPriorOmegaToCholOmegaInvGrad()` C++ function is pure, with no R/Rcpp
   call, and is exposed through the same function-pointer table.
 
+- `rxPriorLogDensity()`/`rxPriorBuildSpec()` now evaluate a marginal
+  `dnorm()`/`dcauchy()` prior placed directly on ONE omega covariance
+  (off-diagonal) element, not just a diagonal (variance) one --
+  `prior(eta.cl, eta.v) ~ dnorm(0, 0.1)` in a model whose `eta.cl`/`eta.v`
+  covary. This is distinct from a whole-block distribution
+  (`invWishart()`/`multiNormal()`), which still requires naming the
+  model's entire connected block; a marginal prior only needs its two
+  names to covary with each other, so it also works on a two-name subset
+  of a larger correlated block. Previously refused outright with "a prior
+  on an off-diagonal omega element is not supported" -- unreachable
+  through real `ini()` syntax until lotri's own `prior(a, b) ~ dnorm(...)`
+  parsing was relaxed to allow it (see lotri's own NEWS). `rxSolve(...,
+  usePrior=TRUE)`'s simulation path does not yet support this (it draws a
+  deviation added to the model's own initial estimate, which this needs
+  its own machinery for) and gives a clear error rather than the
+  confusing one this would otherwise have produced.
+
 - `rxSetActiveParLoader()` / `rxClearActiveParLoader()` activate a registered
   parameter loader for solves that do not go through `rxSolve.rxUi()` -- an
   estimation method's internal solves, for example.  Previously the only way in

--- a/R/prior-sim.R
+++ b/R/prior-sim.R
@@ -186,7 +186,24 @@
     ## a prior on an omega row is on that row's omega *element*, which is
     ## spelled with the `om.` prefix
     .name <- .iniDf$name[.i]
-    if (!is.na(.iniDf$neta1[.i])) .name <- paste0("om.", .name)
+    if (!is.na(.iniDf$neta1[.i])) {
+      if (.iniDf$neta1[.i] != .iniDf$neta2[.i]) {
+        ## a marginal prior on an omega COVARIANCE element is supported for
+        ## estimation-time priors (rxPriorLogDensity()/rxPriorBuildSpec()),
+        ## but not yet here: the draw this function sets up is added to the
+        ## model's own initial estimate (see this function's own doc above),
+        ## and .rxPriorEstLookup()/.rxPriorOmegaElPos() only ever populate a
+        ## DIAGONAL "om.<eta>" key -- proceeding would silently skip the
+        ## mean assertion below (the covariance element has no lookup entry)
+        ## and later fail with a confusing "unknown omega element" instead
+        ## of this explicit, accurate one.
+        .rxPriorStop(.iniDf$name[.i], .iniDf$prior[.i],
+                     paste0("prior simulation does not yet support a marginal ",
+                            "prior on an off-diagonal omega covariance element ",
+                            "(estimation-time priors are unaffected)"))
+      }
+      .name <- paste0("om.", .name)
+    }
     .prior <- .iniDf$prior[.i]
     if (.name %in% .seen) next
     .p <- .rxPriorParse(.prior)

--- a/R/priorDensity.R
+++ b/R/priorDensity.R
@@ -398,8 +398,22 @@
       if (length(.w) != 1L) {
         stop("could not find the omega covariance element '", .eta, "'", call.=FALSE)
       }
-      return(list(thetaIdx=0L, etaIdx=as.integer(.iniDf$neta1[.w]),
-                  etaIdx2=as.integer(.iniDf$neta2[.w])))
+      .e1 <- as.integer(.iniDf$neta1[.w])
+      .e2 <- as.integer(.iniDf$neta2[.w])
+      ## the C kernel indexes omega[e1][e2] with no bounds check of its own
+      ## (termValue()/addGrad() in src/priorDensity.cpp cannot safely call
+      ## back into R to error -- they run inside an OpenMP-parallel region),
+      ## so this is the one place that can and must catch a corrupted or
+      ## unusually-piped iniDf whose off-diagonal row references an eta
+      ## index with no corresponding diagonal row, before it ever reaches
+      ## that C++ code as an out-of-bounds omega[][] read/write.
+      .diag <- !is.na(.iniDf$neta1) & .iniDf$neta1 == .iniDf$neta2
+      if (!(.e1 %in% .iniDf$neta1[.diag]) || !(.e2 %in% .iniDf$neta1[.diag])) {
+        stop("the omega covariance element '", .eta, "' references an eta ",
+             "index with no corresponding diagonal omega element; this can ",
+             "only happen on a hand-edited or piped 'iniDf'", call.=FALSE)
+      }
+      return(list(thetaIdx=0L, etaIdx=.e1, etaIdx2=.e2))
     }
     .w <- which(!is.na(.iniDf$neta1) & .iniDf$neta1 == .iniDf$neta2 & .iniDf$name == .eta)
     if (length(.w) != 1L) {

--- a/R/priorDensity.R
+++ b/R/priorDensity.R
@@ -218,10 +218,17 @@
   .seenPrior <- character(0)
   for (.i in .w) {
     .isOmega <- !is.na(.iniDf$neta1[.i])
-    if (.isOmega && .iniDf$neta1[.i] != .iniDf$neta2[.i]) {
-      stop("a prior on an off-diagonal omega element ('", .iniDf$name[.i],
-           "') is not supported", call.=FALSE)
-    }
+    ## an off-diagonal (covariance) omega row: a marginal normal/Cauchy
+    ## prior on that one cell is supported below via the same "om."-prefixed
+    ## key normal/cauchy terms already use (.name is already the row's own
+    ## "(eta_i,eta_j)" string, so .key = paste0("om.", .name) needs no
+    ## special-casing here) -- but a whole-block distribution (invWishart(),
+    ## multiNormal()) applies to a DIAGONAL row's own block lookup
+    ## (.rxPriorOmegaBlockFor()/.rxPriorCovNames()), which lotri never
+    ## stores a whole-block prior on for an off-diagonal row in the first
+    ## place (a matrix/multivariate distribution is only ever kept on a
+    ## block's first DIAGONAL name), so those branches are naturally
+    ## unreachable for one and need no extra guard here.
     .name <- .iniDf$name[.i]
     if (!.isOmega && startsWith(.name, "om.")) {
       ## `om.<eta>` is how this kernel spells an omega diagonal element
@@ -370,28 +377,41 @@
   .iniDf$name[.d][order(.idx)]
 }
 
-#' The `(thetaIdx, etaIdx)` a term member's key addresses
+#' The `(thetaIdx, etaIdx, etaIdx2)` a term member's key addresses
 #'
 #' @param ui rxode2 ui model
-#' @param key parameter name, or an `om.<eta>` omega element
-#' @return list with `thetaIdx`/`etaIdx` (1-based; the other is `0L`)
+#' @param key parameter name, an `om.<eta>` diagonal omega element, or an
+#'   `om.(eta_i,eta_j)` off-diagonal (covariance) omega element -- the
+#'   `om.` prefix in front of the off-diagonal row's own `iniDf$name`
+#'   (already `"(eta_i,eta_j)"`), which is what `.rxPriorDensityTerms()`
+#'   builds unmodified for such a row
+#' @return list with `thetaIdx`/`etaIdx`/`etaIdx2` (1-based; `etaIdx2` is
+#'   `0L` except for a covariance-pair key)
 #' @noRd
 #' @author Matthew L. Fidler
 .rxPriorKeyIndex <- function(ui, key) {
   .iniDf <- ui$iniDf
   if (startsWith(key, "om.")) {
     .eta <- substring(key, 4)
+    if (grepl("^[(].*,.*[)]$", .eta)) {
+      .w <- which(!is.na(.iniDf$neta1) & .iniDf$neta1 != .iniDf$neta2 & .iniDf$name == .eta)
+      if (length(.w) != 1L) {
+        stop("could not find the omega covariance element '", .eta, "'", call.=FALSE)
+      }
+      return(list(thetaIdx=0L, etaIdx=as.integer(.iniDf$neta1[.w]),
+                  etaIdx2=as.integer(.iniDf$neta2[.w])))
+    }
     .w <- which(!is.na(.iniDf$neta1) & .iniDf$neta1 == .iniDf$neta2 & .iniDf$name == .eta)
     if (length(.w) != 1L) {
       stop("could not find the omega element '", .eta, "'", call.=FALSE)
     }
-    list(thetaIdx=0L, etaIdx=as.integer(.iniDf$neta1[.w]))
+    list(thetaIdx=0L, etaIdx=as.integer(.iniDf$neta1[.w]), etaIdx2=0L)
   } else {
     .w <- which(is.na(.iniDf$neta1) & .iniDf$name == key)
     if (length(.w) != 1L) {
       stop("could not find the population parameter '", key, "'", call.=FALSE)
     }
-    list(thetaIdx=as.integer(.iniDf$ntheta[.w]), etaIdx=0L)
+    list(thetaIdx=as.integer(.iniDf$ntheta[.w]), etaIdx=0L, etaIdx2=0L)
   }
 }
 
@@ -406,7 +426,7 @@
 #' @author Matthew L. Fidler
 .rxPriorFlattenSpec <- function(ui, terms) {
   .type <- integer(0); .n <- integer(0)
-  .thetaIdx <- integer(0); .etaIdx <- integer(0)
+  .thetaIdx <- integer(0); .etaIdx <- integer(0); .etaIdx2 <- integer(0)
   .mu <- numeric(0); .scale <- numeric(0)
   .lower <- numeric(0); .upper <- numeric(0); .nu <- numeric(0)
   ## validate the omega numbering is dense (see .rxPriorEtaOrder()) before
@@ -421,6 +441,7 @@
     .idx <- lapply(.t$names, .rxPriorKeyIndex, ui=ui)
     .thetaIdx <- c(.thetaIdx, vapply(.idx, `[[`, integer(1), "thetaIdx"))
     .etaIdx <- c(.etaIdx, vapply(.idx, `[[`, integer(1), "etaIdx"))
+    .etaIdx2 <- c(.etaIdx2, vapply(.idx, `[[`, integer(1), "etaIdx2"))
     if (.t$type %in% c("normal", "cauchy")) {
       .mu <- c(.mu, .t$mu)
       .scale <- c(.scale, .t$sd)
@@ -444,7 +465,7 @@
     }
   }
   list(type=.type, n=.n, thetaIdx=.thetaIdx, etaIdx=.etaIdx, mu=.mu, scale=.scale,
-       lower=.lower, upper=.upper, nu=.nu)
+       lower=.lower, upper=.upper, nu=.nu, etaIdx2=.etaIdx2)
 }
 
 #' Build the C spec `rxPriorLogDensityEval()` (and the C API) evaluates

--- a/inst/include/rxode2prior.h
+++ b/inst/include/rxode2prior.h
@@ -52,12 +52,28 @@ extern "C" {
 // assigns, which is also the numbering nlmixr2est's own op_focei uses for
 // its theta vector and omega matrix, so the evaluator never needs a name
 // lookup.
+//
+// `etaIdx2[k]` is 0 for every existing use (a population parameter, or a
+// diagonal omega element) -- member k then addresses `omega[e][e]` via
+// `etaIdx[k]` alone, exactly as before this field was added.  A type 0/1/2
+// member whose `etaIdx2[k]` is nonzero instead addresses the OFF-DIAGONAL
+// covariance cell `omega[etaIdx[k]-1][etaIdx2[k]-1]` -- a marginal prior on
+// one covariance element (lotri's `prior(eta.i, eta.j) ~ dnorm(...)`),
+// distinct from an invWishart()/multiNormal() block prior spanning many
+// cells at once (type 3/4 never uses `etaIdx2`; its `etaIdx[0..n-1]` is
+// still a plain list of the block's own diagonal indices).  Purely
+// additive: every reader that only ever checked `etaIdx[k] != 0` to detect
+// "this member touches omega" is still correct unchanged, since `etaIdx[k]`
+// is always the nonzero, primary index for an off-diagonal member too.
 typedef struct rx_prior_term_t {
   int type;      // 0=normal, 1=cauchy, 2=multiNormal, 3=invWishart (general),
                  // 4=invWishart (NONMEM NWPRI)
   int n;         // number of members (1 for normal/cauchy)
   int *thetaIdx; // length n; 0 when member k is an omega element
   int *etaIdx;   // length n; 0 when member k is a population parameter
+  int *etaIdx2;  // length n; 0 unless member k is an off-diagonal omega
+                 // covariance cell, in which case it is that cell's SECOND
+                 // (1-based) eta index -- see the field-level comment above
   double *mu;    // length n; unused (NULL) for invWishart
   double *scale; // normal/cauchy: length-1 sd/scale. multiNormal: n*n
                  // row-major covariance Sigma. invWishart (3 or 4): n*n

--- a/src/priorDensity.cpp
+++ b/src/priorDensity.cpp
@@ -172,19 +172,42 @@ static double logMvGamma(double a, int p) {
 static inline double termValue(const rx_prior_term_t &term, int k,
                                const double *theta, const double *omega, int omegaDim) {
   if (term.thetaIdx[k] > 0) return theta[term.thetaIdx[k] - 1];
-  int e = term.etaIdx[k] - 1;
-  return omega[(size_t)e * omegaDim + e];
+  int e1 = term.etaIdx[k] - 1;
+  if (term.etaIdx2 != NULL && term.etaIdx2[k] > 0) {
+    int e2 = term.etaIdx2[k] - 1;
+    return omega[(size_t)e1 * omegaDim + e2];
+  }
+  return omega[(size_t)e1 * omegaDim + e1];
 }
 
-// Scatter a scalar gradient contribution for term member k.
+// Scatter a scalar gradient contribution for term member k.  An
+// off-diagonal (covariance) member writes ONLY the ONE cell termValue()
+// actually read -- matching the entrywise convention documented in
+// R/priorDensity.R exactly: gradOmega[i,j] and gradOmega[j,i] are treated
+// as independent (this term contributes to the (e1,e2) direction only,
+// nothing to (e2,e1)), and a caller that moves the symmetric pair TOGETHER
+// sums both cells itself -- see that summed total against a central
+// difference in tests/testthat/test-prior-density.R before changing this:
+// writing the scalar into BOTH cells here was tried and measured exactly
+// 2x the correct total (it double-counts once entrywise, once again when a
+// downstream Gsym=0.5*(G+G^T) symmetrization or explicit sum recombines
+// the pair). evalInvWishartTerm's own gradient (below) is NOT the same
+// situation -- its entries come out symmetric from genuine matrix algebra
+// (both (i,j) and (j,i) are independently, correctly nonzero), not from a
+// deliberate double-write of a single scalar.
 static inline void addGrad(const rx_prior_term_t &term, int k, double g,
                            double *gradTheta, double *gradOmega, int omegaDim) {
   if (term.thetaIdx[k] > 0) {
     gradTheta[term.thetaIdx[k] - 1] += g;
-  } else {
-    int e = term.etaIdx[k] - 1;
-    gradOmega[(size_t)e * omegaDim + e] += g;
+    return;
   }
+  int e1 = term.etaIdx[k] - 1;
+  if (term.etaIdx2 != NULL && term.etaIdx2[k] > 0) {
+    int e2 = term.etaIdx2[k] - 1;
+    gradOmega[(size_t)e1 * omegaDim + e2] += g;
+    return;
+  }
+  gradOmega[(size_t)e1 * omegaDim + e1] += g;
 }
 
 // type 0/1: a single (possibly truncated) normal/Cauchy penalty.
@@ -413,6 +436,7 @@ static void rxPriorFreeSpec(void *specPtr) {
   for (int t = 0; t < spec->nTerms; ++t) {
     delete[] spec->terms[t].thetaIdx;
     delete[] spec->terms[t].etaIdx;
+    delete[] spec->terms[t].etaIdx2;
     delete[] spec->terms[t].mu;
     delete[] spec->terms[t].scale;
   }
@@ -436,13 +460,14 @@ static void _rxode2_rxPriorFreeSpecFinalizer(SEXP specSEXP) {
 // specList: type, n (integer, one per term), thetaIdx, etaIdx (integer,
 // concatenated across terms, length sum(n)), mu, scale (numeric,
 // concatenated; scale is n*n per term, row-major, back to back), lower,
-// upper, nu (numeric, one per term).
+// upper, nu (numeric, one per term), etaIdx2 (integer, concatenated,
+// length sum(n) -- 0 unless member k is an off-diagonal covariance cell).
 extern "C" SEXP _rxode2_rxPriorBuildSpec(SEXP specList) {
   SEXP typeS = VECTOR_ELT(specList, 0), nS = VECTOR_ELT(specList, 1),
     thetaIdxS = VECTOR_ELT(specList, 2), etaIdxS = VECTOR_ELT(specList, 3),
     muS = VECTOR_ELT(specList, 4), scaleS = VECTOR_ELT(specList, 5),
     lowerS = VECTOR_ELT(specList, 6), upperS = VECTOR_ELT(specList, 7),
-    nuS = VECTOR_ELT(specList, 8);
+    nuS = VECTOR_ELT(specList, 8), etaIdx2S = VECTOR_ELT(specList, 9);
   int nTerms = LENGTH(typeS);
   rx_prior_spec_t *spec = new rx_prior_spec_t;
   spec->nTerms = nTerms;
@@ -454,10 +479,12 @@ extern "C" SEXP _rxode2_rxPriorBuildSpec(SEXP specList) {
     term.n = INTEGER(nS)[t];
     term.thetaIdx = new int[term.n];
     term.etaIdx = new int[term.n];
+    term.etaIdx2 = new int[term.n];
     term.mu = new double[term.n];
     for (int k = 0; k < term.n; ++k) {
       term.thetaIdx[k] = INTEGER(thetaIdxS)[memberOff + k];
       term.etaIdx[k] = INTEGER(etaIdxS)[memberOff + k];
+      term.etaIdx2[k] = INTEGER(etaIdx2S)[memberOff + k];
       term.mu[k] = REAL(muS)[memberOff + k];
     }
     int nScale = term.n * term.n;

--- a/tests/testthat/test-prior-density.R
+++ b/tests/testthat/test-prior-density.R
@@ -490,14 +490,88 @@ rxTest({
     expect_error(rxPriorLogDensity(u2, theta=c(tka=0.5, tcl=1)), "different priors")
   })
 
-  test_that("an off-diagonal omega prior is refused, not silently evaluated", {
+  test_that("a marginal prior on an off-diagonal omega (covariance) element is evaluated, not refused", {
+    ## a whole-block distribution (invWishart()/multiNormal()) still applies
+    ## to the block's own DIAGONAL lookup, not an off-diagonal row -- only a
+    ## marginal normal/Cauchy on the one covariance cell is supported here
     skip_if_not(.hasPriorSupport())
-    u <- .withPrior(.base(), "eta.cl", "invWishart(20)")
+    u <- rxUiDecompress(.base())
     .ini <- u$iniDf
     .w <- which(.ini$neta1 == 2L & .ini$neta2 == 1L)
+    expect_equal(.ini$name[.w], "(eta.cl,eta.v)")
     .ini$prior[.w] <- "dnorm(0, 1)"
     assign("iniDf", .ini, envir=u)
-    expect_error(rxPriorLogDensity(u), "off-diagonal")
+    ## the block's own covariance element is 0.01 (c(0.3, 0.01, 0.1))
+    r <- rxPriorLogDensity(u, omega=u$omega)
+    expect_equal(r$value, dnorm(0.01, 0, 1, log=TRUE))
+  })
+
+  test_that("real ini()/prior() syntax reaches an off-diagonal covariance element", {
+    skip_if_not(.hasPriorSupport())
+    u <- rxode2(function() {
+      ini({
+        tka <- 0.45; tcl <- 1; tv <- 3.45
+        eta.cl + eta.v ~ c(0.3, 0.05, 0.2)
+        add.sd <- 0.7
+        prior(eta.cl, eta.v) ~ dnorm(0, 0.1)
+      })
+      model({
+        ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    })
+    expect_true("(eta.cl,eta.v)" %in% rxUiPriors(u)$name)
+    r <- rxPriorLogDensity(u, omega=u$omega)
+    expect_equal(r$value, dnorm(0.05, 0, 0.1, log=TRUE))
+  })
+
+  test_that("the off-diagonal covariance gradient matches a central difference", {
+    ## the direct verification of addGrad()'s off-diagonal branch: writes
+    ## ONLY the one cell termValue() read (not both symmetric cells -- an
+    ## earlier version of this wrote both and was measured exactly 2x the
+    ## correct total against this same check)
+    skip_if_not(.hasPriorSupport())
+    u <- rxUiDecompress(.base())
+    .ini <- u$iniDf
+    .w <- which(.ini$neta1 == 2L & .ini$neta2 == 1L)
+    .ini$prior[.w] <- "dnorm(0, 0.1)"
+    assign("iniDf", .ini, envir=u)
+    om <- u$omega
+    g <- .numGrad(function(v) {
+      om2 <- om; om2["eta.cl", "eta.v"] <- v; om2["eta.v", "eta.cl"] <- v
+      rxPriorLogDensity(u, omega=om2)$value
+    }, om["eta.cl", "eta.v"])
+    r <- rxPriorLogDensity(u, omega=om)
+    ## a caller that moves the symmetric pair TOGETHER sums both cells
+    ## (R/priorDensity.R's own documented gradOmega convention)
+    expect_equal(unname(r$gradOmega["eta.cl", "eta.v"] + r$gradOmega["eta.v", "eta.cl"]),
+                 unname(g), tolerance=1e-6)
+  })
+
+  test_that("a whole-block invWishart() prior is unaffected by the off-diagonal relaxation", {
+    skip_if_not(.hasPriorSupport())
+    u <- .withPrior(.base(), c("eta.cl", "eta.v"), "invWishart(20)")
+    r <- rxPriorLogDensity(u, omega=u$omega)
+    expect_true(is.finite(r$value))
+  })
+
+  test_that("prior simulation (usePrior=TRUE) refuses an off-diagonal covariance prior with a clear message", {
+    skip_if_not(.hasPriorSupport())
+    u <- rxode2(function() {
+      ini({
+        tka <- 0.45; tcl <- 1; tv <- 3.45
+        eta.cl + eta.v ~ c(0.3, 0.05, 0.2)
+        add.sd <- 0.7
+        prior(eta.cl, eta.v) ~ dnorm(0, 0.1)
+      })
+      model({
+        ka <- exp(tka); cl <- exp(tcl + eta.cl); v <- exp(tv + eta.v)
+        linCmt() ~ add(add.sd)
+      })
+    })
+    expect_error(
+      rxSolve(u, events=data.frame(id=1, time=0, amt=0, dv=0), nSub=2, usePrior=TRUE),
+      "off-diagonal")
   })
 
   test_that("an unsupported distribution is a clear error, not a silent wrong value", {

--- a/tests/testthat/test-prior-density.R
+++ b/tests/testthat/test-prior-density.R
@@ -555,6 +555,23 @@ rxTest({
     expect_true(is.finite(r$value))
   })
 
+  test_that("an off-diagonal row referencing a non-existent eta index is refused, not read out of bounds", {
+    # .rxPriorKeyIndex() is the one place that can safely error (the C
+    # kernel's termValue()/addGrad() cannot -- they run inside an
+    # OpenMP-parallel region with no R call of any kind); this is the
+    # regression test for that guard. Only reachable via a hand-edited or
+    # piped iniDf, same as the "off-diagonal ... refused" test elsewhere in
+    # this file.
+    skip_if_not(.hasPriorSupport())
+    u <- rxUiDecompress(.base())
+    .ini <- u$iniDf
+    .w <- which(.ini$neta1 == 2L & .ini$neta2 == 1L)
+    .ini$neta2[.w] <- 99L # no diagonal row has neta1 == 99
+    .ini$prior[.w] <- "dnorm(0, 1)"
+    assign("iniDf", .ini, envir = u)
+    expect_error(rxPriorLogDensity(u, omega = u$omega), "no corresponding diagonal")
+  })
+
   test_that("prior simulation (usePrior=TRUE) refuses an off-diagonal covariance prior with a clear message", {
     skip_if_not(.hasPriorSupport())
     u <- rxode2(function() {


### PR DESCRIPTION
## Summary

`rxPriorLogDensity()`/`rxPriorBuildSpec()` can now evaluate a `dnorm()`/`dcauchy()` prior placed directly on ONE omega covariance cell, not just a diagonal (variance) one -- `prior(eta.cl, eta.v) ~ dnorm(0, 0.1)` on a model whose `eta.cl`/`eta.v` covary. Distinct from a whole-block distribution (`invWishart()`/`multiNormal()`), which still requires naming the model's entire connected block -- a marginal prior only needs its two names to covary, so it also works on a two-name subset of a larger block. NONMEM does not reject this and neither should this kernel; it was previously refused outright by a hard `stop()`, unreachable through real syntax until lotri's own `prior()` parsing was relaxed to allow it (nlmixr2/lotri#59).

## Implementation

- `rx_prior_term_t` gets a new `etaIdx2` field (`inst/include/rxode2prior.h`), additive and backward compatible -- `0` for every existing term (population parameter or diagonal omega element, unchanged), nonzero addresses the off-diagonal pair `(etaIdx-1, etaIdx2-1)`.
- `termValue()`/`addGrad()` in `src/priorDensity.cpp` are the only C++ evaluator changes; `evalInvWishartTerm()` (whole-block, type 3/4) never uses them and is untouched.
- **Caught during testing via central difference**: `addGrad()`'s off-diagonal branch must write ONLY the one cell `termValue()` actually read, matching the kernel's own documented entrywise `gradOmega` convention -- writing the same scalar into both symmetric cells (which seemed to mirror invWishart's own naturally-symmetric gradient) measured exactly 2x the correct total, since a downstream caller that wants the derivative along the "move the pair together" direction sums both cells itself.
- `R/prior-sim.R`'s `usePrior=TRUE` simulation path does not yet support this (it draws a deviation added to the model's own initial estimate, a different mechanism) and now gives an explicit, accurate error instead of a confusing "unknown omega element" fallthrough its existing eligibility filter would otherwise have produced once the off-diagonal row became reachable.

## Test plan

- [x] New tests in `tests/testthat/test-prior-density.R`: real `ini()`/`prior()` syntax reaches the off-diagonal row, `rxUiPriors()` surfaces it, central-difference gradient check, whole-block `invWishart()` unaffected, `prior-sim` guard gives a clear error.
- [x] Updated the one existing test that asserted the old (now-relaxed) rejection behavior.
- [x] Full prior-related test suite (`test-prior-density.R`, `test-assert-priors.R`, `test-ini-prior-column.R`, `test-ini-prior-piping.R`, `test-prior-sim-*.R`) passes with no regressions.

Depends on nlmixr2/lotri#59. Part of the shared kernel work for nlmixr2/nlmixr2est#929 (companion PR lands in nlmixr2est, requiring zero source changes there).