### PR TITLE
linCmt(): make linCmtSensType="auto" actually resolve to forward mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,32 +2,20 @@
 
 ## New features
 
-- The default `linCmt()` sensitivity method (`linCmtSensType="auto"`) is now
-  reverse-mode AD (`"ADr"`).  Each row is differentiated on its own nested
-  Stan tape with one adjoint sweep per compartment (at most 4) instead of
-  one forward pass per parameter (up to 7), which measured about 2x faster
-  than the forward-mode default for 2 and 3 compartment models and the same
-  for one compartment, with results matching forward mode to round-off.
-  Reverse mode now also solves across threads (the Stan tape is per thread
-  under `STAN_THREADS`), so it is no longer forced onto one core; the
-  forward-mode path remains available as `linCmtSensType="AD"`.
+- `linCmtSensType="auto"` stays forward-mode AD (`"AD"`).  An intermediate
+  development version made reverse-mode AD (`"ADr"`) the default on the
+  strength of timings that had been taken through `devtools::load_all()`,
+  which compiles at `-O0`; on an optimized build forward mode is at least as
+  fast as reverse for every number of requested sensitivity directions on
+  every configuration, and reverse is 2-4x slower on a three compartment
+  oral model, because its per-row tape build costs more than the extra
+  forward passes.  `"auto"` therefore resolves to `"AD"` on every solve
+  path (`rxSolve()`, threaded solves, `ind_solve()` and
+  `linCmtModelDouble()`), and `"ADr"` remains an explicit option.
 
-- `linCmtSensType="auto"` now chooses between `"AD"` and `"ADr"` per model by
-  counting the sensitivity directions the model requests: forward mode costs
-  one pass per requested direction (the kernel honors the parser's
-  direction mask), reverse mode one adjoint sweep per compartment plus a
-  fixed per-row tape cost, so `"ADr"` is used only when the model requests
-  at least as many directions as it has compartments (depot included) and
-  at least three; `"AD"` otherwise.  The boundary was measured through the
-  solver: one and two compartment solutions are still faster forward when
-  the requested count equals the compartment count, three and four
-  compartment solutions are already 1.1-1.3x faster in reverse there.  The 2x
-  measured for reverse mode above requested every direction; a FOCEi inner
-  model asks only for its eta directions, and with a single eta reverse
-  mode is slower than forward (about 0.6-0.9x on two and three compartment
-  oral models), while an eta on every parameter keeps the 1.3-1.9x gain.
-  Every solve path resolves the same way (`rxSolve()`, threaded solves,
-  `ind_solve()` and `linCmtModelDouble()`).
+- Reverse-mode AD (`linCmtSensType="ADr"`) now solves across threads: the
+  Stan tape is per thread under `STAN_THREADS`, so it is no longer forced
+  onto one core.  Results match forward mode to round-off.
 
 - `rxPriorLogDensity(ui, theta, omega)` evaluates a model's `ini({})` priors
   as a Bayesian penalty at the current parameter values -- the value and

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -871,21 +871,19 @@
 #' @param linCmtSensType The type of linear compartment
 #'   sensitivity/gradients to use.  The current options are:
 #'
-#' - `auto` (the default) -- picks `AD` or `ADr` per model by counting the
-#'   sensitivity directions the model requests: forward mode costs one
-#'   pass per requested direction, reverse mode one adjoint sweep per
-#'   compartment plus a fixed per-row tape cost, so `ADr` is used only
-#'   when the model requests at least as many directions as it has
-#'   compartments (depot included) and at least three; `AD` otherwise.
-#'   A FOCEi inner model asks only for its eta directions, so a model
-#'   with one or two etas on a two or three compartment solution stays
-#'   on `AD`; one with an eta on every parameter gets `ADr`.
+#' - `auto` (the default) -- forward-mode automatic differentiation
+#'   (`AD`).  On an optimized build forward mode is at least as fast as
+#'   reverse mode for every number of requested sensitivity directions on
+#'   every configuration (reverse is 2-4x slower on a three compartment
+#'   oral model: its per-row tape build costs more than the extra forward
+#'   passes), so `auto` resolves to `AD` on every solve path.
 #'
 #' - `ADr` -- reverse-mode automatic differentiation
 #'   (`stan::math::jacobian`): each row is differentiated on its own
 #'   nested tape with one adjoint sweep per compartment, independent of
 #'   how many directions are requested.  The tape is per thread, so this
-#'   solves across threads like `AD`.
+#'   solves across threads like `AD`.  Slower than `AD` on an optimized
+#'   build; kept as an explicit option for validation.
 #'
 #' - `AD` -- forward-mode automatic differentiation
 #'   (`stan::math::fvar`), differentiating the same analytic solution on

--- a/bench/lincmt_auto_boundary.R
+++ b/bench/lincmt_auto_boundary.R
@@ -1,3 +1,9 @@
+# SUPERSEDED: this measurement was taken through devtools::load_all(), which
+# compiles at -O0, and its conclusion (a count-based auto rule) does not hold
+# on an optimized build -- see bench/lincmt_auto_optimized.R and
+# bench/results/lincmt_auto_optimized.rds (every kernel, trans, mask and
+# shape, pinned single thread): forward mode is at least as fast as reverse
+# in every realistic cell.  Kept as the record of what the earlier rule rested on.
 # Boundary measurement for the count-based linCmtSensType="auto" rule
 # (PR #1280): forward-mode fvar costs one pass per requested direction k,
 # reverse mode one adjoint sweep per compartment m = ncmt + oral0.  This

--- a/man/rxSolve.Rd
+++ b/man/rxSolve.Rd
@@ -1348,20 +1348,18 @@ and does not mix ODEs with the solution.  The default is \code{TRUE}.}
 \item{linCmtSensType}{The type of linear compartment
 sensitivity/gradients to use.  The current options are:
 \itemize{
-\item \code{auto} (the default) -- picks \code{AD} or \code{ADr} per model by counting the
-sensitivity directions the model requests: forward mode costs one
-pass per requested direction, reverse mode one adjoint sweep per
-compartment plus a fixed per-row tape cost, so \code{ADr} is used only
-when the model requests at least as many directions as it has
-compartments (depot included) and at least three; \code{AD} otherwise.
-A FOCEi inner model asks only for its eta directions, so a model
-with one or two etas on a two or three compartment solution stays
-on \code{AD}; one with an eta on every parameter gets \code{ADr}.
+\item \code{auto} (the default) -- forward-mode automatic differentiation
+(\code{AD}).  On an optimized build forward mode is at least as fast as
+reverse mode for every number of requested sensitivity directions on
+every configuration (reverse is 2-4x slower on a three compartment
+oral model: its per-row tape build costs more than the extra forward
+passes), so \code{auto} resolves to \code{AD} on every solve path.
 \item \code{ADr} -- reverse-mode automatic differentiation
 (\verb{stan::math::jacobian}): each row is differentiated on its own
 nested tape with one adjoint sweep per compartment, independent of
 how many directions are requested.  The tape is per thread, so this
-solves across threads like \code{AD}.
+solves across threads like \code{AD}.  Slower than \code{AD} on an optimized
+build; kept as an explicit option for validation.
 \item \code{AD} -- forward-mode automatic differentiation
 (\verb{stan::math::fvar}), differentiating the same analytic solution on
 the C++ stack with one pass per requested direction; matches \code{ADr}

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -304,9 +304,9 @@ RObject linCmtModelDouble(double dt,
   Eigen::Matrix<double, 7, 1> scale;
   scale.setZero();
 
-  // The AD methods (3/30 forward fvar, 31 reverse, 100 auto resolved by the
-  // requested-direction count) use the unscaled (isAD = true) path so the
-  // Jacobian comes out in true-theta units.
+  // The AD methods (3/30 forward fvar, 31 reverse, 100 auto -> forward) use
+  // the unscaled (isAD = true) path so the Jacobian comes out in true-theta
+  // units.
   sensType = linCmtSensResolveAuto(sensType, ndiff, ncmt, oral0);
   lc.sensTheta(theta, thetaSens, linCmtSensIsAD(sensType), scale.data());
 

--- a/src/linCmtSensType.h
+++ b/src/linCmtSensType.h
@@ -45,24 +45,21 @@ static inline int linCmtSensNreq(int ndiff, int ncmt, int oral0) {
   return nreq;
 }
 
-// Resolve linCmtSensType="auto" (100) for a model.  Forward-mode fvar costs
-// one pass per REQUESTED direction (the kernel honors the ndiff mask), reverse
-// mode one adjoint sweep per compartment plus a fixed per-row tape cost, so
-// reverse (31) only pays once at least as many directions as compartments
-// (m = ncmt + oral0) are requested AND at least three: measured
-// (bench/lincmt_auto_boundary.R) a one- or two-compartment solution is still
-// faster forward at nreq == m and the tape cost is only amortized from three
-// directions up, while three and four compartments favor reverse already at
-// nreq == m.  No requested direction means no Jacobian is taken; forward is
-// returned so the value-only solve stays on the cheaper stack-local path.
-// Every solve path must resolve through here (rxData.cpp at the control
-// read, setupLinH() for ind_solve(), linCmtModelDouble() for the R-level
-// kernel) so they agree.
+// Resolve linCmtSensType="auto" (100) for a model: forward-mode fvar (3).
+// On an optimized build (bench/lincmt_auto_optimized.R, -O3, single thread
+// pinned to an idle core) forward mode is at least as fast as reverse for
+// every requested-direction count on every configuration -- reverse's
+// per-row tape build costs more than the extra fvar passes even with all
+// seven directions requested (3-cmt oral: reverse 2-4x slower).  The earlier
+// count-based rule came from timings taken through devtools::load_all(),
+// which compiles at -O0 and inverts the comparison.  Reverse stays available
+// as an explicit "ADr".  The ndiff / ncmt / oral0 arguments are kept so every
+// solve path (rxData.cpp at the control read, setupLinH() for ind_solve(),
+// linCmtModelDouble() for the R-level kernel) resolves through one signature.
 static inline int linCmtSensResolveAuto(int sensType, int ndiff, int ncmt, int oral0) {
+  (void)ndiff; (void)ncmt; (void)oral0;
   if (sensType != 100) return sensType;
-  int m = ncmt + oral0;
-  int thr = (m > 3) ? m : 3;
-  return (linCmtSensNreq(ndiff, ncmt, oral0) >= thr) ? 31 : 3;
+  return 3;
 }
 
 #endif // __LINCMTSENSTYPE_H__

--- a/tests/testthat/test-lincmt-sens-adr-threads.R
+++ b/tests/testthat/test-lincmt-sens-adr-threads.R
@@ -52,16 +52,19 @@ rxTest({
     expect_true(max(seen) > 1L)
   })
 
-  # this model requests 5 directions on m = 3 compartments, so the count-based
-  # auto rule resolves it to reverse mode (test-lincmt-sens-auto-count.R
-  # covers the forward side of the rule)
-  test_that("linCmtSensType=\"auto\" (the default) resolves to reverse mode, threaded", {
+  # "auto" resolves to forward mode whatever the model requests
+  # (test-lincmt-sens-auto.R covers the resolution itself); here it only has
+  # to keep solving across threads and agree with the explicit names
+  test_that("linCmtSensType=\"auto\" (the default) resolves to forward mode, threaded", {
     invisible(linCmtBSensTypesSeen(TRUE))
     invisible(linCmtBThreadsSeen(TRUE))
     auto <- rxSolve(m, pars, ev, cores = 0L, returnType = "data.frame")
-    expect_true(31L %in% linCmtBSensTypesSeen(TRUE))
+    seenAuto <- linCmtBSensTypesSeen(TRUE)
+    expect_true(3L %in% seenAuto)
+    expect_false(31L %in% seenAuto)
     expect_true(linCmtBThreadsSeen(TRUE) > 1L)
-    expect_true(cmp(auto, solve("AD", 1L)) < 1e-9)
+    expect_true(cmp(auto, solve("AD", 1L)) < 1e-12)
+    expect_true(cmp(auto, solve("ADr", 1L)) < 1e-9)
   })
 
   test_that("cores=0 (auto) no longer throttles ADr to one core", {

--- a/tests/testthat/test-lincmt-sens-auto.R
+++ b/tests/testthat/test-lincmt-sens-auto.R
@@ -1,11 +1,9 @@
 rxTest({
-  # linCmtSensType = "auto" resolves per model by the number of requested
-  # sensitivity directions: forward mode (3) costs one pass per requested
-  # direction, reverse mode (31) one adjoint sweep per compartment plus a
-  # per-row tape cost, so auto is reverse only when nreq >= max(m, 3) with
-  # m = ncmt + oral0 (measured boundary, bench/lincmt_auto_boundary.R) and
-  # forward otherwise.  Every solve path (single thread, threads,
-  # linCmtModelDouble) has to resolve alike.
+  # linCmtSensType = "auto" resolves to forward-mode AD (3) on every solve
+  # path.  On an optimized build forward mode is at least as fast as reverse
+  # for every requested-direction count on every configuration
+  # (bench/lincmt_auto_optimized.R), so there is no count rule; "AD" and
+  # "ADr" remain explicit overrides and have to agree to round-off.
   mk <- function(dirs, ncmt = 2L, oral0 = 1L) {
     args <- sprintf("rx__PTR__, t, 1, %d, %d, %%d, %%d, 1, cl, v, q, vp, q2, vp2, ka",
                     ncmt, oral0)
@@ -34,51 +32,41 @@ rxTest({
       max(abs(a[[cc]] - b[[cc]]) / pmax(1e-8, abs(b[[cc]])))
     }, 0))
   }
-  # 2-cmt oral: m = 3
-  one <- mk(0L)        # one direction  -> forward
-  two <- mk(0:1)       # two            -> forward (nreq < m)
-  three <- mk(0:2)     # three          -> reverse (nreq == m, m >= 3)
-  all5 <- mk(0:4)      # five           -> reverse
+  # 2-cmt oral: m = 3, npars = 5
+  one <- mk(0L)
+  three <- mk(0:2)
+  all5 <- mk(0:4)
 
-  test_that("auto is forward when fewer directions than compartments are requested", {
+  test_that("auto is forward for any number of requested directions", {
     expect_equal(seen(one, "auto")$st, 3L)
-    expect_equal(seen(two, "auto")$st, 3L)
-    expect_false(31L %in% seen(one, "auto", 0L)$st)
-  })
-
-  test_that("auto is reverse from nreq == m on a three-compartment solution", {
-    expect_equal(seen(three, "auto")$st, 31L)
-    expect_equal(seen(all5, "auto")$st, 31L)
-    expect_equal(seen(all5, "auto", 0L)$st, 31L)
-  })
-
-  test_that("a one- or two-compartment solution stays forward at nreq == m", {
-    # 1-cmt oral: m = 2, npars = 3 (cl, v, ka); the tape cost is only
-    # amortized from three directions up
-    m2two <- mk(0:1, ncmt = 1L, oral0 = 1L)
-    m2three <- mk(c(0L, 1L, 2L), ncmt = 1L, oral0 = 1L)
-    expect_equal(seen(m2two, "auto")$st, 3L)
-    expect_equal(seen(m2three, "auto")$st, 31L)
-    # 1-cmt iv: m = 1, npars = 2 -- never reaches three directions
+    expect_equal(seen(three, "auto")$st, 3L)
+    expect_equal(seen(all5, "auto")$st, 3L)
+    expect_false(31L %in% seen(all5, "auto", 0L)$st)
+    # 3-cmt oral with every direction, 1-cmt iv with both
+    m4all <- mk(0:6, ncmt = 3L, oral0 = 1L)
+    expect_equal(seen(m4all, "auto")$st, 3L)
     m1two <- mk(0:1, ncmt = 1L, oral0 = 0L)
     expect_equal(seen(m1two, "auto")$st, 3L)
   })
 
-  test_that("the explicit names still override the count rule", {
+  test_that("the explicit names override auto", {
     expect_equal(seen(one, "ADr")$st, 31L)
+    expect_equal(seen(all5, "ADr")$st, 31L)
     expect_equal(seen(all5, "AD")$st, 3L)
   })
 
-  test_that("both resolutions agree with each other to round-off", {
+  test_that("auto, AD and ADr agree with each other to round-off", {
     a <- seen(all5, "auto")$r
     f <- seen(all5, "AD")$r
-    expect_true(cmp(a, f, c("cp", paste0("d", 0:4))) < 1e-9)
-    a1 <- seen(one, "auto")$r
-    r1 <- seen(one, "ADr")$r
-    expect_true(cmp(a1, r1, c("cp", "d0")) < 1e-9)
+    r <- seen(all5, "ADr")$r
+    cols <- c("cp", paste0("d", 0:4))
+    expect_true(cmp(a, f, cols) < 1e-12)
+    expect_true(cmp(a, r, cols) < 1e-9)
     if (getRxThreads() > 1L) {
-      aN <- seen(one, "auto", getRxThreads())$r
-      expect_true(cmp(aN, a1, c("cp", "d0")) < 1e-12)
+      aN <- seen(all5, "auto", getRxThreads())$r
+      expect_true(cmp(aN, a, cols) < 1e-12)
+      rN <- seen(all5, "ADr", getRxThreads())$r
+      expect_true(cmp(rN, r, cols) < 1e-12)
     }
   })
 
@@ -89,7 +77,7 @@ rxTest({
     expect_false(31L %in% linCmtBSensTypesSeen(TRUE))
   })
 
-  test_that("linCmtModelDouble resolves auto by the same count", {
+  test_that("linCmtModelDouble resolves auto to forward as well", {
     nAlast <- function(ncmt, oral0) {
       npars <- 2L * ncmt + oral0
       ncmt + oral0 + ncmt * npars + oral0
@@ -102,9 +90,11 @@ rxTest({
                         0L, 0, 0, 0, 0L, as.integer(ndiff), as.integer(sensType), 0.001)
     }
     fwd <- call2(30L, 0L)
+    rev <- call2(31L, 31L)
     for (nd in c(0L, 2L, 31L)) {
       r <- call2(100L, nd)
       expect_equal(r$val, fwd$val, tolerance = 1e-12)
     }
+    expect_equal(rev$val, fwd$val, tolerance = 1e-9)
   })
 })


### PR DESCRIPTION
## What this fixes

PR #1280's title and body state that `linCmtSensType="auto"` resolves to forward-mode AD unconditionally. **That source change was not in its diff.** Commit `8b02848e9`, whose message announces the change, touched only `bench/lincmt_auto_optimized.R`, its `.rds`, and a test rename.

So `main` today still carries the count rule:

```c
int thr = (m > 3) ? m : 3;
return (linCmtSensNreq(ndiff, ncmt, oral0) >= thr) ? 31 : 3;
```

and rxode2's own `test-lincmt-sens-auto.R` asserts that rule -- source and tests agree with each other, and both contradict #1280's description. This PR lands the change that was announced.

## Why forward is right

From the optimized, uncontended sweep (`bench/lincmt_auto_optimized.R`, 1386 cells: every kernel x every `trans` x every requested-direction count x seven designs, pinned to an idle core):

- reverse/forward time, median: 1.05 (1-cmt IV) rising to 3.00 (3-cmt oral) -- reverse never wins
- scored by cell loss: **forward-always is wrong by >5% in 3 of 1386 cells** (max 11%); the **count rule is wrong in 544** (up to 3.6x); reverse-always in 1132
- fit level: `auto` 11.9-14.4 s versus `ADr` 29.6-40.4 s

The count rule was derived from timings taken through `devtools::load_all()`, which compiles at `-O0` and inverts the forward-vs-reverse comparison.

## Changes

- `src/linCmtSensType.h` -- `linCmtSensResolveAuto()` returns `3` for `auto`; the `ndiff`/`ncmt`/`oral0` arguments stay so every solve path keeps one signature. All three consumers (`rxData.cpp` at the control read, `setupLinH()` in `par_solve.cpp`, `linCmtModelDouble()` in `linCmt.cpp`) resolve through this single helper -- verified none re-implements the rule.
- `linCmtSensAdThreadSafe()` is unchanged: reverse mode (31) stays thread-safe and available as an explicit `"ADr"`.
- `tests/testthat/test-lincmt-sens-auto.R` -- now covers "auto is forward whatever the model requests" (including 3-cmt oral with all seven directions, and 1-cmt IV), the explicit overrides, and round-off agreement between `auto`/`AD`/`ADr` single- and multi-threaded.
- `tests/testthat/test-lincmt-sens-adr-threads.R` -- its threaded-default test asserted reverse; it now expects forward, asserts reverse is *absent*, and still checks that the default solves across threads.
- `R/rxsolve.R` roxygen + regenerated `man/rxSolve.Rd`, `NEWS.md`, and the stale header comment in `bench/lincmt_auto_boundary.R`.

## Testing

Optimized build (ordinary `pkgbuild::compile_dll(debug = FALSE)`; no flag forcing -- `-O2` is effective, as R appends it after the Makevars `-O3`).

- all 16 `tests/testthat/test-lincmt*.R`: **6,396 pass, 0 fail**
- carry benches: `lincmt_sensitivity_carry_phase2.R` worst 3.078e-11 PASS; `lincmt_sensitivity_carry_phase3b2.R` 11/11
- `test-rxui-ctl.R` fails one assertion (missing residual-error parameters in an `rxUi` solve) -- pre-existing and unrelated to linCmt sensitivities