### PR TITLE
fix(tad): count infusions in the dose history when the first dose is a bolus

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -684,6 +684,16 @@
 
 ## Bug fixes
 
+- `tad()`, `tafd()`, `tlast()`, `dosenum()` and `dose()` no longer skip an
+  infusion when the subject's dosing record starts with a bolus.  The dose
+  history asked for the infusion duration with the solver's running dose
+  counter (`ind->ixds`), which the output pass never advances, so the lookup
+  either failed -- the infusion was then dropped from the history entirely,
+  leaving `dosenum()` un-incremented and `tad()` counting from the earlier
+  dose -- or silently returned a different infusion's duration, which made
+  `dose()` report the wrong amount.  The duration is now looked up from the
+  record being handled.  Solving itself was never affected (#1316).
+
 - Parsing a model no longer corrupts the caller's `PROTECT` stack.  The
   translation table and `_goodFuns` were claimed on the protect stack by one
   function and released by another, with the whole parse in between; an

--- a/inst/include/rxode2parseHandleEvid.h
+++ b/inst/include/rxode2parseHandleEvid.h
@@ -107,7 +107,9 @@ static inline int getDoseNumberFromIndex(rx_solving_options_ind *ind, int idx) {
 // (rxode2_df.cpp) calls handleTlastInline() without advancing or syncing it, so
 // ixds can point at an unrelated dose there.  Recover the index from ind->idx
 // whenever the record is a real (non-extra) dose, and only fall back to ixds
-// for extra doses, whose idx does not map into idose.
+// for extra doses (idx < 0).  An extra dose's amount lives in extraDoseDose,
+// not in idose, so there is no dose index to recover for it; it keeps the
+// long-standing ixds behavior.
 static inline int handleTlastInlineDoseIndex(rx_solving_options_ind *ind) {
   if (ind->idx < 0) return ind->ixds;
   int cur = ind->ix[ind->idx];

--- a/inst/include/rxode2parseHandleEvid.h
+++ b/inst/include/rxode2parseHandleEvid.h
@@ -110,7 +110,12 @@ static inline int getDoseNumberFromIndex(rx_solving_options_ind *ind, int idx) {
 // for extra doses, whose idx does not map into idose.
 static inline int handleTlastInlineDoseIndex(rx_solving_options_ind *ind) {
   if (ind->idx < 0) return ind->ixds;
-  int m = getDoseNumberFromIndex(ind, ind->ix[ind->idx]);
+  int cur = ind->ix[ind->idx];
+  // the solving pass syncs ixds before handle_evid(), so it usually already
+  // matches and the bisection can be skipped
+  if (ind->ixds >= 0 && ind->ixds < ind->ndoses &&
+      ind->idose[ind->ixds] == cur) return ind->ixds;
+  int m = getDoseNumberFromIndex(ind, cur);
   return (m == -1) ? ind->ixds : m;
 }
 

--- a/inst/include/rxode2parseHandleEvid.h
+++ b/inst/include/rxode2parseHandleEvid.h
@@ -116,7 +116,15 @@ static inline int handleTlastInlineDoseIndex(rx_solving_options_ind *ind) {
   if (ind->ixds >= 0 && ind->ixds < ind->ndoses &&
       ind->idose[ind->ixds] == cur) return ind->ixds;
   int m = getDoseNumberFromIndex(ind, cur);
-  return (m == -1) ? ind->ixds : m;
+  if (m != -1) return m;
+  // _rxPushDose() appends doses at the end of all_times and then re-sorts the
+  // unprocessed idose suffix by time, so idose is not guaranteed to stay
+  // ascending in the record index and the bisection can miss a dose that is
+  // there.  Scan for it before giving up.
+  for (int j = 0; j < ind->ndoses; j++) {
+    if (ind->idose[j] == cur) return j;
+  }
+  return ind->ixds;
 }
 
 static inline int handleTlastInlineUpateDosingInformation(rx_solving_options_ind *ind, double *curDose, double *tinf) {

--- a/inst/include/rxode2parseHandleEvid.h
+++ b/inst/include/rxode2parseHandleEvid.h
@@ -89,6 +89,31 @@ static inline void handleInfusionGetEndOfInfusionIndex(int idx, int *infEixds,
 	}
 }
 
+static inline int getDoseNumberFromIndex(rx_solving_options_ind *ind, int idx) {
+  // bisection https://en.wikipedia.org/wiki/Binary_search_algorithm
+  int l = 0, r = ind->ndoses-1, m=0, idose = 0;
+  while(l <= r){
+    m = FLOOR((l+r)/2);
+    idose= ind->idose[m];
+    if (idose < idx) l = m+1;
+    else if (idose > idx) r = m-1;
+    else return m;
+  }
+  return -1;
+}
+
+// Dose index (into ind->idose) of the record currently being handled.
+// ind->ixds is the solver's running dose counter; the output/lhs pass
+// (rxode2_df.cpp) calls handleTlastInline() without advancing or syncing it, so
+// ixds can point at an unrelated dose there.  Recover the index from ind->idx
+// whenever the record is a real (non-extra) dose, and only fall back to ixds
+// for extra doses, whose idx does not map into idose.
+static inline int handleTlastInlineDoseIndex(rx_solving_options_ind *ind) {
+  if (ind->idx < 0) return ind->ixds;
+  int m = getDoseNumberFromIndex(ind, ind->ix[ind->idx]);
+  return (m == -1) ? ind->ixds : m;
+}
+
 static inline int handleTlastInlineUpateDosingInformation(rx_solving_options_ind *ind, double *curDose, double *tinf) {
   unsigned int p;
   switch (ind->whI) {
@@ -109,8 +134,9 @@ static inline int handleTlastInlineUpateDosingInformation(rx_solving_options_ind
       return 0;
     } else {
       // The amt in rxode2 is the infusion rate, but we need the amt
-      if (ind->fns->getdur) tinf[0] = ind->fns->getdur(ind->ixds, ind, 2, &p);
-      else tinf[0] = _getDur(ind->ixds, ind, 2, &p);
+      int doseIdx = handleTlastInlineDoseIndex(ind);
+      if (ind->fns->getdur) tinf[0] = ind->fns->getdur(doseIdx, ind, 2, &p);
+      else tinf[0] = _getDur(doseIdx, ind, 2, &p);
       if (!ISNA(tinf[0])) {
         curDose[0] = tinf[0] * curDose[0];
         return 1;
@@ -155,18 +181,6 @@ static inline void handleTlastInline(double *time, rx_solving_options_ind *ind) 
   }
 }
 
-static inline int getDoseNumberFromIndex(rx_solving_options_ind *ind, int idx) {
-  // bisection https://en.wikipedia.org/wiki/Binary_search_algorithm
-  int l = 0, r = ind->ndoses-1, m=0, idose = 0;
-  while(l <= r){
-    m = FLOOR((l+r)/2);
-    idose= ind->idose[m];
-    if (idose < idx) l = m+1;
-    else if (idose > idx) r = m-1;
-    else return m;
-  }
-  return -1;
-}
 
 
 static inline int syncIdx(rx_solving_options_ind *ind) {

--- a/src/handle_evid.cpp
+++ b/src/handle_evid.cpp
@@ -76,7 +76,10 @@ extern "C" double _getDur(int l, rx_solving_options_ind *ind, int backward, unsi
     while (p[0] < ind->ndoses && getDoseNumber(ind, p[0]) != -dose){
       p[0]++;
     }
-    if (getDoseNumber(ind, p[0]) != -dose){
+    // A scan that ran off the end must not be re-read: idose only holds ndoses
+    // entries for this subject, so idose[ndoses] belongs to the next subject
+    // (or is past gidose entirely for the last one) and can spuriously match.
+    if (p[0] >= ind->ndoses || getDoseNumber(ind, p[0]) != -dose){
       if (backward==2) return(NA_REAL);
       rx_solving_options *op = (ind->op ? ind->op : &op_global);
       if (omp_in_parallel()) {

--- a/src/handle_evid.cpp
+++ b/src/handle_evid.cpp
@@ -37,18 +37,25 @@ extern "C" void handleTlast(double *time, rx_solving_options_ind *ind) {
 // set badSolve so the error is handled after the parallel region completes.
 // In single-threaded context, call Rf_errorcall for an actionable error message.
 extern "C" double _getDur(int l, rx_solving_options_ind *ind, int backward, unsigned int *p) {
+  // Bounds-check before touching idose: getDoseNumber() dereferences
+  // ind->idose[l], and callers can hand over a dose counter that has run past
+  // the last dose (see the syncIdx() note in rxode2parseHandleEvid.h), so the
+  // read has to be guarded ahead of the branch, not inside it.
+  if (l < 0 || l >= ind->ndoses) {
+    if (backward==2) return(NA_REAL);
+    rx_solving_options *op = (ind->op ? ind->op : &op_global);
+    if (omp_in_parallel()) {
+      int newBadSolve = 1;
+#pragma omp atomic write
+      op->badSolve = newBadSolve;
+      return NA_REAL;
+    }
+    (Rf_errorcall)(R_NilValue, l < 0 ?
+                   "infusion start cannot be found (l <= 0)" :
+                   "infusion end cannot be found (l >= ndoses)");
+  }
   double dose = getDoseNumber(ind, l);
   if (backward==1 && l != 0){
-    if (l <= 0) {
-      rx_solving_options *op = (ind->op ? ind->op : &op_global);
-      if (omp_in_parallel()) {
-        int newBadSolve = 1;
-#pragma omp atomic write
-        op->badSolve = newBadSolve;
-        return NA_REAL;
-      }
-      (Rf_errorcall)(R_NilValue, "infusion start cannot be found (l <= 0)");
-    }
     p[0] = l-1;
     while (p[0] > 0 && getDoseNumber(ind, p[0]) != -dose){
       p[0]--;
@@ -65,17 +72,6 @@ extern "C" double _getDur(int l, rx_solving_options_ind *ind, int backward, unsi
     }
     return getAllTimes(ind, ind->idose[l]) - getAllTimes(ind, ind->idose[p[0]]);
   } else {
-    if (l >= ind->ndoses) {
-      if (backward==2) return(NA_REAL);
-      rx_solving_options *op = (ind->op ? ind->op : &op_global);
-      if (omp_in_parallel()) {
-        int newBadSolve = 1;
-#pragma omp atomic write
-        op->badSolve = newBadSolve;
-        return NA_REAL;
-      }
-      (Rf_errorcall)(R_NilValue, "infusion end cannot be found (l >= ndoses)");
-    }
     p[0] = l+1;
     while (p[0] < ind->ndoses && getDoseNumber(ind, p[0]) != -dose){
       p[0]++;

--- a/tests/testthat/test-tad-infusion-after-bolus.R
+++ b/tests/testthat/test-tad-infusion-after-bolus.R
@@ -1,0 +1,79 @@
+rxTest({
+  # rxode2 issue #1316: an infusion was dropped from the dose history whenever
+  # the subject's dose record started with a bolus.  handleTlastInline() asked
+  # for the infusion duration with ind->ixds, the solver's running dose counter,
+  # which the output/lhs pass never advances, so the duration lookup failed
+  # (tad()/dosenum()/tlast() then skipped the dose) or silently returned the
+  # duration of a different infusion (making dose() wrong).
+
+  .mod <- rxode2({
+    ka <- 1
+    cl <- 5
+    v <- 50
+    d/dt(depot) <- -ka * depot
+    d/dt(center) <- ka * depot - (cl / v) * center
+    tadx <- tad()
+    dn <- dosenum()
+    dz <- dose()
+    tl <- tlast()
+  })
+
+  .obs <- function(t) {
+    data.frame(time = t, evid = 0, amt = 0, cmt = "center", rate = 0, dur = 0)
+  }
+  .dose <- function(time, amt, cmt, rate = 0, dur = 0) {
+    data.frame(time = time, evid = 1, amt = amt, cmt = cmt, rate = rate, dur = dur)
+  }
+  .solve <- function(e) {
+    e$id <- 1
+    rxSolve(.mod, e, returnType = "data.frame")[, c("time", "tadx", "dn", "dz", "tl")]
+  }
+
+  test_that("an infusion after a bolus still updates tad()/dosenum()/dose()", {
+    .r <- .solve(rbind(.dose(0, 100, "depot"),
+                       .dose(240, 50, "center", rate = 40),
+                       .obs(c(1, 241, 250))))
+    expect_equal(.r$dn, c(1, 2, 2))
+    expect_equal(.r$tadx, c(1, 1, 10))
+    expect_equal(.r$tl, c(0, 240, 240))
+    expect_equal(.r$dz, c(100, 50, 50))
+  })
+
+  test_that("a modeled-duration infusion after a bolus is also counted", {
+    .r <- .solve(rbind(.dose(0, 100, "depot"),
+                       .dose(240, 50, "center", dur = 1.25),
+                       .obs(c(1, 241, 250))))
+    expect_equal(.r$dn, c(1, 2, 2))
+    expect_equal(.r$tadx, c(1, 1, 10))
+    expect_equal(.r$dz, c(100, 50, 50))
+  })
+
+  test_that("two infusions after a bolus are both counted", {
+    .r <- .solve(rbind(.dose(0, 100, "depot"),
+                       .dose(120, 50, "center", rate = 40),
+                       .dose(240, 50, "center", rate = 40),
+                       .obs(c(1, 121, 241, 250))))
+    expect_equal(.r$dn, c(1, 2, 3, 3))
+    expect_equal(.r$tadx, c(1, 1, 1, 10))
+    expect_equal(.r$dz, c(100, 50, 50, 50))
+  })
+
+  test_that("a bolus into the infused compartment does not hide the infusion", {
+    .r <- .solve(rbind(.dose(0, 100, "center"),
+                       .dose(240, 50, "center", rate = 40),
+                       .obs(c(1, 241, 250))))
+    expect_equal(.r$dn, c(1, 2, 2))
+    expect_equal(.r$tadx, c(1, 1, 10))
+    expect_equal(.r$dz, c(100, 50, 50))
+  })
+
+  test_that("dose() reports each infusion's own amount, not the first one's", {
+    # both infusions share rate 40 but have different durations; before the fix
+    # the second one reported the first infusion's duration (hence amount)
+    .r <- .solve(rbind(.dose(0, 100, "center", rate = 40),
+                       .dose(240, 50, "center", rate = 40),
+                       .obs(c(1, 241, 250))))
+    expect_equal(.r$dn, c(1, 2, 2))
+    expect_equal(.r$dz, c(100, 50, 50))
+  })
+})

--- a/tests/testthat/test-tad-infusion-after-bolus.R
+++ b/tests/testthat/test-tad-infusion-after-bolus.R
@@ -67,6 +67,57 @@ rxTest({
     expect_equal(.r$dz, c(100, 50, 50))
   })
 
+  test_that("addl-expanded boluses before an infusion keep counting", {
+    .e <- rbind(
+      data.frame(time = 0, evid = 1, amt = 100, cmt = "depot",
+                 rate = 0, dur = 0, ii = 24, addl = 2),
+      data.frame(time = 80, evid = 1, amt = 50, cmt = "center",
+                 rate = 40, dur = 0, ii = 0, addl = 0),
+      data.frame(time = c(1, 25, 49, 81, 90), evid = 0, amt = 0, cmt = "center",
+                 rate = 0, dur = 0, ii = 0, addl = 0))
+    .r <- .solve(.e)
+    expect_equal(.r$dn, c(1, 2, 3, 4, 4))
+    expect_equal(.r$dz, c(100, 100, 100, 50, 50))
+  })
+
+  test_that("an infusion after a reset (evid=3) and a bolus is counted", {
+    .e <- rbind(.dose(0, 100, "depot"),
+                data.frame(time = 50, evid = 3, amt = 0, cmt = "center",
+                           rate = 0, dur = 0),
+                .dose(60, 50, "center", rate = 40),
+                .obs(c(1, 61, 70)))
+    .r <- .solve(.e)
+    expect_equal(.r$dn, c(1, 2, 2))
+    expect_equal(.r$tadx, c(1, 1, 10))
+    expect_equal(.r$dz, c(100, 50, 50))
+  })
+
+  test_that("a modeled lag that reorders the records keeps the history right", {
+    # alag pushes the bolus after the infusion, so ind->ix is no longer the
+    # identity permutation and the dose index must come from ind->ix[ind->idx]
+    .mod2 <- rxode2({
+      ka <- 1
+      cl <- 5
+      v <- 50
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - (cl / v) * center
+      alag(depot) <- 100
+      tadx <- tad()
+      dn <- dosenum()
+      dz <- dose()
+      tl <- tlast()
+    })
+    .e <- rbind(.dose(0, 100, "depot"),
+                .dose(10, 50, "center", rate = 40),
+                .obs(c(12, 20, 105, 120)))
+    .e$id <- 1
+    .r <- rxSolve(.mod2, .e, returnType = "data.frame")
+    expect_equal(.r$dn, c(1, 1, 2, 2))
+    expect_equal(.r$dz, c(50, 50, 100, 100))
+    expect_equal(.r$tl, c(10, 10, 100, 100))
+    expect_equal(.r$tadx, c(2, 10, 5, 20))
+  })
+
   test_that("dose() reports each infusion's own amount, not the first one's", {
     # both infusions share rate 40 but have different durations; before the fix
     # the second one reported the first infusion's duration (hence amount)


### PR DESCRIPTION
Fixes #1316.

## The bug

`tad()`, `tafd()`, `tlast()`, `dosenum()` and `dose()` silently skipped an
infusion whenever a subject's dose record started with a bolus. The infusion was
delivered on schedule -- only the dose-history bookkeeping broke, so TAD-based
diagnostics (`vpcPlotTad()`, anything binned on `tad`) were wrong with nothing
reported.

## Cause

`handleTlastInlineUpateDosingInformation()` looked the infusion duration up with
`ind->ixds`, the solver's running dose counter. `handleEvid1()` syncs that
counter via `syncIdx()` before calling `handle_evid()`, but the output pass in
`src/rxode2_df.cpp` calls `handleTlastInline()` directly with only `ind->idx`
set and never advances or syncs `ixds`, so there it pointed at an unrelated
dose. The lookup then either

- failed, and `_getDur(..., backward=2)` returned `NA` -- the dose was dropped
  from the history entirely, leaving `dosenum()` un-incremented and `tad()`
  counting from the earlier dose; or
- silently returned a *different* infusion's duration, which made `dose()`
  report the wrong amount. This one bit even the sequences the issue lists as
  working: with two rate-40 infusions of different durations, the second
  reported the first one's amount.

## Fix

Derive the dose index from the record being handled (`ind->ix[ind->idx]`)
instead of trusting `ixds`. The new `handleTlastInlineDoseIndex()` tries the
already-synced `ixds` first, then the existing `getDoseNumberFromIndex()`
bisection, then a linear scan, and only falls back to `ixds` for extra doses
(`idx < 0`), whose amount lives in `extraDoseDose` rather than `idose` and for
which there is no dose index to recover -- unchanged behavior there.

`getDoseNumberFromIndex()` moved earlier in the header so it is defined before
use; it is otherwise untouched.

## Also in here

Two pre-existing problems an Antigravity review turned up while checking this
change:

- `_getDur()` read `ind->idose[l]` through `getDoseNumber()` *before* either
  branch's bounds check, so a dose counter run past the last dose (which the
  `syncIdx()` comment already documents as possible) produced an out-of-bounds
  read ahead of the check meant to catch it. A single `l < 0 || l >= ndoses`
  guard is now hoisted to the top, keeping the `NA` return for `backward == 2`
  and both existing messages; the two now-subsumed inner checks are gone.
- `getDoseNumberFromIndex()`'s bisection assumes `idose` stays ascending in
  record index, but `_rxPushDose()` re-sorts the unprocessed `idose` suffix by
  *time*, so it can miss a dose that is present. Hence the linear scan before
  the fallback.

## Verification

`tests/testthat/test-tad-infusion-after-bolus.R` covers the reported case, a
modeled-duration infusion, two infusions after a bolus, a bolus into the infused
compartment, `dose()` reporting each infusion's own amount, `addl`-expanded
boluses, a reset (`evid=3`) in between, and a modeled `alag` that reorders the
records so `ind->ix` is not the identity permutation. Every one of them fails on
the unfixed build.

All nine dosing sequences from the issue's table were re-run and now update the
history. Locally, a targeted subset of 14,175 tests and a 7,792-test subset after
the hardening both pass with no failures; the full suite is left to CI.
