### PR TITLE
Clear the pre-existing -Wall warnings in src/expm.cpp

### DIFF
--- a/src/expm.cpp
+++ b/src/expm.cpp
@@ -4,7 +4,10 @@
 #endif
 #define USE_FC_LEN_T
 #define STRICT_R_HEADER
-#define ARMA_DONT_USE_OPENMP // Known to cause speed problems
+// Known to cause speed problems; also set via PKG_CXXFLAGS, so guard it.
+#ifndef ARMA_DONT_USE_OPENMP
+#define ARMA_DONT_USE_OPENMP
+#endif
 // Must precede RcppArmadillo.h: defined after the include it has no effect, and
 // an Armadillo error message printed from a worker thread is a confirmed crash.
 #define ARMA_DONT_PRINT_ERRORS
@@ -560,7 +563,9 @@ static bool indLinBlockSplit(const arma::mat &H, indLinBlockSplit_t &sp) {
 static bool matrixExpBlock(const arma::mat &H, arma::mat &out, double t,
                            int type, int order) {
   if (__indLinBlockOff) return false;
-  indLinBlockSplit_t sp;
+  // Zero-init: the split is only meaningful when indLinBlockSplit() returns
+  // true, but the compiler cannot see that and warns about reading `sp`.
+  indLinBlockSplit_t sp = {0, 0, 0, 0};
   if (!indLinBlockSplit(H, sp)) return false;
   const int n = sp.n, k = sp.k, nd = sp.nd, nz = sp.nz;
   const int nx = n*(k + 1);
@@ -2671,11 +2676,9 @@ static int indLinDriveAdaptive(int cSub, rx_solving_options *op, rx_solving_opti
                                double *yp_, double tp, double tf, double hCap, int locf,
                                double *InfusionRate_, int *on_, t_ME ME, t_IndF IndF,
                                arma::vec *u) {
-  const double SAFE = 0.9, FACMIN = 0.1, FACMAX = 5.0;
   double span = tf - tp;
   double t = tp;
   double h = (hCap > 0.0 && std::isfinite(hCap) && hCap < span) ? hCap : span;
-  bool lastRejected = false;
   // Steady state re-solves the same tau-sized interval until it stops moving.
   // If the substep schedule drifted between passes the ssRtol/ssAtol test
   // would be reading schedule jitter rather than convergence, so allow the


### PR DESCRIPTION
Closes #1246.

Housekeeping only -- no behavior change.

* **`ARMA_DONT_USE_OPENMP` redefined** -- it is defined at the top of
  `expm.cpp` (where it has to stay, ahead of the `RcppArmadillo.h` include)
  and again on the compile line via `PKG_CXXFLAGS` in `src/Makevars`.
  Guarded the in-file definition with `#ifndef` so both can coexist; the
  `-D` stays in `Makevars` for the other translation units that need it.

* **Dead step-control locals** -- `SAFE`, `FACMIN`, `FACMAX` and
  `lastRejected` in `indLinDriveAdaptive()` are leftovers from when the step
  controller lived in the driver. The live copies are in `indLinAttempt()`
  and in the `indLinProgress_t` struct, so the declarations are simply
  removed.

* **`-Wmaybe-uninitialized` on `indLinBlockSplit_t`** (not listed in the
  issue, but the same file and the same class of noise) -- `matrixExpBlock()`
  only reads `sp` when `indLinBlockSplit()` returns `true`; the compiler
  cannot see that, so the struct is now zero-initialized.

## Verification

Compiled `src/expm.cpp` with the package's own flags plus `-Wall`, before
and after.

Before:

```
expm.cpp:7:9: warning: "ARMA_DONT_USE_OPENMP" redefined
expm.cpp:2674:16: warning: unused variable 'SAFE' [-Wunused-variable]
expm.cpp:2674:28: warning: unused variable 'FACMIN' [-Wunused-variable]
expm.cpp:2674:42: warning: unused variable 'FACMAX' [-Wunused-variable]
expm.cpp:2678:8: warning: unused variable 'lastRejected' [-Wunused-variable]
expm.cpp:568:13: warning: 'sp.indLinBlockSplit_t::nz' may be used uninitialized
expm.cpp:568:21: warning: 'sp.indLinBlockSplit_t::nd' may be used uninitialized
expm.cpp:566:23: warning: 'sp.indLinBlockSplit_t::k'  may be used uninitialized
expm.cpp:568:18: warning: 'sp.indLinBlockSplit_t::n'  may be used uninitialized
```

After: no warnings.