### PR TITLE
linCmt(): give the sensitivity window and value memo to the individual

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,30 @@
 
 ## New features
 
+- `linCmt()`'s sensitivity state now belongs to the INDIVIDUAL rather than to
+  whichever thread happens to be running it.  The theta-keyed window of
+  hoisted closed-form constants and the last-row value memo are the two
+  pieces whose value across calls is the whole point of having them, and
+  holding them per thread meant both had to be keyed on the subject id and
+  were discarded whenever another individual landed on the same slot.  They
+  now live in the solving structure for the individual, allocated on first
+  touch inside the solve and released with the subject alongside the delay
+  history and the rate history; the subject-id keys are gone, and a solve
+  being independent of how subjects were handed to threads is now structural
+  rather than something the transition-matrix path has to restart per subject
+  to enforce.  Pure scratch -- the Eigen work matrices and the kernel object
+  -- deliberately stays per thread, since it is overwritten on every call and
+  a per-individual copy would be memory holding nothing.  Results are bitwise
+  identical, including across thread counts.
+
+- The `linCmt()` per-row path no longer allocates.  `getVc()`, `adjustF()`
+  and `getJacCp()` took a `const Eigen::Matrix&` while every caller passes an
+  `Eigen::Map` over the parameter buffer, so each call materialized a
+  heap-allocated vector and copied into it; they take an `Eigen::Ref` now,
+  which binds the map directly.  `adjustF()` is on the value path, so that
+  temporary was being built for every row, every output and every inner pass
+  of a fit.
+
 - New internal `rxSetIdLvlFactors()` C callable lets a host package (e.g.
   nlmixr2est during `focei`/`saem` estimation) populate the global subject-id
   factor table directly, so aggregated solver warnings can be attributed to the

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,14 @@
   to enforce.  Pure scratch -- the Eigen work matrices and the kernel object
   -- deliberately stays per thread, since it is overwritten on every call and
   a per-individual copy would be memory holding nothing.  Results are bitwise
-  identical, including across thread counts.
+  identical, including across thread counts.  Measured on an idle machine by
+  alternating two cleanly built installations, a FOCEi fit runs 1.15x (two
+  compartment) to 1.19x (one compartment) faster at an identical objective
+  and an identical evaluation count.  A plain `rxSolve()` shows almost
+  nothing, and that is the expected shape: every subject of one solve shares
+  a theta, so the window was already valid as a thread walked from subject to
+  subject -- only a fit, where each individual carries its own random
+  effects, has anything here to recover.
 
 - The `linCmt()` per-row path no longer allocates.  `getVc()`, `adjustF()`
   and `getJacCp()` took a `const Eigen::Matrix&` while every caller passes an

--- a/inst/include/rxode2parseStruct.h
+++ b/inst/include/rxode2parseStruct.h
@@ -446,6 +446,19 @@ struct rx_solving_options_ind_s {
   long int autoStiffNonsti; /* clean verdicts since the last stiff one */
   long int autoStiffNaccpt; /* accepted steps across the subject's intervals */
   int      autoBackoff;     /* re-probe wait multiplier while on the secondary */
+  // linCmtB()'s per-INDIVIDUAL carried state (src/linCmt.cpp): the theta-keyed
+  // window of hoisted closed-form constants and the last-row value memo.  Both
+  // are state whose value ACROSS calls is the whole point, so they belong to
+  // the individual rather than to whichever thread happens to be running it --
+  // owned by a thread they had to be keyed on the subject id and were thrown
+  // away whenever another individual landed on the same slot.  Pure scratch
+  // (the Eigen work matrices and the kernel object) stays per thread; only the
+  // carried state is here.
+  //
+  // Opaque on purpose: this is a C header and the state holds C++ members.
+  // Allocated on first touch inside the solve and released with the subject in
+  // rxFreeInd(), the same lifecycle linCmtRateHist and delayHist above use.
+  void    *linCmtBind;      /* linCmtBind*, or NULL before first touch */
 };
 
 typedef struct rx_solve_s {

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -250,9 +250,26 @@ typedef struct linB_s {
   // fix (see project_lincmt_timevarying_covariate_bug); an ordinary,
   // constant-theta solve never requests it and pays nothing extra.
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> JAlast;
+} linB_t;
+
+// linCmtB()'s per-INDIVIDUAL carried state, owned by rx_solving_options_ind.
+//
+// Everything here is state whose value ACROSS calls is the point: the window
+// exists to hoist theta-only work out of the row loop, and the memo exists to
+// serve the repeats the generated model makes of one row.  Held per THREAD,
+// as it was, both had to be keyed on the subject id and were discarded the
+// moment another individual landed on the same slot -- so the memo carried an
+// id it only needed because it was in the wrong place.  Held per INDIVIDUAL
+// the ids disappear, the state survives for the whole solve, and freedom from
+// the thread schedule is structural rather than something the phi path has to
+// restart per subject to enforce.
+//
+// Pure scratch (the Eigen work matrices, the kernel object) deliberately does
+// NOT come here: it is overwritten on every call and has no meaning across
+// them, so a per-individual copy would be memory allocated to hold nothing.
+typedef struct linCmtBind_s {
   // Theta-keyed window of hoisted constants for the amortized sequential
-  // row Jacobian (linCmtSeqTailJac); per-thread, refilled on a theta or
-  // shape change.
+  // row Jacobian (linCmtSeqTailJac); refilled on a theta or shape change.
   linCmtWin win{};
   // Last-row value memo: a repeated (-1,-1) call for the same row (the
   // generated model executes the value line from dydt, calc_lhs and the
@@ -261,11 +278,28 @@ typedef struct linB_s {
   // invalidated by a model reshape and by any carry/dose-time sentinel.
   // Row last served by the thin value path (fx + Vc only): J/Jg are stale
   // for that row until a call-form query lazily restores them.
-  int liteId = -1, liteIdx = -1;
-  int memoId = -1, memoIdx = -1, memoFlag = -1, memoDoSS = -1, memoHpar = -9;
+  int liteIdx = -1;
+  int memoIdx = -1, memoFlag = -1, memoDoSS = -1, memoHpar = -9;
   double memoT = 0.0, memoH = 0.0, memoHV = 0.0, memoVal = 0.0;
   double memoArgs[7] = {0, 0, 0, 0, 0, 0, 0};
-} linB_t;
+} linCmtBind;
+
+// Allocated on first touch inside the solve; released with the subject in
+// rxFreeInd().  One individual is only ever solved by one thread at a time,
+// so this needs no locking.
+static inline linCmtBind &linCmtBindGet(rx_solving_options_ind *ind) {
+  if (ind->linCmtBind == NULL) {
+    ind->linCmtBind = (void*) new linCmtBind();
+  }
+  return *((linCmtBind*)(ind->linCmtBind));
+}
+
+extern "C" void linCmtBindFree(rx_solving_options_ind *ind) {
+  if (ind->linCmtBind != NULL) {
+    delete ((linCmtBind*)(ind->linCmtBind));
+    ind->linCmtBind = NULL;
+  }
+}
 
 std::vector<linB_t> __linCmtB;
 
@@ -280,10 +314,11 @@ extern "C" void ensureLinCmtB(int nCores) {
 // first touch of a slot for a shape must go through here -- sizing only the
 // kernel leaves isSame() true for the next ordinary call, which then skips
 // this block and runs on zero-length scratch.
-static inline void linCmtBsetModel(linB_t &lcb, int ncmt, int oral0, int trans,
+static inline void linCmtBsetModel(linB_t &lcb, linCmtBind &wsp,
+                                   int ncmt, int oral0, int trans,
                                    int linSS, rx_solve *rx) {
-  lcb.memoIdx = -1; // reshape invalidates the last-row value memo
-  lcb.liteId = lcb.liteIdx = -1;
+  wsp.memoIdx = -1; // reshape invalidates the last-row value memo
+  wsp.liteIdx = -1;
   lcb.lc.setModelType(ncmt, oral0, trans, linSS, rx->ndiff);
   int npars = lcb.lc.getNpars();
   lcb.fx = Eigen::Matrix<double, Eigen::Dynamic, 1>(ncmt + oral0);
@@ -1224,8 +1259,8 @@ static int linCmtAblateMode() {
 // linCmtFwdJac exactly: fx, the masked Js (columns in canonical requested
 // order, as updateJfromJs expects) and the Asave_ amounts for the next
 // row's carry.
-static bool linCmtSeqTailJac(linB_t &lcb, int phiCtl, int subjId, int idx,
-                             int dual) {
+static bool linCmtSeqTailJac(linB_t &lcb, linCmtBind &wsp, int phiCtl,
+                             int subjId, int idx, int dual) {
   stan::math::linCmtStan &lc = lcb.lc;
   if (lc.type_ != linCmtNormal) return false;
   int ncmt = lc.ncmt_, oral0 = lc.oral0_, trans = lc.trans_;
@@ -1233,7 +1268,7 @@ static bool linCmtSeqTailJac(linB_t &lcb, int phiCtl, int subjId, int idx,
   if (npars > RX_LINWIN_MAXP || ncmt + oral0 > RX_LINWIN_MAXM) return false;
   int m = ncmt + oral0;
   const double *thetaD = getLinCmtDoubleAddr(lcb, linCmtBaddrTheta);
-  linCmtWin &w = lcb.win;
+  linCmtWin &w = wsp.win;
   if (!w.valid || w.ncmt != ncmt || w.oral0 != oral0 || w.trans != trans ||
       w.npars != npars || memcmp(w.theta, thetaD, npars*sizeof(double)) != 0) {
     linCmtWinFill(lc, w, thetaD, ncmt, oral0, trans);
@@ -1291,14 +1326,19 @@ static bool linCmtSeqTailJac(linB_t &lcb, int phiCtl, int subjId, int idx,
     return false; // nothing requested
   }
   if (phiOn == 1 && (w.phiId != subjId || idx < w.phiLastIdx)) {
-    // Start every subject from the same blank interval state.  The window
-    // is per THREAD and outlives a subject, so without this the answer to
-    // "has this interval been seen before" -- and with it which rows
-    // propagate through a matrix and which evaluate the tail -- would
-    // depend on how subjects happened to be handed to threads, and the
-    // last digits of a solve would move with the thread count.  Restarting
-    // per subject costs a few exponentials and one matrix per subject and
-    // keeps a solve identical however many threads run it.
+    // Start every pass over a subject from the same blank interval state,
+    // so that the answer to "has this interval been seen before" -- and
+    // with it which rows propagate through a matrix and which evaluate the
+    // tail -- is a property of the design and not of what ran before.
+    //
+    // The window used to be per THREAD, which is what made this necessary:
+    // without it a subject inherited whichever intervals the previous
+    // subject on that thread had cached, so the last digits of a solve
+    // moved with the thread count.  The window now belongs to the
+    // INDIVIDUAL, so that particular hazard is gone by construction and the
+    // subject-id half of this test can never fire twice; what remains is
+    // the per-pass restart (idx moving backwards), which is still the thing
+    // that keeps repeated passes over one subject identical.
     w.phiId = subjId;
     w.nDelta = 0;
     w.deltaNext = 0;
@@ -2167,7 +2207,7 @@ static inline double linCmtBtransition(linB_t &lcb, rx_solve *rx,
   if (which2 < 0 || col >= m) return NA_REAL;
   // may be the first touch of this slot (a model with no -1 call)
   if (!lcb.lc.isSame(ncmt, oral0, trans, rx->ndiff)) {
-    linCmtBsetModel(lcb, ncmt, oral0, trans, ind->linSS, rx);
+    linCmtBsetModel(lcb, linCmtBindGet(ind), ncmt, oral0, trans, ind->linSS, rx);
   }
   Eigen::Matrix<linCmtFv, Eigen::Dynamic, 2> gF;
   linCmtFv kaV;
@@ -2291,7 +2331,7 @@ static inline double linCmtBcarryAdvance(linB_t &lcb, rx_solve *rx,
   if (linCmtBcarryFast(ind, thNow, _t)) return ind->linCmtCarryT[slot];
   // may be the first touch of lc on this thread (a standalone re-query)
   if (!lcb.lc.isSame(ncmt, oral0, trans, rx->ndiff)) {
-    linCmtBsetModel(lcb, ncmt, oral0, trans, ind->linSS, rx);
+    linCmtBsetModel(lcb, linCmtBindGet(ind), ncmt, oral0, trans, ind->linSS, rx);
   }
   // The advance interval is the time since this sentinel's OWN previous
   // invocation: calc_lhs fires once per event row in solve order, but in
@@ -2337,7 +2377,8 @@ static inline bool linCmtBread(linB_t &lcb, int which1, int which2, double *out)
 // the -1,-1 solve for this row has already run.  Returns false for a
 // combination no sentinel handles, in which case linCmtB() falls through
 // to the ordinary solve path.
-static inline bool linCmtBquery(linB_t &lcb, rx_solve *rx, rx_solving_options_ind *ind,
+static inline bool linCmtBquery(linB_t &lcb, linCmtBind &wsp, rx_solve *rx,
+                                rx_solving_options_ind *ind,
                                 rx_solving_options *op, int idx, double _t,
                                 int ncmt, int oral0, int which1, int which2, int trans,
                                 double p1, double v1, double p2, double p3,
@@ -2346,7 +2387,7 @@ static inline bool linCmtBquery(linB_t &lcb, rx_solve *rx, rx_solving_options_in
   // A dose-time/carry sentinel may touch lc state between value calls;
   // pure reads (above) do not.  Drop the last-row value memo either way --
   // correctness over a lost short-circuit.
-  lcb.memoIdx = -1;
+  wsp.memoIdx = -1;
   if (which1 == -3) {
     // idx already solved -> a re-query (e.g. the output pass) where
     // ind->InfusionRate has since been cleared/moved on; use the cached rate.
@@ -2426,7 +2467,8 @@ static inline void linCmtBfdJac(linB_t &lcb, int kind, double *linH,
 
 // The row's Jacobian by rx->sensType: a finite-difference family, reverse-
 // mode AD (31), or forward-mode AD (3/30 and anything unspecified).
-static inline void linCmtBjac(linB_t &lcb, rx_solve *rx, rx_solving_options_ind *ind,
+static inline void linCmtBjac(linB_t &lcb, linCmtBind &wsp, rx_solve *rx,
+                              rx_solving_options_ind *ind,
                               int sensType, int id, int idx,
                               Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, 1> > &theta,
                               Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, 1> > &thetaSens) {
@@ -2440,7 +2482,7 @@ static inline void linCmtBjac(linB_t &lcb, rx_solve *rx, rx_solving_options_ind 
   } else if (sensType == 31) {
     linCmtRevTapeInit();
     stan::math::jacobian(lcb.lc, thetaSens, lcb.fx, lcb.Js);
-  } else if (linCmtSeqTailJac(lcb, rx->linCmtSensPhi, id, idx,
+  } else if (linCmtSeqTailJac(lcb, wsp, rx->linCmtSensPhi, id, idx,
                               sensType == 32)) {
 #pragma omp atomic
     linCmtSeqTailN++;
@@ -2463,7 +2505,8 @@ static inline void linCmtBjac(linB_t &lcb, rx_solve *rx, rx_solving_options_ind 
 // otherwise advance the kernel from the previous state over dt and take
 // the Jacobian.  ind->tprior is the prior solved time, ind->tout the time
 // solved, _t the requested time (with ODE solving not necessarily tout).
-static inline void linCmtBsolveRow(linB_t &lcb, rx_solve *rx, rx_solving_options_ind *ind,
+static inline void linCmtBsolveRow(linB_t &lcb, linCmtBind &wsp, rx_solve *rx,
+                                   rx_solving_options_ind *ind,
                                    rx_solving_options *op, int id, int idx, double _t,
                                    double *a, const double *r, int ncmt, int oral0, int trans,
                                    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, 1> > &theta,
@@ -2480,7 +2523,7 @@ static inline void linCmtBsolveRow(linB_t &lcb, rx_solve *rx, rx_solving_options
   linCmtValCompN++;
   lcb.lc.setDt(ind->doSS ? (ind->tout - ind->tprior) : (_t - ind->tprior));
   if (rx->ndiff != 0 && ind->linCmtHparIndex < -1) {
-    linCmtBjac(lcb, rx, ind, rx->sensType, id, idx, theta, thetaSens);
+    linCmtBjac(lcb, wsp, rx, ind, rx->sensType, id, idx, theta, thetaSens);
     return;
   }
   if (rx->ndiff != 0 && ind->linCmtHparIndex >= 0) {
@@ -2504,15 +2547,24 @@ extern "C" double linCmtB(rx_solve *rx, int id,
   // Per-thread linCmtB state (matching linCmtA pattern for thread safety)
   int _tid = rx_get_thread(__linCmtB.size());
   linB_t &lcb = __linCmtB[_tid];
-  if (_tid < RX_LINCMTB_THREAD_SEEN) {
+  // Diagnostic only (linCmtBThreads()).  The plain read in front of the
+  // atomic matters: this is on the entry of a function a FOCEi fit calls
+  // upwards of a million times per objective evaluation, and the only
+  // transition is 0 -> 1, so a racy read costs at worst one redundant
+  // store and never a wrong answer.
+  if (_tid < RX_LINCMTB_THREAD_SEEN && !linCmtBThreadSeen[_tid]) {
 #pragma omp atomic write
     linCmtBThreadSeen[_tid] = 1;
   }
   rx_solving_options_ind *ind = &(rx->subjects[id]);
+  // The individual's own carried state: window + value memo.  Because it
+  // belongs to the individual, none of the keys below need the subject id
+  // any more -- this block IS the subject.
+  linCmtBind &wsp = linCmtBindGet(ind);
   rx_solving_options *op = rx->op;
   int idx = ind->idx;
   if (which1 != -1 || which2 != -1) {
-    if (lcb.liteIdx == idx && lcb.liteId == id) {
+    if (wsp.liteIdx == idx) {
       // The thin value path left J/Jg stale for this row; a call-form
       // query consumes them -- restore once, lazily.
       Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, 1> >
@@ -2522,15 +2574,15 @@ extern "C" double linCmtB(rx_solve *rx, int id,
       lcb.lc.restoreJacTo(acur, lcb.J);
       lcb.lc.restoreFxTo(acur, lcb.fx);
       lcb.lc.getJacCp(lcb.J, lcb.fx, theta, lcb.Jg);
-      lcb.liteId = lcb.liteIdx = -1;
+      wsp.liteIdx = -1;
     }
     double out;
-    if (linCmtBquery(lcb, rx, ind, op, idx, _t, ncmt, oral0, which1, which2, trans,
+    if (linCmtBquery(lcb, wsp, rx, ind, op, idx, _t, ncmt, oral0, which1, which2, trans,
                      p1, v1, p2, p3, p4, p5, ka, &out)) {
       return out;
     }
   } else if (!lcb.lc.isSame(ncmt, oral0, trans, rx->ndiff)) {
-    linCmtBsetModel(lcb, ncmt, oral0, trans, ind->linSS, rx);
+    linCmtBsetModel(lcb, wsp, ncmt, oral0, trans, ind->linSS, rx);
   } else {
     // Last-row value memo: the generated model executes this value call
     // many times per row (compute phase and restore path alike); a repeat
@@ -2539,14 +2591,14 @@ extern "C" double linCmtB(rx_solve *rx, int id,
     // depends on; sentinels and reshapes invalidate (see linCmtBquery /
     // linCmtBsetModel).
     const double args[7] = {p1, v1, p2, p3, p4, p5, ka};
-    if (lcb.memoIdx == idx && lcb.memoId == id && lcb.memoT == _t &&
-        lcb.memoFlag == ind->_rxFlag && lcb.memoDoSS == (int)ind->doSS &&
-        lcb.memoHpar == ind->linCmtHparIndex &&
-        lcb.memoH == ind->linCmtH && lcb.memoHV == ind->linCmtHV &&
-        memcmp(lcb.memoArgs, args, sizeof(args)) == 0) {
+    if (wsp.memoIdx == idx && wsp.memoT == _t &&
+        wsp.memoFlag == ind->_rxFlag && wsp.memoDoSS == (int)ind->doSS &&
+        wsp.memoHpar == ind->linCmtHparIndex &&
+        wsp.memoH == ind->linCmtH && wsp.memoHV == ind->linCmtHV &&
+        memcmp(wsp.memoArgs, args, sizeof(args)) == 0) {
 #pragma omp atomic
       linCmtMemoHitN++;
-      return lcb.memoVal;
+      return wsp.memoVal;
     }
     lcb.lc.setSsType(ind->linSS);
   }
@@ -2567,15 +2619,15 @@ extern "C" double linCmtB(rx_solve *rx, int id,
     double val = lcb.lc.adjustF(lcb.fx, thetaL, ind->linCmtHV);
 #pragma omp atomic
     linCmtValLiteN++;
-    lcb.liteId = id; lcb.liteIdx = idx;
-    lcb.memoId = id; lcb.memoIdx = idx; lcb.memoT = _t;
-    lcb.memoFlag = ind->_rxFlag; lcb.memoDoSS = (int)ind->doSS;
-    lcb.memoHpar = ind->linCmtHparIndex;
-    lcb.memoH = ind->linCmtH; lcb.memoHV = ind->linCmtHV;
-    lcb.memoArgs[0] = p1; lcb.memoArgs[1] = v1; lcb.memoArgs[2] = p2;
-    lcb.memoArgs[3] = p3; lcb.memoArgs[4] = p4; lcb.memoArgs[5] = p5;
-    lcb.memoArgs[6] = ka;
-    lcb.memoVal = val;
+    wsp.liteIdx = idx;
+    wsp.memoIdx = idx; wsp.memoT = _t;
+    wsp.memoFlag = ind->_rxFlag; wsp.memoDoSS = (int)ind->doSS;
+    wsp.memoHpar = ind->linCmtHparIndex;
+    wsp.memoH = ind->linCmtH; wsp.memoHV = ind->linCmtHV;
+    wsp.memoArgs[0] = p1; wsp.memoArgs[1] = v1; wsp.memoArgs[2] = p2;
+    wsp.memoArgs[3] = p3; wsp.memoArgs[4] = p4; wsp.memoArgs[5] = p5;
+    wsp.memoArgs[6] = ka;
+    wsp.memoVal = val;
     return val;
   }
   if (id == 0 && ind->linH[0] == 0) {
@@ -2601,16 +2653,16 @@ extern "C" double linCmtB(rx_solve *rx, int id,
   double *a = (ind->linCmtAlast == NULL) ? getAdvan(ind->solvedIdx) : ind->linCmtAlast;
   lcb.lc.setPtr(a, r, ind->linCmtSave);
 
-  linCmtBsolveRow(lcb, rx, ind, op, id, idx, _t, a, r, ncmt, oral0, trans, theta, thetaSens);
+  linCmtBsolveRow(lcb, wsp, rx, ind, op, id, idx, _t, a, r, ncmt, oral0, trans, theta, thetaSens);
   lcb.lc.getJacCp(lcb.J, lcb.fx, theta, lcb.Jg);
   double val = lcb.lc.adjustF(lcb.fx, theta, ind->linCmtHV);
-  lcb.memoId = id; lcb.memoIdx = idx; lcb.memoT = _t;
-  lcb.memoFlag = ind->_rxFlag; lcb.memoDoSS = (int)ind->doSS;
-  lcb.memoHpar = ind->linCmtHparIndex;
-  lcb.memoH = ind->linCmtH; lcb.memoHV = ind->linCmtHV;
-  lcb.memoArgs[0] = p1; lcb.memoArgs[1] = v1; lcb.memoArgs[2] = p2;
-  lcb.memoArgs[3] = p3; lcb.memoArgs[4] = p4; lcb.memoArgs[5] = p5;
-  lcb.memoArgs[6] = ka;
-  lcb.memoVal = val;
+  wsp.memoIdx = idx; wsp.memoT = _t;
+  wsp.memoFlag = ind->_rxFlag; wsp.memoDoSS = (int)ind->doSS;
+  wsp.memoHpar = ind->linCmtHparIndex;
+  wsp.memoH = ind->linCmtH; wsp.memoHV = ind->linCmtHV;
+  wsp.memoArgs[0] = p1; wsp.memoArgs[1] = v1; wsp.memoArgs[2] = p2;
+  wsp.memoArgs[3] = p3; wsp.memoArgs[4] = p4; wsp.memoArgs[5] = p5;
+  wsp.memoArgs[6] = ka;
+  wsp.memoVal = val;
   return val;
 }

--- a/src/linCmt.h
+++ b/src/linCmt.h
@@ -2839,7 +2839,9 @@ namespace stan {
         }
       }
 
-      double getVc(const Eigen::Matrix<double, Eigen::Dynamic, 1>& theta) {
+      // Ref, not Matrix -- see getJacCp: a Map argument would materialize a
+      // heap-allocated temporary on every call.
+      double getVc(const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1> >& theta) {
         int sw = ncmt_*100 + trans_;
         switch (sw) {
         case 311:
@@ -2878,10 +2880,16 @@ namespace stan {
         return NA_REAL;
       }
 
+      // theta is an Eigen::Ref, not a Matrix.  Every caller passes an
+      // Eigen::Map over the per-block theta buffer, and a Map does not bind
+      // to `const Matrix&` -- it MATERIALIZES one, which for a dynamic
+      // vector is a heap allocation and a copy on EVERY call.  This is on
+      // the per-row path of a FOCEi fit, so that temporary showed up as its
+      // own entry in the profile.  Ref binds the Map directly.
       void
       getJacCp(const Eigen::Matrix<double, -1, -1>& J0,
                const Eigen::VectorXd& ret0,
-               const Eigen::Matrix<double, Eigen::Dynamic, 1>& theta,
+               const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1> >& theta,
                Eigen::Matrix<double, Eigen::Dynamic, 1>& Jf) {
         // no per-call temporaries: J is an expression over J0's central row
         auto J = J0.row(oral0_).transpose();
@@ -3036,14 +3044,14 @@ namespace stan {
       }
 
       double adjustF(const Eigen::VectorXd& ret0,
-                     const Eigen::Matrix<double, Eigen::Dynamic, 1>& theta,
+                     const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1> >& theta,
                      double &vc) {
         vc = getVc(theta);
         return ret0(oral0_, 0) / vc;
       }
 
       double adjustF(const Eigen::VectorXd& ret0,
-                     const Eigen::Matrix<double, Eigen::Dynamic, 1>& theta) {
+                     const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1> >& theta) {
         double vc=0;
         return adjustF(ret0, theta, vc);
       }

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -48,6 +48,7 @@ using namespace arma;
 extern "C" void seedEng(int ncores);
 extern "C" void ensureLinCmtA(int nCores);
 extern "C" void ensureLinCmtB(int nCores);
+extern "C" void linCmtBindFree(rx_solving_options_ind *ind);
 extern "C" void ensureLsodaCtxPool(int nCores);
 extern "C" void ensureIndLinExpCache(int nCores);
 extern "C" void ensureRworkPool(int nCores, int lrw, int liw);
@@ -1951,6 +1952,10 @@ static void rxFreeInd(rx_solving_options_ind *ind) {
   ind->linCmtRateHist = NULL;
   ind->linCmtRateHistCap = 0;
   ind->linCmtRateHistW = 0;
+  // linCmtB()'s per-individual carried state (window + value memo), allocated
+  // on first touch inside the solve; same lifecycle as the two above.  It
+  // holds C++ members, so linCmt.cpp owns the delete.
+  linCmtBindFree(ind);
 }
 
 extern "C" void gFree(){


### PR DESCRIPTION
`linCmtB()`'s state lived in a per-**thread** pool. The two pieces whose value *across* calls is the entire point of having them — the theta-keyed window of hoisted closed-form constants, and the last-row value memo — therefore had to be keyed on the subject id, and were thrown away the moment another individual landed on the same slot. The memo carried an id it only needed because it was in the wrong place.

### What moves

The window and the memo now live in `rx_solving_options_ind`, allocated on first touch inside the solve and released in `rxFreeInd()` alongside `delayHist` and `linCmtRateHist` — the lifecycle those two already document. `memoId`, `liteId` and the subject-id half of the transition-matrix restart are deleted outright. A solve being independent of how subjects were handed to threads stops being something that path restarts per subject to enforce and becomes structural: the state is never shared.

### What stays

Pure scratch — `fx`/`yp`/`g`/`J`/`Js`/`Jg`/`JAlast` and the kernel object — remains per thread. It is overwritten on every call and means nothing across them, so a per-individual copy would be memory allocated to hold nothing. That split also lands `linCmtScaleInitPar`/`linCmtScaleInitN`/`linCmtZeroJac` cleanly: all three read only the kernel, so they keep their signatures and their per-thread lookup unchanged.

The header field is an opaque pointer appended at the end of the struct — it is a C header and the state has C++ members, and downstream reaches `ind` through the `rxode2ptr.h` function table rather than by offset.

### Also: per-row allocations

`getVc()`, `adjustF()` and `getJacCp()` declared `theta` as `const Eigen::Matrix&` while every caller passes an `Eigen::Map` over the parameter buffer — which does not bind, so each call heap-allocated a vector and copied into it. They take `Eigen::Ref` now. `adjustF()` is on the value path, so that temporary was built for every row, every output and every inner pass of a fit; it had its own line in the profile.

### Measured

Alternating two cleanly built installations on an idle machine, pinned:

| | before | after | |
|---|---|---|---|
| U004 (1-cmt bolus, 120x58) | 2.358 s | 1.988 s | **1.19x** |
| U035 (2-cmt bolus, full data) | 3.858 s | 3.355 s | **1.15x** |

Identical objective and identical `feval` in every run, so this is per-evaluation cost and not a different path to convergence; repeats agree to ~0.5%.

`perf` on the same fit shows the `PlainObjectBase<Matrix<double,-1,1>>::PlainObjectBase<Map<...>>` entry (105 samples, 1.34%) **gone**, with `sensTheta` and `restoreJacTo` each down about 21%. `linCmtB`'s own self time barely moves — the win is the work behind the call, not the call.

A plain `rxSolve()` shows almost nothing (1-3%), and that is the expected shape rather than a disappointment: every subject of one solve shares a theta, so the per-thread window was already valid as a thread walked from subject to subject. Only a fit, where each individual carries its own random effects, has anything here to recover.

### Verification

- 612-cell single-subject fingerprint (1/2/3 cmt x IV/oral x direction masks x uniform/irregular/infusion/multidose/ss/ss-inf x `linCmtSensPhi` 0/1/2 x AD/ADm): **bitwise identical**.
- New 216-cell multi-subject grid — 24 subjects differing in schedule *and* dose, some infusing — is the one that can see this change at all: `cores=1` matches `cores=4` on all 108 pairs.
- No leak: per-solve RSS growth at 800 subjects is +0.41 MB for `linCmtB` against +0.67 MB for `linCmtA`, which allocates no such block, so the growth is R's own.
- Full suite **40,001 pass, 0 fail**.