### PR TITLE
fix(linCmt): decide the dose-time sensitivity's shared-delay assumption from the regimen (#1119)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1242,7 +1242,11 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
   instead of the single-delay answer, and one dosing only lagged
   compartments is unchanged.  A paired IV/oral design -- the case that most
   often estimates a modeled `alag()`/`f()` -- previously took a silently
-  wrong gradient on its IV arm (#1119, #1237).
+  wrong gradient on its IV arm.  The same rule fixes an individual with no
+  `linCmt()` dose at all whose compartments were started from an initial
+  condition: those amounts decay in time, so `-dA/dt` reported a nonzero
+  sensitivity, but an initial condition is not delayed by `alag()` and the
+  answer is 0 (#1119, #1237).
 
 - `linCmtSensH` (the fixed finite-difference step used by the `forwardH`/
   `centralH`/`forward3H`/`endpoint5H` `linCmtSensType` options) is now read

--- a/NEWS.md
+++ b/NEWS.md
@@ -1247,7 +1247,10 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
   condition: those amounts decay in time, so `-dA/dt` reported a nonzero
   sensitivity, but an initial condition is not delayed by `alag()` and the
   answer is 0.  A plain `amt = 0` dose is not counted, so it cannot refuse a
-  regimen it contributes nothing to (#1119, #1237).
+  regimen it contributes nothing to, and neither is a dose into a mixed
+  model's ODE compartment -- including a steady-state infusion there, which
+  used to cost the `linCmt()` compartments an answer that was exact
+  (#1119, #1237).
 
 - `linCmtSensH` (the fixed finite-difference step used by the `forwardH`/
   `centralH`/`forward3H`/`endpoint5H` `linCmtSensType` options) is now read

--- a/NEWS.md
+++ b/NEWS.md
@@ -1246,7 +1246,8 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
   `linCmt()` dose at all whose compartments were started from an initial
   condition: those amounts decay in time, so `-dA/dt` reported a nonzero
   sensitivity, but an initial condition is not delayed by `alag()` and the
-  answer is 0 (#1119, #1237).
+  answer is 0.  A plain `amt = 0` dose is not counted, so it cannot refuse a
+  regimen it contributes nothing to (#1119, #1237).
 
 - `linCmtSensH` (the fixed finite-difference step used by the `forwardH`/
   `centralH`/`forward3H`/`endpoint5H` `linCmtSensType` options) is now read

--- a/NEWS.md
+++ b/NEWS.md
@@ -1230,6 +1230,20 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
   an event-modifier jump fed to `-7` is propagated); they are not reached by
   a model that does not request them.
 
+- `linCmtB(which1 = -3)` -- the dose-time (moving boundary) sensitivity a
+  modeled `alag()` on a `linCmt()` compartment needs -- no longer reports a
+  biased value for an individual whose regimen does not carry one shared
+  delay.  The `-dA/dt` identity it rests on assumes every dose feeding the
+  linear system is delayed together; which compartments the model lags is
+  known when the model is built, but which ones an individual actually doses
+  is data, so it is now decided while solving.  An individual dosing only
+  unlagged `linCmt()` compartments gets an exact `0` (its amounts do not
+  depend on the delay), one mixing lagged and unlagged doses gets `NA`
+  instead of the single-delay answer, and one dosing only lagged
+  compartments is unchanged.  A paired IV/oral design -- the case that most
+  often estimates a modeled `alag()`/`f()` -- previously took a silently
+  wrong gradient on its IV arm (#1119, #1237).
+
 - `linCmtSensH` (the fixed finite-difference step used by the `forwardH`/
   `centralH`/`forward3H`/`endpoint5H` `linCmtSensType` options) is now read
   from its own control slot instead of `linCmtSensType`'s.  `rx->sensH` was

--- a/R/eventSens.R
+++ b/R/eventSens.R
@@ -573,9 +573,11 @@
 #' This is a static, text-level check: it does not know which compartments
 #' actually receive doses (that is event-table, not model, information), so a
 #' model with one modeled `alag()` that ALSO doses an unlagged (implicit
-#' delay-0) linCmt() compartment still passes -- that was already the
-#' documented requirement before this guard existed and remains a gap only
-#' the full per-compartment fix (shared with #1236) closes.
+#' delay-0) linCmt() compartment still passes here.  That case is caught
+#' while solving instead, where the regimen is known: `linCmtBdoseTime()`
+#' (`src/linCmt.cpp`) compares the compartments an individual doses against
+#' `op->linCmtLagMask` and reports `NA` for a mixed-delay regimen (and an
+#' exact 0 when no dose reaches a lagged compartment).
 #'
 #' A single compartment's `alag()` may be assigned conditionally (different
 #' text per `if`/`else` branch) without violating the shared-delay

--- a/inst/include/rxode2parseStruct.h
+++ b/inst/include/rxode2parseStruct.h
@@ -172,6 +172,13 @@ typedef struct {
   int    indLinIteration;      /* method="indLin" substep scheme: 0 picard, 1 newton, 2 exprb, 3 auto (stiffness-gated) */
   int    indLinJac;            /* forcing Jacobian source: 0 auto, 1 symbolic (calc_jac - A), 2 finite difference */
   int    indLinForcing;        /* forcing over a substep: 0 constant, 1 linear ramp between its endpoint values */
+  /* Bitmask over the linCmt() block's physical compartments (bit c = block
+     index c, 0 = depot when oral) of those carrying a modeled alag().  Set at
+     solve setup from the model's stateProp; read by linCmtBdoseTime()
+     (which1 = -3) to tell whether every dose reaching the linear system
+     really does share one delay (nlmixr2/rxode2#1119, #1237).  0 when the
+     model declares no modeled alag() on a linCmt() compartment. */
+  int    linCmtLagMask;
 } rx_solving_options;
 
 

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -48,7 +48,10 @@ extern "C" double linCmtB(rx_solve *rx, int id,
 // Steady-state infusion:
 //
 // The dose-time sensitivity (linCmtB which1 = -3) needs dA/dt, which includes
-// the infusion rate.  A regular (non-SS) infusion's rate is recovered at
+// the infusion rate feeding the LINEAR system (ind->InfusionRate +
+// op->linOffset), so only a steady-state infusion into a linCmt() compartment
+// matters -- one into a mixed model's ODE compartment never touches that
+// slice and must not refuse the answer.  A regular (non-SS) infusion's rate is recovered at
 // output time via the linCmtRateHist cache (see linCmtBRateSlot() /
 // linCmtBdoseTime() below, nlmixr2/rxode2#1236).  A steady-state infusion
 // establishes its amounts analytically (handleSSinf8()/solveSSinf(), setting
@@ -88,14 +91,14 @@ static inline void linCmtDoseScan(rx_solving_options_ind *ind,
   for (int i = 0; i < ind->ndoses; ++i) {
     int wh, cmt, wh100, whI, wh0;
     getWh(getEvid(ind, ind->idose[i]), &wh, &cmt, &wh100, &whI, &wh0);
+    int c = cmt - op->linOffset;
+    if (c < 0 || c >= nLin) continue;   // not part of the linear system
     if ((wh0 == EVID0_SS0 || wh0 == EVID0_SS || wh0 == EVID0_SS20 ||
          wh0 == EVID0_SS2 || wh0 == EVID0_SSINF) &&
         whI != EVIDF_NORMAL && whI != EVIDF_REPLACE && whI != EVIDF_MULT) {
       ss = 1;
     }
-    int c = cmt - op->linOffset;
-    if (c >= 0 && c < nLin &&
-        !(whI == EVIDF_NORMAL && wh0 == EVID0_REGULAR &&
+    if (!(whI == EVIDF_NORMAL && wh0 == EVID0_REGULAR &&
           getDoseNumber(ind, i) == 0.0)) {
       mask |= (1 << c);
     }

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -42,7 +42,10 @@ extern "C" double linCmtB(rx_solve *rx, int id,
 #define getLinRate ind->InfusionRate + op->linOffset
 #define isSameTime(xout, xp) (fabs((xout)-(xp)) <= 2.0*DBL_EPSILON*max2(fabs(xout),fabs(xp)))
 
-// Does this individual have a steady-state infusion (rate/dur) dose?
+// What does this individual's REGIMEN look like, as far as the dose-time
+// sensitivity (linCmtB which1 = -3) is concerned?
+//
+// Steady-state infusion:
 //
 // The dose-time sensitivity (linCmtB which1 = -3) needs dA/dt, which includes
 // the infusion rate.  A regular (non-SS) infusion's rate is recovered at
@@ -57,38 +60,39 @@ extern "C" double linCmtB(rx_solve *rx, int id,
 // solve-order happenstance.  A steady-state BOLUS (linCmtSsBolus) never
 // touches InfusionRate and is unaffected -- it stays exact (see
 // test-lincmt-dose-time-sens.R).
-static inline int linCmtHasSsInfusion(rx_solving_options_ind *ind) {
+//
+// Dosed compartments:
+//
+// The -dA/dt identity assumes every dose feeding the linear system carries
+// the same delay, so which linCmt() compartments this individual actually
+// doses has to be compared against op->linCmtLagMask (the ones the model
+// lags).  `*dosedMask` is a bitmask over the linCmt() block of the physical
+// compartments actually dosed (bit c = block index c, 0 = depot when oral),
+// matching
+// op->linCmtLagMask: `cmt` out of getWh() is the 0-based index into the full
+// state vector and the linCmt() block starts at op->linOffset, so block index
+// c = cmt - op->linOffset.  Doses into a mixed model's ODE compartments fall
+// outside the block and are ignored -- they do not feed the linear system.
+//
+// Both answers come out of ONE pass over ind->idose.
+static inline void linCmtDoseScan(rx_solving_options_ind *ind,
+                                  rx_solving_options *op,
+                                  int *dosedMask, int *ssInf) {
+  int mask = 0, ss = 0;
+  int nLin = op->numLin < 31 ? op->numLin : 31;
   for (int i = 0; i < ind->ndoses; ++i) {
     int wh, cmt, wh100, whI, wh0;
     getWh(getEvid(ind, ind->idose[i]), &wh, &cmt, &wh100, &whI, &wh0);
     if ((wh0 == EVID0_SS0 || wh0 == EVID0_SS || wh0 == EVID0_SS20 ||
          wh0 == EVID0_SS2 || wh0 == EVID0_SSINF) &&
         whI != EVIDF_NORMAL && whI != EVIDF_REPLACE && whI != EVIDF_MULT) {
-      return 1;
+      ss = 1;
     }
-  }
-  return 0;
-}
-
-// Which physical linCmt() compartments does this individual actually dose?
-//
-// Bitmask over the linCmt() block (bit c = block index c, 0 = depot when
-// oral), matching op->linCmtLagMask.  `cmt` out of getWh() is the 0-based
-// index into the full state vector, and the linCmt() block starts at
-// op->linOffset, so block index c = cmt - op->linOffset.  Doses into a mixed
-// model's ODE compartments fall outside the block and are ignored -- they do
-// not feed the linear system.
-static inline int linCmtDosedMask(rx_solving_options_ind *ind,
-                                  rx_solving_options *op) {
-  int mask = 0;
-  int nLin = op->numLin < 31 ? op->numLin : 31;
-  for (int i = 0; i < ind->ndoses; ++i) {
-    int wh, cmt, wh100, whI, wh0;
-    getWh(getEvid(ind, ind->idose[i]), &wh, &cmt, &wh100, &whI, &wh0);
     int c = cmt - op->linOffset;
     if (c >= 0 && c < nLin) mask |= (1 << c);
   }
-  return mask;
+  *dosedMask = mask;
+  *ssInf = ss;
 }
 
 // Per-idx cache of the infusion rate feeding a linCmt() model, keyed the same
@@ -1995,12 +1999,13 @@ extern "C" int linCmtZeroJac(int i) {
 // feeding the linear system carries the same delay, which is a property of
 // this individual's REGIMEN, so op->linCmtLagMask (which compartments the
 // model lags) is compared against the compartments actually dosed: an
-// individual dosing only unlagged compartments gets an exact 0, and one
+// individual that doses no lagged compartment (including one that doses
+// none at all and runs off an initial condition) gets an exact 0, and one
 // mixing lagged and unlagged doses gets NA_REAL rather than the biased
 // single-delay answer (nlmixr2/rxode2#1237).  Also NA_REAL for a call that
 // does not describe the model `lc` is set up for, when `rate` could not be
 // recovered (NULL -- see linCmtBRateSlot()), for a steady-state infusion
-// (linCmtHasSsInfusion()), or for an out of range `which2`.
+// (linCmtDoseScan()), or for an out of range `which2`.
 static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
                                      const Eigen::Matrix<double, Eigen::Dynamic, 1> &amt,
                                      rx_solving_options_ind *ind,
@@ -2016,6 +2021,8 @@ static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
     return NA_REAL;
   }
   if (which2 != -3 && (which2 < 0 || which2 >= ncmt + oral0)) return NA_REAL;
+  int dosed, ssInf;
+  linCmtDoseScan(ind, op, &dosed, &ssInf);
   // Does this individual's regimen actually satisfy the one-shared-delay
   // assumption the -dA/dt identity rests on (nlmixr2/rxode2#1237)?  Which
   // compartments carry a modeled alag() is model information
@@ -2024,25 +2031,27 @@ static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
   // compartment there is nothing to compare against -- the caller is asking
   // for a delay it applies to every dose itself, so answer as before.
   if (op->linCmtLagMask != 0) {
-    int dosed = linCmtDosedMask(ind, op);
-    if (dosed != 0) {
-      if ((dosed & op->linCmtLagMask) == 0) {
-        // No dose reaches a lagged compartment, so the amounts do not depend
-        // on the delay at all: the derivative is exactly 0.  (An IV arm of a
-        // paired IV/oral design lands here.)
-        return 0.0;
-      }
-      if ((dosed & ~op->linCmtLagMask) != 0) {
-        // Some doses are delayed and some are not, so there is no single
-        // delay to differentiate wrt.  Refuse rather than return the
-        // single-delay answer, which is biased by the undelayed doses'
-        // contribution -- see nlmixr2/rxode2#1237.
-        return NA_REAL;
-      }
+    if ((dosed & op->linCmtLagMask) == 0) {
+      // No dose reaches a lagged compartment, so the amounts do not depend on
+      // the delay at all: the derivative is exactly 0, whatever the rest of
+      // the regimen looks like.  (The IV arm of a paired IV/oral design lands
+      // here, and it is exact even for the steady-state infusion refused
+      // below.)  This covers an individual with no linCmt() dose at all,
+      // whose amounts are whatever the initial conditions put there -- those
+      // are not delayed either, so -dA/dt would be a nonzero answer to a
+      // question whose answer is 0.
+      return 0.0;
+    }
+    if ((dosed & ~op->linCmtLagMask) != 0) {
+      // Some doses are delayed and some are not, so there is no single delay
+      // to differentiate wrt.  Refuse rather than return the single-delay
+      // answer, which is biased by the undelayed doses' contribution -- see
+      // nlmixr2/rxode2#1237.
+      return NA_REAL;
     }
   }
   if (rate == NULL) return NA_REAL;
-  if (linCmtHasSsInfusion(ind)) return NA_REAL;
+  if (ssInf) return NA_REAL;
   Eigen::Matrix<double, Eigen::Dynamic, 1> th(lc.getNpars());
   if (!linCmtFillTheta(th, ncmt, oral0, p1, v1, p2, p3, p4, p5, ka)) {
     return NA_REAL;
@@ -2109,10 +2118,11 @@ static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
  *  individual whose REGIMEN doses both a lagged and an unlagged linCmt()
  *  compartment -- data this package only sees while solving -- gets
  *  `NA_REAL` here.  An individual dosing no lagged compartment at all gets
- *  an exact 0 (its amounts do not depend on the delay).  A regular
+ *  an exact 0: its amounts do not depend on the delay, whether they came
+ *  from undelayed doses or from an initial condition.  A regular
  *  infusion's rate is recovered at output time via the linCmtBRateSlot()
  *  per-idx cache (nlmixr2/rxode2#1236); an individual with a steady-state
- *  infusion still gets `NA_REAL` -- see linCmtHasSsInfusion().
+  *  infusion still gets `NA_REAL` -- see linCmtDoseScan().
  *
  *  The parameter order is as follows:
  *

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -70,6 +70,27 @@ static inline int linCmtHasSsInfusion(rx_solving_options_ind *ind) {
   return 0;
 }
 
+// Which physical linCmt() compartments does this individual actually dose?
+//
+// Bitmask over the linCmt() block (bit c = block index c, 0 = depot when
+// oral), matching op->linCmtLagMask.  `cmt` out of getWh() is the 0-based
+// index into the full state vector, and the linCmt() block starts at
+// op->linOffset, so block index c = cmt - op->linOffset.  Doses into a mixed
+// model's ODE compartments fall outside the block and are ignored -- they do
+// not feed the linear system.
+static inline int linCmtDosedMask(rx_solving_options_ind *ind,
+                                  rx_solving_options *op) {
+  int mask = 0;
+  int nLin = op->numLin < 31 ? op->numLin : 31;
+  for (int i = 0; i < ind->ndoses; ++i) {
+    int wh, cmt, wh100, whI, wh0;
+    getWh(getEvid(ind, ind->idose[i]), &wh, &cmt, &wh100, &whI, &wh0);
+    int c = cmt - op->linOffset;
+    if (c >= 0 && c < nLin) mask |= (1 << c);
+  }
+  return mask;
+}
+
 // Per-idx cache of the infusion rate feeding a linCmt() model, keyed the same
 // way as the amounts cached via getAdvan()/Alast: written once, while the
 // index is genuinely being solved (ind->InfusionRate live and correct), and
@@ -1970,13 +1991,20 @@ extern "C" int linCmtZeroJac(int i) {
 // right-hand side gives d/dL exactly (see linCmtStan::dAdt()).  `rate` is
 // either the live ind->InfusionRate slice (while genuinely solving) or the
 // linCmtBRateSlot() cache for that idx (a re-query, e.g. the output pass);
-// see the caller in linCmtB().  Returns NA_REAL for a call that does not
-// describe the model `lc` is set up for, when `rate` could not be recovered
-// (NULL -- see linCmtBRateSlot()), for a steady-state infusion
+// see the caller in linCmtB().  The identity holds only while every dose
+// feeding the linear system carries the same delay, which is a property of
+// this individual's REGIMEN, so op->linCmtLagMask (which compartments the
+// model lags) is compared against the compartments actually dosed: an
+// individual dosing only unlagged compartments gets an exact 0, and one
+// mixing lagged and unlagged doses gets NA_REAL rather than the biased
+// single-delay answer (nlmixr2/rxode2#1237).  Also NA_REAL for a call that
+// does not describe the model `lc` is set up for, when `rate` could not be
+// recovered (NULL -- see linCmtBRateSlot()), for a steady-state infusion
 // (linCmtHasSsInfusion()), or for an out of range `which2`.
 static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
                                      const Eigen::Matrix<double, Eigen::Dynamic, 1> &amt,
                                      rx_solving_options_ind *ind,
+                                     rx_solving_options *op,
                                      const double *rate,
                                      int ncmt, int oral0, int which2, int trans,
                                      double p1, double v1,
@@ -1986,6 +2014,32 @@ static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
   if (lc.ncmt_ != ncmt || lc.oral0_ != oral0 || lc.trans_ != trans ||
       (int)amt.size() != ncmt + oral0) {
     return NA_REAL;
+  }
+  if (which2 != -3 && (which2 < 0 || which2 >= ncmt + oral0)) return NA_REAL;
+  // Does this individual's regimen actually satisfy the one-shared-delay
+  // assumption the -dA/dt identity rests on (nlmixr2/rxode2#1237)?  Which
+  // compartments carry a modeled alag() is model information
+  // (op->linCmtLagMask); which ones this individual doses is DATA, so it can
+  // only be decided here.  With no modeled alag() declared on any linCmt()
+  // compartment there is nothing to compare against -- the caller is asking
+  // for a delay it applies to every dose itself, so answer as before.
+  if (op->linCmtLagMask != 0) {
+    int dosed = linCmtDosedMask(ind, op);
+    if (dosed != 0) {
+      if ((dosed & op->linCmtLagMask) == 0) {
+        // No dose reaches a lagged compartment, so the amounts do not depend
+        // on the delay at all: the derivative is exactly 0.  (An IV arm of a
+        // paired IV/oral design lands here.)
+        return 0.0;
+      }
+      if ((dosed & ~op->linCmtLagMask) != 0) {
+        // Some doses are delayed and some are not, so there is no single
+        // delay to differentiate wrt.  Refuse rather than return the
+        // single-delay answer, which is biased by the undelayed doses'
+        // contribution -- see nlmixr2/rxode2#1237.
+        return NA_REAL;
+      }
+    }
   }
   if (rate == NULL) return NA_REAL;
   if (linCmtHasSsInfusion(ind)) return NA_REAL;
@@ -2048,14 +2102,17 @@ static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
  *  with d(alag)/dp to get the sensitivity wrt a model parameter.  This
  *  requires that EVERY dose reaching the linear system carries the same
  *  `alag()`; it is not the per-compartment derivative of a model that lags
- *  its compartments differently (nlmixr2/rxode2#1237).  A model that would
- *  violate this -- calling `linCmtB(which1 = -3)` while its linCmt()
- *  compartments carry more than one distinct `alag()` expression -- is
- *  refused at build time by `.rxLinCmtDoseTimeSensCheck()` (R/eventSens.R)
- *  rather than silently given the single-delay answer.  A regular infusion's
- *  rate is recovered at output time via the linCmtBRateSlot() per-idx cache
- *  (nlmixr2/rxode2#1236); an individual with a steady-state infusion still
- *  gets `NA_REAL` -- see linCmtHasSsInfusion().
+ *  its compartments differently (nlmixr2/rxode2#1237).  Two complementary
+ *  checks keep it from silently answering anyway: a model whose linCmt()
+ *  compartments carry more than one distinct `alag()` expression is refused
+ *  at build time by `.rxLinCmtDoseTimeSensCheck()` (R/eventSens.R), and an
+ *  individual whose REGIMEN doses both a lagged and an unlagged linCmt()
+ *  compartment -- data this package only sees while solving -- gets
+ *  `NA_REAL` here.  An individual dosing no lagged compartment at all gets
+ *  an exact 0 (its amounts do not depend on the delay).  A regular
+ *  infusion's rate is recovered at output time via the linCmtBRateSlot()
+ *  per-idx cache (nlmixr2/rxode2#1236); an individual with a steady-state
+ *  infusion still gets `NA_REAL` -- see linCmtHasSsInfusion().
  *
  *  The parameter order is as follows:
  *
@@ -2352,7 +2409,7 @@ static inline bool linCmtBquery(linB_t &lcb, rx_solve *rx, rx_solving_options_in
     // ind->InfusionRate has since been cleared/moved on; use the cached rate.
     const double *rate = (!ind->doSS && ind->solvedIdx >= idx) ?
       linCmtBRateSlot(ind, idx, op->numLin, 0) : getLinRate;
-    *out = linCmtBdoseTime(lcb.lc, lcb.fx, ind, rate, ncmt, oral0, which2,
+    *out = linCmtBdoseTime(lcb.lc, lcb.fx, ind, op, rate, ncmt, oral0, which2,
                            trans, p1, v1, p2, p3, p4, p5, ka);
   } else if (which1 == -4) {
     *out = linCmtBtransition(lcb, rx, ind, op, idx, _t, ncmt, oral0, which2, trans,

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -68,11 +68,16 @@ extern "C" double linCmtB(rx_solve *rx, int id,
 // doses has to be compared against op->linCmtLagMask (the ones the model
 // lags).  `*dosedMask` is a bitmask over the linCmt() block of the physical
 // compartments actually dosed (bit c = block index c, 0 = depot when oral),
-// matching
-// op->linCmtLagMask: `cmt` out of getWh() is the 0-based index into the full
-// state vector and the linCmt() block starts at op->linOffset, so block index
-// c = cmt - op->linOffset.  Doses into a mixed model's ODE compartments fall
-// outside the block and are ignored -- they do not feed the linear system.
+// matching op->linCmtLagMask: `cmt` out of getWh() is the 0-based index into
+// the full state vector and the linCmt() block starts at op->linOffset, so
+// block index c = cmt - op->linOffset.  Doses into a mixed model's ODE
+// compartments fall outside the block and are ignored -- they do not feed the
+// linear system, and neither does a plain zero bolus: it puts nothing into
+// the compartment, so it cannot break the shared-delay assumption and must
+// not be allowed to refuse an otherwise answerable regimen.  ONLY that shape
+// is skipped -- a zero `amt` on a rate/duration record is an infinite
+// infusion, and on a replace or multiply record it sets the compartment to
+// zero; both genuinely dose.
 //
 // Both answers come out of ONE pass over ind->idose.
 static inline void linCmtDoseScan(rx_solving_options_ind *ind,
@@ -89,7 +94,11 @@ static inline void linCmtDoseScan(rx_solving_options_ind *ind,
       ss = 1;
     }
     int c = cmt - op->linOffset;
-    if (c >= 0 && c < nLin) mask |= (1 << c);
+    if (c >= 0 && c < nLin &&
+        !(whI == EVIDF_NORMAL && wh0 == EVID0_REGULAR &&
+          getDoseNumber(ind, i) == 0.0)) {
+      mask |= (1 << c);
+    }
   }
   *dosedMask = mask;
   *ssInf = ss;

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -82,6 +82,12 @@ extern "C" double linCmtB(rx_solve *rx, int id,
 // infusion, and on a replace or multiply record it sets the compartment to
 // zero; both genuinely dose.
 //
+// The scan covers the individual's WHOLE regimen: an EVID 3 reset between a
+// lagged and an unlagged dose means the two never coexist in the system, but
+// resets are not in ind->idose and this does not window on them, so such a
+// regimen is refused rather than answered.  That is the conservative
+// direction (a loud NA, not a wrong number).
+//
 // Both answers come out of ONE pass over ind->idose.
 static inline void linCmtDoseScan(rx_solving_options_ind *ind,
                                   rx_solving_options *op,

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -6101,7 +6101,8 @@ static inline int rxLinCmtLagMask(List mv, int linOffset, int numLin) {
   IntegerVector stateProp = mv[RxMv_stateProp];
   int mask = 0;
   int n = stateProp.size();
-  for (int c = 0; c < numLin; ++c) {
+  int nLin = numLin < 31 ? numLin : 31;   // same clamp linCmtDoseScan() uses
+  for (int c = 0; c < nLin; ++c) {
     int i = linOffset + c;
     if (i < 0 || i >= n) continue;
     if ((stateProp[i] & 4) != 0) mask |= (1 << c);
@@ -6156,6 +6157,13 @@ SEXP rxSolveFromRaw_(const RObject &obj, const RObject &rawObj,
     rx_solve* rx = getRxSolve_();
     rx_solving_options* op = rx->op;
     if (op->cores == 0) op->cores = 1;
+    // Which linCmt() compartments carry a modeled alag() is a property of the
+    // MODEL, so take it from the model rather than the stream: a stream
+    // written before format 6 does not carry it at all, and would otherwise
+    // leave the mask at 0 and let linCmtB(which1 = -3) answer a mixed-delay
+    // regimen it should refuse (nlmixr2/rxode2#1119).
+    op->linCmtLagMask = rxLinCmtLagMask(rxModelVars_(obj), op->linOffset,
+                                        op->numLin);
     seedEng((int)(op->cores));
     ensureLinCmtA((int)op->cores);
     ensureLinCmtB((int)op->cores);

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -6097,7 +6097,7 @@ void getLinInfo(List mv, int &numLinSens, int &numLin, int &depotLin);
 // the trailing `numLin + numLinSens` compartments, so block index c is state
 // index `linOffset + c`.  propAlag is src/tran.h's bit 4 (not included here).
 static inline int rxLinCmtLagMask(List mv, int linOffset, int numLin) {
-  if (numLin <= 0) return 0;
+  if (numLin <= 0 || mv.size() <= RxMv_stateProp) return 0;
   IntegerVector stateProp = mv[RxMv_stateProp];
   int mask = 0;
   int n = stateProp.size();
@@ -6125,6 +6125,13 @@ SEXP rxSolveFromRaw_(const RObject &obj, const RObject &rawObj,
   if (!rxDynLoad(obj)) {
     (Rf_error)(_("rxSolve: cannot load rxode2 dll for model"));
   }
+
+  // Take the model variables BEFORE the restore.  rxModelVars_() can run R --
+  // a model that came from another package and no longer validates is
+  // re-parsed here -- and nothing that runs R belongs between rxRestoreState_()
+  // and the solve it set up.  This is also the order the ordinary rxSolve_()
+  // path uses: model vars first, then op.
+  List mvRaw = rxModelVars_(obj);
 
   // Restore the pre-integration solve state from binary file.
   // rxRestoreState_ calls rxSolveFreeC() (which clears ODE function pointers),
@@ -6161,9 +6168,15 @@ SEXP rxSolveFromRaw_(const RObject &obj, const RObject &rawObj,
     // MODEL, so take it from the model rather than the stream: a stream
     // written before format 6 does not carry it at all, and would otherwise
     // leave the mask at 0 and let linCmtB(which1 = -3) answer a mixed-delay
-    // regimen it should refuse (nlmixr2/rxode2#1119).
-    op->linCmtLagMask = rxLinCmtLagMask(rxModelVars_(obj), op->linOffset,
-                                        op->numLin);
+    // regimen it should refuse (nlmixr2/rxode2#1119).  Only when the model
+    // describes the layout that was just restored, though -- otherwise the
+    // stream's own value (format 6 and later) is the better answer.
+    if (mvRaw.size() > RxMv_state) {
+      CharacterVector mvState = mvRaw[RxMv_state];
+      if (mvState.size() == op->neq) {
+        op->linCmtLagMask = rxLinCmtLagMask(mvRaw, op->linOffset, op->numLin);
+      }
+    }
     seedEng((int)(op->cores));
     ensureLinCmtA((int)op->cores);
     ensureLinCmtB((int)op->cores);

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -6070,6 +6070,7 @@ static inline void iniRx(rx_solve* rx) {
   op->numLin = 0;
   op->depotLin = 0;
   op->linOffset = 0;
+  op->linCmtLagMask = 0;
   rx->svar = _globals.gsvar;
   rx->ovar = _globals.govar;
   op->nLlik = 0;
@@ -6089,6 +6090,24 @@ static inline void rxLoadSplitBolus(List mv, rx_solve *rx) {
 }
 
 void getLinInfo(List mv, int &numLinSens, int &numLin, int &depotLin);
+
+// Bitmask of the linCmt() block's physical compartments carrying a modeled
+// alag(), for op->linCmtLagMask.  `mv[RxMv_stateProp]` is parallel to
+// `mv[RxMv_state]`, which is the compartment order, and the linCmt() block is
+// the trailing `numLin + numLinSens` compartments, so block index c is state
+// index `linOffset + c`.  propAlag is src/tran.h's bit 4 (not included here).
+static inline int rxLinCmtLagMask(List mv, int linOffset, int numLin) {
+  if (numLin <= 0) return 0;
+  IntegerVector stateProp = mv[RxMv_stateProp];
+  int mask = 0;
+  int n = stateProp.size();
+  for (int c = 0; c < numLin; ++c) {
+    int i = linOffset + c;
+    if (i < 0 || i >= n) continue;
+    if ((stateProp[i] & 4) != 0) mask |= (1 << c);
+  }
+  return mask;
+}
 
 static int _rxSolveCallN = 0;
 
@@ -6752,6 +6771,7 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
     op->numLin = numLin;
     op->depotLin = depotLin;
     op->linOffset = op->neq - numLin - numLinSens;
+    op->linCmtLagMask = rxLinCmtLagMask(rxSolveDat->mv, op->linOffset, numLin);
     op->nLlik = INTEGER(rxSolveDat->mv[RxMv_flags])[RxMvFlag_nLlik];
     if (!Rf_isNull(rxControl[Rxc_nLlikAlloc])) {
       op->nLlik = max2(asInt(rxControl[Rxc_nLlikAlloc],"control$nLlikAlloc"), op->nLlik);

--- a/src/rxSerialize.cpp
+++ b/src/rxSerialize.cpp
@@ -727,7 +727,9 @@ SEXP rxRestoreState_(SEXP rawSexp) {
   if (fmt >= 6u) {
     R_I32(linCmtLagMask);
   } else {
-    op->linCmtLagMask = 0;   // pre-fix behavior: nothing known to be lagged
+    // A pre-format-6 stream cannot carry it; rxSolveFromRaw_() recomputes it
+    // from the model right after this restore, so 0 is only a placeholder.
+    op->linCmtLagMask = 0;
   }
   R_I32(ssSolved);
   R_I32(indOwnAlloc);

--- a/src/rxSerialize.cpp
+++ b/src/rxSerialize.cpp
@@ -20,7 +20,8 @@ extern "C" void rxOptionsIniEnsure(int mx, int cores);
 extern rx_globals _globals;
 
 static const char rxSerializeMagic[8] = {'R','X','O','D','E','2','S','Z'};
-static const uint32_t rxSerializeFormatVer = 5u;
+static const uint32_t rxSerializeFormatVer = 6u;
+// Format 6 added op->linCmtLagMask after linOffset.
 // Format 5 dropped the linCmt() sensitivity-strategy fields format 4 had
 // introduced (the strategy was removed; a format-4 stream's four strategy
 // ints are read and discarded), keeping linCmtBraw after sensH.
@@ -160,7 +161,7 @@ SEXP rxSaveState_() {
   W_I32(doIndLin); W_I32(strictSS);
   W_DBL(infSSstep); W_I32(mxhnil); W_DBL(hmxi);
   W_I32(nLlik); W_I32(numLinSens); W_I32(numLin);
-  W_I32(depotLin); W_I32(linOffset); W_I32(ssSolved);
+  W_I32(depotLin); W_I32(linOffset); W_I32(linCmtLagMask); W_I32(ssSolved);
   W_I32(indOwnAlloc);
 
 #undef W_I32
@@ -715,7 +716,7 @@ SEXP rxRestoreState_(SEXP rawSexp) {
   R_I32(doIndLin); R_I32(strictSS);
   R_DBL(infSSstep); R_I32(mxhnil); R_DBL(hmxi);
   R_I32(nLlik); R_I32(numLinSens); R_I32(numLin);
-  R_I32(depotLin); R_I32(linOffset); R_I32(ssSolved);
+  R_I32(depotLin); R_I32(linOffset); R_I32(linCmtLagMask); R_I32(ssSolved);
   R_I32(indOwnAlloc);
 
 #undef R_I32

--- a/src/rxSerialize.cpp
+++ b/src/rxSerialize.cpp
@@ -21,7 +21,9 @@ extern rx_globals _globals;
 
 static const char rxSerializeMagic[8] = {'R','X','O','D','E','2','S','Z'};
 static const uint32_t rxSerializeFormatVer = 6u;
-// Format 6 added op->linCmtLagMask after linOffset.
+// Format 6 added op->linCmtLagMask after linOffset (read only when fmt >= 6:
+// it landed in the struct's tail padding, so sizeof(rx_solving_options) is
+// unchanged and the size check below cannot reject a format 5 stream).
 // Format 5 dropped the linCmt() sensitivity-strategy fields format 4 had
 // introduced (the strategy was removed; a format-4 stream's four strategy
 // ints are read and discarded), keeping linCmtBraw after sensH.
@@ -716,7 +718,18 @@ SEXP rxRestoreState_(SEXP rawSexp) {
   R_I32(doIndLin); R_I32(strictSS);
   R_DBL(infSSstep); R_I32(mxhnil); R_DBL(hmxi);
   R_I32(nLlik); R_I32(numLinSens); R_I32(numLin);
-  R_I32(depotLin); R_I32(linOffset); R_I32(linCmtLagMask); R_I32(ssSolved);
+  R_I32(depotLin); R_I32(linOffset);
+  // Format 6 appended linCmtLagMask here.  An older stream does not carry it,
+  // so reading it unconditionally would shift every field after it by one.
+  // The sizeof(rx_solving_options) check above does NOT catch that: the
+  // struct ends in a run of ints, and the new int landed in tail padding the
+  // 8 byte alignment already had -- measured, sizeof is 1488 either way.
+  if (fmt >= 6u) {
+    R_I32(linCmtLagMask);
+  } else {
+    op->linCmtLagMask = 0;   // pre-fix behavior: nothing known to be lagged
+  }
+  R_I32(ssSolved);
   R_I32(indOwnAlloc);
 
 #undef R_I32

--- a/tests/testthat/test-lincmt-dose-time-sens.R
+++ b/tests/testthat/test-lincmt-dose-time-sens.R
@@ -362,6 +362,26 @@ rxTest({
     expect_equal(s$dcp, .fdCol(m, e, "cp"), tolerance = 1e-5)
   })
 
+  test_that("linCmtB(-3) still counts a zero-amount replace/multiply record", {
+    # Only a PLAIN zero bolus contributes nothing.  `evid = 5`/`evid = 6` with
+    # `amt = 0` set the compartment to zero at a FIXED time that no alag()
+    # shifts, so A(t; L) = A(t - L; 0) genuinely fails and the regimen has to
+    # be refused rather than answered from the lagged doses alone.
+    m <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); ka <- exp(tka); lag <- 2 * exp(eta_lag)
+      alag(depot) <- lag
+      cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+      dcp <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -3, -3, 1, cl, v, 0, 0, 0, 0, ka)
+    })
+    for (.evid in c(5, 6)) {
+      e <- et(amt = 100, cmt = "depot") |>
+        et(amt = 0, cmt = "central", time = 2, evid = .evid) |>
+        et(seq(0.1, 24, 0.25))
+      s <- rxSolve(m, e, params = .p)
+      expect_true(all(is.na(s$dcp)), info = paste0("evid ", .evid))
+    }
+  })
+
   test_that("linCmtB(-3) accepts dosing a subset of the lagged compartments", {
     # Both linCmt() compartments carry the SAME modeled alag(), so every dose
     # is delayed alike however many of them the regimen actually uses.  Pins

--- a/tests/testthat/test-lincmt-dose-time-sens.R
+++ b/tests/testthat/test-lincmt-dose-time-sens.R
@@ -382,6 +382,46 @@ rxTest({
     }
   })
 
+  test_that("linCmtB(-3) still counts a zero-amount infusion record", {
+    # The other half of the same distinction: a zero `amt` on a rate record is
+    # not a no-op, so it has to keep counting as a dose.
+    m <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); ka <- exp(tka); lag <- 2 * exp(eta_lag)
+      alag(depot) <- lag
+      cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+      dcp <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -3, -3, 1, cl, v, 0, 0, 0, 0, ka)
+    })
+    e <- et(amt = 100, cmt = "depot") |>
+      et(amt = 0, rate = 10, cmt = "central", time = 2) |>
+      et(seq(0.1, 24, 0.25))
+    expect_true(all(is.na(rxSolve(m, e, params = .p)$dcp)))
+  })
+
+  test_that("a steady-state infusion into an ODE compartment does not refuse linCmtB(-3)", {
+    # -dA/dt needs the rate feeding the LINEAR system (ind->InfusionRate +
+    # op->linOffset).  A steady-state infusion into a mixed model's ODE
+    # compartment never touches that slice, so it must not cost the linCmt()
+    # compartments their (exact) dose-time sensitivity.
+    m <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); lag <- 2 * exp(eta_lag); ke0 <- 0.5
+      alag(central) <- lag
+      cp <- linCmtB(rx__PTR__, t, 1, 1, 0, -1, -1, 1, cl, v, 0, 0, 0, 0, 0)
+      dcp <- lag * linCmtB(rx__PTR__, t, 1, 1, 0, -3, -3, 1, cl, v, 0, 0, 0, 0, 0)
+      d/dt(ce) <- (cp - ce) * ke0
+    })
+    e <- et(amt = 100, cmt = "central") |>
+      et(amt = 10, rate = 5, ss = 1, ii = 12, cmt = "ce") |>
+      et(seq(0.1, 12, 0.25))
+    s <- rxSolve(m, e, params = .p)
+    expect_false(any(is.na(s$dcp)))
+    expect_equal(s$dcp, .fdCol(m, e, "cp"), tolerance = 1e-5)
+    # ... while a steady-state infusion into the linCmt() compartment itself
+    # still is refused
+    eLin <- et(amt = 100, rate = 25, ss = 1, ii = 12, cmt = "central") |>
+      et(seq(0.1, 12, 0.25))
+    expect_true(all(is.na(rxSolve(m, eLin, params = .p)$dcp)))
+  })
+
   test_that("linCmtB(-3) accepts dosing a subset of the lagged compartments", {
     # Both linCmt() compartments carry the SAME modeled alag(), so every dose
     # is delayed alike however many of them the regimen actually uses.  Pins

--- a/tests/testthat/test-lincmt-dose-time-sens.R
+++ b/tests/testthat/test-lincmt-dose-time-sens.R
@@ -263,6 +263,65 @@ rxTest({
     }
   })
 
+  test_that("linCmtB(-3) is exactly 0 when no dose reaches the lagged compartment", {
+    # The identity -dA/dt is the derivative wrt a delay carried by every dose.
+    # If this individual doses no lagged compartment its amounts do not depend
+    # on the delay at all, so the derivative is exactly 0 -- NOT -dA/dt, which
+    # is the (nonzero) derivative the undelayed doses would have had if they
+    # were delayed.  The IV arm of a paired IV/oral design lands here
+    # (nlmixr2/rxode2#1237).
+    m <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); ka <- exp(tka); lag <- 2 * exp(eta_lag)
+      alag(depot) <- lag
+      cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+      dcp <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -3, -3, 1, cl, v, 0, 0, 0, 0, ka)
+    })
+    e <- et(amt = 100, cmt = "central") |> et(seq(0.1, 24, 0.25))
+    s <- rxSolve(m, e, params = .p)
+    expect_false(any(is.na(s$dcp)))
+    expect_equal(s$dcp, rep(0, length(s$dcp)))
+    # the finite difference agrees: cp does not move with the lag parameter
+    expect_equal(.fdCol(m, e, "cp"), rep(0, nrow(s)), tolerance = 1e-8)
+  })
+
+  test_that("linCmtB(-3) refuses a regimen mixing lagged and unlagged doses", {
+    # A lagged depot plus an unlagged bolus into central is out of scope for
+    # which1 = -3 (an unlagged dose is a lag of 0, still a different delay).
+    # Which compartments the model lags is build-time information, but which
+    # ones an individual doses is DATA, so this can only be caught while
+    # solving -- report NA rather than the single-delay answer, which is
+    # biased by the undelayed dose's contribution (nlmixr2/rxode2#1237).
+    m <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); ka <- exp(tka); lag <- 2 * exp(eta_lag)
+      alag(depot) <- lag
+      cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+      dcp <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -3, -3, 1, cl, v, 0, 0, 0, 0, ka)
+    })
+    e <- et(amt = 100, cmt = "depot") |> et(amt = 50, cmt = "central", time = 0) |>
+      et(seq(0.1, 24, 0.25))
+    s <- rxSolve(m, e, params = .p)
+    expect_true(all(is.na(s$dcp)))
+    expect_false(any(is.na(s$cp)))   # the model itself still solves
+  })
+
+  test_that("linCmtB(-3) ignores doses into a mixed model's ODE compartments", {
+    # Only doses reaching the LINEAR system can violate the shared-delay
+    # assumption; an ODE compartment of a mixed model is not part of it, so
+    # dosing it must not turn the answer into NA.
+    m <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); lag <- 2 * exp(eta_lag); ke0 <- 0.5
+      alag(central) <- lag
+      cp <- linCmtB(rx__PTR__, t, 1, 1, 0, -1, -1, 1, cl, v, 0, 0, 0, 0, 0)
+      dcp <- lag * linCmtB(rx__PTR__, t, 1, 1, 0, -3, -3, 1, cl, v, 0, 0, 0, 0, 0)
+      d/dt(ce) <- (cp - ce) * ke0
+    })
+    e <- et(amt = 100, cmt = "central") |> et(amt = 5, cmt = "ce", time = 1) |>
+      et(seq(0.1, 12, 0.25))
+    s <- rxSolve(m, e, params = .p)
+    expect_false(any(is.na(s$dcp)))
+    expect_equal(s$dcp, .fdCol(m, e, "cp"), tolerance = 1e-5)
+  })
+
   test_that("linCmtB(-3) rejects a mismatched model shape", {
     # which1 = -3 reads the amounts cached by the which1/which2 = -1 call, so a
     # call describing a different model returns NA rather than reading them.

--- a/tests/testthat/test-lincmt-dose-time-sens.R
+++ b/tests/testthat/test-lincmt-dose-time-sens.R
@@ -12,10 +12,14 @@ rxTest({
   .p <- c(tcl = log(4), tv = log(20), tka = log(1.1), tq = log(2),
           tv2 = log(50), eta_lag = 0.1)
 
-  .fdCol <- function(m, e, col, h = 1e-5) {
+  .fdCol <- function(m, e, col, h = 1e-5, inits = NULL) {
     .p1 <- .p; .p1[["eta_lag"]] <- .p[["eta_lag"]] + h
     .p0 <- .p; .p0[["eta_lag"]] <- .p[["eta_lag"]] - h
-    (rxSolve(m, e, params = .p1)[[col]] - rxSolve(m, e, params = .p0)[[col]]) / (2 * h)
+    .go <- function(.pp) {
+      if (is.null(inits)) rxSolve(m, e, params = .pp)[[col]]
+      else rxSolve(m, e, params = .pp, inits = inits)[[col]]
+    }
+    (.go(.p1) - .go(.p0)) / (2 * h)
   }
 
   test_that("linCmtB(-3) dose-time sensitivity matches finite differences", {
@@ -284,6 +288,25 @@ rxTest({
     expect_equal(.fdCol(m, e, "cp"), rep(0, nrow(s)), tolerance = 1e-8)
   })
 
+  test_that("linCmtB(-3) is exactly 0 for an individual with no linCmt() dose", {
+    # A linCmt() compartment started from an initial condition rather than a
+    # dose still has amounts that move in time, so -dA/dt is nonzero -- but
+    # an initial condition is not delayed by alag(), so the derivative wrt the
+    # delay is 0.  Nothing dosed means nothing delayed.
+    m <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); lag <- 2 * exp(eta_lag)
+      alag(central) <- lag
+      cp <- linCmtB(rx__PTR__, t, 1, 1, 0, -1, -1, 1, cl, v, 0, 0, 0, 0, 0)
+      dcp <- lag * linCmtB(rx__PTR__, t, 1, 1, 0, -3, -3, 1, cl, v, 0, 0, 0, 0, 0)
+    })
+    e <- et(seq(0.1, 12, 0.5))
+    s <- rxSolve(m, e, params = .p, inits = c(central = 100))
+    expect_true(max(abs(s$cp)) > 1e-3)   # the amounts really do decay
+    expect_equal(s$dcp, rep(0, nrow(s)))
+    expect_equal(.fdCol(m, e, "cp", inits = c(central = 100)), rep(0, nrow(s)),
+                 tolerance = 1e-8)
+  })
+
   test_that("linCmtB(-3) refuses a regimen mixing lagged and unlagged doses", {
     # A lagged depot plus an unlagged bolus into central is out of scope for
     # which1 = -3 (an unlagged dose is a lag of 0, still a different delay).
@@ -291,17 +314,35 @@ rxTest({
     # ones an individual doses is DATA, so this can only be caught while
     # solving -- report NA rather than the single-delay answer, which is
     # biased by the undelayed dose's contribution (nlmixr2/rxode2#1237).
-    m <- rxode2({
-      cl <- exp(tcl); v <- exp(tv); ka <- exp(tka); lag <- 2 * exp(eta_lag)
-      alag(depot) <- lag
-      cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
-      dcp <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -3, -3, 1, cl, v, 0, 0, 0, 0, ka)
-    })
+    .ms <- list(
+      # numLin = 2 (depot, central): lagged bit 0, dosed bits 0 and 1
+      "1cmt oral" = rxode2({
+        cl <- exp(tcl); v <- exp(tv); ka <- exp(tka); lag <- 2 * exp(eta_lag)
+        alag(depot) <- lag
+        cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+        dcp <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -3, -3, 1, cl, v, 0, 0, 0, 0, ka)
+      }),
+      # numLin = 3 (depot, central, peripheral1): the same bits, one block wider
+      "2cmt oral" = rxode2({
+        cl <- exp(tcl); v <- exp(tv); ka <- exp(tka); q <- exp(tq); v2 <- exp(tv2)
+        lag <- 2 * exp(eta_lag)
+        alag(depot) <- lag
+        cp <- linCmtB(rx__PTR__, t, 3, 2, 1, -1, -1, 1, cl, v, q, v2, 0, 0, ka)
+        dcp <- lag * linCmtB(rx__PTR__, t, 3, 2, 1, -3, -3, 1, cl, v, q, v2, 0, 0, ka)
+      })
+    )
     e <- et(amt = 100, cmt = "depot") |> et(amt = 50, cmt = "central", time = 0) |>
       et(seq(0.1, 24, 0.25))
-    s <- rxSolve(m, e, params = .p)
-    expect_true(all(is.na(s$dcp)))
-    expect_false(any(is.na(s$cp)))   # the model itself still solves
+    for (.nm in names(.ms)) {
+      s <- rxSolve(.ms[[.nm]], e, params = .p)
+      expect_true(all(is.na(s$dcp)), info = .nm)
+      expect_false(any(is.na(s$cp)), info = .nm)   # the model itself still solves
+      # and the lagged-only regimen of the same model is still exact
+      eL <- et(amt = 100, cmt = "depot") |> et(seq(0.1, 24, 0.25))
+      sL <- rxSolve(.ms[[.nm]], eL, params = .p)
+      expect_false(any(is.na(sL$dcp)), info = .nm)
+      expect_equal(sL$dcp, .fdCol(.ms[[.nm]], eL, "cp"), tolerance = 1e-5, info = .nm)
+    }
   })
 
   test_that("linCmtB(-3) ignores doses into a mixed model's ODE compartments", {

--- a/tests/testthat/test-lincmt-dose-time-sens.R
+++ b/tests/testthat/test-lincmt-dose-time-sens.R
@@ -345,6 +345,52 @@ rxTest({
     }
   })
 
+  test_that("linCmtB(-3) is not refused by a zero bolus into an unlagged compartment", {
+    # A plain `amt = 0` dose puts nothing into the compartment, so it cannot
+    # break the shared-delay assumption: refusing the regimen over it would
+    # cost a gradient that is perfectly answerable.
+    m <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); ka <- exp(tka); lag <- 2 * exp(eta_lag)
+      alag(depot) <- lag
+      cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+      dcp <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -3, -3, 1, cl, v, 0, 0, 0, 0, ka)
+    })
+    e <- et(amt = 100, cmt = "depot") |> et(amt = 0, cmt = "central", time = 0) |>
+      et(seq(0.1, 24, 0.25))
+    s <- rxSolve(m, e, params = .p)
+    expect_false(any(is.na(s$dcp)))
+    expect_equal(s$dcp, .fdCol(m, e, "cp"), tolerance = 1e-5)
+  })
+
+  test_that("linCmtB(-3) accepts dosing a subset of the lagged compartments", {
+    # Both linCmt() compartments carry the SAME modeled alag(), so every dose
+    # is delayed alike however many of them the regimen actually uses.  Pins
+    # the gate as a SUBSET test (dosed & ~lagged) rather than an equality one:
+    # an equality test would wrongly refuse the depot-only regimen.
+    m <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); ka <- exp(tka); lag <- 2 * exp(eta_lag)
+      alag(depot) <- lag
+      alag(central) <- lag
+      cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+      dcp <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -3, -3, 1, cl, v, 0, 0, 0, 0, ka)
+    })
+    .es <- list(
+      "depot only (subset of the lagged set)" =
+        et(amt = 100, cmt = "depot") |> et(seq(0.1, 24, 0.25)),
+      "central only (subset of the lagged set)" =
+        et(amt = 100, cmt = "central") |> et(seq(0.1, 24, 0.25)),
+      "both lagged compartments" =
+        et(amt = 100, cmt = "depot") |> et(amt = 50, cmt = "central", time = 0) |>
+          et(seq(0.1, 24, 0.25))
+    )
+    for (.nm in names(.es)) {
+      s <- rxSolve(m, .es[[.nm]], params = .p)
+      expect_false(any(is.na(s$dcp)), info = .nm)
+      expect_true(max(abs(s$dcp)) > 1e-3, info = .nm)
+      expect_equal(s$dcp, .fdCol(m, .es[[.nm]], "cp"), tolerance = 1e-5, info = .nm)
+    }
+  })
+
   test_that("linCmtB(-3) ignores doses into a mixed model's ODE compartments", {
     # Only doses reaching the LINEAR system can violate the shared-delay
     # assumption; an ODE compartment of a mixed model is not part of it, so

--- a/tests/testthat/test-serialize.R
+++ b/tests/testthat/test-serialize.R
@@ -310,5 +310,32 @@ rxTest({
                                   rxControl(method = "indLin"))),
         as.data.frame(indLinRef))
     })
+
+    # op->linCmtLagMask (which linCmt() compartments carry a modeled alag()) is
+    # only computed on a full setup, so the C-state replay has to carry it in
+    # the stream: without it linCmtB(which1 = -3) reads a zero mask and falls
+    # back to answering a regimen it should refuse (nlmixr2/rxode2#1119).
+    lagMod <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); ka <- exp(tka); lag <- 2 * exp(eta_lag)
+      alag(depot) <- lag
+      cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+      dcp <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -3, -3, 1, cl, v, 0, 0, 0, 0, ka)
+    })
+    lagTheta <- c(tcl = log(4), tv = log(20), tka = log(1.1), eta_lag = 0.1)
+    # doses BOTH the lagged depot and the unlagged central -- a mixed-delay
+    # regimen, which must be refused (NA) on the replay just as on the solve
+    lagEv <- et(amt = 100, cmt = "depot") |>
+      et(amt = 50, cmt = "central", time = 0) |> et(seq(0.1, 24, 0.5))
+    lagRef <- rxSolve(lagMod, lagTheta, lagEv)
+    lagFile <- tempfile(fileext = ".rxbin")
+    rxSolve(lagMod, lagTheta, lagEv, serializeFile = lagFile)
+
+    test_that("C-state replay keeps the linCmt() modeled-alag mask", {
+      expect_true(all(is.na(lagRef$dcp)))   # the behavior being preserved
+      expect_equal(
+        as.data.frame(cStateSolve(lagMod, .rxReadStateBundle(lagFile),
+                                  params = lagTheta)),
+        as.data.frame(lagRef))
+    })
   })
 })


### PR DESCRIPTION
Closes the last silently-wrong path left by #1119 / #1235: `linCmtB(which1 = -3)`,
the dose-time (moving boundary) sensitivity a modeled `alag()` on a `linCmt()`
compartment needs.

## The bug

`which1 = -3` is exact because a linear system whose WHOLE input is delayed by
`L` satisfies `A(t; L) = A(t - L; 0)`, so `dA/dL = -dA/dt`. That needs every
dose feeding the linear system to carry the same delay.

Whether the MODEL lags its `linCmt()` compartments differently is checked when
the model is built (`.rxLinCmtDoseTimeSensCheck()`), but whether an
individual's REGIMEN delays every dose is data, and nothing checked it. A
lagged depot plus an unlagged bolus into central returned the single-delay
answer, biased by the undelayed dose's contribution -- measured **1.05 against
a true 0**, with no warning. nlmixr2est's `R/foceiLinCmtAlagSens.R` (the #920
consumer) documents this as its one silent failure mode, and notes it matters
most for a paired IV/oral design, which is exactly how a modeled `alag()`/`f()`
is usually estimated.

Two smaller cases of the same thing: an individual dosing only unlagged
compartments, and one with no `linCmt()` dose at all whose compartments were
started from an `inits=` initial condition. Both have a true derivative of 0;
both got a nonzero `-dA/dt`.

## The fix

Decide it from the regimen, while solving.

* `op->linCmtLagMask` (new `rx_solving_options` field) records which
  `linCmt()`-block compartments carry a modeled `alag()`, computed at solve
  setup from the model's `stateProp` alongside `numLin`/`linOffset` so the
  three cannot disagree. Also serialized (`rxSerialize.cpp`, format 6).
* `linCmtDoseScan()` -- one pass over `ind->idose`, replacing the pass
  `linCmtHasSsInfusion()` already made -- returns which `linCmt()` compartments
  this individual doses, plus the steady-state-infusion flag.
* `linCmtBdoseTime()` compares them:

| regimen | before | now |
| --- | --- | --- |
| every dosed compartment lagged | exact | exact (unchanged) |
| no dosed compartment lagged | biased `-dA/dt` | **exactly 0** |
| no `linCmt()` dose at all (`inits=` only) | biased `-dA/dt` | **exactly 0** |
| lagged and unlagged doses mixed | **silently biased** | `NA` |

A model declaring no modeled `alag()` on any `linCmt()` compartment keeps the
previous behavior: with nothing to compare against, the caller is applying the
delay to every dose itself. Doses into a mixed model's ODE compartments are
outside the block and ignored -- including a steady-state infusion there, which
used to cost the `linCmt()` compartments an answer that was exact -- and so is
a plain `amt = 0` bolus, which contributes nothing and must not refuse a
regimen. Only that shape is skipped: a zero `amt` on a rate/duration record is
an infinite infusion, and on a replace/multiply record it zeroes the
compartment at a time no `alag()` shifts; both genuinely dose.

The IV arm of a paired IV/oral design now gets its exact 0 instead of a wrong
gradient, and only an individual mixing both routes in one regimen is refused.

## Verification

Every case is checked against a central finite difference of the concentration.
The mixed-route reproducer goes from 1.05 (true 0) to `NA`; the previously
exact cases -- 1/2/3 compartment, IV/oral, bolus/multiple/steady-state
bolus/infusion, and `linCmt()` mixed with ODE compartments -- still match to
~1e-9. Tests in `tests/testthat/test-lincmt-dose-time-sens.R` (56 -> 78
assertions) cover the zero answer, the refusal, the zero bolus, the
replace/multiply and zero-rate records, a two-lagged-compartment model dosed
three ways (so the gate is pinned as a subset test, not an equality test), a 2
compartment oral model (a wider `linCmt()` block), a mixed model dosing its ODE
compartment, and a steady-state infusion into that ODE compartment.
`test-serialize.R` replays a mixed-delay `linCmt()` regimen through the C-state
restore -- which is what would have silently answered instead of refusing had
the mask not survived.

## Review

Seven rounds of independent review (Antigravity / `gemini-3.1-pro-high`), the
last clean. Four findings reproduced and are fixed:

* the `inits=`-only case above (round 1);
* a plain `amt = 0` bolus into an unlagged compartment refusing a regimen it
  contributes nothing to (round 2);
* a **serialization framing error** (round 4) -- `rxSerialize.cpp` writes
  `rx_solving_options` field by field and guards only on
  `sizeof(rx_solving_options)`, which did NOT change: the new `int` landed in
  tail padding the struct's 8 byte alignment already had (measured, 1488 bytes
  either way). A format 5 stream would have had every field after the new one
  shifted. The field is now read only when `fmt >= 6`, and
  `rxSolveFromRaw_()` recomputes the mask from the model, which fixes older
  streams too;
* a steady-state infusion into a mixed model's ODE compartment refusing the
  `linCmt()` compartments' (exact) sensitivity (round 4).

Round 6 also pointed out that the recompute read the model variables AFTER the
state restore, and `rxModelVars_()` can run R; that read now happens up front,
matching the ordinary `rxSolve_()` order.

Four findings did not reproduce and were rejected with measurements: a lagged
dose coexisting with a nonzero initial condition (raised three times -- a
`linCmt()` model discards its initial conditions as soon as the individual has
any dose); a steady-state zero bolus being counted when it contributes nothing
(it is a reset that wipes the system to zero, and the sensitivity is exact); a
modeled rate/duration record with `amt = 0` (event translation rejects it
before any solve); and dosing a `linCmt()` sensitivity compartment (those
cannot perturb the amounts, which are recomputed from `linCmtSave` every step).
Every test-coverage suggestion was taken.

## Still open (not this PR)

* A steady-state infusion still reports `NA` (its rate at output time is not
  recoverable from the per-idx cache).
* The true PER-COMPARTMENT dose-time sensitivity, which would answer a
  mixed-route regimen instead of refusing it, still needs a jump-seeded
  contribution vector carried through the `linCmt()` linear recompute.
* rxode2 still downgrades a model with a modeled `alag()` on a `linCmt()`
  compartment to `eventSens = "fd"` in `.rxEventSensEffectiveMode()`; flipping
  that is a consumer-coordination decision with nlmixr2est, deliberately not
  taken here.

Refs #1119, #1237. Predecessor: #1235.
