### PR TITLE
fix(ui): promote an ini() comment only where the statement is complete

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -990,6 +990,26 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
   dropped silently -- the model still parsed and built, it simply lost the label
   (#1205).
 
+- A `#` comment inside an `ini({})` statement that spans more than one line no
+  longer breaks the model.  The comment was promoted by appending
+  `; label("...")` whether or not the statement on that line had finished, so a
+  comment between an opening `(` and its `)` -- or on a line ending in an
+  operator such as `+` or `~` -- put the `;` in the middle of the statement and
+  the model failed with a bare `unexpected ';'` pointing into regenerated text
+  rather than at the offending source line.  A comment is now promoted only
+  where it trails a complete statement; one inside an unfinished statement stays
+  a comment and is dropped.  A comment on the line that closes the statement
+  still becomes that parameter's label.  As with #1195 the promotion only runs
+  when source refs are kept, so the same model built fine from an installed
+  package while failing under `keep.source = TRUE` (#1318).
+
+- A comment-only `ini({})` line indented with a tab is no longer turned into the
+  label of the preceding parameter.  The comment-only test allowed leading
+  spaces only, so a tab-indented comment fell through to the label branch, whose
+  code portion then captured just the tab.  The bare `; label("...")` that
+  produced parses -- a leading `;` is legal -- so there was no error and the
+  comment silently became the label of the parameter above it (#1318).
+
 ### Estimation / symengine translation
 
 - A model using the modulo operator `%%` can now be estimated.  `%%` was

--- a/R/ui.R
+++ b/R/ui.R
@@ -1,3 +1,18 @@
+#' Do the accumulated `ini({})` lines parse as a complete statement?
+#'
+#' A `; label()` may only be appended where the statement is finished; the lines
+#' are wrapped in a block so completeness is judged in the context they occupy.
+#'
+#' @param lines `ini({})` source lines accumulated for the current statement
+#' @return `TRUE` when the lines parse as complete R code
+#' @author Matthew Fidler
+#' @noRd
+.rxIniLinesComplete <- function(lines) {
+  .txt <- paste0("{\n", paste(lines, collapse="\n"), "\n}")
+  !inherits(try(parse(text=.txt, keep.source=FALSE), silent=TRUE),
+            "try-error")
+}
+
 #' Replace comments with label()
 #'
 #' @param src source function
@@ -8,10 +23,17 @@
   .env <- new.env(parent=emptyenv())#match.call(expand.dots = TRUE)[-(1:2)]
   .env$inIni <- FALSE
   .env$convertLabel <- FALSE
+  # lines of the `ini({})` statement being accumulated; a `; label()` may only be
+  # appended once they parse as complete
+  .env$pending <- character(0)
   .regIni <- rex::rex(boundary, or("ini", "lotri"), "(", any_spaces, "{", any_spaces)
   .regOther1 <- rex::rex(any_spaces, "}", any_spaces, ")", any_spaces)
   .regOther2 <- rex::rex(any_spaces, "model", any_spaces, "(", any_spaces, "{", any_spaces)
-  .regCommentOnBlankLine <- "^ *#+ *(.*) *$"
+  # any whitespace may precede the `#`.  With spaces only, a tab-indented
+  # comment-only line fell through to .regLabel, whose code group then captured
+  # just the tab; the bare `; label()` that produced parses -- a leading `;` is
+  # legal -- so it silently became the label of the PRECEDING parameter.
+  .regCommentOnBlankLine <- "^[[:space:]]*#+ *(.*) *$"
   # `#` is excluded from the code group so it stops at the FIRST `#`.  POSIX ERE
   # is leftmost-longest, so a greedy `[^\n"]+` ran on to the LAST `#` and left
   # the earlier one in the emitted code, where it commented out the label() just
@@ -23,12 +45,20 @@
                  function(line) {
                    if (regexpr(.regIni, line, perl=TRUE) != -1) {
                      assign("inIni", TRUE, envir=.env)
+                     assign("pending", character(0), envir=.env)
                    } else if (regexpr(.regOther1, line, perl=TRUE) != -1) {
                      assign("inIni", FALSE, envir=.env)
                    } else if (regexpr(.regOther2, line, perl=TRUE) != -1) {
                      assign("inIni", FALSE, envir=.env)
                    } else if (.env$inIni) {
+                     assign("pending", c(.env$pending, line), envir=.env)
+                     .complete <- .rxIniLinesComplete(.env$pending)
+                     if (.complete) assign("pending", character(0), envir=.env)
                      if (regexpr(.regCommentOnBlankLine, line) != -1) {
+                     } else if (!.complete) {
+                       # a comment inside an unfinished statement stays a comment; a
+                       # `;` here would split the statement and the re-parse below
+                       # would fail (rxode2 issue 1318)
                      } else if (regexpr(.regLabel, line) != -1) {
                        .env$convertLabel <- TRUE
                        .label <- deparse1(sub(.regLabel, "\\2", line))

--- a/tests/testthat/test-ui.R
+++ b/tests/testthat/test-ui.R
@@ -192,6 +192,111 @@ rxTest({
     expect_equal(.labelOf("## mg\\L # per dose"), "mg\\L # per dose")
   })
 
+  test_that("a comment in an unfinished ini({}) statement is not a label (rxode2 issue 1318)", {
+
+    .mkSrc <- function(iniLines) {
+      c("function() {", "  ini({",
+        iniLines,
+        "    add.sd <- 0.7", "  })", "  model({",
+        "    ka <- exp(tka)", "    linCmt() ~ add(add.sd)", "  })", "}")
+    }
+    .resOf <- function(iniLines) {
+      suppressMessages(.rxReplaceCommentWithLabel(.mkSrc(iniLines)))
+    }
+    .labelsOf <- function(res) {
+      vapply(res[grepl("^ *label\\(", res)],
+             function(.l) as.character(parse(text = .l)[[1]][[2]]),
+             character(1), USE.NAMES = FALSE)
+    }
+
+    # `; label()` used to be appended to any commented line whether or not the
+    # statement on it had finished, so a comment between an opening `(` and its
+    # `)` -- or on a line ending in an operator -- put the `;` in the middle of
+    # the statement and the re-parse died with `unexpected ';'`.  Only a comment
+    # trailing a COMPLETE statement may be promoted.
+    .cases <- list(
+      noComment      = list(src = c("    tka <- c(", "      1.0", "    )"),
+                            labels = character(0)),
+      insideOpenCall = list(src = c("    tka <- c(", "      1.0   # note", "    )"),
+                            labels = character(0)),
+      onOpeningLine  = list(src = c("    tka <- c( # note", "      1.0", "    )"),
+                            labels = character(0)),
+      trailingPlus   = list(src = c("    tka <- 0.45 +  # note", "      0.1"),
+                            labels = character(0)),
+      trailingTilde  = list(src = c("    eta.cl + eta.v ~  # note",
+                                    "      c(1, 0.01, 1)"),
+                            labels = character(0)),
+      onClosingLine  = list(src = c("    tka <- c(", "      1.0", "    ) # note"),
+                            labels = "note"),
+      singleLineCall = list(src = "    tka <- c(1.0) # note", labels = "note"),
+      plainLine      = list(src = "    tka <- 1.0 # note", labels = "note")
+    )
+    for (.n in names(.cases)) {
+      .res <- .resOf(.cases[[.n]]$src)
+      expect_true(is.function(eval(parse(text = paste(.res, collapse = "\n"),
+                                         keep.source = FALSE))), info = .n)
+      expect_equal(.labelsOf(.res), .cases[[.n]]$labels, info = .n)
+    }
+
+    # the comment inside the call is dropped and nothing else about the model
+    # changes
+    expect_equal(.resOf(c("    tka <- c(", "      1.0   # note", "    )")),
+                 c("function () ", "{", "    ini({", "        tka <- c(1)",
+                   "        add.sd <- 0.7", "    })", "    model({",
+                   "        ka <- exp(tka)", "        linCmt() ~ add(add.sd)",
+                   "    })", "}"))
+    # a comment on the line that closes the statement still labels it
+    expect_equal(.resOf(c("    tka <- c(", "      1.0", "    ) # note")),
+                 c("function () ", "{", "    ini({", "        tka <- c(1)",
+                   "        label(\"note\")", "        add.sd <- 0.7", "    })",
+                   "    model({", "        ka <- exp(tka)",
+                   "        linCmt() ~ add(add.sd)", "    })", "}"))
+
+    # the multi-line covariance form of test-pheno.R keeps both of its labels
+    expect_equal(.labelsOf(.resOf(c(
+      "    tka <- log(0.008) # typical value of clearance",
+      "    eta.cl + eta.v ~ c(1,",
+      "                       0.01, 1) ## cov(eta.cl, eta.v), var(eta.v)"))),
+      c("typical value of clearance", "cov(eta.cl, eta.v), var(eta.v)"))
+  })
+
+  test_that("a tab-indented comment-only ini({}) line is not a label (rxode2 issue 1318)", {
+
+    # The comment-only test allowed leading spaces only, so a tab-indented
+    # comment fell through to the label branch, whose code group captured just
+    # the tab.  The bare `; label()` that produced parses -- a leading `;` is
+    # legal -- so there was no error: the comment silently became the label of
+    # the PRECEDING parameter.
+    .src <- c("function() {", "  ini({",
+              "    tka <- 0.45",
+              "\t# tab indented comment",
+              "    tcl <- 1",
+              "    tv <- 3.45",
+              "    add.sd <- 0.7", "  })", "  model({",
+              "    ka <- exp(tka)", "    cl <- exp(tcl)", "    v <- exp(tv)",
+              "    linCmt() ~ add(add.sd)", "  })", "}")
+    suppressMessages(.res <- .rxReplaceCommentWithLabel(.src))
+    expect_equal(.res,
+                 c("function () ", "{", "    ini({", "        tka <- 0.45",
+                   "        tcl <- 1", "        tv <- 3.45",
+                   "        add.sd <- 0.7", "    })", "    model({",
+                   "        ka <- exp(tka)", "        cl <- exp(tcl)",
+                   "        v <- exp(tv)", "        linCmt() ~ add(add.sd)",
+                   "    })", "}"))
+
+    # and the orphan label does not land on the parameter above it
+    .ui <- suppressMessages(eval(parse(text = paste(.res, collapse = "\n")))())
+    expect_equal(.ui$iniDf$name, c("tka", "tcl", "tv", "add.sd"))
+    expect_equal(.ui$iniDf$label, rep(NA_character_, 4L))
+
+    # a tab-indented line with code before the comment still gets its label
+    .tabCode <- c("function() {", "  ini({", "\ttka <- 0.45 # Log Ka",
+                  "    add.sd <- 0.7", "  })", "  model({",
+                  "    ka <- exp(tka)", "    linCmt() ~ add(add.sd)", "  })", "}")
+    suppressMessages(.res <- .rxReplaceCommentWithLabel(.tabCode))
+    expect_equal(.res[grepl("^ *label\\(", .res)], "        label(\"Log Ka\")")
+  })
+
   test_that("meta information parsing", {
 
     one.cmt <- function() {


### PR DESCRIPTION
Fixes #1318.

`.rxReplaceCommentWithLabel()` rewrote a trailing `#` comment in `ini({})` into
`; label("...")` on any line carrying one, regardless of whether the R statement on
that line had finished. A comment between an opening `(` and its `)` therefore put
the `;` in the middle of the statement and the re-parse failed with a bare
`unexpected ';'` pointing into regenerated text rather than at the source line.

The same defect breaks a line that is incomplete because it *ends in an operator*,
which bracket-depth tracking would not catch:

```r
ini({
  tcl <- 0.45 +   # note
    0.1
  eta.cl + eta.v ~  # note
    c(1, 0.01, 1)
})
```

So instead of counting brackets, this asks R's own parser whether the accumulated
statement is complete before promoting. A comment inside an unfinished statement now
stays a comment and is dropped; a comment on the line that *closes* the statement
still becomes that parameter's label, unchanged.

### Second, silent defect fixed here too

`.regCommentOnBlankLine` allowed leading spaces only, so a **tab**-indented
comment-only line fell through to the label branch, whose code group then captured
just the tab. The bare `; label("...")` that produced parses -- a leading `;` is
legal -- so there was no error: the comment silently became the label of the
**preceding** parameter. On 5.1.7 this source gives `tka` the label
`"tab indented comment"`:

```r
ini({
  tka <- 0.45
	# tab indented comment
  tcl <- 1
})
```

### Why it hides in CI

The promotion only runs with source refs intact, so `devtools::load_all()` hits it
while an installed package does not. In nlmixr2lib this showed as
`Ahmed_2016_lorenzosOil` failing `checkModelConventions()` and its vignette locally
while the identical commit rendered green in CI.

### Tests

23 assertions in `tests/testthat/test-ui.R` covering all eight statement shapes, both
tab cases, and exact generated-source assertions. The tab regression guard builds the
model and asserts `iniDf$label` is all-`NA`, pinning the silent misattribution.

Full suite: `FAIL 0 | WARN 33 | SKIP 7 | PASS 40109`.