### PR TITLE
feat(linCmt): per-compartment dose-time and bioavailability sensitivities (#1119 part B)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,23 @@
 
 ## New features
 
+- `linCmt()` models can now report a PER-COMPARTMENT dose-time sensitivity.
+  `linCmtB(which1 = -3)` differentiates with respect to one delay shared by
+  every dose feeding the linear system, so a regimen that doses a lagged
+  depot alongside an unlagged central -- the paired IV/oral design
+  bioavailability is routinely estimated from -- had to be refused.  Two new
+  modes read a per-origin decomposition of the linCmt() amounts instead:
+  `which1 = -9` is the derivative with respect to a delay on one
+  compartment's doses alone, and `which1 = -10` returns the amounts that
+  arrived through one compartment, which chain-rules to bioavailability as
+  `A^(q)/F_q`.  `which2` packs the origin compartment and the wanted output
+  (`q*8 + out`, `out = 7` for the reported concentration).  Both match
+  central finite differences across one to three compartments, IV and oral,
+  bolus, infusion and steady-state bolus regimens, including models that lag
+  their linCmt() compartments differently.  The decomposition is maintained
+  only for a model that declares a modeled `alag()`/`f()` on a `linCmt()`
+  compartment (nlmixr2/rxode2#1119).
+
 - `linCmt()`'s sensitivity state now belongs to the INDIVIDUAL rather than to
   whichever thread happens to be running it.  The theta-keyed window of
   hoisted closed-form constants and the last-row value memo are the two

--- a/R/eventSens.R
+++ b/R/eventSens.R
@@ -602,7 +602,8 @@
        "dose feeding the linear system shares one alag(); this model lags ",
        "linCmt() compartment(s) '", paste(.cmts, collapse = "', '"),
        "' differently ('", paste(unique(unname(.lag)), collapse = "' vs '"),
-       "'), which it cannot represent -- see nlmixr2/rxode2#1237", call. = FALSE)
+       "'), which it cannot represent -- use the per-compartment ",
+       "'linCmtB(which1 = -9)' instead; see nlmixr2/rxode2#1237", call. = FALSE)
 }
 
 #' Free symbols of a dosing expression in symengine (SE-mangled) names

--- a/inst/include/rxode2parseStruct.h
+++ b/inst/include/rxode2parseStruct.h
@@ -396,31 +396,6 @@ struct rx_solving_options_ind_s {
   double *linCmtRateHist;   /* flat idx-indexed rate history, or NULL when unused */
   int     linCmtRateHistCap; /* capacity in idx slots */
   int     linCmtRateHistW;   /* doubles per idx slot (op->numLin); realloc if changed */
-  // Per-ORIGIN decomposition of the linCmt() amounts: row q holds the part of
-  // the amount vector that arrived through doses into linCmt block
-  // compartment q.  The system is linear, so the rows sum to the amounts, and
-  // each row obeys the same dynamics as the amounts with the regimen
-  // restricted to compartment q -- which is exactly what the PER-COMPARTMENT
-  // dose-time sensitivity needs: delaying only compartment q's doses gives
-  // dA/dL_q = -(M A^(q) + r^(q)) (linCmtB which1 = -9), and scaling only its
-  // dose gives dA/dF_q = A^(q)/F_q (which1 = -10).  That answers the
-  // mixed-route regimen -- a lagged depot alongside an unlagged central --
-  // which the single shared delay of which1 = -3 has to refuse
-  // (nlmixr2/rxode2#1119 part B, #1237).
-  //
-  // Fixed stride RX_LINCMT_ORIGIN_MAX regardless of the model's actual
-  // m = ncmt + oral0 so iniSubject() can reset it without knowing m:
-  // linCmtOrigin[q*RX_LINCMT_ORIGIN_MAX + j].  Only rows/cols < m are used.
-  // Opt-in: maintained only when op->linCmtOriginMask is nonzero.
-#define RX_LINCMT_ORIGIN_MAX 4
-  double  linCmtOrigin[RX_LINCMT_ORIGIN_MAX*RX_LINCMT_ORIGIN_MAX];
-  int     linCmtOriginSeeded; /* 0 until this subject's first advance seeded it */
-  // Per-idx history of the above, kept for the same reason linCmtRateHist is:
-  // the output pass re-queries an already-solved index after the live state
-  // has moved on.  Flat idx-major, idx*linCmtOriginHistW + k.
-  double *linCmtOriginHist;   /* flat idx-indexed origin history, or NULL when unused */
-  int     linCmtOriginHistCap; /* capacity in idx slots */
-  int     linCmtOriginHistW;   /* doubles per idx slot (m*RX_LINCMT_ORIGIN_MAX) */
   // Cumulative sensitivity carry state for the linCmt()-time-varying-covariate
   // fix (project_lincmt_timevarying_covariate_bug): d(Alast_i)/d(eta), one
   // column per carried (linCmt-parameter, eta) pair, one row per linCmt()
@@ -499,6 +474,31 @@ struct rx_solving_options_ind_s {
   // Allocated on first touch inside the solve and released with the subject in
   // rxFreeInd(), the same lifecycle linCmtRateHist and delayHist above use.
   void    *linCmtBind;      /* linCmtBind*, or NULL before first touch */
+  // Per-ORIGIN decomposition of the linCmt() amounts: row q holds the part of
+  // the amount vector that arrived through doses into linCmt block
+  // compartment q.  The system is linear, so the rows sum to the amounts, and
+  // each row obeys the same dynamics as the amounts with the regimen
+  // restricted to compartment q -- which is exactly what the PER-COMPARTMENT
+  // dose-time sensitivity needs: delaying only compartment q's doses gives
+  // dA/dL_q = -(M A^(q) + r^(q)) (linCmtB which1 = -9), and scaling only its
+  // dose gives dA/dF_q = A^(q)/F_q (which1 = -10).  That answers the
+  // mixed-route regimen -- a lagged depot alongside an unlagged central --
+  // which the single shared delay of which1 = -3 has to refuse
+  // (nlmixr2/rxode2#1119 part B, #1237).
+  //
+  // Fixed stride RX_LINCMT_ORIGIN_MAX regardless of the model's actual
+  // m = ncmt + oral0 so iniSubject() can reset it without knowing m:
+  // linCmtOrigin[q*RX_LINCMT_ORIGIN_MAX + j].  Only rows/cols < m are used.
+  // Opt-in: maintained only when op->linCmtOriginMask is nonzero.
+#define RX_LINCMT_ORIGIN_MAX 4
+  double  linCmtOrigin[RX_LINCMT_ORIGIN_MAX*RX_LINCMT_ORIGIN_MAX];
+  int     linCmtOriginSeeded; /* 0 until this subject's first advance seeded it */
+  // Per-idx history of the above, kept for the same reason linCmtRateHist is:
+  // the output pass re-queries an already-solved index after the live state
+  // has moved on.  Flat idx-major, idx*linCmtOriginHistW + k.
+  double *linCmtOriginHist;   /* flat idx-indexed origin history, or NULL when unused */
+  int     linCmtOriginHistCap; /* capacity in idx slots */
+  int     linCmtOriginHistW;   /* doubles per idx slot (m*RX_LINCMT_ORIGIN_MAX) */
 };
 
 typedef struct rx_solve_s {

--- a/inst/include/rxode2parseStruct.h
+++ b/inst/include/rxode2parseStruct.h
@@ -179,6 +179,14 @@ typedef struct {
      really does share one delay (nlmixr2/rxode2#1119, #1237).  0 when the
      model declares no modeled alag() on a linCmt() compartment. */
   int    linCmtLagMask;
+  /* Bitmask over the same block of the compartments whose DOSE the model
+     moves or scales -- a modeled alag() (propAlag) or f() (propF).  Gates the
+     per-origin decomposition of the linCmt() amounts that answers the
+     PER-COMPARTMENT dose-time and bioavailability sensitivities
+     (linCmtB which1 = -9 / -10, src/linCmt.cpp).  Tracking costs one extra
+     kernel evaluation per origin per step, so a model that cannot use it
+     pays nothing.  Superset of linCmtLagMask. */
+  int    linCmtOriginMask;
 } rx_solving_options;
 
 
@@ -388,6 +396,31 @@ struct rx_solving_options_ind_s {
   double *linCmtRateHist;   /* flat idx-indexed rate history, or NULL when unused */
   int     linCmtRateHistCap; /* capacity in idx slots */
   int     linCmtRateHistW;   /* doubles per idx slot (op->numLin); realloc if changed */
+  // Per-ORIGIN decomposition of the linCmt() amounts: row q holds the part of
+  // the amount vector that arrived through doses into linCmt block
+  // compartment q.  The system is linear, so the rows sum to the amounts, and
+  // each row obeys the same dynamics as the amounts with the regimen
+  // restricted to compartment q -- which is exactly what the PER-COMPARTMENT
+  // dose-time sensitivity needs: delaying only compartment q's doses gives
+  // dA/dL_q = -(M A^(q) + r^(q)) (linCmtB which1 = -9), and scaling only its
+  // dose gives dA/dF_q = A^(q)/F_q (which1 = -10).  That answers the
+  // mixed-route regimen -- a lagged depot alongside an unlagged central --
+  // which the single shared delay of which1 = -3 has to refuse
+  // (nlmixr2/rxode2#1119 part B, #1237).
+  //
+  // Fixed stride RX_LINCMT_ORIGIN_MAX regardless of the model's actual
+  // m = ncmt + oral0 so iniSubject() can reset it without knowing m:
+  // linCmtOrigin[q*RX_LINCMT_ORIGIN_MAX + j].  Only rows/cols < m are used.
+  // Opt-in: maintained only when op->linCmtOriginMask is nonzero.
+#define RX_LINCMT_ORIGIN_MAX 4
+  double  linCmtOrigin[RX_LINCMT_ORIGIN_MAX*RX_LINCMT_ORIGIN_MAX];
+  int     linCmtOriginSeeded; /* 0 until this subject's first advance seeded it */
+  // Per-idx history of the above, kept for the same reason linCmtRateHist is:
+  // the output pass re-queries an already-solved index after the live state
+  // has moved on.  Flat idx-major, idx*linCmtOriginHistW + k.
+  double *linCmtOriginHist;   /* flat idx-indexed origin history, or NULL when unused */
+  int     linCmtOriginHistCap; /* capacity in idx slots */
+  int     linCmtOriginHistW;   /* doubles per idx slot (m*RX_LINCMT_ORIGIN_MAX) */
   // Cumulative sensitivity carry state for the linCmt()-time-varying-covariate
   // fix (project_lincmt_timevarying_covariate_bug): d(Alast_i)/d(eta), one
   // column per carried (linCmt-parameter, eta) pair, one row per linCmt()

--- a/inst/include/rxode2parseStruct.h
+++ b/inst/include/rxode2parseStruct.h
@@ -493,6 +493,25 @@ struct rx_solving_options_ind_s {
 #define RX_LINCMT_ORIGIN_MAX 4
   double  linCmtOrigin[RX_LINCMT_ORIGIN_MAX*RX_LINCMT_ORIGIN_MAX];
   int     linCmtOriginSeeded; /* 0 until this subject's first advance seeded it */
+  // linCmtOrigin above is the decomposition at the START of the row
+  // linCmtOriginIdx names -- the analogue of Alast -- and linCmtOriginOut is
+  // the advanced result for that row.  They have to be separate because a
+  // model that mixes linCmt() with ODEs re-enters linCmtB() many times WITHIN
+  // one row (dydt fires at every internal solver step), so the advance must be
+  // a pure function of the row's entry state, exactly as the amounts are a
+  // pure function of Alast.  The last call for the row wins, which is the same
+  // convention copyLinCmt() applies to the amounts (it evaluates dydt once at
+  // ind->tout and copies what that produced).  linCmtOriginIdx = -1 means no
+  // row has been advanced for this subject yet.
+  double  linCmtOriginOut[RX_LINCMT_ORIGIN_MAX*RX_LINCMT_ORIGIN_MAX];
+  int     linCmtOriginOutSeeded;
+  int     linCmtOriginIdx;
+  /* ind->linSS the row named by linCmtOriginIdx was advanced under.  A
+     steady-state linCmt() record runs its SS solve and the normal advance
+     that follows it at the SAME idx (handleSSbolus(), src/par_solve.cpp), so
+     idx alone does not identify the row -- keying on both keeps the normal
+     advance building on the SS result instead of discarding it. */
+  int     linCmtOriginSS;
   // Per-idx history of the above, kept for the same reason linCmtRateHist is:
   // the output pass re-queries an already-solved index after the live state
   // has moved on.  Flat idx-major, idx*linCmtOriginHistW + k.

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -89,10 +89,15 @@ extern "C" double linCmtB(rx_solve *rx, int id,
 // direction (a loud NA, not a wrong number).
 //
 // Both answers come out of ONE pass over ind->idose.
+// `ssInfMask` (optional, may be NULL) narrows the steady-state-infusion
+// answer to the compartments it actually reaches, which the PER-COMPARTMENT
+// modes (which1 = -9/-10) can use to refuse only the affected origin instead
+// of the whole model.
 static inline void linCmtDoseScan(rx_solving_options_ind *ind,
                                   rx_solving_options *op,
-                                  int *dosedMask, int *ssInf) {
-  int mask = 0, ss = 0;
+                                  int *dosedMask, int *ssInf,
+                                  int *ssInfMask = NULL) {
+  int mask = 0, ss = 0, ssMask = 0;
   int nLin = op->numLin < 31 ? op->numLin : 31;
   for (int i = 0; i < ind->ndoses; ++i) {
     int wh, cmt, wh100, whI, wh0;
@@ -103,6 +108,7 @@ static inline void linCmtDoseScan(rx_solving_options_ind *ind,
          wh0 == EVID0_SS2 || wh0 == EVID0_SSINF) &&
         whI != EVIDF_NORMAL && whI != EVIDF_REPLACE && whI != EVIDF_MULT) {
       ss = 1;
+      ssMask |= (1 << c);
     }
     if (!(whI == EVIDF_NORMAL && wh0 == EVID0_REGULAR &&
           getDoseNumber(ind, i) == 0.0)) {
@@ -111,6 +117,7 @@ static inline void linCmtDoseScan(rx_solving_options_ind *ind,
   }
   *dosedMask = mask;
   *ssInf = ss;
+  if (ssInfMask != NULL) *ssInfMask = ssMask;
 }
 
 // Per-idx cache of the infusion rate feeding a linCmt() model, keyed the same
@@ -144,6 +151,39 @@ static inline double *linCmtBRateSlot(rx_solving_options_ind *ind, int idx, int 
     ind->linCmtRateHistCap = newCap;
   }
   return ind->linCmtRateHist + (size_t)idx * width;
+}
+
+// Per-idx cache of the per-origin decomposition of the linCmt() amounts
+// (ind->linCmtOrigin), keyed and grown exactly like linCmtBRateSlot() above
+// and read back for the same reason: the output pass re-queries an index the
+// live state has already moved past.  `width` is m*RX_LINCMT_ORIGIN_MAX.
+static inline double *linCmtOriginSlot(rx_solving_options_ind *ind, int idx, int width, int grow) {
+  if (idx < 0 || width <= 0) return NULL;
+  if (ind->linCmtOriginHistW != width) {
+    free(ind->linCmtOriginHist);
+    ind->linCmtOriginHist = NULL;
+    ind->linCmtOriginHistCap = 0;
+    ind->linCmtOriginHistW = width;
+  }
+  if (idx >= ind->linCmtOriginHistCap) {
+    if (!grow) return NULL;
+    int newCap = ind->linCmtOriginHistCap > 0 ? ind->linCmtOriginHistCap : 64;
+    while (idx >= newCap) newCap *= 2;
+    double *np = (double*) realloc(ind->linCmtOriginHist, (size_t)newCap * width * sizeof(double));
+    if (np == NULL) (Rf_error)("cannot allocate linCmt origin history");
+    memset(np + (size_t)ind->linCmtOriginHistCap * width, 0,
+           (size_t)(newCap - ind->linCmtOriginHistCap) * width * sizeof(double));
+    ind->linCmtOriginHist = np;
+    ind->linCmtOriginHistCap = newCap;
+  }
+  return ind->linCmtOriginHist + (size_t)idx * width;
+}
+
+// The rate slot feeding linCmt block compartment `q`, or -1 when nothing can
+// infuse into it.  The rate vector is getNrate() = 1 + oral0 long: depot then
+// central when oral, central alone otherwise; peripherals are never infused.
+static inline int linCmtOriginRateIdx(int q, int oral0) {
+  return (q >= 0 && q < 1 + oral0) ? q : -1;
 }
 
 // Create linear compartment models for testing
@@ -2123,6 +2163,165 @@ static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
   return NA_REAL;
 }
 
+// The per-origin decomposition of the linCmt() amounts, kept in step with the
+// solve one interval at a time.
+//
+// Row q of ind->linCmtOrigin is the part of the amount vector that arrived
+// through doses into linCmt block compartment q.  The system is linear, so the
+// rows sum to the amounts -- which is what makes them recoverable here without
+// any cooperation from handle_evid.  Whatever a dose added to the amounts since
+// the previous advance shows up as the difference between the amounts now and
+// the rows' sum, and a bolus only changes the compartment it was given to, so
+// that difference IS the dose, already attributed to the right row.  Each row
+// is then advanced by the same kernel that advances the amounts, with the rate
+// restricted to its own compartment.  Rounding keeps the rows summing to the
+// amounts exactly, because the residual is re-attributed every step.
+//
+// Before the first advance the compartments hold the initial conditions, which
+// are not a dose: op->inits is subtracted once so they are not attributed to
+// one.  A steady-state record replaces the state outright rather than adding
+// to it, so its whole result belongs to the compartment the SS dose was given
+// to.  If that compartment cannot be identified the state is poisoned
+// (linCmtOriginSeeded = 2) and every later query answers NA rather than a
+// number built on a guess.
+static inline void linCmtOriginAdvance(stan::math::linCmtStan &lc,
+                                       rx_solving_options_ind *ind,
+                                       rx_solving_options *op,
+                                       const double *aPrev,
+                                       const Eigen::Matrix<double, Eigen::Dynamic, 1> &fx,
+                                       const double *rate,
+                                       int ncmt, int oral0, int trans,
+                                       double p1, double v1,
+                                       double p2, double p3,
+                                       double p4, double p5,
+                                       double ka, int idx) {
+  const int m = ncmt + oral0;
+  if (m <= 0 || m > RX_LINCMT_ORIGIN_MAX) return;
+  const int st = RX_LINCMT_ORIGIN_MAX;
+  double *O = ind->linCmtOrigin;
+  if (ind->linSS != 0) {
+    int cmt = (ind->linSS == linCmtSsBolus) ? ind->linSSbolusCmt : ind->cmt;
+    int q0 = cmt - op->linOffset;
+    memset(O, 0, sizeof(ind->linCmtOrigin));
+    if (q0 < 0 || q0 >= m || (int)fx.size() != m) {
+      ind->linCmtOriginSeeded = 2;
+      return;
+    }
+    for (int j = 0; j < m; ++j) O[q0*st + j] = fx(j, 0);
+    ind->linCmtOriginSeeded = 1;
+  } else {
+    // Attribute whatever entered the compartments since the last advance.
+    for (int j = 0; j < m; ++j) {
+      double sum = 0.0;
+      for (int q = 0; q < m; ++q) sum += O[q*st + j];
+      double base = 0.0;
+      if (ind->linCmtOriginSeeded == 0 && op->inits != NULL) {
+        base = op->inits[op->linOffset + j];
+      }
+      O[j*st + j] += aPrev[j] - sum - base;
+    }
+    ind->linCmtOriginSeeded = 1;
+    // Advance every row over this interval, each seeing only its own rate.
+    Eigen::Matrix<double, Eigen::Dynamic, 1> th(lc.getNpars());
+    if (!linCmtFillTheta(th, ncmt, oral0, p1, v1, p2, p3, p4, p5, ka)) {
+      ind->linCmtOriginSeeded = 2;
+      return;
+    }
+    Eigen::Matrix<double, Eigen::Dynamic, 2> g =
+      stan::math::macros2micros(th, ncmt, trans);
+    double rq[RX_LINCMT_ORIGIN_MAX];
+    Eigen::Matrix<double, Eigen::Dynamic, 1> in(m), outv(m);
+    for (int q = 0; q < m; ++q) {
+      int nr = 1 + oral0;
+      for (int k = 0; k < nr; ++k) rq[k] = 0.0;
+      int ri = linCmtOriginRateIdx(q, oral0);
+      if (ri >= 0 && rate != NULL) rq[ri] = rate[ri];
+      for (int j = 0; j < m; ++j) in(j, 0) = O[q*st + j];
+      lc.advanceWithRate(in, g, ka, rq, outv);
+      for (int j = 0; j < m; ++j) O[q*st + j] = outv(j, 0);
+    }
+  }
+  double *slot = linCmtOriginSlot(ind, idx, m*st, 1);
+  if (slot != NULL) std::copy(O, O + m*st, slot);
+}
+
+// linCmtB's which1 = -9 / -10 cases: the PER-COMPARTMENT dose-time and
+// bioavailability sensitivities.
+//
+// which1 = -3 differentiates wrt ONE delay shared by every dose feeding the
+// linear system, which a regimen that doses a lagged depot alongside an
+// unlagged central cannot supply -- it has to be refused
+// (nlmixr2/rxode2#1237).  These modes answer it instead, by asking the
+// per-origin decomposition (linCmtOriginAdvance() above) what part of the
+// amounts came through compartment q:
+//
+//   which1 = -9   d/dL_q, the derivative wrt a delay on compartment q's doses
+//                 alone.  Only that part of the state moves with L_q, so the
+//                 same A(t; L) = A(t - L; 0) argument gives -(M A^(q) + r^(q)),
+//                 the system's own right-hand side evaluated on the row.
+//   which1 = -10  A^(q) itself, the amounts that arrived through compartment q.
+//                 The system is linear in the dose, so the bioavailability
+//                 sensitivity is d/dF_q = A^(q)/F_q -- no extra mode needed.
+//
+// which2 packs both indices: q*RX_LINCMT_ORIGIN_W2 + out, with out the
+// compartment whose amount is wanted, or RX_LINCMT_ORIGIN_CONC for the
+// reported concentration.  Summing which1 = -9 over every dosed q reproduces
+// which1 = -3 where -3 is defined.
+//
+// NA_REAL for a call that does not describe the model `lc` is set up for, an
+// out of range q/out, a poisoned decomposition, or -- for which1 = -9 -- a
+// rate that could not be recovered or a steady-state infusion into q itself
+// (its rate is not carried past the SS solve; see linCmtDoseScan()).
+#define RX_LINCMT_ORIGIN_W2   8
+#define RX_LINCMT_ORIGIN_CONC 7
+static inline double linCmtBorigin(stan::math::linCmtStan &lc,
+                                   rx_solving_options_ind *ind,
+                                   rx_solving_options *op,
+                                   const double *origin, const double *rate,
+                                   int ncmt, int oral0, int which1, int which2,
+                                   int trans,
+                                   double p1, double v1,
+                                   double p2, double p3,
+                                   double p4, double p5,
+                                   double ka) {
+  const int m = ncmt + oral0;
+  if (lc.ncmt_ != ncmt || lc.oral0_ != oral0 || lc.trans_ != trans ||
+      m > RX_LINCMT_ORIGIN_MAX) {
+    return NA_REAL;
+  }
+  if (which2 < 0 || origin == NULL || ind->linCmtOriginSeeded == 2) return NA_REAL;
+  int q   = which2 / RX_LINCMT_ORIGIN_W2;
+  int out = which2 % RX_LINCMT_ORIGIN_W2;
+  if (q >= m) return NA_REAL;
+  if (out != RX_LINCMT_ORIGIN_CONC && out >= m) return NA_REAL;
+  const int st = RX_LINCMT_ORIGIN_MAX;
+  Eigen::Matrix<double, Eigen::Dynamic, 1> th(lc.getNpars());
+  if (!linCmtFillTheta(th, ncmt, oral0, p1, v1, p2, p3, p4, p5, ka)) {
+    return NA_REAL;
+  }
+  if (which1 == -10) {
+    double val = (out == RX_LINCMT_ORIGIN_CONC) ? origin[q*st + oral0] : origin[q*st + out];
+    if (out == RX_LINCMT_ORIGIN_CONC) val /= lc.getVc(th);
+    return val;
+  }
+  if (rate == NULL) return NA_REAL;
+  int dosed, ssInf, ssInfMask;
+  linCmtDoseScan(ind, op, &dosed, &ssInf, &ssInfMask);
+  if ((ssInfMask & (1 << q)) != 0) return NA_REAL;
+  Eigen::Matrix<double, Eigen::Dynamic, 2> gm =
+    stan::math::macros2micros(th, ncmt, trans);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> Aq(m), dot(m);
+  for (int j = 0; j < m; ++j) Aq(j, 0) = origin[q*st + j];
+  double rq[RX_LINCMT_ORIGIN_MAX];
+  int nr = 1 + oral0;
+  for (int k = 0; k < nr; ++k) rq[k] = 0.0;
+  int ri = linCmtOriginRateIdx(q, oral0);
+  if (ri >= 0) rq[ri] = rate[ri];
+  lc.dAdt(Aq, gm, ka, rq, dot);
+  if (out == RX_LINCMT_ORIGIN_CONC) return -dot(oral0, 0) / lc.getVc(th);
+  return -dot(out, 0);
+}
+
 /*
  *  linCmtB
  *
@@ -2181,6 +2380,17 @@ static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
  *  infusion's rate is recovered at output time via the linCmtBRateSlot()
  *  per-idx cache (nlmixr2/rxode2#1236); an individual with a steady-state
   *  infusion still gets `NA_REAL` -- see linCmtDoseScan().
+ *
+ *  When which1 is -9, the PER-COMPARTMENT dose-time sensitivity is returned:
+ *  the derivative wrt a delay on ONE linCmt() compartment's doses rather than
+ *  a delay shared by all of them, so a regimen that doses a lagged depot
+ *  alongside an unlagged central is answered instead of refused.  When which1
+ *  is -10, the amounts that arrived through one compartment are returned,
+ *  which chain-rules to bioavailability as A^(q)/F_q.  Both take which2 =
+ *  q*8 + out (out = the compartment whose amount is wanted, or 7 for the
+ *  reported concentration) and both need the model to declare a modeled
+ *  alag()/f() on a linCmt() compartment, which is what turns the underlying
+ *  decomposition on.  See linCmtBorigin() below.
  *
  *  The parameter order is as follows:
  *
@@ -2483,6 +2693,17 @@ static inline bool linCmtBquery(linB_t &lcb, linCmtBind &wsp, rx_solve *rx,
   } else if (which1 == -4) {
     *out = linCmtBtransition(lcb, rx, ind, op, idx, _t, ncmt, oral0, which2, trans,
                              p1, v1, p2, p3, p4, p5, ka);
+  } else if (which1 == -9 || which1 == -10) {
+    // Same re-query rule as which1 = -3: an already-solved idx reads the
+    // per-idx caches, since both the live rate and the live decomposition
+    // have moved on by the time the output pass asks.
+    int reQuery = (!ind->doSS && ind->solvedIdx >= idx);
+    const double *rate = reQuery ? linCmtBRateSlot(ind, idx, op->numLin, 0) : getLinRate;
+    const double *origin = reQuery ?
+      linCmtOriginSlot(ind, idx, op->numLin*RX_LINCMT_ORIGIN_MAX, 0) :
+      ind->linCmtOrigin;
+    *out = linCmtBorigin(lcb.lc, ind, op, origin, rate, ncmt, oral0, which1, which2,
+                         trans, p1, v1, p2, p3, p4, p5, ka);
   } else if (which1 == -7) {
     *out = linCmtBcarryAdd(ind, ncmt, oral0, which2, p2);
   } else if (which1 == -8) {
@@ -2739,6 +2960,16 @@ extern "C" double linCmtB(rx_solve *rx, int id,
   lcb.lc.setPtr(a, r, ind->linCmtSave);
 
   linCmtBsolveRow(lcb, wsp, rx, ind, op, id, idx, _t, a, r, ncmt, oral0, trans, theta, thetaSens);
+  // Keep the per-origin decomposition (which1 = -9/-10) in step, but only on
+  // a row that is GENUINELY being solved -- never on a restore/lhs re-query
+  // (it would advance the state twice) and never on an H-perturbed
+  // evaluation (its amounts belong to a perturbed parameter, not the solve).
+  // Opt-in: a model that moves or scales no linCmt() dose pays nothing.
+  if (op->linCmtOriginMask != 0 && ind->linCmtHparIndex < -1 &&
+      !((!ind->doSS && ind->solvedIdx >= idx) || ind->_rxFlag == 11)) {
+    linCmtOriginAdvance(lcb.lc, ind, op, a, lcb.fx, r, ncmt, oral0, trans,
+                        p1, v1, p2, p3, p4, p5, ka, idx);
+  }
   lcb.lc.getJacCp(lcb.J, lcb.fx, theta, lcb.Jg);
   double val = lcb.lc.adjustF(lcb.fx, theta, ind->linCmtHV);
   wsp.memoIdx = idx; wsp.memoT = _t;

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -2244,7 +2244,14 @@ static inline void linCmtOriginAdvance(stan::math::linCmtStan &lc,
   // Every later call for the same row recomputes from that same entry, so the
   // many re-entries a mixed linCmt()+ODE model makes within one row (dydt
   // fires at every internal solver step) cannot accumulate; the last call
-  // wins, which is where copyLinCmt() takes the amounts from too.  A
+  // wins, which is where copyLinCmt() takes the amounts from too.
+  //
+  // Recomputing (rather than stepping) is what the surrounding machinery
+  // already does: ind->tprior is set once per event interval by preSolve(),
+  // never per internal step, so linCmtBsolveRow()'s dt = _t - ind->tprior
+  // spans the whole interval on every call and `aPrev` stays the interval's
+  // starting amounts until copyLinCmt() writes at the end of it.  Advancing
+  // incrementally instead read ~16% off on a mixed linCmt()+ODE model.  A
   // steady-state record runs its SS solve and the normal advance that follows
   // it at the SAME idx, so ind->linSS is part of the row's identity.
   if (ind->linCmtOriginIdx != idx || ind->linCmtOriginSS != ind->linSS) {
@@ -2334,6 +2341,15 @@ static inline void linCmtOriginAdvance(stan::math::linCmtStan &lc,
 // compartment whose amount is wanted, or RX_LINCMT_ORIGIN_CONC for the
 // reported concentration.  Summing which1 = -9 over every dosed q reproduces
 // which1 = -3 where -3 is defined.
+//
+// NA_REAL for a call that does not describe the model `lc` is set up for, an
+// The micro-constants come from the CALLER's p1..ka, while the decomposition
+// they are applied to was advanced with lc.trueTheta(thetaSens).  Those agree
+// on every ordinary row and differ only on a finite-difference H-optimization
+// probe, where linCmtBsolveRow() perturbs thetaSens but not the caller's
+// arguments -- exactly the convention which1 = -3 has always used
+// (linCmtBdoseTime() builds gm the same way from amounts that came out of the
+// perturbed solve), so the two modes stay consistent with each other.
 //
 // NA_REAL for a call that does not describe the model `lc` is set up for, an
 // out of range q/out, a poisoned decomposition, a regimen carrying a record

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -2353,7 +2353,6 @@ static inline void linCmtOriginAdvance(stan::math::linCmtStan &lc,
 // reported concentration.  Summing which1 = -9 over every dosed q reproduces
 // which1 = -3 where -3 is defined.
 //
-// NA_REAL for a call that does not describe the model `lc` is set up for, an
 // The micro-constants come from the CALLER's p1..ka, while the decomposition
 // they are applied to was advanced with lc.trueTheta(thetaSens).  Those agree
 // on every ordinary row and differ only on a finite-difference H-optimization
@@ -2371,6 +2370,28 @@ static inline void linCmtOriginAdvance(stan::math::linCmtStan &lc,
 // past the SS solve; see linCmtDoseScan()).
 #define RX_LINCMT_ORIGIN_W2   8
 #define RX_LINCMT_ORIGIN_CONC 7
+// Is this a call the decomposition can answer, and which (origin, output) does
+// its which2 name?  `seeded` != 1 is either a row that never advanced the
+// decomposition -- a model taking its VALUE from linCmtA() rather than the
+// linCmtB(which1 = which2 = -1) call these modes require, or one that declares
+// no modeled alag()/f() so op->linCmtOriginMask left it off -- or one poisoned
+// by a record whose origin could not be identified.  All of them are NA, never
+// a 0 that reads like a real derivative.
+static inline bool linCmtOriginDecode(stan::math::linCmtStan &lc, const double *origin,
+                                      int seeded, int ncmt, int oral0, int which2,
+                                      int trans, int *q, int *out) {
+  const int m = ncmt + oral0;
+  if (lc.ncmt_ != ncmt || lc.oral0_ != oral0 || lc.trans_ != trans ||
+      m > RX_LINCMT_ORIGIN_MAX) {
+    return false;
+  }
+  if (which2 < 0 || origin == NULL || seeded != 1) return false;
+  *q   = which2 / RX_LINCMT_ORIGIN_W2;
+  *out = which2 % RX_LINCMT_ORIGIN_W2;
+  if (*q >= m) return false;
+  return *out == RX_LINCMT_ORIGIN_CONC || *out < m;
+}
+
 // Can this individual's regimen be split into origins at all?  A REPLACE or
 // MULTIPLY into the linCmt() block, or an ss = 2 steady state, changes a
 // compartment holding several origins' mass in a way the amounts alone cannot
@@ -2424,22 +2445,10 @@ static inline double linCmtBorigin(stan::math::linCmtStan &lc,
                                    double p2, double p3,
                                    double p4, double p5,
                                    double ka) {
-  const int m = ncmt + oral0;
-  if (lc.ncmt_ != ncmt || lc.oral0_ != oral0 || lc.trans_ != trans ||
-      m > RX_LINCMT_ORIGIN_MAX) {
+  int q, out;
+  if (!linCmtOriginDecode(lc, origin, seeded, ncmt, oral0, which2, trans, &q, &out)) {
     return NA_REAL;
   }
-  // `seeded` != 1 is either a row that never advanced the decomposition -- a
-  // model taking its VALUE from linCmtA() rather than the
-  // linCmtB(which1 = which2 = -1) call these modes require, or one that
-  // declares no modeled alag()/f() so op->linCmtOriginMask left it off -- or
-  // one poisoned by a record whose origin could not be identified.  Both are
-  // NA, never a 0 that reads like a real derivative.
-  if (which2 < 0 || origin == NULL || seeded != 1) return NA_REAL;
-  int q   = which2 / RX_LINCMT_ORIGIN_W2;
-  int out = which2 % RX_LINCMT_ORIGIN_W2;
-  if (q >= m) return NA_REAL;
-  if (out != RX_LINCMT_ORIGIN_CONC && out >= m) return NA_REAL;
   Eigen::Matrix<double, Eigen::Dynamic, 1> th(lc.getNpars());
   if (!linCmtFillTheta(th, ncmt, oral0, p1, v1, p2, p3, p4, p5, ka)) {
     return NA_REAL;

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -92,15 +92,20 @@ extern "C" double linCmtB(rx_solve *rx, int id,
 // `ssInfMask` (optional, may be NULL) narrows the steady-state-infusion
 // answer to the compartments it actually reaches, which the PER-COMPARTMENT
 // modes (which1 = -9/-10) can use to refuse only the affected origin instead
-// of the whole model.  `replMult` (optional) reports whether any REPLACE or
-// MULTIPLY record targets the linCmt() block at all: those rewrite a
-// compartment that may hold mass from several origins, and the amounts alone
-// cannot say how the rewrite divided among them, so the decomposition -- not
-// just one row of it -- stops being recoverable (see linCmtBorigin()).
+// of the whole model.  `unsplit` (optional) reports whether the regimen
+// carries a record the decomposition cannot follow at all -- one that changes
+// a compartment holding several origins' mass in a way the amounts alone
+// cannot divide among them, so the whole decomposition, not just one row of
+// it, stops being recoverable (see linCmtBorigin()):
+//
+//   REPLACE / MULTIPLY  rewrites or rescales a compartment outright.
+//   ss = 2 (EVID0_SS2 / EVID0_SS20)  ADDS a steady state to whatever was
+//     already there, so the result is neither a fresh SS solution to
+//     attribute to the SS compartment nor a dose the amounts reveal.
 static inline void linCmtDoseScan(rx_solving_options_ind *ind,
                                   rx_solving_options *op,
                                   int *dosedMask, int *ssInf,
-                                  int *ssInfMask = NULL, int *replMult = NULL) {
+                                  int *ssInfMask = NULL, int *unsplit = NULL) {
   int mask = 0, ss = 0, ssMask = 0, rm = 0;
   int nLin = op->numLin < 31 ? op->numLin : 31;
   for (int i = 0; i < ind->ndoses; ++i) {
@@ -114,7 +119,8 @@ static inline void linCmtDoseScan(rx_solving_options_ind *ind,
       ss = 1;
       ssMask |= (1 << c);
     }
-    if (whI == EVIDF_REPLACE || whI == EVIDF_MULT) {
+    if (whI == EVIDF_REPLACE || whI == EVIDF_MULT ||
+        wh0 == EVID0_SS2 || wh0 == EVID0_SS20) {
       rm = 1;
     }
     if (!(whI == EVIDF_NORMAL && wh0 == EVID0_REGULAR &&
@@ -125,7 +131,7 @@ static inline void linCmtDoseScan(rx_solving_options_ind *ind,
   *dosedMask = mask;
   *ssInf = ss;
   if (ssInfMask != NULL) *ssInfMask = ssMask;
-  if (replMult != NULL) *replMult = rm;
+  if (unsplit != NULL) *unsplit = rm;
 }
 
 // Per-idx cache of the infusion rate feeding a linCmt() model, keyed the same
@@ -2330,10 +2336,10 @@ static inline void linCmtOriginAdvance(stan::math::linCmtStan &lc,
 // which1 = -3 where -3 is defined.
 //
 // NA_REAL for a call that does not describe the model `lc` is set up for, an
-// out of range q/out, a poisoned decomposition, a regimen carrying a REPLACE
-// or MULTIPLY record into the linCmt() block (it rewrites a compartment that
-// may hold several origins' mass, and the amounts cannot say how the rewrite
-// divided among them), or -- for which1 = -9 -- a rate that could not be
+// out of range q/out, a poisoned decomposition, a regimen carrying a record
+// the decomposition cannot follow (a REPLACE/MULTIPLY into the linCmt() block,
+// or an ss = 2 steady state, which ADDS to whatever was already there -- see
+// linCmtDoseScan()), or -- for which1 = -9 -- a rate that could not be
 // recovered or a steady-state infusion into q itself (its rate is not carried
 // past the SS solve; see linCmtDoseScan()).
 #define RX_LINCMT_ORIGIN_W2   8
@@ -2370,17 +2376,17 @@ static inline double linCmtBorigin(stan::math::linCmtStan &lc,
     return NA_REAL;
   }
   if (which1 == -10) {
-    int dosed0, ssInf0, ssInfMask0, replMult0;
-    linCmtDoseScan(ind, op, &dosed0, &ssInf0, &ssInfMask0, &replMult0);
-    if (replMult0) return NA_REAL;
+    int dosed0, ssInf0, ssInfMask0, unsplit0;
+    linCmtDoseScan(ind, op, &dosed0, &ssInf0, &ssInfMask0, &unsplit0);
+    if (unsplit0) return NA_REAL;
     double val = (out == RX_LINCMT_ORIGIN_CONC) ? origin[q*st + oral0] : origin[q*st + out];
     if (out == RX_LINCMT_ORIGIN_CONC) val /= lc.getVc(th);
     return val;
   }
   if (rate == NULL) return NA_REAL;
-  int dosed, ssInf, ssInfMask, replMult;
-  linCmtDoseScan(ind, op, &dosed, &ssInf, &ssInfMask, &replMult);
-  if (replMult) return NA_REAL;
+  int dosed, ssInf, ssInfMask, unsplit;
+  linCmtDoseScan(ind, op, &dosed, &ssInf, &ssInfMask, &unsplit);
+  if (unsplit) return NA_REAL;
   if ((ssInfMask & (1 << q)) != 0) return NA_REAL;
   Eigen::Matrix<double, Eigen::Dynamic, 2> gm =
     stan::math::macros2micros(th, ncmt, trans);

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -2229,6 +2229,80 @@ static inline void linCmtOriginCacheRow(rx_solving_options_ind *ind, int idx, in
 // perturbed one of them, and wherever rx->ndiff masks a parameter out of the
 // sensitivity set.  Advancing the rows with anything else would let the
 // mismatch reappear as a phantom dose on the next interval.
+// Roll the row-entry state forward the first time a NEW row is advanced.
+// Every later call for the same row recomputes from that same entry, so the
+// many re-entries a mixed linCmt()+ODE model makes within one row (dydt fires
+// at every internal solver step) cannot accumulate; the last call wins, which
+// is where copyLinCmt() takes the amounts from too.
+//
+// Recomputing (rather than stepping) is what the surrounding machinery already
+// does: ind->tprior is set once per event interval by preSolve(), never per
+// internal step, so linCmtBsolveRow()'s dt = _t - ind->tprior spans the whole
+// interval on every call and `aPrev` stays the interval's starting amounts
+// until copyLinCmt() writes at the end of it.  Advancing incrementally instead
+// read ~16% off on a mixed linCmt()+ODE model.  A steady-state record runs its
+// SS solve and the normal advance that follows it at the SAME idx, so
+// ind->linSS is part of the row's identity.
+static inline void linCmtOriginRollForward(rx_solving_options_ind *ind, int idx) {
+  if (ind->linCmtOriginIdx == idx && ind->linCmtOriginSS == ind->linSS) return;
+  if (ind->linCmtOriginIdx >= 0) {
+    memcpy(ind->linCmtOrigin, ind->linCmtOriginOut, sizeof(ind->linCmtOrigin));
+    ind->linCmtOriginSeeded = ind->linCmtOriginOutSeeded;
+  }
+  ind->linCmtOriginIdx = idx;
+  ind->linCmtOriginSS = ind->linSS;
+}
+
+// A steady-state record establishes the amounts analytically, replacing
+// whatever was there, so the whole result came through the SS dose's own
+// compartment.  Returns the seeded state to record (2 = the compartment could
+// not be identified, so nothing may be attributed).
+static inline int linCmtOriginSeedSs(rx_solving_options_ind *ind,
+                                     rx_solving_options *op, double *O,
+                                     const Eigen::Matrix<double, Eigen::Dynamic, 1> &fx,
+                                     int m) {
+  int cmt = (ind->linSS == linCmtSsBolus) ? ind->linSSbolusCmt : ind->cmt;
+  int q0 = cmt - op->linOffset;
+  memset(O, 0, sizeof(ind->linCmtOriginOut));
+  if (q0 < 0 || q0 >= m || (int)fx.size() != m) return 2;
+  for (int j = 0; j < m; ++j) O[q0*RX_LINCMT_ORIGIN_MAX + j] = fx(j, 0);
+  return 1;
+}
+
+// Attribute whatever entered the compartments since the last advance, then
+// carry every row over this interval seeing only its own rate.  Before the
+// first advance the compartments hold the initial conditions, which are not a
+// dose: op->inits is subtracted once (`sIn` == 0) so they are not booked as
+// one.  Returns the seeded state to record.
+static inline int linCmtOriginStep(stan::math::linCmtStan &lc,
+                                   rx_solving_options *op, double *O,
+                                   const double *aPrev, const double *rate,
+                                   const Eigen::Matrix<double, Eigen::Dynamic, 1> &th,
+                                   int ncmt, int oral0, int trans, int m, int sIn) {
+  const int st = RX_LINCMT_ORIGIN_MAX;
+  for (int j = 0; j < m; ++j) {
+    double sum = 0.0;
+    for (int q = 0; q < m; ++q) sum += O[q*st + j];
+    double base = (sIn == 0 && op->inits != NULL) ? op->inits[op->linOffset + j] : 0.0;
+    O[j*st + j] += aPrev[j] - sum - base;
+  }
+  if ((int)th.size() != 2*ncmt + oral0) return 2;
+  double ka = oral0 ? th(2*ncmt, 0) : 0.0;
+  Eigen::Matrix<double, Eigen::Dynamic, 2> g =
+    stan::math::macros2micros(th, ncmt, trans);
+  double rq[RX_LINCMT_ORIGIN_MAX];
+  Eigen::Matrix<double, Eigen::Dynamic, 1> in(m), outv(m);
+  for (int q = 0; q < m; ++q) {
+    for (int k = 0; k < 1 + oral0; ++k) rq[k] = 0.0;
+    int ri = linCmtOriginRateIdx(q, oral0);
+    if (ri >= 0 && rate != NULL) rq[ri] = rate[ri];
+    for (int j = 0; j < m; ++j) in(j, 0) = O[q*st + j];
+    lc.advanceWithRate(in, g, ka, rq, outv);
+    for (int j = 0; j < m; ++j) O[q*st + j] = outv(j, 0);
+  }
+  return 1;
+}
+
 static inline void linCmtOriginAdvance(stan::math::linCmtStan &lc,
                                        rx_solving_options_ind *ind,
                                        rx_solving_options *op,
@@ -2239,81 +2313,18 @@ static inline void linCmtOriginAdvance(stan::math::linCmtStan &lc,
                                        int ncmt, int oral0, int trans, int idx) {
   const int m = ncmt + oral0;
   if (m <= 0 || m > RX_LINCMT_ORIGIN_MAX) return;
-  const int st = RX_LINCMT_ORIGIN_MAX;
-  // Roll the row-entry state forward the first time a NEW row is advanced.
-  // Every later call for the same row recomputes from that same entry, so the
-  // many re-entries a mixed linCmt()+ODE model makes within one row (dydt
-  // fires at every internal solver step) cannot accumulate; the last call
-  // wins, which is where copyLinCmt() takes the amounts from too.
-  //
-  // Recomputing (rather than stepping) is what the surrounding machinery
-  // already does: ind->tprior is set once per event interval by preSolve(),
-  // never per internal step, so linCmtBsolveRow()'s dt = _t - ind->tprior
-  // spans the whole interval on every call and `aPrev` stays the interval's
-  // starting amounts until copyLinCmt() writes at the end of it.  Advancing
-  // incrementally instead read ~16% off on a mixed linCmt()+ODE model.  A
-  // steady-state record runs its SS solve and the normal advance that follows
-  // it at the SAME idx, so ind->linSS is part of the row's identity.
-  if (ind->linCmtOriginIdx != idx || ind->linCmtOriginSS != ind->linSS) {
-    if (ind->linCmtOriginIdx >= 0) {
-      memcpy(ind->linCmtOrigin, ind->linCmtOriginOut, sizeof(ind->linCmtOrigin));
-      ind->linCmtOriginSeeded = ind->linCmtOriginOutSeeded;
-    }
-    ind->linCmtOriginIdx = idx;
-    ind->linCmtOriginSS = ind->linSS;
-  }
+  linCmtOriginRollForward(ind, idx);
   double *O = ind->linCmtOriginOut;
   memcpy(O, ind->linCmtOrigin, sizeof(ind->linCmtOriginOut));
   int sIn = ind->linCmtOriginSeeded, sOut;
   if (ind->linSS != 0) {
-    int cmt = (ind->linSS == linCmtSsBolus) ? ind->linSSbolusCmt : ind->cmt;
-    int q0 = cmt - op->linOffset;
-    memset(O, 0, sizeof(ind->linCmtOriginOut));
-    if (q0 < 0 || q0 >= m || (int)fx.size() != m) {
-      ind->linCmtOriginOutSeeded = 2;
-      linCmtOriginCacheRow(ind, idx, m, O, 2);
-      return;
-    }
-    for (int j = 0; j < m; ++j) O[q0*st + j] = fx(j, 0);
-    sOut = 1;
+    sOut = linCmtOriginSeedSs(ind, op, O, fx, m);
   } else if (sIn == 2) {
     // Poisoned by an earlier record whose origin could not be identified;
     // there is nothing to attribute the amounts to any more.
-    ind->linCmtOriginOutSeeded = 2;
-    linCmtOriginCacheRow(ind, idx, m, O, 2);
-    return;
+    sOut = 2;
   } else {
-    // Attribute whatever entered the compartments since the last advance.
-    for (int j = 0; j < m; ++j) {
-      double sum = 0.0;
-      for (int q = 0; q < m; ++q) sum += O[q*st + j];
-      double base = 0.0;
-      if (sIn == 0 && op->inits != NULL) {
-        base = op->inits[op->linOffset + j];
-      }
-      O[j*st + j] += aPrev[j] - sum - base;
-    }
-    // Advance every row over this interval, each seeing only its own rate.
-    if ((int)th.size() != 2*ncmt + oral0) {
-      ind->linCmtOriginOutSeeded = 2;
-      linCmtOriginCacheRow(ind, idx, m, O, 2);
-      return;
-    }
-    double ka = oral0 ? th(2*ncmt, 0) : 0.0;
-    Eigen::Matrix<double, Eigen::Dynamic, 2> g =
-      stan::math::macros2micros(th, ncmt, trans);
-    double rq[RX_LINCMT_ORIGIN_MAX];
-    Eigen::Matrix<double, Eigen::Dynamic, 1> in(m), outv(m);
-    for (int q = 0; q < m; ++q) {
-      int nr = 1 + oral0;
-      for (int k = 0; k < nr; ++k) rq[k] = 0.0;
-      int ri = linCmtOriginRateIdx(q, oral0);
-      if (ri >= 0 && rate != NULL) rq[ri] = rate[ri];
-      for (int j = 0; j < m; ++j) in(j, 0) = O[q*st + j];
-      lc.advanceWithRate(in, g, ka, rq, outv);
-      for (int j = 0; j < m; ++j) O[q*st + j] = outv(j, 0);
-    }
-    sOut = 1;
+    sOut = linCmtOriginStep(lc, op, O, aPrev, rate, th, ncmt, oral0, trans, m, sIn);
   }
   ind->linCmtOriginOutSeeded = sOut;
   linCmtOriginCacheRow(ind, idx, m, O, sOut);
@@ -2360,6 +2371,49 @@ static inline void linCmtOriginAdvance(stan::math::linCmtStan &lc,
 // past the SS solve; see linCmtDoseScan()).
 #define RX_LINCMT_ORIGIN_W2   8
 #define RX_LINCMT_ORIGIN_CONC 7
+// Can this individual's regimen be split into origins at all?  A REPLACE or
+// MULTIPLY into the linCmt() block, or an ss = 2 steady state, changes a
+// compartment holding several origins' mass in a way the amounts alone cannot
+// divide among them -- see linCmtDoseScan().  `ssInfQ` additionally reports a
+// steady-state infusion reaching origin `q`, whose rate is not carried past
+// the SS solve.
+static inline bool linCmtOriginFollows(rx_solving_options_ind *ind,
+                                       rx_solving_options *op, int q, int *ssInfQ) {
+  int dosed, ssInf, ssInfMask, unsplit;
+  linCmtDoseScan(ind, op, &dosed, &ssInf, &ssInfMask, &unsplit);
+  if (ssInfQ != NULL) *ssInfQ = (ssInfMask & (1 << q)) != 0;
+  return unsplit == 0;
+}
+
+// The amounts that arrived through origin `q`, as the requested output.
+static inline double linCmtOriginAmount(stan::math::linCmtStan &lc, const double *origin,
+                                        const Eigen::Matrix<double, Eigen::Dynamic, 1> &th,
+                                        int oral0, int q, int out) {
+  const int st = RX_LINCMT_ORIGIN_MAX;
+  if (out == RX_LINCMT_ORIGIN_CONC) return origin[q*st + oral0] / lc.getVc(th);
+  return origin[q*st + out];
+}
+
+// -(M A^(q) + r^(q)): the system's own right-hand side on origin `q`'s row,
+// which is its dose-time derivative.
+static inline double linCmtOriginDoseTime(stan::math::linCmtStan &lc, const double *origin,
+                                          const Eigen::Matrix<double, Eigen::Dynamic, 1> &th,
+                                          const double *rate, int ncmt, int oral0,
+                                          int trans, int q, int out, double ka) {
+  const int m = ncmt + oral0, st = RX_LINCMT_ORIGIN_MAX;
+  Eigen::Matrix<double, Eigen::Dynamic, 2> gm =
+    stan::math::macros2micros(th, ncmt, trans);
+  Eigen::Matrix<double, Eigen::Dynamic, 1> Aq(m), dot(m);
+  for (int j = 0; j < m; ++j) Aq(j, 0) = origin[q*st + j];
+  double rq[RX_LINCMT_ORIGIN_MAX];
+  for (int k = 0; k < 1 + oral0; ++k) rq[k] = 0.0;
+  int ri = linCmtOriginRateIdx(q, oral0);
+  if (ri >= 0) rq[ri] = rate[ri];
+  lc.dAdt(Aq, gm, ka, rq, dot);
+  if (out == RX_LINCMT_ORIGIN_CONC) return -dot(oral0, 0) / lc.getVc(th);
+  return -dot(out, 0);
+}
+
 static inline double linCmtBorigin(stan::math::linCmtStan &lc,
                                    rx_solving_options_ind *ind,
                                    rx_solving_options *op,
@@ -2386,36 +2440,17 @@ static inline double linCmtBorigin(stan::math::linCmtStan &lc,
   int out = which2 % RX_LINCMT_ORIGIN_W2;
   if (q >= m) return NA_REAL;
   if (out != RX_LINCMT_ORIGIN_CONC && out >= m) return NA_REAL;
-  const int st = RX_LINCMT_ORIGIN_MAX;
   Eigen::Matrix<double, Eigen::Dynamic, 1> th(lc.getNpars());
   if (!linCmtFillTheta(th, ncmt, oral0, p1, v1, p2, p3, p4, p5, ka)) {
     return NA_REAL;
   }
+  int ssInfQ = 0;
+  if (!linCmtOriginFollows(ind, op, q, &ssInfQ)) return NA_REAL;
   if (which1 == -10) {
-    int dosed0, ssInf0, ssInfMask0, unsplit0;
-    linCmtDoseScan(ind, op, &dosed0, &ssInf0, &ssInfMask0, &unsplit0);
-    if (unsplit0) return NA_REAL;
-    double val = (out == RX_LINCMT_ORIGIN_CONC) ? origin[q*st + oral0] : origin[q*st + out];
-    if (out == RX_LINCMT_ORIGIN_CONC) val /= lc.getVc(th);
-    return val;
+    return linCmtOriginAmount(lc, origin, th, oral0, q, out);
   }
-  if (rate == NULL) return NA_REAL;
-  int dosed, ssInf, ssInfMask, unsplit;
-  linCmtDoseScan(ind, op, &dosed, &ssInf, &ssInfMask, &unsplit);
-  if (unsplit) return NA_REAL;
-  if ((ssInfMask & (1 << q)) != 0) return NA_REAL;
-  Eigen::Matrix<double, Eigen::Dynamic, 2> gm =
-    stan::math::macros2micros(th, ncmt, trans);
-  Eigen::Matrix<double, Eigen::Dynamic, 1> Aq(m), dot(m);
-  for (int j = 0; j < m; ++j) Aq(j, 0) = origin[q*st + j];
-  double rq[RX_LINCMT_ORIGIN_MAX];
-  int nr = 1 + oral0;
-  for (int k = 0; k < nr; ++k) rq[k] = 0.0;
-  int ri = linCmtOriginRateIdx(q, oral0);
-  if (ri >= 0) rq[ri] = rate[ri];
-  lc.dAdt(Aq, gm, ka, rq, dot);
-  if (out == RX_LINCMT_ORIGIN_CONC) return -dot(oral0, 0) / lc.getVc(th);
-  return -dot(out, 0);
+  if (rate == NULL || ssInfQ) return NA_REAL;
+  return linCmtOriginDoseTime(lc, origin, th, rate, ncmt, oral0, trans, q, out, ka);
 }
 
 /*
@@ -2764,6 +2799,33 @@ static inline bool linCmtBread(linB_t &lcb, int which1, int which2, double *out)
   return false;
 }
 
+// which1 = -9/-10 dispatch: find this row's decomposition and rate, then read
+// it.  Same re-query rule as which1 = -3 -- an already-solved idx reads the
+// per-idx caches, since both the live rate and the live decomposition have
+// moved on by the time the output pass asks, and a re-queried row carries its
+// own seeded state because the live flag is gone by then.  The cache width
+// must match what linCmtOriginAdvance() wrote, so it comes from the CALL's
+// shape (ncmt + oral0), not from op->numLin.
+static inline double linCmtBoriginQuery(linB_t &lcb, rx_solving_options_ind *ind,
+                                        rx_solving_options *op, int idx,
+                                        int ncmt, int oral0, int which1, int which2,
+                                        int trans,
+                                        double p1, double v1, double p2, double p3,
+                                        double p4, double p5, double ka) {
+  int reQuery = (!ind->doSS && ind->solvedIdx >= idx);
+  int mOrig = ncmt + oral0;
+  const double *rate = reQuery ? linCmtBRateSlot(ind, idx, op->numLin, 0) : getLinRate;
+  const double *origin = reQuery ?
+    linCmtOriginSlot(ind, idx, RX_LINCMT_ORIGIN_SLOTW(mOrig), 0) :
+    ind->linCmtOriginOut;
+  int seeded = ind->linCmtOriginOutSeeded;
+  if (reQuery) {
+    seeded = (origin == NULL) ? 0 : (int)origin[mOrig*RX_LINCMT_ORIGIN_MAX];
+  }
+  return linCmtBorigin(lcb.lc, ind, op, origin, seeded, rate, ncmt, oral0,
+                       which1, which2, trans, p1, v1, p2, p3, p4, p5, ka);
+}
+
 // Sentinel reads and carry calls (which1/which2 not both -1).  These assume
 // the -1,-1 solve for this row has already run.  Returns false for a
 // combination no sentinel handles, in which case linCmtB() falls through
@@ -2790,24 +2852,8 @@ static inline bool linCmtBquery(linB_t &lcb, linCmtBind &wsp, rx_solve *rx,
     *out = linCmtBtransition(lcb, rx, ind, op, idx, _t, ncmt, oral0, which2, trans,
                              p1, v1, p2, p3, p4, p5, ka);
   } else if (which1 == -9 || which1 == -10) {
-    // Same re-query rule as which1 = -3: an already-solved idx reads the
-    // per-idx caches, since both the live rate and the live decomposition
-    // have moved on by the time the output pass asks.
-    int reQuery = (!ind->doSS && ind->solvedIdx >= idx);
-    const double *rate = reQuery ? linCmtBRateSlot(ind, idx, op->numLin, 0) : getLinRate;
-    // Width must match what linCmtOriginAdvance() wrote, so it comes from the
-    // CALL's shape (ncmt + oral0), not from op->numLin.  A re-queried row
-    // carries its own seeded state; the live flag is gone by then.
-    int mOrig = ncmt + oral0;
-    const double *origin = reQuery ?
-      linCmtOriginSlot(ind, idx, RX_LINCMT_ORIGIN_SLOTW(mOrig), 0) :
-      ind->linCmtOriginOut;
-    int seeded = ind->linCmtOriginOutSeeded;
-    if (reQuery) {
-      seeded = (origin == NULL) ? 0 : (int)origin[mOrig*RX_LINCMT_ORIGIN_MAX];
-    }
-    *out = linCmtBorigin(lcb.lc, ind, op, origin, seeded, rate, ncmt, oral0,
-                         which1, which2, trans, p1, v1, p2, p3, p4, p5, ka);
+    *out = linCmtBoriginQuery(lcb, ind, op, idx, ncmt, oral0, which1, which2,
+                              trans, p1, v1, p2, p3, p4, p5, ka);
   } else if (which1 == -7) {
     *out = linCmtBcarryAdd(ind, ncmt, oral0, which2, p2);
   } else if (which1 == -8) {

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -156,7 +156,13 @@ static inline double *linCmtBRateSlot(rx_solving_options_ind *ind, int idx, int 
 // Per-idx cache of the per-origin decomposition of the linCmt() amounts
 // (ind->linCmtOrigin), keyed and grown exactly like linCmtBRateSlot() above
 // and read back for the same reason: the output pass re-queries an index the
-// live state has already moved past.  `width` is m*RX_LINCMT_ORIGIN_MAX.
+// live state has already moved past.  A slot is
+// RX_LINCMT_ORIGIN_SLOTW(m) wide: the m*RX_LINCMT_ORIGIN_MAX decomposition
+// followed by the `seeded` state that produced it.  That state has to travel
+// WITH the row rather than be read off ind->linCmtOriginSeeded, because the
+// output pass runs after iniSubject() has cleared the live flag -- which is
+// the very reason this cache exists.
+#define RX_LINCMT_ORIGIN_SLOTW(m) ((m)*RX_LINCMT_ORIGIN_MAX + 1)
 static inline double *linCmtOriginSlot(rx_solving_options_ind *ind, int idx, int width, int grow) {
   if (idx < 0 || width <= 0) return NULL;
   if (ind->linCmtOriginHistW != width) {
@@ -2163,6 +2169,23 @@ static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
   return NA_REAL;
 }
 
+// Record this row's decomposition in the per-idx cache.
+//
+// The stored flag is 1 for any usable decomposition and 2 for a poisoned one;
+// a slot never written keeps the 0 linCmtOriginSlot() zero-fills it with, so a
+// re-query can tell "this row has no answer" from "this row's answer is 0".
+// A row that only RESTORED (no advance -- the first record of a subject, whose
+// amounts are still the initial conditions) is a usable all-zero
+// decomposition, but the live linCmtOriginSeeded stays 0 there: it also means
+// "op->inits has not been subtracted yet", which the first real advance needs.
+static inline void linCmtOriginCacheRow(rx_solving_options_ind *ind, int idx, int m) {
+  if (m <= 0 || m > RX_LINCMT_ORIGIN_MAX) return;
+  double *slot = linCmtOriginSlot(ind, idx, RX_LINCMT_ORIGIN_SLOTW(m), 1);
+  if (slot == NULL) return;
+  std::copy(ind->linCmtOrigin, ind->linCmtOrigin + m*RX_LINCMT_ORIGIN_MAX, slot);
+  slot[m*RX_LINCMT_ORIGIN_MAX] = (ind->linCmtOriginSeeded == 2) ? 2.0 : 1.0;
+}
+
 // The per-origin decomposition of the linCmt() amounts, kept in step with the
 // solve one interval at a time.
 //
@@ -2205,10 +2228,16 @@ static inline void linCmtOriginAdvance(stan::math::linCmtStan &lc,
     memset(O, 0, sizeof(ind->linCmtOrigin));
     if (q0 < 0 || q0 >= m || (int)fx.size() != m) {
       ind->linCmtOriginSeeded = 2;
+      linCmtOriginCacheRow(ind, idx, m);
       return;
     }
     for (int j = 0; j < m; ++j) O[q0*st + j] = fx(j, 0);
     ind->linCmtOriginSeeded = 1;
+  } else if (ind->linCmtOriginSeeded == 2) {
+    // Poisoned by an earlier record whose origin could not be identified;
+    // there is nothing to attribute the amounts to any more.
+    linCmtOriginCacheRow(ind, idx, m);
+    return;
   } else {
     // Attribute whatever entered the compartments since the last advance.
     for (int j = 0; j < m; ++j) {
@@ -2225,6 +2254,7 @@ static inline void linCmtOriginAdvance(stan::math::linCmtStan &lc,
     Eigen::Matrix<double, Eigen::Dynamic, 1> th(lc.getNpars());
     if (!linCmtFillTheta(th, ncmt, oral0, p1, v1, p2, p3, p4, p5, ka)) {
       ind->linCmtOriginSeeded = 2;
+      linCmtOriginCacheRow(ind, idx, m);
       return;
     }
     Eigen::Matrix<double, Eigen::Dynamic, 2> g =
@@ -2241,8 +2271,7 @@ static inline void linCmtOriginAdvance(stan::math::linCmtStan &lc,
       for (int j = 0; j < m; ++j) O[q*st + j] = outv(j, 0);
     }
   }
-  double *slot = linCmtOriginSlot(ind, idx, m*st, 1);
-  if (slot != NULL) std::copy(O, O + m*st, slot);
+  linCmtOriginCacheRow(ind, idx, m);
 }
 
 // linCmtB's which1 = -9 / -10 cases: the PER-COMPARTMENT dose-time and
@@ -2277,7 +2306,7 @@ static inline void linCmtOriginAdvance(stan::math::linCmtStan &lc,
 static inline double linCmtBorigin(stan::math::linCmtStan &lc,
                                    rx_solving_options_ind *ind,
                                    rx_solving_options *op,
-                                   const double *origin, const double *rate,
+                                   const double *origin, int seeded, const double *rate,
                                    int ncmt, int oral0, int which1, int which2,
                                    int trans,
                                    double p1, double v1,
@@ -2289,7 +2318,13 @@ static inline double linCmtBorigin(stan::math::linCmtStan &lc,
       m > RX_LINCMT_ORIGIN_MAX) {
     return NA_REAL;
   }
-  if (which2 < 0 || origin == NULL || ind->linCmtOriginSeeded == 2) return NA_REAL;
+  // `seeded` != 1 is either a row that never advanced the decomposition -- a
+  // model taking its VALUE from linCmtA() rather than the
+  // linCmtB(which1 = which2 = -1) call these modes require, or one that
+  // declares no modeled alag()/f() so op->linCmtOriginMask left it off -- or
+  // one poisoned by a record whose origin could not be identified.  Both are
+  // NA, never a 0 that reads like a real derivative.
+  if (which2 < 0 || origin == NULL || seeded != 1) return NA_REAL;
   int q   = which2 / RX_LINCMT_ORIGIN_W2;
   int out = which2 % RX_LINCMT_ORIGIN_W2;
   if (q >= m) return NA_REAL;
@@ -2699,11 +2734,19 @@ static inline bool linCmtBquery(linB_t &lcb, linCmtBind &wsp, rx_solve *rx,
     // have moved on by the time the output pass asks.
     int reQuery = (!ind->doSS && ind->solvedIdx >= idx);
     const double *rate = reQuery ? linCmtBRateSlot(ind, idx, op->numLin, 0) : getLinRate;
+    // Width must match what linCmtOriginAdvance() wrote, so it comes from the
+    // CALL's shape (ncmt + oral0), not from op->numLin.  A re-queried row
+    // carries its own seeded state; the live flag is gone by then.
+    int mOrig = ncmt + oral0;
     const double *origin = reQuery ?
-      linCmtOriginSlot(ind, idx, op->numLin*RX_LINCMT_ORIGIN_MAX, 0) :
+      linCmtOriginSlot(ind, idx, RX_LINCMT_ORIGIN_SLOTW(mOrig), 0) :
       ind->linCmtOrigin;
-    *out = linCmtBorigin(lcb.lc, ind, op, origin, rate, ncmt, oral0, which1, which2,
-                         trans, p1, v1, p2, p3, p4, p5, ka);
+    int seeded = ind->linCmtOriginSeeded;
+    if (reQuery) {
+      seeded = (origin == NULL) ? 0 : (int)origin[mOrig*RX_LINCMT_ORIGIN_MAX];
+    }
+    *out = linCmtBorigin(lcb.lc, ind, op, origin, seeded, rate, ncmt, oral0,
+                         which1, which2, trans, p1, v1, p2, p3, p4, p5, ka);
   } else if (which1 == -7) {
     *out = linCmtBcarryAdd(ind, ncmt, oral0, which2, p2);
   } else if (which1 == -8) {
@@ -2966,9 +3009,23 @@ extern "C" double linCmtB(rx_solve *rx, int id,
   // evaluation (its amounts belong to a perturbed parameter, not the solve).
   // Opt-in: a model that moves or scales no linCmt() dose pays nothing.
   if (op->linCmtOriginMask != 0 && ind->linCmtHparIndex < -1 &&
-      !((!ind->doSS && ind->solvedIdx >= idx) || ind->_rxFlag == 11)) {
-    linCmtOriginAdvance(lcb.lc, ind, op, a, lcb.fx, r, ncmt, oral0, trans,
-                        p1, v1, p2, p3, p4, p5, ka, idx);
+      ind->_rxFlag != 11) {
+    if (ind->doSS || ind->solvedIdx < idx) {
+      linCmtOriginAdvance(lcb.lc, ind, op, a, lcb.fx, r, ncmt, oral0, trans,
+                          p1, v1, p2, p3, p4, p5, ka, idx);
+    } else {
+      // A restored row advances nothing, but the FIRST record of a subject
+      // only ever restores -- its amounts are still the initial conditions --
+      // and the output pass has no other way to learn that its decomposition
+      // is a real, empty one.  Cache it once; a later restore of an index the
+      // solve has already moved past must not overwrite what it recorded.
+      int mOrig = ncmt + oral0;
+      double *slot = (mOrig > 0 && mOrig <= RX_LINCMT_ORIGIN_MAX) ?
+        linCmtOriginSlot(ind, idx, RX_LINCMT_ORIGIN_SLOTW(mOrig), 1) : NULL;
+      if (slot != NULL && slot[mOrig*RX_LINCMT_ORIGIN_MAX] == 0.0) {
+        linCmtOriginCacheRow(ind, idx, mOrig);
+      }
+    }
   }
   lcb.lc.getJacCp(lcb.J, lcb.fx, theta, lcb.Jg);
   double val = lcb.lc.adjustF(lcb.fx, theta, ind->linCmtHV);

--- a/src/linCmt.cpp
+++ b/src/linCmt.cpp
@@ -92,12 +92,16 @@ extern "C" double linCmtB(rx_solve *rx, int id,
 // `ssInfMask` (optional, may be NULL) narrows the steady-state-infusion
 // answer to the compartments it actually reaches, which the PER-COMPARTMENT
 // modes (which1 = -9/-10) can use to refuse only the affected origin instead
-// of the whole model.
+// of the whole model.  `replMult` (optional) reports whether any REPLACE or
+// MULTIPLY record targets the linCmt() block at all: those rewrite a
+// compartment that may hold mass from several origins, and the amounts alone
+// cannot say how the rewrite divided among them, so the decomposition -- not
+// just one row of it -- stops being recoverable (see linCmtBorigin()).
 static inline void linCmtDoseScan(rx_solving_options_ind *ind,
                                   rx_solving_options *op,
                                   int *dosedMask, int *ssInf,
-                                  int *ssInfMask = NULL) {
-  int mask = 0, ss = 0, ssMask = 0;
+                                  int *ssInfMask = NULL, int *replMult = NULL) {
+  int mask = 0, ss = 0, ssMask = 0, rm = 0;
   int nLin = op->numLin < 31 ? op->numLin : 31;
   for (int i = 0; i < ind->ndoses; ++i) {
     int wh, cmt, wh100, whI, wh0;
@@ -110,6 +114,9 @@ static inline void linCmtDoseScan(rx_solving_options_ind *ind,
       ss = 1;
       ssMask |= (1 << c);
     }
+    if (whI == EVIDF_REPLACE || whI == EVIDF_MULT) {
+      rm = 1;
+    }
     if (!(whI == EVIDF_NORMAL && wh0 == EVID0_REGULAR &&
           getDoseNumber(ind, i) == 0.0)) {
       mask |= (1 << c);
@@ -118,6 +125,7 @@ static inline void linCmtDoseScan(rx_solving_options_ind *ind,
   *dosedMask = mask;
   *ssInf = ss;
   if (ssInfMask != NULL) *ssInfMask = ssMask;
+  if (replMult != NULL) *replMult = rm;
 }
 
 // Per-idx cache of the infusion rate feeding a linCmt() model, keyed the same
@@ -2178,12 +2186,13 @@ static inline double linCmtBdoseTime(stan::math::linCmtStan &lc,
 // amounts are still the initial conditions) is a usable all-zero
 // decomposition, but the live linCmtOriginSeeded stays 0 there: it also means
 // "op->inits has not been subtracted yet", which the first real advance needs.
-static inline void linCmtOriginCacheRow(rx_solving_options_ind *ind, int idx, int m) {
+static inline void linCmtOriginCacheRow(rx_solving_options_ind *ind, int idx, int m,
+                                       const double *O, int seeded) {
   if (m <= 0 || m > RX_LINCMT_ORIGIN_MAX) return;
   double *slot = linCmtOriginSlot(ind, idx, RX_LINCMT_ORIGIN_SLOTW(m), 1);
   if (slot == NULL) return;
-  std::copy(ind->linCmtOrigin, ind->linCmtOrigin + m*RX_LINCMT_ORIGIN_MAX, slot);
-  slot[m*RX_LINCMT_ORIGIN_MAX] = (ind->linCmtOriginSeeded == 2) ? 2.0 : 1.0;
+  std::copy(O, O + m*RX_LINCMT_ORIGIN_MAX, slot);
+  slot[m*RX_LINCMT_ORIGIN_MAX] = (seeded == 2) ? 2.0 : 1.0;
 }
 
 // The per-origin decomposition of the linCmt() amounts, kept in step with the
@@ -2207,36 +2216,58 @@ static inline void linCmtOriginCacheRow(rx_solving_options_ind *ind, int idx, in
 // to.  If that compartment cannot be identified the state is poisoned
 // (linCmtOriginSeeded = 2) and every later query answers NA rather than a
 // number built on a guess.
+//
+// `th` must be the parameters the amounts were ACTUALLY advanced with -- i.e.
+// lc.trueTheta(thetaSens), not the p1..ka the caller passed.  They differ on
+// a finite-difference H-optimization probe row, where linCmtBsolveRow() has
+// perturbed one of them, and wherever rx->ndiff masks a parameter out of the
+// sensitivity set.  Advancing the rows with anything else would let the
+// mismatch reappear as a phantom dose on the next interval.
 static inline void linCmtOriginAdvance(stan::math::linCmtStan &lc,
                                        rx_solving_options_ind *ind,
                                        rx_solving_options *op,
                                        const double *aPrev,
                                        const Eigen::Matrix<double, Eigen::Dynamic, 1> &fx,
                                        const double *rate,
-                                       int ncmt, int oral0, int trans,
-                                       double p1, double v1,
-                                       double p2, double p3,
-                                       double p4, double p5,
-                                       double ka, int idx) {
+                                       const Eigen::Matrix<double, Eigen::Dynamic, 1> &th,
+                                       int ncmt, int oral0, int trans, int idx) {
   const int m = ncmt + oral0;
   if (m <= 0 || m > RX_LINCMT_ORIGIN_MAX) return;
   const int st = RX_LINCMT_ORIGIN_MAX;
-  double *O = ind->linCmtOrigin;
+  // Roll the row-entry state forward the first time a NEW row is advanced.
+  // Every later call for the same row recomputes from that same entry, so the
+  // many re-entries a mixed linCmt()+ODE model makes within one row (dydt
+  // fires at every internal solver step) cannot accumulate; the last call
+  // wins, which is where copyLinCmt() takes the amounts from too.  A
+  // steady-state record runs its SS solve and the normal advance that follows
+  // it at the SAME idx, so ind->linSS is part of the row's identity.
+  if (ind->linCmtOriginIdx != idx || ind->linCmtOriginSS != ind->linSS) {
+    if (ind->linCmtOriginIdx >= 0) {
+      memcpy(ind->linCmtOrigin, ind->linCmtOriginOut, sizeof(ind->linCmtOrigin));
+      ind->linCmtOriginSeeded = ind->linCmtOriginOutSeeded;
+    }
+    ind->linCmtOriginIdx = idx;
+    ind->linCmtOriginSS = ind->linSS;
+  }
+  double *O = ind->linCmtOriginOut;
+  memcpy(O, ind->linCmtOrigin, sizeof(ind->linCmtOriginOut));
+  int sIn = ind->linCmtOriginSeeded, sOut;
   if (ind->linSS != 0) {
     int cmt = (ind->linSS == linCmtSsBolus) ? ind->linSSbolusCmt : ind->cmt;
     int q0 = cmt - op->linOffset;
-    memset(O, 0, sizeof(ind->linCmtOrigin));
+    memset(O, 0, sizeof(ind->linCmtOriginOut));
     if (q0 < 0 || q0 >= m || (int)fx.size() != m) {
-      ind->linCmtOriginSeeded = 2;
-      linCmtOriginCacheRow(ind, idx, m);
+      ind->linCmtOriginOutSeeded = 2;
+      linCmtOriginCacheRow(ind, idx, m, O, 2);
       return;
     }
     for (int j = 0; j < m; ++j) O[q0*st + j] = fx(j, 0);
-    ind->linCmtOriginSeeded = 1;
-  } else if (ind->linCmtOriginSeeded == 2) {
+    sOut = 1;
+  } else if (sIn == 2) {
     // Poisoned by an earlier record whose origin could not be identified;
     // there is nothing to attribute the amounts to any more.
-    linCmtOriginCacheRow(ind, idx, m);
+    ind->linCmtOriginOutSeeded = 2;
+    linCmtOriginCacheRow(ind, idx, m, O, 2);
     return;
   } else {
     // Attribute whatever entered the compartments since the last advance.
@@ -2244,19 +2275,18 @@ static inline void linCmtOriginAdvance(stan::math::linCmtStan &lc,
       double sum = 0.0;
       for (int q = 0; q < m; ++q) sum += O[q*st + j];
       double base = 0.0;
-      if (ind->linCmtOriginSeeded == 0 && op->inits != NULL) {
+      if (sIn == 0 && op->inits != NULL) {
         base = op->inits[op->linOffset + j];
       }
       O[j*st + j] += aPrev[j] - sum - base;
     }
-    ind->linCmtOriginSeeded = 1;
     // Advance every row over this interval, each seeing only its own rate.
-    Eigen::Matrix<double, Eigen::Dynamic, 1> th(lc.getNpars());
-    if (!linCmtFillTheta(th, ncmt, oral0, p1, v1, p2, p3, p4, p5, ka)) {
-      ind->linCmtOriginSeeded = 2;
-      linCmtOriginCacheRow(ind, idx, m);
+    if ((int)th.size() != 2*ncmt + oral0) {
+      ind->linCmtOriginOutSeeded = 2;
+      linCmtOriginCacheRow(ind, idx, m, O, 2);
       return;
     }
+    double ka = oral0 ? th(2*ncmt, 0) : 0.0;
     Eigen::Matrix<double, Eigen::Dynamic, 2> g =
       stan::math::macros2micros(th, ncmt, trans);
     double rq[RX_LINCMT_ORIGIN_MAX];
@@ -2270,8 +2300,10 @@ static inline void linCmtOriginAdvance(stan::math::linCmtStan &lc,
       lc.advanceWithRate(in, g, ka, rq, outv);
       for (int j = 0; j < m; ++j) O[q*st + j] = outv(j, 0);
     }
+    sOut = 1;
   }
-  linCmtOriginCacheRow(ind, idx, m);
+  ind->linCmtOriginOutSeeded = sOut;
+  linCmtOriginCacheRow(ind, idx, m, O, sOut);
 }
 
 // linCmtB's which1 = -9 / -10 cases: the PER-COMPARTMENT dose-time and
@@ -2298,9 +2330,12 @@ static inline void linCmtOriginAdvance(stan::math::linCmtStan &lc,
 // which1 = -3 where -3 is defined.
 //
 // NA_REAL for a call that does not describe the model `lc` is set up for, an
-// out of range q/out, a poisoned decomposition, or -- for which1 = -9 -- a
-// rate that could not be recovered or a steady-state infusion into q itself
-// (its rate is not carried past the SS solve; see linCmtDoseScan()).
+// out of range q/out, a poisoned decomposition, a regimen carrying a REPLACE
+// or MULTIPLY record into the linCmt() block (it rewrites a compartment that
+// may hold several origins' mass, and the amounts cannot say how the rewrite
+// divided among them), or -- for which1 = -9 -- a rate that could not be
+// recovered or a steady-state infusion into q itself (its rate is not carried
+// past the SS solve; see linCmtDoseScan()).
 #define RX_LINCMT_ORIGIN_W2   8
 #define RX_LINCMT_ORIGIN_CONC 7
 static inline double linCmtBorigin(stan::math::linCmtStan &lc,
@@ -2335,13 +2370,17 @@ static inline double linCmtBorigin(stan::math::linCmtStan &lc,
     return NA_REAL;
   }
   if (which1 == -10) {
+    int dosed0, ssInf0, ssInfMask0, replMult0;
+    linCmtDoseScan(ind, op, &dosed0, &ssInf0, &ssInfMask0, &replMult0);
+    if (replMult0) return NA_REAL;
     double val = (out == RX_LINCMT_ORIGIN_CONC) ? origin[q*st + oral0] : origin[q*st + out];
     if (out == RX_LINCMT_ORIGIN_CONC) val /= lc.getVc(th);
     return val;
   }
   if (rate == NULL) return NA_REAL;
-  int dosed, ssInf, ssInfMask;
-  linCmtDoseScan(ind, op, &dosed, &ssInf, &ssInfMask);
+  int dosed, ssInf, ssInfMask, replMult;
+  linCmtDoseScan(ind, op, &dosed, &ssInf, &ssInfMask, &replMult);
+  if (replMult) return NA_REAL;
   if ((ssInfMask & (1 << q)) != 0) return NA_REAL;
   Eigen::Matrix<double, Eigen::Dynamic, 2> gm =
     stan::math::macros2micros(th, ncmt, trans);
@@ -2740,8 +2779,8 @@ static inline bool linCmtBquery(linB_t &lcb, linCmtBind &wsp, rx_solve *rx,
     int mOrig = ncmt + oral0;
     const double *origin = reQuery ?
       linCmtOriginSlot(ind, idx, RX_LINCMT_ORIGIN_SLOTW(mOrig), 0) :
-      ind->linCmtOrigin;
-    int seeded = ind->linCmtOriginSeeded;
+      ind->linCmtOriginOut;
+    int seeded = ind->linCmtOriginOutSeeded;
     if (reQuery) {
       seeded = (origin == NULL) ? 0 : (int)origin[mOrig*RX_LINCMT_ORIGIN_MAX];
     }
@@ -3008,11 +3047,17 @@ extern "C" double linCmtB(rx_solve *rx, int id,
   // (it would advance the state twice) and never on an H-perturbed
   // evaluation (its amounts belong to a perturbed parameter, not the solve).
   // Opt-in: a model that moves or scales no linCmt() dose pays nothing.
-  if (op->linCmtOriginMask != 0 && ind->linCmtHparIndex < -1 &&
-      ind->_rxFlag != 11) {
+  if (op->linCmtOriginMask != 0 && ind->_rxFlag != 11) {
     if (ind->doSS || ind->solvedIdx < idx) {
-      linCmtOriginAdvance(lcb.lc, ind, op, a, lcb.fx, r, ncmt, oral0, trans,
-                          p1, v1, p2, p3, p4, p5, ka, idx);
+      // trueTheta(thetaSens) is what linCmtBsolveRow() just advanced the
+      // amounts with, H perturbation and ndiff masking included, so the rows
+      // stay in step with them on every pass -- an H-optimization probe solve
+      // included, which is a genuine solve of its own (iniSubject() runs
+      // before it) and must not be left without a decomposition.
+      // trueTheta() takes a Matrix, and thetaSens is a Map over lcb's buffer.
+      Eigen::Matrix<double, Eigen::Dynamic, 1> tsOrig = thetaSens;
+      linCmtOriginAdvance(lcb.lc, ind, op, a, lcb.fx, r,
+                          lcb.lc.trueTheta(tsOrig), ncmt, oral0, trans, idx);
     } else {
       // A restored row advances nothing, but the FIRST record of a subject
       // only ever restores -- its amounts are still the initial conditions --
@@ -3023,7 +3068,8 @@ extern "C" double linCmtB(rx_solve *rx, int id,
       double *slot = (mOrig > 0 && mOrig <= RX_LINCMT_ORIGIN_MAX) ?
         linCmtOriginSlot(ind, idx, RX_LINCMT_ORIGIN_SLOTW(mOrig), 1) : NULL;
       if (slot != NULL && slot[mOrig*RX_LINCMT_ORIGIN_MAX] == 0.0) {
-        linCmtOriginCacheRow(ind, idx, mOrig);
+        linCmtOriginCacheRow(ind, idx, mOrig, ind->linCmtOrigin,
+                             ind->linCmtOriginSeeded);
       }
     }
   }

--- a/src/linCmt.h
+++ b/src/linCmt.h
@@ -3043,6 +3043,42 @@ namespace stan {
         }
       }
 
+      //' Advance an arbitrary state vector over the current `dt_`
+      //'
+      //' The kernel (`linCmtStan1/2/3`) is affine in the starting amounts and
+      //' in the rate, so the same call that advances the amounts advances any
+      //' other vector obeying the same dynamics -- which is what the
+      //' per-origin decomposition of the amounts needs (see
+      //' `rx_solving_options_ind::linCmtOrigin`).  `rate` temporarily replaces
+      //' the rate pointer `setPtr()` installed, so the caller can supply a
+      //' masked rate; it is restored before returning.  `dt_` must already be
+      //' set for the interval.
+      //'
+      //' @param in Vector at the start of the interval.
+      //' @param g Micro-constant matrix from `macros2micros()`.
+      //' @param ka Absorption rate (ignored when not oral).
+      //' @param rate Rates for this vector, `getNrate()` long.
+      //' @param out Filled with the advanced vector.
+      //'
+      //' @return nothing, updates `out` instead
+      void advanceWithRate(const Eigen::Matrix<double, Eigen::Dynamic, 1>& in,
+                           const Eigen::Matrix<double, Eigen::Dynamic, 2>& g,
+                           double ka, const double *rate,
+                           Eigen::Matrix<double, Eigen::Dynamic, 1>& out) {
+        double *saveRate = rate_;
+        rate_ = const_cast<double*>(rate);
+        out.resize(ncmt_ + oral0_);
+        out.setZero();
+        if (ncmt_ == 1) {
+          linCmtStan1<double>(g, in, ka, out);
+        } else if (ncmt_ == 2) {
+          linCmtStan2<double>(g, in, ka, out);
+        } else {
+          linCmtStan3<double>(g, in, ka, out);
+        }
+        rate_ = saveRate;
+      }
+
       double adjustF(const Eigen::VectorXd& ret0,
                      const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1> >& theta,
                      double &vc) {

--- a/src/par_solve.h
+++ b/src/par_solve.h
@@ -115,6 +115,23 @@ extern "C" void cvode_solveWith1Pt(int *neq, double *yp, double *xp_ptr, double 
   extern double maxAtolRtolFactor;
 
 
+  // Forget every dose the per-origin decomposition of the linCmt() amounts
+  // has attributed (linCmtB which1 = -9/-10, src/linCmt.cpp), so the next
+  // advance starts from a system nothing has been given yet.  Both callers
+  // mean exactly that: a fresh subject, and an EVID 3 reset, which
+  // re-establishes the compartments from op->inits -- initial conditions,
+  // not a dose, and so not something a delay moves.  Clearing `seeded` is
+  // what tells that first advance to subtract op->inits rather than book it
+  // as a phantom dose.
+  static inline void linCmtOriginReset(rx_solving_options_ind *ind) {
+    memset(ind->linCmtOrigin, 0, sizeof(ind->linCmtOrigin));
+    memset(ind->linCmtOriginOut, 0, sizeof(ind->linCmtOriginOut));
+    ind->linCmtOriginSeeded = 0;
+    ind->linCmtOriginOutSeeded = 0;
+    ind->linCmtOriginIdx = -1;
+    ind->linCmtOriginSS = 0;
+  }
+
 	static inline int iniSubject(int solveid, int inLhs, rx_solving_options_ind *ind, rx_solving_options *op, rx_solve *rx,
 															 t_update_inis u_inis) {
 		ind->_rxFlag=1;
@@ -244,17 +261,7 @@ extern "C" void cvode_solveWith1Pt(int *neq, double *yp, double *xp_ptr, double 
       memset(ind->linCmtCarryT, 0, sizeof(ind->linCmtCarryT));
       ind->linCmtCarryTlast = NAN;
       ind->linCmtCarryVarying = 0;
-      // Per-origin decomposition of the linCmt() amounts (linCmtB
-      // which1 = -9/-10).  A fresh subject has not been dosed, so every
-      // origin row starts empty; `seeded` is cleared so the first advance
-      // attributes whatever the initial conditions put in the compartments
-      // to no dose at all rather than to a phantom one.
-      memset(ind->linCmtOrigin, 0, sizeof(ind->linCmtOrigin));
-      memset(ind->linCmtOriginOut, 0, sizeof(ind->linCmtOriginOut));
-      ind->linCmtOriginSeeded = 0;
-      ind->linCmtOriginOutSeeded = 0;
-      ind->linCmtOriginIdx = -1;
-      ind->linCmtOriginSS = 0;
+      linCmtOriginReset(ind);
     }
     // Compute model times using ind->solve (which has user-specified inits after u_inis).
     // ind->solve is always a valid calloc'd pointer, unlike op->inits which may be unset.
@@ -336,15 +343,7 @@ extern "C" void cvode_solveWith1Pt(int *neq, double *yp, double *xp_ptr, double 
     *xout -= rx->maxShift;
     *xp = *xout;
     ind->linCmtAlast = yp ;
-    // A reset re-establishes the compartments from op->inits, which is not a
-    // dose: re-seed the per-origin decomposition (linCmtB which1 = -9/-10)
-    // so the restored amounts are not attributed to a delayed dose.
-    memset(ind->linCmtOrigin, 0, sizeof(ind->linCmtOrigin));
-    memset(ind->linCmtOriginOut, 0, sizeof(ind->linCmtOriginOut));
-    ind->linCmtOriginSeeded = 0;
-    ind->linCmtOriginOutSeeded = 0;
-    ind->linCmtOriginIdx = -1;
-    ind->linCmtOriginSS = 0;
+    linCmtOriginReset(ind);
     ind->ixds++;
     // Reset dose-tracking after time reset so tad is never negative post-reset.
     // Any dose that fires after this EVID=3 re-establishes tlast from scratch.

--- a/src/par_solve.h
+++ b/src/par_solve.h
@@ -244,6 +244,13 @@ extern "C" void cvode_solveWith1Pt(int *neq, double *yp, double *xp_ptr, double 
       memset(ind->linCmtCarryT, 0, sizeof(ind->linCmtCarryT));
       ind->linCmtCarryTlast = NAN;
       ind->linCmtCarryVarying = 0;
+      // Per-origin decomposition of the linCmt() amounts (linCmtB
+      // which1 = -9/-10).  A fresh subject has not been dosed, so every
+      // origin row starts empty; `seeded` is cleared so the first advance
+      // attributes whatever the initial conditions put in the compartments
+      // to no dose at all rather than to a phantom one.
+      memset(ind->linCmtOrigin, 0, sizeof(ind->linCmtOrigin));
+      ind->linCmtOriginSeeded = 0;
     }
     // Compute model times using ind->solve (which has user-specified inits after u_inis).
     // ind->solve is always a valid calloc'd pointer, unlike op->inits which may be unset.
@@ -325,6 +332,11 @@ extern "C" void cvode_solveWith1Pt(int *neq, double *yp, double *xp_ptr, double 
     *xout -= rx->maxShift;
     *xp = *xout;
     ind->linCmtAlast = yp ;
+    // A reset re-establishes the compartments from op->inits, which is not a
+    // dose: re-seed the per-origin decomposition (linCmtB which1 = -9/-10)
+    // so the restored amounts are not attributed to a delayed dose.
+    memset(ind->linCmtOrigin, 0, sizeof(ind->linCmtOrigin));
+    ind->linCmtOriginSeeded = 0;
     ind->ixds++;
     // Reset dose-tracking after time reset so tad is never negative post-reset.
     // Any dose that fires after this EVID=3 re-establishes tlast from scratch.

--- a/src/par_solve.h
+++ b/src/par_solve.h
@@ -250,7 +250,11 @@ extern "C" void cvode_solveWith1Pt(int *neq, double *yp, double *xp_ptr, double 
       // attributes whatever the initial conditions put in the compartments
       // to no dose at all rather than to a phantom one.
       memset(ind->linCmtOrigin, 0, sizeof(ind->linCmtOrigin));
+      memset(ind->linCmtOriginOut, 0, sizeof(ind->linCmtOriginOut));
       ind->linCmtOriginSeeded = 0;
+      ind->linCmtOriginOutSeeded = 0;
+      ind->linCmtOriginIdx = -1;
+      ind->linCmtOriginSS = 0;
     }
     // Compute model times using ind->solve (which has user-specified inits after u_inis).
     // ind->solve is always a valid calloc'd pointer, unlike op->inits which may be unset.
@@ -336,7 +340,11 @@ extern "C" void cvode_solveWith1Pt(int *neq, double *yp, double *xp_ptr, double 
     // dose: re-seed the per-origin decomposition (linCmtB which1 = -9/-10)
     // so the restored amounts are not attributed to a delayed dose.
     memset(ind->linCmtOrigin, 0, sizeof(ind->linCmtOrigin));
+    memset(ind->linCmtOriginOut, 0, sizeof(ind->linCmtOriginOut));
     ind->linCmtOriginSeeded = 0;
+    ind->linCmtOriginOutSeeded = 0;
+    ind->linCmtOriginIdx = -1;
+    ind->linCmtOriginSS = 0;
     ind->ixds++;
     // Reset dose-tracking after time reset so tad is never negative post-reset.
     // Any dose that fires after this EVID=3 re-establishes tlast from scratch.

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -1952,6 +1952,11 @@ static void rxFreeInd(rx_solving_options_ind *ind) {
   ind->linCmtRateHist = NULL;
   ind->linCmtRateHistCap = 0;
   ind->linCmtRateHistW = 0;
+  // linCmtB(which1 = -9/-10)'s per-origin amount history; same lifecycle.
+  free(ind->linCmtOriginHist);
+  ind->linCmtOriginHist = NULL;
+  ind->linCmtOriginHistCap = 0;
+  ind->linCmtOriginHistW = 0;
   // linCmtB()'s per-individual carried state (window + value memo), allocated
   // on first touch inside the solve; same lifecycle as the two above.  It
   // holds C++ members, so linCmt.cpp owns the delete.
@@ -6076,6 +6081,7 @@ static inline void iniRx(rx_solve* rx) {
   op->depotLin = 0;
   op->linOffset = 0;
   op->linCmtLagMask = 0;
+  op->linCmtOriginMask = 0;
   rx->svar = _globals.gsvar;
   rx->ovar = _globals.govar;
   op->nLlik = 0;
@@ -6101,7 +6107,7 @@ void getLinInfo(List mv, int &numLinSens, int &numLin, int &depotLin);
 // `mv[RxMv_state]`, which is the compartment order, and the linCmt() block is
 // the trailing `numLin + numLinSens` compartments, so block index c is state
 // index `linOffset + c`.  propAlag is src/tran.h's bit 4 (not included here).
-static inline int rxLinCmtLagMask(List mv, int linOffset, int numLin) {
+static inline int rxLinCmtPropMask(List mv, int linOffset, int numLin, int bits) {
   if (numLin <= 0 || mv.size() <= RxMv_stateProp) return 0;
   IntegerVector stateProp = mv[RxMv_stateProp];
   int mask = 0;
@@ -6110,9 +6116,19 @@ static inline int rxLinCmtLagMask(List mv, int linOffset, int numLin) {
   for (int c = 0; c < nLin; ++c) {
     int i = linOffset + c;
     if (i < 0 || i >= n) continue;
-    if ((stateProp[i] & 4) != 0) mask |= (1 << c);
+    if ((stateProp[i] & bits) != 0) mask |= (1 << c);
   }
   return mask;
+}
+
+static inline int rxLinCmtLagMask(List mv, int linOffset, int numLin) {
+  return rxLinCmtPropMask(mv, linOffset, numLin, 4);
+}
+
+// Compartments whose DOSE the model moves or scales -- a modeled alag()
+// (propAlag, bit 4) or f() (propF, bit 2) -- for op->linCmtOriginMask.
+static inline int rxLinCmtOriginMask(List mv, int linOffset, int numLin) {
+  return rxLinCmtPropMask(mv, linOffset, numLin, 2 | 4);
 }
 
 static int _rxSolveCallN = 0;
@@ -6180,6 +6196,7 @@ SEXP rxSolveFromRaw_(const RObject &obj, const RObject &rawObj,
       CharacterVector mvState = mvRaw[RxMv_state];
       if (mvState.size() == op->neq) {
         op->linCmtLagMask = rxLinCmtLagMask(mvRaw, op->linOffset, op->numLin);
+        op->linCmtOriginMask = rxLinCmtOriginMask(mvRaw, op->linOffset, op->numLin);
       }
     }
     seedEng((int)(op->cores));
@@ -6798,6 +6815,7 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
     op->depotLin = depotLin;
     op->linOffset = op->neq - numLin - numLinSens;
     op->linCmtLagMask = rxLinCmtLagMask(rxSolveDat->mv, op->linOffset, numLin);
+    op->linCmtOriginMask = rxLinCmtOriginMask(rxSolveDat->mv, op->linOffset, numLin);
     op->nLlik = INTEGER(rxSolveDat->mv[RxMv_flags])[RxMvFlag_nLlik];
     if (!Rf_isNull(rxControl[Rxc_nLlikAlloc])) {
       op->nLlik = max2(asInt(rxControl[Rxc_nLlikAlloc],"control$nLlikAlloc"), op->nLlik);

--- a/src/rxSerialize.cpp
+++ b/src/rxSerialize.cpp
@@ -20,7 +20,12 @@ extern "C" void rxOptionsIniEnsure(int mx, int cores);
 extern rx_globals _globals;
 
 static const char rxSerializeMagic[8] = {'R','X','O','D','E','2','S','Z'};
-static const uint32_t rxSerializeFormatVer = 6u;
+static const uint32_t rxSerializeFormatVer = 7u;
+// Format 7 added op->linCmtOriginMask after linCmtLagMask (read only when
+// fmt >= 7).  Unlike format 6's field this one does grow
+// sizeof(rx_solving_options), so the size check below rejects an older
+// stream before the version check can reach it -- the same outcome, a clear
+// refusal to restore a stream this build cannot read.
 // Format 6 added op->linCmtLagMask after linOffset (read only when fmt >= 6:
 // it landed in the struct's tail padding, so sizeof(rx_solving_options) is
 // unchanged and the size check below cannot reject a format 5 stream).
@@ -163,7 +168,8 @@ SEXP rxSaveState_() {
   W_I32(doIndLin); W_I32(strictSS);
   W_DBL(infSSstep); W_I32(mxhnil); W_DBL(hmxi);
   W_I32(nLlik); W_I32(numLinSens); W_I32(numLin);
-  W_I32(depotLin); W_I32(linOffset); W_I32(linCmtLagMask); W_I32(ssSolved);
+  W_I32(depotLin); W_I32(linOffset); W_I32(linCmtLagMask);
+  W_I32(linCmtOriginMask); W_I32(ssSolved);
   W_I32(indOwnAlloc);
 
 #undef W_I32
@@ -730,6 +736,11 @@ SEXP rxRestoreState_(SEXP rawSexp) {
     // A pre-format-6 stream cannot carry it; rxSolveFromRaw_() recomputes it
     // from the model right after this restore, so 0 is only a placeholder.
     op->linCmtLagMask = 0;
+  }
+  if (fmt >= 7u) {
+    R_I32(linCmtOriginMask);
+  } else {
+    op->linCmtOriginMask = 0;
   }
   R_I32(ssSolved);
   R_I32(indOwnAlloc);

--- a/tests/testthat/helper-lincmt-origin.R
+++ b/tests/testthat/helper-lincmt-origin.R
@@ -1,0 +1,47 @@
+# Shared setup for the linCmtB(which1 = -9 / -10) per-origin tests, which split
+# in two: what the modes COMPUTE (test-lincmt-origin-sens.R) and what the
+# decomposition REFUSES to answer (test-lincmt-origin-limits.R).
+#
+# which2 packs the origin compartment and the wanted output: q*8 + out, with
+# out = 7 meaning the reported concentration.  Nothing here builds a model at
+# load time, so this is inert until a test calls it.
+
+.p <- c(tcl = log(4), tv = log(20), tka = log(1.1), tq = log(2),
+        tv2 = log(50), tq2 = log(1), tv3 = log(80),
+        eta_lag = 0.1, eta_f = 0.05)
+
+# Build a pure linCmt() model of the requested shape whose dosed compartment
+# (depot when oral, central otherwise) carries a modeled alag(), reporting
+# the concentration, the shared-delay sensitivity (-3) and the
+# per-compartment one (-9) for origin `q` and the next compartment up.
+.rxOriginModel <- function(ncmt, oral0, q) {
+  .pars <- c("cl, v, 0, 0, 0, 0", "cl, v, qq, v2, 0, 0",
+             "cl, v, qq, v2, q2, v3")[ncmt]
+  .ka <- if (oral0) "ka" else "0"
+  .m <- ncmt + oral0
+  .cmt <- if (oral0) "depot" else "central"
+  .call <- function(w1, w2) {
+    sprintf("linCmtB(rx__PTR__, t, %d, %d, %d, %s, %s, 1, %s, %s)",
+            .m, ncmt, oral0, w1, w2, .pars, .ka)
+  }
+  .b <- if (q + 1L < .m) .call("-9", (q + 1L) * 8 + 7) else "0"
+  rxode2(sprintf("
+    cl <- exp(tcl); v <- exp(tv); qq <- exp(tq); v2 <- exp(tv2)
+    q2 <- exp(tq2); v3 <- exp(tv3); ka <- exp(tka)
+    lag <- 2 * exp(eta_lag)
+    alag(%s) <- lag
+    cp  <- %s
+    d3  <- lag * %s
+    d9  <- lag * %s
+    d9b <- lag * (%s)
+  ", .cmt, .call("-1", "-1"), .call("-3", "-3"),
+     .call("-9", q * 8 + 7), .b))
+}
+
+.fd <- function(m, e, par, h = 1e-6) {
+  .p1 <- .p; .p1[[par]] <- .p[[par]] + h
+  .p0 <- .p; .p0[[par]] <- .p[[par]] - h
+  (rxSolve(m, e, params = .p1)$cp - rxSolve(m, e, params = .p0)$cp) / (2 * h)
+}
+.rel <- function(a, b) max(abs(a - b)) / (max(abs(b)) + 1e-8)
+

--- a/tests/testthat/test-lincmt-origin-limits.R
+++ b/tests/testthat/test-lincmt-origin-limits.R
@@ -1,0 +1,81 @@
+rxTest({
+  # What the linCmtB(which1 = -9 / -10) per-origin decomposition REFUSES to
+  # answer, and the one case where its answer is an exact zero rather than a
+  # derivative.  Every refusal here is NA on purpose: a wrong number that
+  # looks like a real sensitivity is worse than no number at all.  The
+  # finite-difference accuracy cases are in test-lincmt-origin-sens.R; the
+  # shared helpers are in helper-lincmt-origin.R.
+
+  test_that("linCmtB(-9) is exactly 0 when no dose reaches the origin", {
+    .m <- .rxOriginModel(1L, 1L, 0L)
+    .e <- et(amt = 50, cmt = "central") |> et(seq(0.1, 24, 0.5))
+    .s <- rxSolve(.m, .e, params = .p)
+    expect_true(all(.s$d9 == 0))
+  })
+
+  test_that("linCmtB(-9) reports NA for a steady-state infusion", {
+    # The SS infusion's rate is not carried past the SS solve, so -dA/dt is
+    # not recoverable for that origin (same limit as -3, see linCmtDoseScan).
+    .m <- .rxOriginModel(1L, 0L, 0L)
+    .e <- et(amt = 100, rate = 25, ii = 12, ss = 1, cmt = "central") |>
+      et(seq(0.1, 12, 0.5))
+    .s <- rxSolve(.m, .e, params = .p)
+    expect_true(all(is.na(.s$d9)))
+  })
+
+  test_that("linCmtB(-9)/(-10) reject an out of range origin or output", {
+    # q or out past the model's compartment count is NA, never an out of
+    # bounds read.
+    .m <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); lag <- 2 * exp(eta_lag)
+      alag(central) <- lag
+      cp <- linCmtB(rx__PTR__, t, 1, 1, 0, -1, -1, 1, cl, v, 0, 0, 0, 0, 0)
+      badQ <- linCmtB(rx__PTR__, t, 1, 1, 0, -9, 3 * 8 + 7, 1, cl, v, 0, 0, 0, 0, 0)
+      badO <- linCmtB(rx__PTR__, t, 1, 1, 0, -10, 2, 1, cl, v, 0, 0, 0, 0, 0)
+    })
+    .e <- et(amt = 100, cmt = "central") |> et(seq(0.1, 12, 0.5))
+    .s <- rxSolve(.m, .e, params = .p)
+    expect_true(all(is.na(.s$badQ)))
+    expect_true(all(is.na(.s$badO)))
+  })
+
+  test_that("linCmtB(-9)/(-10) refuse a record the decomposition cannot follow", {
+    # A replace or multiply rewrites a compartment that may hold mass from
+    # several origins, and the amounts cannot say how the rewrite divided among
+    # them -- so the decomposition stops being recoverable.  NA, not a number
+    # that keeps reporting the pre-rewrite origin forever.
+    .m <- .rxOriginModel(1L, 1L, 0L)
+    .base <- et(amt = 100, cmt = "depot")
+    # ss = 2 ADDS a steady state to whatever was already there, so the result
+    # is neither a fresh SS solution to attribute to the SS compartment nor a
+    # dose the amounts reveal.  Attributing it wholesale read ~8% off.
+    .eSs2 <- .base |> et(amt = 50, cmt = "depot", ii = 8, ss = 2, time = 10) |>
+      et(seq(0.1, 40, 0.5))
+    expect_true(all(is.na(rxSolve(.m, .eSs2, params = .p)$d9)))
+    # ss = 1 replaces, which the decomposition does follow
+    .eSs1 <- .base |> et(amt = 50, cmt = "depot", ii = 8, ss = 1, time = 10) |>
+      et(seq(0.1, 40, 0.5))
+    .s1 <- rxSolve(.m, .eSs1, params = .p)
+    expect_false(anyNA(.s1$d9))
+    expect_true(.rel(.s1$d9, .fd(.m, .eSs1, "eta_lag")) < 1e-6)
+    for (.evid in c(5, 6)) {
+      .e <- .base |> et(amt = 0.5, cmt = "central", evid = .evid, time = 10) |>
+        et(seq(0.1, 24, 0.5))
+      .s <- rxSolve(.m, .e, params = .p)
+      expect_true(all(is.na(.s$d9)), label = paste("evid", .evid))
+    }
+    # ... but a replace on an ODE compartment is none of its business
+    .mOde <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); ka <- exp(tka)
+      lag <- 2 * exp(eta_lag)
+      alag(depot) <- lag
+      d/dt(eff) <- -0.1 * eff
+      cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+      d9 <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -9, 7, 1, cl, v, 0, 0, 0, 0, ka)
+    })
+    .eOde <- et(amt = 100, cmt = "depot") |>
+      et(amt = 1, cmt = "eff", evid = 5, time = 10) |> et(seq(0.1, 24, 0.5))
+    .s <- rxSolve(.mOde, .eOde, params = .p, inits = c(eff = 5))
+    expect_false(anyNA(.s$d9))
+  })
+})

--- a/tests/testthat/test-lincmt-origin-sens.R
+++ b/tests/testthat/test-lincmt-origin-sens.R
@@ -7,47 +7,10 @@ rxTest({
   # per-origin decomposition of the amounts instead and answer it.
   #
   # which2 packs the origin compartment and the wanted output: q*8 + out, with
-  # out = 7 meaning the reported concentration.  Every case below is checked
-  # against a central finite difference of that concentration.
-
-  .p <- c(tcl = log(4), tv = log(20), tka = log(1.1), tq = log(2),
-          tv2 = log(50), tq2 = log(1), tv3 = log(80),
-          eta_lag = 0.1, eta_f = 0.05)
-
-  # Build a pure linCmt() model of the requested shape whose dosed compartment
-  # (depot when oral, central otherwise) carries a modeled alag(), reporting
-  # the concentration, the shared-delay sensitivity (-3) and the
-  # per-compartment one (-9) for origin `q` and the next compartment up.
-  .rxOriginModel <- function(ncmt, oral0, q) {
-    .pars <- c("cl, v, 0, 0, 0, 0", "cl, v, qq, v2, 0, 0",
-               "cl, v, qq, v2, q2, v3")[ncmt]
-    .ka <- if (oral0) "ka" else "0"
-    .m <- ncmt + oral0
-    .cmt <- if (oral0) "depot" else "central"
-    .call <- function(w1, w2) {
-      sprintf("linCmtB(rx__PTR__, t, %d, %d, %d, %s, %s, 1, %s, %s)",
-              .m, ncmt, oral0, w1, w2, .pars, .ka)
-    }
-    .b <- if (q + 1L < .m) .call("-9", (q + 1L) * 8 + 7) else "0"
-    rxode2(sprintf("
-      cl <- exp(tcl); v <- exp(tv); qq <- exp(tq); v2 <- exp(tv2)
-      q2 <- exp(tq2); v3 <- exp(tv3); ka <- exp(tka)
-      lag <- 2 * exp(eta_lag)
-      alag(%s) <- lag
-      cp  <- %s
-      d3  <- lag * %s
-      d9  <- lag * %s
-      d9b <- lag * (%s)
-    ", .cmt, .call("-1", "-1"), .call("-3", "-3"),
-       .call("-9", q * 8 + 7), .b))
-  }
-
-  .fd <- function(m, e, par, h = 1e-6) {
-    .p1 <- .p; .p1[[par]] <- .p[[par]] + h
-    .p0 <- .p; .p0[[par]] <- .p[[par]] - h
-    (rxSolve(m, e, params = .p1)$cp - rxSolve(m, e, params = .p0)$cp) / (2 * h)
-  }
-  .rel <- function(a, b) max(abs(a - b)) / (max(abs(b)) + 1e-8)
+  # out = 7 meaning the reported concentration.  Every case here is checked
+  # against a central finite difference of that concentration.  What the modes
+  # REFUSE to answer is in test-lincmt-origin-limits.R; the shared model
+  # builder and finite-difference helpers are in helper-lincmt-origin.R.
 
   test_that("linCmtB(-9) matches finite differences across model shapes", {
     # q = 0 is the dosed compartment in every case (depot when oral, central
@@ -147,39 +110,6 @@ rxTest({
     expect_true(.rel(.s$cp, .f) > 0.1)
   })
 
-  test_that("linCmtB(-9) is exactly 0 when no dose reaches the origin", {
-    .m <- .rxOriginModel(1L, 1L, 0L)
-    .e <- et(amt = 50, cmt = "central") |> et(seq(0.1, 24, 0.5))
-    .s <- rxSolve(.m, .e, params = .p)
-    expect_true(all(.s$d9 == 0))
-  })
-
-  test_that("linCmtB(-9) reports NA for a steady-state infusion", {
-    # The SS infusion's rate is not carried past the SS solve, so -dA/dt is
-    # not recoverable for that origin (same limit as -3, see linCmtDoseScan).
-    .m <- .rxOriginModel(1L, 0L, 0L)
-    .e <- et(amt = 100, rate = 25, ii = 12, ss = 1, cmt = "central") |>
-      et(seq(0.1, 12, 0.5))
-    .s <- rxSolve(.m, .e, params = .p)
-    expect_true(all(is.na(.s$d9)))
-  })
-
-  test_that("linCmtB(-9)/(-10) reject an out of range origin or output", {
-    # q or out past the model's compartment count is NA, never an out of
-    # bounds read.
-    .m <- rxode2({
-      cl <- exp(tcl); v <- exp(tv); lag <- 2 * exp(eta_lag)
-      alag(central) <- lag
-      cp <- linCmtB(rx__PTR__, t, 1, 1, 0, -1, -1, 1, cl, v, 0, 0, 0, 0, 0)
-      badQ <- linCmtB(rx__PTR__, t, 1, 1, 0, -9, 3 * 8 + 7, 1, cl, v, 0, 0, 0, 0, 0)
-      badO <- linCmtB(rx__PTR__, t, 1, 1, 0, -10, 2, 1, cl, v, 0, 0, 0, 0, 0)
-    })
-    .e <- et(amt = 100, cmt = "central") |> et(seq(0.1, 12, 0.5))
-    .s <- rxSolve(.m, .e, params = .p)
-    expect_true(all(is.na(.s$badQ)))
-    expect_true(all(is.na(.s$badO)))
-  })
-
   test_that("linCmtB(-9) is right when linCmt() is mixed with an ODE", {
     # A model that also has d/dt() re-enters linCmtB() many times within one
     # event row (dydt fires at every internal solver step), so the advance of
@@ -201,46 +131,6 @@ rxTest({
     expect_true(.rel(.s$d9, .f) < 1e-6)
     # the whole regimen doses one lagged compartment, so -3 agrees
     expect_true(.rel(.s$d9, .s$d3) < 1e-8)
-  })
-
-  test_that("linCmtB(-9)/(-10) refuse a record the decomposition cannot follow", {
-    # A replace or multiply rewrites a compartment that may hold mass from
-    # several origins, and the amounts cannot say how the rewrite divided among
-    # them -- so the decomposition stops being recoverable.  NA, not a number
-    # that keeps reporting the pre-rewrite origin forever.
-    .m <- .rxOriginModel(1L, 1L, 0L)
-    .base <- et(amt = 100, cmt = "depot")
-    # ss = 2 ADDS a steady state to whatever was already there, so the result
-    # is neither a fresh SS solution to attribute to the SS compartment nor a
-    # dose the amounts reveal.  Attributing it wholesale read ~8% off.
-    .eSs2 <- .base |> et(amt = 50, cmt = "depot", ii = 8, ss = 2, time = 10) |>
-      et(seq(0.1, 40, 0.5))
-    expect_true(all(is.na(rxSolve(.m, .eSs2, params = .p)$d9)))
-    # ss = 1 replaces, which the decomposition does follow
-    .eSs1 <- .base |> et(amt = 50, cmt = "depot", ii = 8, ss = 1, time = 10) |>
-      et(seq(0.1, 40, 0.5))
-    .s1 <- rxSolve(.m, .eSs1, params = .p)
-    expect_false(anyNA(.s1$d9))
-    expect_true(.rel(.s1$d9, .fd(.m, .eSs1, "eta_lag")) < 1e-6)
-    for (.evid in c(5, 6)) {
-      .e <- .base |> et(amt = 0.5, cmt = "central", evid = .evid, time = 10) |>
-        et(seq(0.1, 24, 0.5))
-      .s <- rxSolve(.m, .e, params = .p)
-      expect_true(all(is.na(.s$d9)), label = paste("evid", .evid))
-    }
-    # ... but a replace on an ODE compartment is none of its business
-    .mOde <- rxode2({
-      cl <- exp(tcl); v <- exp(tv); ka <- exp(tka)
-      lag <- 2 * exp(eta_lag)
-      alag(depot) <- lag
-      d/dt(eff) <- -0.1 * eff
-      cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
-      d9 <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -9, 7, 1, cl, v, 0, 0, 0, 0, ka)
-    })
-    .eOde <- et(amt = 100, cmt = "depot") |>
-      et(amt = 1, cmt = "eff", evid = 5, time = 10) |> et(seq(0.1, 24, 0.5))
-    .s <- rxSolve(.mOde, .eOde, params = .p, inits = c(eff = 5))
-    expect_false(anyNA(.s$d9))
   })
 
   test_that("linCmtB(-9) is per-individual", {

--- a/tests/testthat/test-lincmt-origin-sens.R
+++ b/tests/testthat/test-lincmt-origin-sens.R
@@ -203,13 +203,25 @@ rxTest({
     expect_true(.rel(.s$d9, .s$d3) < 1e-8)
   })
 
-  test_that("linCmtB(-9)/(-10) refuse a replace/multiply into the linCmt() block", {
+  test_that("linCmtB(-9)/(-10) refuse a record the decomposition cannot follow", {
     # A replace or multiply rewrites a compartment that may hold mass from
     # several origins, and the amounts cannot say how the rewrite divided among
     # them -- so the decomposition stops being recoverable.  NA, not a number
     # that keeps reporting the pre-rewrite origin forever.
     .m <- .rxOriginModel(1L, 1L, 0L)
     .base <- et(amt = 100, cmt = "depot")
+    # ss = 2 ADDS a steady state to whatever was already there, so the result
+    # is neither a fresh SS solution to attribute to the SS compartment nor a
+    # dose the amounts reveal.  Attributing it wholesale read ~8% off.
+    .eSs2 <- .base |> et(amt = 50, cmt = "depot", ii = 8, ss = 2, time = 10) |>
+      et(seq(0.1, 40, 0.5))
+    expect_true(all(is.na(rxSolve(.m, .eSs2, params = .p)$d9)))
+    # ss = 1 replaces, which the decomposition does follow
+    .eSs1 <- .base |> et(amt = 50, cmt = "depot", ii = 8, ss = 1, time = 10) |>
+      et(seq(0.1, 40, 0.5))
+    .s1 <- rxSolve(.m, .eSs1, params = .p)
+    expect_false(anyNA(.s1$d9))
+    expect_true(.rel(.s1$d9, .fd(.m, .eSs1, "eta_lag")) < 1e-6)
     for (.evid in c(5, 6)) {
       .e <- .base |> et(amt = 0.5, cmt = "central", evid = .evid, time = 10) |>
         et(seq(0.1, 24, 0.5))

--- a/tests/testthat/test-lincmt-origin-sens.R
+++ b/tests/testthat/test-lincmt-origin-sens.R
@@ -1,0 +1,199 @@
+rxTest({
+  # linCmtB(which1 = -9 / -10): the PER-COMPARTMENT dose-time and
+  # bioavailability sensitivities of a linCmt() model (nlmixr2/rxode2#1119
+  # part B).  which1 = -3 differentiates wrt ONE delay shared by every dose
+  # feeding the linear system, so it has to refuse a regimen that doses a
+  # lagged compartment alongside an unlagged one (#1237); these modes read the
+  # per-origin decomposition of the amounts instead and answer it.
+  #
+  # which2 packs the origin compartment and the wanted output: q*8 + out, with
+  # out = 7 meaning the reported concentration.  Every case below is checked
+  # against a central finite difference of that concentration.
+
+  .p <- c(tcl = log(4), tv = log(20), tka = log(1.1), tq = log(2),
+          tv2 = log(50), tq2 = log(1), tv3 = log(80),
+          eta_lag = 0.1, eta_f = 0.05)
+
+  # Build a pure linCmt() model of the requested shape whose dosed compartment
+  # (depot when oral, central otherwise) carries a modeled alag(), reporting
+  # the concentration, the shared-delay sensitivity (-3) and the
+  # per-compartment one (-9) for origin `q` and the next compartment up.
+  .rxOriginModel <- function(ncmt, oral0, q) {
+    .pars <- c("cl, v, 0, 0, 0, 0", "cl, v, qq, v2, 0, 0",
+               "cl, v, qq, v2, q2, v3")[ncmt]
+    .ka <- if (oral0) "ka" else "0"
+    .m <- ncmt + oral0
+    .cmt <- if (oral0) "depot" else "central"
+    .call <- function(w1, w2) {
+      sprintf("linCmtB(rx__PTR__, t, %d, %d, %d, %s, %s, 1, %s, %s)",
+              .m, ncmt, oral0, w1, w2, .pars, .ka)
+    }
+    .b <- if (q + 1L < .m) .call("-9", (q + 1L) * 8 + 7) else "0"
+    rxode2(sprintf("
+      cl <- exp(tcl); v <- exp(tv); qq <- exp(tq); v2 <- exp(tv2)
+      q2 <- exp(tq2); v3 <- exp(tv3); ka <- exp(tka)
+      lag <- 2 * exp(eta_lag)
+      alag(%s) <- lag
+      cp  <- %s
+      d3  <- lag * %s
+      d9  <- lag * %s
+      d9b <- lag * (%s)
+    ", .cmt, .call("-1", "-1"), .call("-3", "-3"),
+       .call("-9", q * 8 + 7), .b))
+  }
+
+  .fd <- function(m, e, par, h = 1e-6) {
+    .p1 <- .p; .p1[[par]] <- .p[[par]] + h
+    .p0 <- .p; .p0[[par]] <- .p[[par]] - h
+    (rxSolve(m, e, params = .p1)$cp - rxSolve(m, e, params = .p0)$cp) / (2 * h)
+  }
+  .rel <- function(a, b) max(abs(a - b)) / (max(abs(b)) + 1e-8)
+
+  test_that("linCmtB(-9) matches finite differences across model shapes", {
+    # q = 0 is the dosed compartment in every case (depot when oral, central
+    # otherwise), so -9 asks for exactly the delay the model declares.
+    .cases <- list(
+      list(nm = "1cmt IV bolus", ncmt = 1, oral0 = 0,
+           e = et(amt = 100, cmt = "central") |> et(seq(0.1, 24, 0.5))),
+      list(nm = "1cmt IV multiple infusion", ncmt = 1, oral0 = 0,
+           e = et(amt = 100, rate = 50, ii = 8, addl = 3, cmt = "central") |>
+             et(seq(0.1, 40, 0.5))),
+      list(nm = "1cmt IV steady-state bolus", ncmt = 1, oral0 = 0,
+           e = et(amt = 100, ii = 8, ss = 1, cmt = "central") |>
+             et(seq(0.1, 8, 0.25))),
+      list(nm = "1cmt oral multiple bolus", ncmt = 1, oral0 = 1,
+           e = et(amt = 100, ii = 8, addl = 3, cmt = "depot") |>
+             et(seq(0.1, 40, 0.5))),
+      list(nm = "2cmt IV bolus", ncmt = 2, oral0 = 0,
+           e = et(amt = 100, cmt = "central") |> et(seq(0.1, 24, 0.5))),
+      list(nm = "2cmt oral infusion", ncmt = 2, oral0 = 1,
+           e = et(amt = 100, rate = 50, cmt = "depot") |> et(seq(0.1, 24, 0.5))),
+      list(nm = "3cmt IV multiple bolus", ncmt = 3, oral0 = 0,
+           e = et(amt = 100, ii = 8, addl = 3, cmt = "central") |>
+             et(seq(0.1, 40, 0.5))),
+      list(nm = "3cmt oral steady-state bolus", ncmt = 3, oral0 = 1,
+           e = et(amt = 100, ii = 8, ss = 1, cmt = "depot") |>
+             et(seq(0.1, 8, 0.25)))
+    )
+    for (.case in .cases) {
+      .m <- .rxOriginModel(.case$ncmt, .case$oral0, 0L)
+      .s <- rxSolve(.m, .case$e, params = .p)
+      .f <- .fd(.m, .case$e, "eta_lag")
+      expect_true(.rel(.s$d9, .f) < 1e-6, label = .case$nm)
+      # Where the shared-delay assumption does hold, -9 on the only dosed
+      # compartment is the same answer -3 gives.
+      expect_true(.rel(.s$d9, .s$d3) < 1e-8, label = paste(.case$nm, "vs -3"))
+    }
+  })
+
+  test_that("linCmtB(-9) answers a mixed-route regimen that -3 must refuse", {
+    # A lagged oral depot alongside an unlagged IV bolus into central: two
+    # different delays, so -3 reports NA rather than the biased single-delay
+    # answer.  -9 asks only about the depot's own delay.
+    .m <- .rxOriginModel(2L, 1L, 0L)
+    .e <- et(amt = 100, cmt = "depot", ii = 12, addl = 1) |>
+      et(amt = 50, cmt = "central", time = 1) |>
+      et(seq(0.1, 30, 0.5))
+    .s <- rxSolve(.m, .e, params = .p)
+    .f <- .fd(.m, .e, "eta_lag")
+    expect_true(all(is.na(.s$d3)))
+    expect_true(.rel(.s$d9, .f) < 1e-6)
+    # The unlagged central's own origin is a real, nonzero derivative too --
+    # it is what would be added if THAT dose were delayed.
+    expect_true(max(abs(.s$d9b)) > 0)
+  })
+
+  test_that("linCmtB(-9) handles compartments lagged differently", {
+    # Two modeled alag()s with different expressions -- the model shape
+    # .rxLinCmtDoseTimeSensCheck() refuses outright for -3.
+    .m <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); ka <- exp(tka)
+      lag1 <- 2 * exp(eta_lag)
+      lag2 <- 0.75
+      alag(depot) <- lag1
+      alag(central) <- lag2
+      cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+      d9 <- lag1 * linCmtB(rx__PTR__, t, 2, 1, 1, -9, 7, 1, cl, v, 0, 0, 0, 0, ka)
+    })
+    .e <- et(amt = 100, cmt = "depot", ii = 12, addl = 1) |>
+      et(amt = 40, cmt = "central", time = 1) |>
+      et(seq(0.1, 30, 0.5))
+    .s <- rxSolve(.m, .e, params = .p)
+    .f <- .fd(.m, .e, "eta_lag")
+    expect_true(.rel(.s$d9, .f) < 1e-6)
+  })
+
+  test_that("linCmtB(-10) gives the per-compartment bioavailability sensitivity", {
+    # d(pred)/dF_q = A^(q)/F_q: the system is linear in the dose, but only in
+    # the part of the state that arrived through q.  With F = exp(eta_f) the
+    # chain rule cancels F, so the reported concentration derivative IS
+    # A^(depot) scaled by the central volume.
+    .m <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); ka <- exp(tka)
+      fdep <- exp(eta_f)
+      f(depot) <- fdep
+      cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+      dF <- linCmtB(rx__PTR__, t, 2, 1, 1, -10, 7, 1, cl, v, 0, 0, 0, 0, ka)
+    })
+    .e <- et(amt = 100, cmt = "depot", ii = 12, addl = 1) |>
+      et(amt = 40, cmt = "central", time = 1) |>
+      et(seq(0.1, 30, 0.5))
+    .s <- rxSolve(.m, .e, params = .p)
+    .f <- .fd(.m, .e, "eta_f")
+    expect_true(.rel(.s$dF, .f) < 1e-6)
+    # The whole-concentration answer (what a model blind to the mixed route
+    # would use) is wrong here by a wide margin -- pin that the decomposition
+    # is what makes the difference.
+    expect_true(.rel(.s$cp, .f) > 0.1)
+  })
+
+  test_that("linCmtB(-9) is exactly 0 when no dose reaches the origin", {
+    .m <- .rxOriginModel(1L, 1L, 0L)
+    .e <- et(amt = 50, cmt = "central") |> et(seq(0.1, 24, 0.5))
+    .s <- rxSolve(.m, .e, params = .p)
+    expect_true(all(.s$d9 == 0))
+  })
+
+  test_that("linCmtB(-9) reports NA for a steady-state infusion", {
+    # The SS infusion's rate is not carried past the SS solve, so -dA/dt is
+    # not recoverable for that origin (same limit as -3, see linCmtDoseScan).
+    .m <- .rxOriginModel(1L, 0L, 0L)
+    .e <- et(amt = 100, rate = 25, ii = 12, ss = 1, cmt = "central") |>
+      et(seq(0.1, 12, 0.5))
+    .s <- rxSolve(.m, .e, params = .p)
+    expect_true(all(is.na(.s$d9)))
+  })
+
+  test_that("linCmtB(-9)/(-10) reject an out of range origin or output", {
+    # q or out past the model's compartment count is NA, never an out of
+    # bounds read.
+    .m <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); lag <- 2 * exp(eta_lag)
+      alag(central) <- lag
+      cp <- linCmtB(rx__PTR__, t, 1, 1, 0, -1, -1, 1, cl, v, 0, 0, 0, 0, 0)
+      badQ <- linCmtB(rx__PTR__, t, 1, 1, 0, -9, 3 * 8 + 7, 1, cl, v, 0, 0, 0, 0, 0)
+      badO <- linCmtB(rx__PTR__, t, 1, 1, 0, -10, 2, 1, cl, v, 0, 0, 0, 0, 0)
+    })
+    .e <- et(amt = 100, cmt = "central") |> et(seq(0.1, 12, 0.5))
+    .s <- rxSolve(.m, .e, params = .p)
+    expect_true(all(is.na(.s$badQ)))
+    expect_true(all(is.na(.s$badO)))
+  })
+
+  test_that("linCmtB(-9) is per-individual", {
+    .m <- .rxOriginModel(2L, 1L, 0L)
+    .e <- do.call(rbind, lapply(1:5, function(i) {
+      .d <- as.data.frame(et(amt = 100, cmt = "depot") |>
+                            et(amt = 50, cmt = "central", time = 0) |>
+                            et(seq(0.1, 24, 1)))
+      .d$id <- i
+      .d
+    }))
+    .s <- rxSolve(.m, .e, params = .p)
+    .f <- .fd(.m, .e, "eta_lag")
+    expect_true(.rel(.s$d9, .f) < 1e-6)
+    for (.i in 2:5) {
+      expect_equal(.s$d9[.s$id == 1], .s$d9[.s$id == .i])
+    }
+  })
+})

--- a/tests/testthat/test-lincmt-origin-sens.R
+++ b/tests/testthat/test-lincmt-origin-sens.R
@@ -180,6 +180,57 @@ rxTest({
     expect_true(all(is.na(.s$badO)))
   })
 
+  test_that("linCmtB(-9) is right when linCmt() is mixed with an ODE", {
+    # A model that also has d/dt() re-enters linCmtB() many times within one
+    # event row (dydt fires at every internal solver step), so the advance of
+    # the decomposition has to be a pure function of the row's entry state.
+    # Accumulating instead read ~16% off here.
+    .m <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); ka <- exp(tka)
+      lag <- 2 * exp(eta_lag)
+      alag(depot) <- lag
+      d/dt(eff) <- -0.1 * eff
+      cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+      d3 <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -3, -3, 1, cl, v, 0, 0, 0, 0, ka)
+      d9 <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -9, 7, 1, cl, v, 0, 0, 0, 0, ka)
+    })
+    .e <- et(amt = 100, cmt = "depot") |> et(seq(0.1, 24, 0.5))
+    .s <- rxSolve(.m, .e, params = .p, inits = c(eff = 5))
+    .f <- .fd(.m, .e, "eta_lag")
+    expect_false(anyNA(.s$d9))
+    expect_true(.rel(.s$d9, .f) < 1e-6)
+    # the whole regimen doses one lagged compartment, so -3 agrees
+    expect_true(.rel(.s$d9, .s$d3) < 1e-8)
+  })
+
+  test_that("linCmtB(-9)/(-10) refuse a replace/multiply into the linCmt() block", {
+    # A replace or multiply rewrites a compartment that may hold mass from
+    # several origins, and the amounts cannot say how the rewrite divided among
+    # them -- so the decomposition stops being recoverable.  NA, not a number
+    # that keeps reporting the pre-rewrite origin forever.
+    .m <- .rxOriginModel(1L, 1L, 0L)
+    .base <- et(amt = 100, cmt = "depot")
+    for (.evid in c(5, 6)) {
+      .e <- .base |> et(amt = 0.5, cmt = "central", evid = .evid, time = 10) |>
+        et(seq(0.1, 24, 0.5))
+      .s <- rxSolve(.m, .e, params = .p)
+      expect_true(all(is.na(.s$d9)), label = paste("evid", .evid))
+    }
+    # ... but a replace on an ODE compartment is none of its business
+    .mOde <- rxode2({
+      cl <- exp(tcl); v <- exp(tv); ka <- exp(tka)
+      lag <- 2 * exp(eta_lag)
+      alag(depot) <- lag
+      d/dt(eff) <- -0.1 * eff
+      cp <- linCmtB(rx__PTR__, t, 2, 1, 1, -1, -1, 1, cl, v, 0, 0, 0, 0, ka)
+      d9 <- lag * linCmtB(rx__PTR__, t, 2, 1, 1, -9, 7, 1, cl, v, 0, 0, 0, 0, ka)
+    })
+    .eOde <- et(amt = 100, cmt = "depot") |>
+      et(amt = 1, cmt = "eff", evid = 5, time = 10) |> et(seq(0.1, 24, 0.5))
+    .s <- rxSolve(.mOde, .eOde, params = .p, inits = c(eff = 5))
+    expect_false(anyNA(.s$d9))
+  })
+
   test_that("linCmtB(-9) is per-individual", {
     .m <- .rxOriginModel(2L, 1L, 0L)
     .e <- do.call(rbind, lapply(1:5, function(i) {


### PR DESCRIPTION
Closes the remaining half of #1119.

## What was left

#1235 landed Part A and Part B's numeric core, `linCmtB(which1 = -3)`: a linear
system whose *whole* input is delayed by `L` satisfies `A(t; L) = A(t - L; 0)`,
so `dA/dL = -dA/dt` exactly. That identity needs every dose feeding the system
to carry the same delay, which is why #1237 had to be answered with a refusal:
a regimen that doses a lagged depot alongside an unlagged central gets `NA`
rather than a single-delay answer biased by the undelayed dose. The same gap
applies to bioavailability, where `d(pred)/dF = pred/F` assumes all of `pred`
came from the F-scaled dose -- and a paired IV/oral design, which is exactly
how `f()` is usually estimated, is precisely the regimen that breaks it.

## What this adds

A per-origin decomposition of the `linCmt()` amounts. Row `q` of the new
`ind->linCmtOrigin` is the part of the amount vector that arrived through doses
into `linCmt()` block compartment `q`. Two modes read it:

| `which1` | returns |
| --- | --- |
| `-9` | `d/dL_q` -- the derivative wrt a delay on compartment `q`'s doses alone, `-(M A^(q) + r^(q))` |
| `-10` | `A^(q)` itself, so `d/dF_q = A^(q)/F_q` |

`which2` packs both indices: `q*8 + out`, with `out` the compartment whose
amount is wanted or `7` for the reported concentration.

The decomposition needs no cooperation from `handle_evid`. The system is
linear, so the rows sum to the amounts; a bolus only changes the compartment it
was given to, so whatever entered the compartments since the last advance *is*
the dose, already attributed. Each row then advances by the same kernel that
advances the amounts, with the rate restricted to its own compartment. Rounding
cannot drift, because the residual is re-attributed every step.

`which1 = -3`'s behavior is unchanged -- it still refuses a mixed-delay regimen.
The new modes are the answer to that question, not a redefinition of it.

## Cost

Gated on a new `op->linCmtOriginMask` (the `linCmt()` compartments carrying a
modeled `alag()`/`f()`), so a model that cannot use it does no extra work.
When it is on, the cost is one extra kernel evaluation per origin per step.

## Correctness

Against a central finite difference of the concentration, worst relative error
**7.4e-10** across a 36-case grid: 1/2/3 compartments x IV/oral x single bolus,
multiple bolus, infusion, multiple infusion and steady-state bolus, plus six
mixed-route cases. Also checked: two compartments lagged by different
expressions (a build-time refusal before this), the bioavailability chain rule
on a mixed-route regimen (where the naive `pred/F` is off by 49%), and
per-individual independence.

Also checked: a model mixing `linCmt()` with an ODE (that one re-enters
`linCmtB()` at every internal solver step, so the advance has to be a pure
function of the row's entry state).

Limits, all reported as `NA` rather than a number:

- a steady-state infusion into the origin asked about (its rate is not carried
  past the SS solve -- the tail of #1236)
- a `REPLACE`/`MULTIPLY` record into the `linCmt()` block, or an `ss = 2`
  steady state: both change a compartment holding several origins' mass in a
  way the amounts cannot divide among them
- a row whose decomposition was never maintained (a model taking its *value*
  from `linCmtA()` rather than the `linCmtB(-1, -1)` call these modes require,
  or one declaring no modeled `alag()`/`f()`)
- an out of range origin or output index

## Review

Three rounds of an independent (Antigravity/Gemini) review. Four real defects
came out of it, all fixed and all now covered by tests:

1. a `REPLACE`/`MULTIPLY` into the `linCmt()` block left the decomposition
   reporting the pre-rewrite origin forever;
2. the advance was skipped on finite-difference H-optimization probe rows,
   leaving them with no decomposition at all;
3. *(found while checking 2, not reported by the review)* a model mixing
   `linCmt()` with an ODE accumulated the advance across the many re-entries
   `dydt` makes within one row -- **~16% off**;
4. an `ss = 2` record erased the earlier mass's origins -- **7.8% off**, where
   `which1 = -3` stays exact.

Two further review claims were checked and rejected, both recorded as comments
rather than changes: that the advance should step per internal solver step
(`ind->tprior` is set per event interval by `preSolve()`, so `dt` already spans
the whole interval -- stepping is what measured 16% off), and that a
conditional `linCmt()` call can strand the decomposition on a rejected step
(real, but not introduced here -- such a model's *concentration* is already
wrong by a larger margin, measured 0.46 against the unconditional model, and
the decomposition stays self-consistent with it).

## Testing

- New `tests/testthat/test-lincmt-origin-sens.R`.
- Full rxode2 suite: **FAIL 0 | PASS 40134** (316 files).
- nlmixr2est built against this branch: the linCmt/FOCEi files pass, with the
  alag-sens file at **0 failures / 34 assertions**. Three unrelated files
  (`phi-engage`, `carry-trans`, `carry-ll-fit`) show the same failures against
  released rxode2 5.1.7 + nlmixr2est 7.0.3, so they are pre-existing.

## Consumer

nlmixr2/nlmixr2est#1032 emits these modes from the FOCEi inner model,
dropping the "more than one lagged/F'd compartment leaves the gradient
uncorrected" restrictions that `-3` and `pred/F` forced.
