### PR TITLE
fix(#1279): merge repeated param() statements in the normalized model text

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -856,6 +856,25 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
   positions without checking how many arguments were actually given, so a
   short call dereferenced a NULL parse node (#1266).
 
+- A `param()`/`params()` statement, and the interpolation statements
+  (`locf()`, `linear()`, `nocb()`, `midpoint()`), no longer splice the
+  preceding line into their own normalized text.  They build that text by
+  appending to the normalizing buffer and, unlike an assignment, did not
+  reset it when the statement started, so `"y=z*a;param(a,c);"` normalized to
+  `"paramy=z*a(a,c);"` -- text that no longer parses -- whenever such a
+  statement followed an assignment or a `d/dt()` line (#1279).
+
+- Repeated `param()` statements in one model now normalize to the single
+  merged declaration that `rxModelVars()$params` already reports, instead of
+  being kept as separate statements.  A generated model that appends a
+  `param()` statement to an already-built model text (for example to add
+  `DV` to a general-likelihood prediction model) previously left a normalized
+  model whose first `param()` statement did not name every parameter, so
+  code that read or edited that statement silently missed the later
+  declarations.  The merged statement spans the declared parameters and
+  anything that landed between them in the parameter vector, so re-parsing
+  the normalized text gives back the same parameter order (#1279).
+
 ### Compilation
 
 - The per-thread `linCmtB()` object is a tagged struct rather than an anonymous

--- a/NEWS.md
+++ b/NEWS.md
@@ -871,9 +871,17 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
   `DV` to a general-likelihood prediction model) previously left a normalized
   model whose first `param()` statement did not name every parameter, so
   code that read or edited that statement silently missed the later
-  declarations.  The merged statement spans the declared parameters and
-  anything that landed between them in the parameter vector, so re-parsing
-  the normalized text gives back the same parameter order (#1279).
+  declarations.  The merged statement takes the place of the first `param()`
+  statement and spans the parameter vector up to the last declared
+  parameter, so re-parsing the normalized text gives back the same
+  parameter order (#1279).
+
+- A variable that is both declared in `param()` and assigned in the model now
+  gets its interpolation recorded.  Such a dual lhs/parameter takes a slot in
+  the parameter vector like any other parameter, but the slot in the
+  (uninitialized) interpolation vector was never written, so
+  `rxModelVars()$interp` held a garbage code for it and printing it could fail
+  with `malformed factor`.
 
 ### Compilation
 

--- a/src/genModelVars.c
+++ b/src/genModelVars.c
@@ -300,6 +300,10 @@ SEXP generateModelVars(void) {
   SET_STRING_ELT(trann,21,Rf_mkChar("IndF"));
   SET_STRING_ELT(tran, 21,Rf_mkChar(_bufw.s));
 
+  // nlmixr2/rxode2#1279: collapse repeated param() statements into the single
+  // merged declaration the parameter vector already reports.
+  mergeNormParamStatements(params);
+
   SET_STRING_ELT(modeln,0,Rf_mkChar("normModel"));
   SET_STRING_ELT(model,0,Rf_mkChar(sbNrm.s));
 

--- a/src/genModelVars.h
+++ b/src/genModelVars.h
@@ -18,6 +18,7 @@
 #include "tran.h"
 #include "../inst/include/rxode2parseVer.h"
 #include "rxProtect.h"
+#include "parseParamMerge.h"
 
 static inline SEXP calcSLinCmt(void) {
   rxProtectGuard;

--- a/src/genModelVars.h
+++ b/src/genModelVars.h
@@ -620,9 +620,9 @@ static inline int assertStateCannotHaveDiff(int islhs, int i, char *buf) {
   return 0;
 }
 
-static inline int setLhsAndDualLhsParam(int islhs, SEXP lhs, SEXP params, char *buf,
-                                        int *li, int *pi, SEXP lhsStr, int *lhsOrd,
-                                        int *i) {
+static inline int setLhsAndDualLhsParam(int islhs, SEXP lhs, SEXP params, int *interp,
+                                        char *buf, int *li, int *pi, SEXP lhsStr,
+                                        int *lhsOrd, int *i) {
   if (islhs == isLHS || islhs == isLHSstr ||
       islhs == isLhsStateExtra || islhs == isLHSparam) {
     SET_STRING_ELT(lhs, li[0], Rf_mkChar(buf));
@@ -633,6 +633,11 @@ static inline int setLhsAndDualLhsParam(int islhs, SEXP lhs, SEXP params, char *
       if (!strcmp("CMT", buf)) {
         tb.hasCmt = 1;
       }
+      // a dual lhs/parameter takes a slot in the parameter vector like any
+      // other parameter, so its interpolation has to be set here too; the
+      // vector is allocated uninitialized, so skipping it left the factor
+      // holding garbage.
+      interp[pi[0]] = tb.interp[i[0]] + 1;
       SET_STRING_ELT(params, pi[0], Rf_mkChar(buf));
       pi[0] = pi[0]+1;
     }
@@ -694,7 +699,7 @@ static inline void populateParamsLhsSlhs(SEXP params, SEXP lhs, SEXP slhs, int *
     if (assertStateCannotHaveDiff(islhs, i, buf)) continue;
     assertLhsAndDualLhsDiffNotLegal(islhs, i, buf);
     /* is a state var */
-    if (!setLhsAndDualLhsParam(islhs, lhs, params, buf, &li, &pi, lhsStr, lhsOrd, &i)) {
+    if (!setLhsAndDualLhsParam(islhs, lhs, params, interp, buf, &li, &pi, lhsStr, lhsOrd, &i)) {
       paramSubThetaEtaToBufw(buf);
       interp[pi] = tb.interp[i] + 1; // Makes into a legible factor
       SET_STRING_ELT(params, pi++, Rf_mkChar(_bufw.s));

--- a/src/parseParamMerge.h
+++ b/src/parseParamMerge.h
@@ -54,34 +54,35 @@ static inline void mergeNormParamStatements(SEXP params) {
   // text reproduces the same parameter order.  When no declared name survived
   // as a parameter (they all became states) the statements declare nothing and
   // are dropped.
-  sbuf merged;
-  sNull(&merged);
-  sIniTo(&merged, SBUF_MXBUF);
+  //
+  // sbt and sbNrmL2 are scratch globals freed by parseFree(); everything the
+  // model needed from sbt has already been emitted by the time model variables
+  // are generated, and using globals here means an R error raised by addLine()
+  // or sAppend() cannot leak a buffer.
+  sClear(&sbt);
   if (hi >= lo) {
-    sAppendN(&merged, "param(", 6);
+    sAppendN(&sbt, "param(", 6);
     for (int j = lo; j <= hi; j++) {
-      if (j != lo) sAppendN(&merged, ",", 1);
-      sAppend(&merged, "%s", CHAR(STRING_ELT(params, j)));
+      if (j != lo) sAppendN(&sbt, ",", 1);
+      sAppend(&sbt, "%s", CHAR(STRING_ELT(params, j)));
     }
-    sAppendN(&merged, ");\n", 3);
+    sAppendN(&sbt, ");\n", 3);
   }
-  vLines newL;
-  lineNull(&newL);
-  lineIni(&newL);
+  lineIni(&sbNrmL2);
   int seen = 0;
   for (int i = 0; i < sbNrmL.n; i++) {
     const char *cur = sbNrmL.line[i];
     if (rxIsNormParamLine(cur)) {
-      if (seen++ || merged.o == 0) continue;
-      cur = merged.s;
+      if (seen++ || sbt.o == 0) continue;
+      cur = sbt.s;
     }
-    curLineProp(&newL, sbNrmL.lProp[i]);
-    curLineType(&newL, sbNrmL.lType[i]);
-    addLine(&newL, "%s", cur);
+    curLineProp(&sbNrmL2, sbNrmL.lProp[i]);
+    curLineType(&sbNrmL2, sbNrmL.lType[i]);
+    addLine(&sbNrmL2, "%s", cur);
   }
-  sFree(&merged);
-  lineFree(&sbNrmL);
-  sbNrmL = newL;
+  vLines swap = sbNrmL;
+  sbNrmL = sbNrmL2;
+  sbNrmL2 = swap;
   // sbNrm is the concatenation of the normalized lines; rebuild it so the two
   // cannot disagree.
   sClear(&sbNrm);

--- a/src/parseParamMerge.h
+++ b/src/parseParamMerge.h
@@ -40,7 +40,13 @@ static inline void mergeNormParamStatements(SEXP params) {
   for (int i = 0; i < sbNrmL.n; i++) {
     if (rxIsNormParamLine(sbNrmL.line[i])) nParam++;
   }
-  if (nParam < 2) return; // nothing to merge
+  // Nothing to merge.  A lone `param()` statement is left exactly as it is,
+  // even when every name it declares turned out to be a state and it therefore
+  // declares no parameter at all -- normalizing that away is not what #1279 is
+  // about and would change the normalized text of models that were never
+  // broken.  Two such statements are dropped below (`hi` stays -1), so the two
+  // cases do not agree; both still re-parse to the same model.
+  if (nParam < 2) return;
   int np = Rf_length(params);
   int hi = -1;
   for (int i = 0; i < sbNrmL.n; i++) {

--- a/src/parseParamMerge.h
+++ b/src/parseParamMerge.h
@@ -1,0 +1,95 @@
+#ifndef __parseParamMerge_H__
+#define __parseParamMerge_H__
+#pragma once
+
+// nlmixr2/rxode2#1279: a model may carry more than one `param()` statement -- a
+// generated model often appends one when it splices extra parameters into an
+// already-built model text.  The parser merges every declaration into the one
+// parameter vector reported by `rxModelVars()$params`, but the normalized model
+// text kept each statement, so a consumer reading or editing "the" `param()`
+// statement of that text saw only the first one and silently missed the later
+// declarations.  Rewrite the normalized text to a single merged `param()`
+// statement so the text agrees with `$params`.
+
+#define rxIsNormParamLine(l) (!strncmp((l), "param(", 6))
+
+// Mark the parameters named by one normalized `param(a,b);` line, tracking the
+// lowest and highest position they take in the final parameter vector.
+static inline void markNormParamLine(const char *line, SEXP params, int np,
+                                     int *lo, int *hi) {
+  const char *p = line + 6; // past "param("
+  while (*p != '\0' && *p != ')') {
+    const char *start = p;
+    while (*p != '\0' && *p != ')' && *p != ',') p++;
+    size_t n = (size_t)(p - start);
+    if (n > 0) {
+      for (int j = 0; j < np; j++) {
+        const char *cur = CHAR(STRING_ELT(params, j));
+        if (strlen(cur) == n && !strncmp(start, cur, n)) {
+          if (j < *lo) *lo = j;
+          if (j > *hi) *hi = j;
+          break;
+        }
+      }
+    }
+    if (*p == ',') p++;
+  }
+}
+
+static inline void mergeNormParamStatements(SEXP params) {
+  int nParam = 0;
+  for (int i = 0; i < sbNrmL.n; i++) {
+    if (rxIsNormParamLine(sbNrmL.line[i])) nParam++;
+  }
+  if (nParam < 2) return; // nothing to merge
+  int np = Rf_length(params);
+  int lo = np, hi = -1;
+  for (int i = 0; i < sbNrmL.n; i++) {
+    if (rxIsNormParamLine(sbNrmL.line[i])) {
+      markNormParamLine(sbNrmL.line[i], params, np, &lo, &hi);
+    }
+  }
+  // The merged statement spans the declared parameters plus anything that
+  // landed between them in the parameter vector, so re-parsing the normalized
+  // text reproduces the same parameter order.  When no declared name survived
+  // as a parameter (they all became states) the statements declare nothing and
+  // are dropped.
+  sbuf merged;
+  sNull(&merged);
+  sIniTo(&merged, SBUF_MXBUF);
+  if (hi >= lo) {
+    sAppendN(&merged, "param(", 6);
+    for (int j = lo; j <= hi; j++) {
+      if (j != lo) sAppendN(&merged, ",", 1);
+      sAppend(&merged, "%s", CHAR(STRING_ELT(params, j)));
+    }
+    sAppendN(&merged, ");\n", 3);
+  }
+  vLines newL;
+  lineNull(&newL);
+  lineIni(&newL);
+  int seen = 0;
+  for (int i = 0; i < sbNrmL.n; i++) {
+    const char *cur = sbNrmL.line[i];
+    if (rxIsNormParamLine(cur)) {
+      if (seen++ || merged.o == 0) continue;
+      cur = merged.s;
+    }
+    curLineProp(&newL, sbNrmL.lProp[i]);
+    curLineType(&newL, sbNrmL.lType[i]);
+    addLine(&newL, "%s", cur);
+  }
+  sFree(&merged);
+  lineFree(&sbNrmL);
+  sbNrmL = newL;
+  // sbNrm is the concatenation of the normalized lines; rebuild it so the two
+  // cannot disagree.
+  sClear(&sbNrm);
+  for (int i = 0; i < sbNrmL.n; i++) {
+    sAppend(&sbNrm, "%s", sbNrmL.line[i]);
+  }
+}
+
+#undef rxIsNormParamLine
+
+#endif // __parseParamMerge_H__

--- a/src/parseParamMerge.h
+++ b/src/parseParamMerge.h
@@ -14,9 +14,9 @@
 #define rxIsNormParamLine(l) (!strncmp((l), "param(", 6))
 
 // Mark the parameters named by one normalized `param(a,b);` line, tracking the
-// lowest and highest position they take in the final parameter vector.
+// highest position any of them takes in the final parameter vector.
 static inline void markNormParamLine(const char *line, SEXP params, int np,
-                                     int *lo, int *hi) {
+                                     int *hi) {
   const char *p = line + 6; // past "param("
   while (*p != '\0' && *p != ')') {
     const char *start = p;
@@ -26,7 +26,6 @@ static inline void markNormParamLine(const char *line, SEXP params, int np,
       for (int j = 0; j < np; j++) {
         const char *cur = CHAR(STRING_ELT(params, j));
         if (strlen(cur) == n && !strncmp(start, cur, n)) {
-          if (j < *lo) *lo = j;
           if (j > *hi) *hi = j;
           break;
         }
@@ -43,27 +42,33 @@ static inline void mergeNormParamStatements(SEXP params) {
   }
   if (nParam < 2) return; // nothing to merge
   int np = Rf_length(params);
-  int lo = np, hi = -1;
+  int hi = -1;
   for (int i = 0; i < sbNrmL.n; i++) {
     if (rxIsNormParamLine(sbNrmL.line[i])) {
-      markNormParamLine(sbNrmL.line[i], params, np, &lo, &hi);
+      markNormParamLine(sbNrmL.line[i], params, np, &hi);
     }
   }
-  // The merged statement spans the declared parameters plus anything that
-  // landed between them in the parameter vector, so re-parsing the normalized
-  // text reproduces the same parameter order.  When no declared name survived
-  // as a parameter (they all became states) the statements declare nothing and
-  // are dropped.
+  // The merged statement takes the place of the first `param()` statement and
+  // spans the whole parameter vector up to the last declared parameter, not
+  // just the declared names.  Everything registered before that first statement
+  // is a prefix of the parameter vector, and any declared name that survived as
+  // a parameter is registered at or after it, so declaring `params[0..hi]`
+  // there re-registers exactly the names the earlier lines already introduced,
+  // in the same order, and re-parsing the normalized text gives back the same
+  // parameter vector.  Spanning only the declared names would not: with
+  // "param(b);y=c;param(d);d/dt(b)=-b;" `b` becomes a state and the merged
+  // statement would move `d` ahead of `c`.  When no declared name survived as a
+  // parameter the statements declare nothing and are dropped.
   //
   // sbt and sbNrmL2 are scratch globals freed by parseFree(); everything the
   // model needed from sbt has already been emitted by the time model variables
   // are generated, and using globals here means an R error raised by addLine()
   // or sAppend() cannot leak a buffer.
   sClear(&sbt);
-  if (hi >= lo) {
+  if (hi >= 0) {
     sAppendN(&sbt, "param(", 6);
-    for (int j = lo; j <= hi; j++) {
-      if (j != lo) sAppendN(&sbt, ",", 1);
+    for (int j = 0; j <= hi; j++) {
+      if (j != 0) sAppendN(&sbt, ",", 1);
       sAppend(&sbt, "%s", CHAR(STRING_ELT(params, j)));
     }
     sAppendN(&sbt, ");\n", 3);

--- a/src/tran.c
+++ b/src/tran.c
@@ -231,6 +231,16 @@ void wprint_parsetree(D_ParserTables pt, D_ParseNode *pn, int depth, print_node_
   if (handleLevelStr(ni, name, value)) return;
   if (nch != 0) {
     int isWhile=0;
+    // param()/params() and the interpolation statements (locf()/linear()/
+    // nocb()/midpoint()) build their normalized text by appending to sbt and
+    // read it back in finalizeLineParam()/finalizeLineInterp().  Unlike an
+    // assignment, neither resets sbt when the statement starts, so following an
+    // assignment they spliced that line's text into their own -- e.g.
+    // "y=z*a;param(a,c);" normalized to "paramy=z*a(a,c);", which no longer
+    // parses (nlmixr2/rxode2#1279).
+    if (nodeHas(param_statement) || nodeHas(interp_statement)) {
+      sClear(&sb); sClear(&sbDt); sClear(&sbt);
+    }
     if (nodeHas(power_expression)) {
       aAppendN("Rx_pow(", 7);
     } else if (nodeHas(mod_expression)) {

--- a/src/tran.c
+++ b/src/tran.c
@@ -95,6 +95,7 @@ sbuf firstErr;
 int firstErrD=0;
 
 vLines sbPm, sbPmDt, sbNrmL;
+vLines sbNrmL2;
 vLines sbDoseArgVar, sbDoseArgCtx;
 sbuf sbNrm;
 sbuf sbExtra;
@@ -298,6 +299,7 @@ void parseFree(int last) {
   lineFree(&sbPm);
   lineFree(&sbPmDt);
   lineFree(&sbNrmL);
+  lineFree(&sbNrmL2);
   lineFree(&sbDoseArgVar);
   lineFree(&sbDoseArgCtx);
   lineFree(&(tb.ss));
@@ -889,6 +891,7 @@ void transIniNull(void) {
   lineNull(&(sbPm));
   lineNull(&(sbPmDt));
   lineNull(&(sbNrmL));
+  lineNull(&(sbNrmL2));
   lineNull(&(sbDoseArgVar));
   lineNull(&(sbDoseArgCtx));
   lineNull(&(depotLines));

--- a/src/tran.h
+++ b/src/tran.h
@@ -230,6 +230,8 @@ static inline int parse_micro_constant(const char *name, char *cmt1, char *cmt2)
 extern vLines depotLines;
 extern vLines centralLines;
 extern vLines sbPm, sbPmDt, sbNrmL;
+// scratch line buffer used to rewrite sbNrmL (see mergeNormParamStatements)
+extern vLines sbNrmL2;
 // Identifiers seen inside an adaptive dosing argument, and a description of
 // where each came from.  Checked once the whole model has been parsed, since
 // the variable may be assigned further down (see #1231).

--- a/tests/testthat/test-param-order.R
+++ b/tests/testthat/test-param-order.R
@@ -50,4 +50,53 @@ dvid(5, 6)"), NA)
       "CMT"
     ))
   })
+  # nlmixr2/rxode2#1279
+  test_that("param()/interp statements do not splice in the prior line", {
+    .m <- rxModelVars("d/dt(x)=-a*x;\nparam(a,b);\ny=x*b;\n")
+    expect_equal(rxNorm(.m), "d/dt(x)=-a*x;\nparam(a,b);\ny=x*b;\n")
+    expect_equal(.m$params, c("a", "b"))
+    # the normalized text has to parse back to the same model
+    expect_equal(rxModelVars(rxNorm(.m))$params, .m$params)
+
+    .i <- rxModelVars("y=z*a;\nlocf(z);\n")
+    expect_equal(rxNorm(.i), "y=z*a;\nlocf(z);\n")
+    expect_equal(rxModelVars(rxNorm(.i))$params, .i$params)
+  })
+
+  test_that("repeated param() statements merge into one", {
+    .two <- rxModelVars(paste0("param(THETA[1],THETA[2],ETA[1]);\ncmt(centr);\n",
+                               "param(THETA[1],THETA[2],ETA[1],DV);\n",
+                               "d/dt(centr)=-exp(THETA[1]+ETA[1])*centr;\n",
+                               "rx_pred_=llikNorm(DV,centr,exp(THETA[2]));\nrx_r_=0;\n"))
+    .one <- rxModelVars(paste0("param(THETA[1],THETA[2],ETA[1],DV);\ncmt(centr);\n",
+                               "d/dt(centr)=-exp(THETA[1]+ETA[1])*centr;\n",
+                               "rx_pred_=llikNorm(DV,centr,exp(THETA[2]));\nrx_r_=0;\n"))
+    expect_equal(.two$params, c("THETA[1]", "THETA[2]", "ETA[1]", "DV"))
+    expect_equal(.two$params, .one$params)
+    # a single param() statement in the normalized model, matching $params
+    expect_equal(sum(grepl("^param\\(", strsplit(rxNorm(.two), "\n")[[1]])), 1L)
+    expect_equal(rxNorm(.two), rxNorm(.one))
+
+    # a parameter introduced by use between the two statements keeps its place
+    .mid <- rxModelVars("param(a);\ny=z*a;\nparam(a,c);\nw=c;\n")
+    expect_equal(.mid$params, c("a", "z", "c"))
+    expect_equal(rxNorm(.mid), "param(a,z,c);\ny=z*a;\nw=c;\n")
+    expect_equal(rxModelVars(rxNorm(.mid))$params, .mid$params)
+
+    # every declared name became a state, so nothing is left to declare
+    expect_equal(rxNorm(rxModelVars("param(a);\nparam(a);\nd/dt(a)=-a;\n")),
+                 "d/dt(a)=-a;\n")
+
+    # a single param() statement is left alone
+    expect_equal(rxNorm(rxModelVars("param(a,b);\nd/dt(x)=-a*x*b;\n")),
+                 "param(a,b);\nd/dt(x)=-a*x*b;\n")
+  })
+
+  test_that("a parameter declared by a later param() is filled at solve time", {
+    .m <- rxode2("param(a,b);\ncmt(centr);\nparam(a,b,DV);\nd/dt(centr)=-a*centr;\ny=centr*b+DV;\n")
+    .d <- as.data.frame(et(et(amt = 100, cmt = "centr"), 1:3))
+    .d$DV <- 7
+    .s <- rxSolve(.m, .d, params = c(a = 0.1, b = 1))
+    expect_equal(.s$y, .s$centr + 7)
+  })
 })

--- a/tests/testthat/test-param-order.R
+++ b/tests/testthat/test-param-order.R
@@ -99,6 +99,13 @@ dvid(5, 6)"), NA)
     expect_equal(rxNorm(.st), "param(c,d);\ny=c;\nd/dt(b)=-b;\n")
     expect_equal(rxModelVars(rxNorm(.st))$params, .st$params)
 
+    # every declared name became a state, but the model still has an implicit
+    # parameter: the statements go, the parameter stays
+    .dropAll <- rxModelVars("param(a);\nd/dt(a)=-a;\ny=c;\nparam(b);\nd/dt(b)=-b;\n")
+    expect_equal(.dropAll$params, "c")
+    expect_equal(rxNorm(.dropAll), "d/dt(a)=-a;\ny=c;\nd/dt(b)=-b;\n")
+    expect_equal(rxModelVars(rxNorm(.dropAll))$params, .dropAll$params)
+
     # every declared name became a state, so nothing is left to declare
     expect_equal(rxNorm(rxModelVars("param(a);\nparam(a);\nd/dt(a)=-a;\n")),
                  "d/dt(a)=-a;\n")

--- a/tests/testthat/test-param-order.R
+++ b/tests/testthat/test-param-order.R
@@ -131,6 +131,24 @@ dvid(5, 6)"), NA)
     expect_equal(rxModelVars(rxNorm(.dual))$params, .dual$params)
     expect_equal(unclass(rxModelVars(rxNorm(.dual))$interp), unclass(.dual$interp))
 
+    # the `params()` spelling merges the same way
+    .alias <- rxModelVars("params(a, b);\nparams(c, d);\ny=a*b*c*d;\n")
+    expect_equal(.alias$params, c("a", "b", "c", "d"))
+    expect_equal(rxNorm(.alias), "param(a,b,c,d);\ny=a*b*c*d;\n")
+    expect_equal(rxModelVars(rxNorm(.alias))$params, .alias$params)
+
+    # the first statement declares nothing but states, the second survives
+    .st2 <- rxModelVars("param(a,b);\nd/dt(a)=-a;\nd/dt(b)=-b;\nparam(c);\ny=c;\n")
+    expect_equal(.st2$params, "c")
+    expect_equal(rxNorm(.st2), "param(c);\nd/dt(a)=-a;\nd/dt(b)=-b;\ny=c;\n")
+    expect_equal(rxModelVars(rxNorm(.st2))$params, .st2$params)
+
+    # an interpolation statement sitting between the two is kept in place
+    .int2 <- rxModelVars("param(a);\nlocf(b);\nparam(b);\ny=a*b;\n")
+    expect_equal(.int2$params, c("a", "b"))
+    expect_equal(rxNorm(.int2), "param(a,b);\nlocf(b);\ny=a*b;\n")
+    expect_equal(unclass(rxModelVars(rxNorm(.int2))$interp), unclass(.int2$interp))
+
     # a single param() statement is left alone
     expect_equal(rxNorm(rxModelVars("param(a,b);\nd/dt(x)=-a*x*b;\n")),
                  "param(a,b);\nd/dt(x)=-a*x*b;\n")

--- a/tests/testthat/test-param-order.R
+++ b/tests/testthat/test-param-order.R
@@ -118,6 +118,19 @@ dvid(5, 6)"), NA)
     expect_equal(rxModelVars(rxNorm(.lvl))$strCmpParams, .lvl$strCmpParams)
     expect_equal(rxModelVars(rxNorm(.lvl))$interp, .lvl$interp)
 
+    # a parameter introduced only after the last statement keeps its place
+    .post <- rxModelVars("param(a);\nparam(b);\ny=c;\n")
+    expect_equal(.post$params, c("a", "b", "c"))
+    expect_equal(rxNorm(.post), "param(a,b);\ny=c;\n")
+    expect_equal(rxModelVars(rxNorm(.post))$params, .post$params)
+
+    # a dual lhs/parameter assigned before the first statement is merged in
+    .dual <- rxModelVars("param(q);\ny=1;\nparam(y,a);\n")
+    expect_equal(.dual$params, c("q", "y", "a"))
+    expect_equal(rxNorm(.dual), "param(q,y,a);\ny=1;\n")
+    expect_equal(rxModelVars(rxNorm(.dual))$params, .dual$params)
+    expect_equal(unclass(rxModelVars(rxNorm(.dual))$interp), unclass(.dual$interp))
+
     # a single param() statement is left alone
     expect_equal(rxNorm(rxModelVars("param(a,b);\nd/dt(x)=-a*x*b;\n")),
                  "param(a,b);\nd/dt(x)=-a*x*b;\n")

--- a/tests/testthat/test-param-order.R
+++ b/tests/testthat/test-param-order.R
@@ -58,9 +58,12 @@ dvid(5, 6)"), NA)
     # the normalized text has to parse back to the same model
     expect_equal(rxModelVars(rxNorm(.m))$params, .m$params)
 
-    .i <- rxModelVars("y=z*a;\nlocf(z);\n")
-    expect_equal(rxNorm(.i), "y=z*a;\nlocf(z);\n")
-    expect_equal(rxModelVars(rxNorm(.i))$params, .i$params)
+    for (.f in c("locf", "linear", "nocb", "midpoint")) {
+      .txt <- paste0("y=z*a;\n", .f, "(z);\n")
+      .i <- rxModelVars(.txt)
+      expect_equal(rxNorm(.i), .txt)
+      expect_equal(rxModelVars(rxNorm(.i))$params, .i$params)
+    }
   })
 
   test_that("repeated param() statements merge into one", {
@@ -77,6 +80,12 @@ dvid(5, 6)"), NA)
     expect_equal(sum(grepl("^param\\(", strsplit(rxNorm(.two), "\n")[[1]])), 1L)
     expect_equal(rxNorm(.two), rxNorm(.one))
 
+    # a parameter introduced by use before the first statement keeps its place
+    .pre <- rxModelVars("y=z*a;\nparam(a,b);\nparam(a,b,c);\nw=b*c;\n")
+    expect_equal(.pre$params, c("z", "a", "b", "c"))
+    expect_equal(rxNorm(.pre), "y=z*a;\nparam(a,b,c);\nw=b*c;\n")
+    expect_equal(rxModelVars(rxNorm(.pre))$params, .pre$params)
+
     # a parameter introduced by use between the two statements keeps its place
     .mid <- rxModelVars("param(a);\ny=z*a;\nparam(a,c);\nw=c;\n")
     expect_equal(.mid$params, c("a", "z", "c"))
@@ -86,6 +95,21 @@ dvid(5, 6)"), NA)
     # every declared name became a state, so nothing is left to declare
     expect_equal(rxNorm(rxModelVars("param(a);\nparam(a);\nd/dt(a)=-a;\n")),
                  "d/dt(a)=-a;\n")
+
+    # an interpolation set on a parameter pulled into the merged statement stays
+    .int <- rxModelVars("param(a);\nlocf(z);\ny=z*a;\nparam(a,c);\nw=c;\n")
+    expect_equal(.int$params, c("a", "z", "c"))
+    expect_equal(rxNorm(.int), "param(a,z,c);\nlocf(z);\ny=z*a;\nw=c;\n")
+    expect_equal(rxModelVars(rxNorm(.int))$interp, .int$interp)
+    expect_equal(as.character(.int$interp[["z"]]), "locf")
+
+    # a string covariate pulled into the merged statement keeps its levels
+    .lvl <- rxModelVars(paste0("param(a);\nif (SEX == \"male\") {\n b <- 1\n} else {\n b <- 2\n}\n",
+                               "param(a,c);\ny=a*b*c;\n"))
+    expect_true("SEX" %in% .lvl$params)
+    expect_equal(rxModelVars(rxNorm(.lvl))$params, .lvl$params)
+    expect_equal(rxModelVars(rxNorm(.lvl))$strCmpParams, .lvl$strCmpParams)
+    expect_equal(rxModelVars(rxNorm(.lvl))$interp, .lvl$interp)
 
     # a single param() statement is left alone
     expect_equal(rxNorm(rxModelVars("param(a,b);\nd/dt(x)=-a*x*b;\n")),

--- a/tests/testthat/test-param-order.R
+++ b/tests/testthat/test-param-order.R
@@ -156,9 +156,14 @@ dvid(5, 6)"), NA)
     expect_equal(rxNorm(.int2), "param(a,b);\nlocf(b);\ny=a*b;\n")
     expect_equal(unclass(rxModelVars(rxNorm(.int2))$interp), unclass(.int2$interp))
 
-    # a single param() statement is left alone
+    # a single param() statement is left alone, even when every name it
+    # declares became a state and it declares no parameter at all
     expect_equal(rxNorm(rxModelVars("param(a,b);\nd/dt(x)=-a*x*b;\n")),
                  "param(a,b);\nd/dt(x)=-a*x*b;\n")
+    .lone <- rxModelVars("param(a);\nd/dt(a)=-a;\n")
+    expect_length(.lone$params, 0)
+    expect_equal(rxNorm(.lone), "param(a);\nd/dt(a)=-a;\n")
+    expect_equal(rxModelVars(rxNorm(.lone))$params, .lone$params)
   })
 
   test_that("a dual lhs/parameter gets its interpolation set", {

--- a/tests/testthat/test-param-order.R
+++ b/tests/testthat/test-param-order.R
@@ -83,7 +83,7 @@ dvid(5, 6)"), NA)
     # a parameter introduced by use before the first statement keeps its place
     .pre <- rxModelVars("y=z*a;\nparam(a,b);\nparam(a,b,c);\nw=b*c;\n")
     expect_equal(.pre$params, c("z", "a", "b", "c"))
-    expect_equal(rxNorm(.pre), "y=z*a;\nparam(a,b,c);\nw=b*c;\n")
+    expect_equal(rxNorm(.pre), "y=z*a;\nparam(z,a,b,c);\nw=b*c;\n")
     expect_equal(rxModelVars(rxNorm(.pre))$params, .pre$params)
 
     # a parameter introduced by use between the two statements keeps its place
@@ -91,6 +91,13 @@ dvid(5, 6)"), NA)
     expect_equal(.mid$params, c("a", "z", "c"))
     expect_equal(rxNorm(.mid), "param(a,z,c);\ny=z*a;\nw=c;\n")
     expect_equal(rxModelVars(rxNorm(.mid))$params, .mid$params)
+
+    # the first statement declares only names that became states, so the merged
+    # statement must still keep the parameters introduced ahead of it in place
+    .st <- rxModelVars("param(b);\ny=c;\nparam(d);\nd/dt(b)=-b;\n")
+    expect_equal(.st$params, c("c", "d"))
+    expect_equal(rxNorm(.st), "param(c,d);\ny=c;\nd/dt(b)=-b;\n")
+    expect_equal(rxModelVars(rxNorm(.st))$params, .st$params)
 
     # every declared name became a state, so nothing is left to declare
     expect_equal(rxNorm(rxModelVars("param(a);\nparam(a);\nd/dt(a)=-a;\n")),
@@ -114,6 +121,16 @@ dvid(5, 6)"), NA)
     # a single param() statement is left alone
     expect_equal(rxNorm(rxModelVars("param(a,b);\nd/dt(x)=-a*x*b;\n")),
                  "param(a,b);\nd/dt(x)=-a*x*b;\n")
+  })
+
+  test_that("a dual lhs/parameter gets its interpolation set", {
+    # `a` is declared by param() and assigned, so it is both an lhs and a
+    # parameter; the interp vector is allocated uninitialized, so the slot has
+    # to be written on that path too
+    .m <- rxModelVars("param(a,n);\nlocf(n);\na=a+1;\ny=a*n;\n")
+    expect_equal(.m$params, c("a", "n"))
+    expect_equal(as.character(.m$interp), c("default", "locf"))
+    expect_equal(unclass(rxModelVars(rxNorm(.m))$interp), unclass(.m$interp))
   })
 
   test_that("a parameter declared by a later param() is filled at solve time", {


### PR DESCRIPTION
Fixes #1279.

## What was actually wrong

The issue reports that a second `param()` statement is silently ignored.  Chasing
it down, the *compiled* side turns out to be fine: for the model in the issue the
generated C puts `DV` at `_PP[7]` and `_update_par_ptr()` fills it from the data
like any other covariate, and a solve confirms it.  What is broken is the
**normalized model text** -- `rxNorm()` / `rxModelVars()$model[["normModel"]]` --
which is what downstream code reads, edits and re-parses.  Two separate defects:

1. **`param()`/`locf()`/`linear()`/`nocb()`/`midpoint()` spliced the previous
   line into their own normalized text.**  `finalizeLineParam()` /
   `finalizeLineInterp()` do `sbt.o = 0` and *then* format `sbt.s` -- setting the
   offset to 0 does not terminate the buffer -- and, unlike an assignment,
   neither statement resets the buffer when it *starts*.  So after an assignment:

   ```
   "d/dt(x)=-a*x;param(a,b,DV);"  ->  "paramd/dt(x)=-a*x(a,b,DV);"
   ```

   which no longer parses.  Fixed by clearing `sb`/`sbDt`/`sbt` when a
   `param_statement`/`interp_statement` node starts.

2. **Repeated `param()` statements were kept as separate lines** while
   `$params` reported the merged set, so anything that read or rewrote "the"
   `param()` statement of that text silently missed the later declarations.
   `mergeNormParamStatements()` now collapses them into the single declaration
   `$params` already reports.

The two-`param()` shape in the issue is emitted by nlmixr2est's
general-likelihood model building, so erroring on it was not an option; merging
is what makes the text agree with `$params`.

## Merge semantics

The merged statement takes the place of the first `param()` statement and spans
`params[0..hi]`, where `hi` is the last position any declared name takes in the
parameter vector -- not just the declared names.  Spanning only the declared
names reorders the vector: with `param(b);y=c;param(d);d/dt(b)=-b;` the first
statement declares only a state, so a merged `param(d)` landed ahead of `c` and
the text re-parsed to `d,c` instead of `c,d`.  (Caught by the Antigravity review,
below.)  Because everything registered before the first `param()` statement is a
prefix of the parameter vector, and any surviving declared name is registered at
or after it, declaring `params[0..hi]` there re-registers exactly the names the
earlier lines already introduced, in the same order.

A lone `param()` statement is left exactly as-is, even when every name it
declares became a state; normalizing that away would change the text of models
that were never broken.  Two such statements are dropped (`hi` stays -1), so the
two cases do not agree -- both still re-parse to the same model, and both are
pinned by tests.

## Also fixed

A variable that is both declared in `param()` and assigned (`isLHSparam`) took a
slot in the parameter vector without ever writing the matching entry in the
(uninitialized) interpolation vector, so `rxModelVars()$interp` held a garbage
code for it and printing it could fail with `malformed factor`.  Found while
fuzzing round-trips for this change; it is one line in
`setLhsAndDualLhsParam()`.

## Testing

`tests/testthat/test-param-order.R` gains 64 assertions covering: every
interpolation statement, a parameter introduced before / between / after the
`param()` statements, the `params()` spelling, a first statement made entirely of
states, an interpolation between two statements, string-covariate levels and
interpolation carried through the merge, a dual lhs/parameter, and solve-time
covariate matching for a parameter declared only by a later statement.

Full suite (`NOT_CRAN=true devtools::test()`) is clean on a from-scratch build.

## Review

Reviewed with Antigravity (`gemini-3.1-pro-high`) over several rounds.  It found
the parameter-ordering bug described above, which is fixed here, plus a series of
test-coverage gaps, all added.  The final round reports no findings.
