### PR TITLE
docs(solve): dop853 does support parallel thread-based solving

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -808,6 +808,12 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
   supplied (`The following parameter(s) are required for solving: eta.b`).  The
   matching `sigma` code already guarded this.
 
+- `?rxSolve` no longer states that `method="dop853"` cannot solve in
+  parallel.  Only the non-reentrant Fortran COMMON block solvers (`lsoda`,
+  `lsode`, `bdf`) are excluded from threading by `solveMethodThreadSafe()`;
+  `dop853` has been thread-safe and has honored `cores`.  Documentation only,
+  no behavior change (#1305).
+
 ### Sensitivities
 
 - A model reading only some `linCmtB()` sensitivity directions (a FOCEi inner

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -4745,8 +4745,8 @@ rxEtDispatchSolve.rxode2et <- function(x, ...) {
 #' * `"lsoda"` -- LSODA solver.  Does not support parallel thread-based
 #'       solving, but allows user Jacobian specification.
 #'
-#' * `"dop853"` -- DOP853 solver.  Does not support parallel thread-based
-#'         solving nor user Jacobian specification
+#' * `"dop853"` -- DOP853 solver.  Supports parallel thread-based solving;
+#'         does not support user Jacobian specification.
 #'
 #' * `"indLin"` -- Solving through inductive linearization.  The rxode2 dll
 #'         must be setup specially to use this solving routine.  Supports
@@ -5557,6 +5557,20 @@ rxIsDense <- function(method) {
 }
 
 #' Check whether an ODE method code is thread-safe for parallel solving
+#'
+#' Deliberately stricter than the C gate `solveMethodThreadSafe()`
+#' (`src/rxData.cpp`), which excludes only the non-reentrant Fortran COMMON
+#' block solvers `lsoda` (1), `lsode` (106) and `bdf` (107).  This predicate
+#' additionally lists `liblsoda` (2), which IS thread safe in C.
+#'
+#' The extra entries are unreachable rather than wrong: the only caller is
+#' `.parseAutoSwitchMethod()`, and `lsoda`/`liblsoda` are switchers that
+#' [rxIsStiff()] and [rxIsNonStiff()] both return `FALSE` for, so a composite
+#' naming either is rejected as "must be a non-stiff method" / "must be a stiff
+#' method" before it gets here.  Only 106 and 107 are load bearing.  Left as is
+#' so the two predicates keep the same shape; do not "fix" the divergence by
+#' dropping 2L without checking every caller, since widening this predicate
+#' would admit composites the C AutoSwitch driver does not implement.
 #'
 #' @param code Integer method code as returned by [odeMethodToInt()].
 #' @return `TRUE` if safe to use in parallel OpenMP loops.

--- a/man/odeMethodToInt.Rd
+++ b/man/odeMethodToInt.Rd
@@ -36,8 +36,8 @@ odeMethodToInt(
 thread-based solving, and ignores user Jacobian specification.
 \item \code{"lsoda"} -- LSODA solver.  Does not support parallel thread-based
 solving, but allows user Jacobian specification.
-\item \code{"dop853"} -- DOP853 solver.  Does not support parallel thread-based
-solving nor user Jacobian specification
+\item \code{"dop853"} -- DOP853 solver.  Supports parallel thread-based solving;
+does not support user Jacobian specification.
 \item \code{"indLin"} -- Solving through inductive linearization.  The rxode2 dll
 must be setup specially to use this solving routine.  Supports
 parallel thread-based solving and honors \code{cores}.

--- a/man/rxSolve.Rd
+++ b/man/rxSolve.Rd
@@ -345,8 +345,8 @@ variable by 2.}
 thread-based solving, and ignores user Jacobian specification.
 \item \code{"lsoda"} -- LSODA solver.  Does not support parallel thread-based
 solving, but allows user Jacobian specification.
-\item \code{"dop853"} -- DOP853 solver.  Does not support parallel thread-based
-solving nor user Jacobian specification
+\item \code{"dop853"} -- DOP853 solver.  Supports parallel thread-based solving;
+does not support user Jacobian specification.
 \item \code{"indLin"} -- Solving through inductive linearization.  The rxode2 dll
 must be setup specially to use this solving routine.  Supports
 parallel thread-based solving and honors \code{cores}.


### PR DESCRIPTION
Documentation only, no behavior change.  Falls out of the measurements in #1305.

## What was wrong

`?rxSolve` and `?odeMethodToInt` both said:

> `"dop853"` -- DOP853 solver.  Does not support parallel thread-based solving nor user Jacobian specification

The threading half is not true.  The gate that actually decides this is
`solveMethodThreadSafe()` in `src/rxData.cpp`:

```c
/* lsoda (1), lsode (106), and bdf (107) use non-reentrant Fortran COMMON
 * blocks and must run single-threaded. */
return stiff != 1 && stiff != 106 && stiff != 107;
```

`dop853` is code 0, so it is not excluded, and it threads like any other
method.  That is also what it does in practice -- solving 100 subjects of a
1-compartment oral model went 0.0645 s at one thread to 0.0367 s at eleven.

The Jacobian half of the sentence is correct and is kept.

## Changes

- Corrected the `dop853` bullet in the `@param method` roxygen block, which
  regenerates into both `man/rxSolve.Rd` and `man/odeMethodToInt.Rd`.
- Added a comment on `.rxIsThreadSafeMethod()` explaining why it is
  deliberately stricter than the C gate, and why it should not be "fixed".
- `NEWS.md` entry under the existing 5.1.7 `### Solving` bug fixes.

## Note on `.rxIsThreadSafeMethod()`

The R predicate excludes `c(1L, 2L, 106L, 107L)` while the C gate excludes
only `1, 106, 107` -- so R additionally lists `liblsoda` (2), which is thread
safe in C.

I deliberately did **not** change the returned values.  The extra entries are
unreachable rather than wrong: the only caller is `.parseAutoSwitchMethod()`,
and `lsoda`/`liblsoda` are switchers for which `rxIsStiff()` and
`rxIsNonStiff()` both return `FALSE`, so a composite naming either is
rejected as "must be a non-stiff method" / "must be a stiff method" before it
reaches this predicate.  Only 106 and 107 are load bearing there.

Widening the predicate to match C would admit composites such as
`"dop853+liblsoda"` that the C AutoSwitch driver does not implement, so the
divergence is now documented in place instead.

## Verification

- `parse("R/rxsolve.R")` clean.
- `tools::checkRd()` clean on both regenerated `.Rd` files.
- Rd regenerated with `roxygen2::roxygenise(load_code = "installed")`; the
  incidental `man/rxode2.Rd` regeneration was reverted, since building it
  needs the internal `.rxDocTable()` and it came out with the `@includeRmd`
  hunk dropped.