### PR TITLE
fix(rxode2): decode rxQ character literals in the C translator; make the build lock atomic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -684,6 +684,20 @@
 
 ## Bug fixes
 
+- A model comparing a string covariate against a literal (e.g. `cl <- exp(tcl
+  + eta.cl + cllow * (LowID == "Yes"))`) no longer translates to an undefined
+  parameter.  A character literal reaches symengine as the symbol
+  `rxQ__<escaped>__rxQ`, and while the R translator decodes it back to a
+  quoted string, the C translator added in 5.1.7 emitted the symbol verbatim
+  -- so the generated model carried `LowID==rxQ__Yes__rxQ` and solving it
+  failed with "the following parameter(s) are required for solving:
+  rxQ__Yes__rxQ".  Only symengine's own underscore naming reached the C path
+  (the bracket form declines and falls back to R), which is why it surfaced in
+  the sensitivity models a `nlmixr2est` FOCEi fit builds rather than in a
+  plain `rxode2()` call.  The C translator now decodes the literal, and hands
+  the expression back to the R translator for any byte whose `deparse1()`
+  spelling it cannot reproduce exactly.
+
 - `tad()`, `tafd()`, `tlast()`, `dosenum()` and `dose()` no longer skip an
   infusion when the subject's dosing record starts with a bolus.  The dose
   history asked for the infusion duration with the solver's running dose

--- a/NEWS.md
+++ b/NEWS.md
@@ -684,6 +684,22 @@
 
 ## Bug fixes
 
+- Building a model no longer hangs forever on a lock left behind by an
+  interrupted session, and two processes no longer build the same model at
+  once.  `rxTempDir()` exports itself with `Sys.setenv()`, so every subprocess
+  (a `testthat` parallel worker, for one) inherits ONE shared build directory
+  -- but the build lock was acquired as `file.exists()` followed by `sink()`,
+  a check-then-create pair that does not exclude, so two processes could both
+  see no lock and both compile the same artifact into that directory.  The
+  losing write surfaced as "error building model", "cannot open the
+  connection" or "cannot change working directory", depending on which step
+  it lost.  Separately, nothing ever removed a lock whose owner had been
+  killed, and the wait for it was unbounded, so a single interrupted compile
+  wedged that model for the life of the cache.  The lock is now taken with
+  `dir.create()` -- the portable atomic test-and-set -- and the wait for
+  another builder is bounded (`options(rxode2.buildLockTimeout=)`, 300s by
+  default) before the abandoned lock is reclaimed.
+
 - A model comparing a string covariate against a literal (e.g. `cl <- exp(tcl
   + eta.cl + cllow * (LowID == "Yes"))`) no longer translates to an undefined
   parameter.  A character literal reaches symengine as the symbol

--- a/R/rxode2.R
+++ b/R/rxode2.R
@@ -2184,24 +2184,46 @@ rxCompile.rxModelVars <- function(model, # Model
   }
   if (force || .needCompile) {
     .lock <- paste0(.cFile, ".lock")
-    if (file.exists(.lock)) {
+    ## Acquire the lock ATOMICALLY.  This was file.exists() followed by sink():
+    ## a check-then-create pair, so two processes could both see no lock and
+    ## both build the SAME artifact into the same directory.  That is not
+    ## hypothetical -- rxTempDir() exports itself with Sys.setenv(), so every
+    ## subprocess (testthat's parallel workers, for one) inherits ONE shared
+    ## build directory, and the concurrent builds surface as "error building
+    ## model", "cannot open the connection" or "cannot change working
+    ## directory" depending on which write lost.  dir.create() is the portable
+    ## atomic test-and-set: it creates the directory or returns FALSE, never
+    ## both.
+    if (file.exists(.lock) && !dir.exists(.lock)) {
+      unlink(.lock)              # stale file lock from an older rxode2
+    }
+    .haveLock <- dir.create(.lock, showWarnings = FALSE)
+    if (!.haveLock) {
       message("rxode2 already building model, waiting for lock file removal")
       message(sprintf("lock file: \"%s\"", .lock))
-      while (file.exists(.lock)) {
+      ## Bounded: a builder killed mid-compile leaves the lock behind, and an
+      ## unbounded wait would then wedge every later build of this model.
+      .lockWait <- getOption("rxode2.buildLockTimeout", 300)
+      .waited <- 0
+      while (dir.exists(.lock) && .waited < .lockWait) {
         Sys.sleep(0.5)
+        .waited <- .waited + 0.5
         message(".", appendLF = FALSE)
       }
       message("")
+      if (dir.exists(.lock)) {
+        unlink(.lock, recursive = TRUE)   # abandoned; take it over
+        .haveLock <- dir.create(.lock, showWarnings = FALSE)
+      }
+    }
+    if (!.haveLock) {
       if (!(file.exists(.cDllFile))) {
         stop("error building model on another thread", call. = FALSE)
       }
     } else {
-      sink(.lock)
-      cat("\n")
-      sink()
       on.exit(
         {
-          unlink(.lock)
+          unlink(.lock, recursive = TRUE)
         },
         add = TRUE
       )

--- a/src/seFromSEemit.h
+++ b/src/seFromSEemit.h
@@ -89,7 +89,13 @@ static const char *seBinary(seCtx *ctx, D_ParseNode *pn) {
    names, then the mangling chain */
 static const char *seEmitSymbol(seCtx *ctx, D_ParseNode *pn) {
   const char *raw = seNodeText(ctx, pn);
+  const char *lit;
   int i;
+  /* .rxRepRxQ() in .rxFromSE(): an encoded character literal becomes a quoted
+     string.  Checked first -- rxQ__<esc>__rxQ can be neither a reserved name
+     nor a number, and the mangling chain below would leave it untouched */
+  lit = seRepRxQ(ctx, raw);
+  if (lit != NULL) return lit;
   /* .cnst in .rxFromSE(): rx_SymPy_Res_<name> unshadows a reserved name */
   if (strncmp(raw, "rx_SymPy_Res_", 13) == 0) {
     for (i = 0; i < seNres; i++) {

--- a/src/seFromSEnames.h
+++ b/src/seFromSEnames.h
@@ -187,6 +187,73 @@ static const seCnt seRes[] = {
 };
 #define seNres ((int)(sizeof(seRes)/sizeof(seRes[0])))
 
+/* ------------------------------------------------ character literals --
+   A character literal reaches symengine as the SYMBOL rxQ__<esc>__rxQ
+   (.rxStrEncode() in R/symengine.R): every byte outside [A-Za-z0-9] is
+   written as "_" followed by its two hex digits.  .rxFromSE() turns that
+   back into a quoted string (.rxRepRxQ() -> .rxStrDecode() -> deparse1()),
+   so this emitter has to as well -- otherwise the encoded symbol reaches
+   the generated model as an undefined parameter, e.g.
+     cl <- exp(... + cllow * (LowID == "Yes"))
+   compiles to `LowID==rxQ__Yes__rxQ` and the solve then reports
+   "parameter(s) are required for solving: rxQ__Yes__rxQ".
+
+   The length/prefix test mirrors .rxRepRxQ() exactly (more than 10
+   characters, leading "rxQ__", trailing 5 dropped) so both emitters agree
+   on what counts as an encoded literal.
+
+   deparse1() renders a string with its own escaping rules; rather than
+   reproduce all of them, only PRINTABLE ASCII is decoded here (where
+   deparse1() emits the byte verbatim, or backslash-escaped for the two
+   cases below).  Anything else hands the expression back to the R walker,
+   per this file's rule that falling back is safe and guessing is not. */
+static int seHexDigit(char c) {
+  if (c >= '0' && c <= '9') return c - '0';
+  if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+  if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+  return -1;
+}
+
+/* NULL: not an encoded literal, carry on with the normal name handling. */
+static const char *seRepRxQ(seCtx *ctx, const char *raw) {
+  size_t n = strlen(raw), bn, i;
+  const char *body;
+  char *out, *q;
+  if (n <= 10 || strncmp(raw, "rxQ__", 5) != 0) return NULL;
+  body = raw + 5;
+  bn = n - 10;                       /* substr(x, 6, nchar(x) - 5) */
+  out = seAlloc(ctx, 2 * bn + 3);    /* every byte may escape, plus "" and NUL */
+  if (out == NULL) return "";
+  q = out;
+  *q++ = '"';
+  i = 0;
+  while (i < bn) {
+    char c = body[i];
+    if (c == '_' && i + 2 < bn) {
+      int hi = seHexDigit(body[i + 1]), lo = seHexDigit(body[i + 2]);
+      if (hi >= 0 && lo >= 0) {
+        c = (char)((hi << 4) | lo);
+        i += 3;
+      } else {
+        i++;
+      }
+    } else {
+      i++;
+    }
+    if (c == '\\' || c == '"') {
+      *q++ = '\\';
+      *q++ = c;
+    } else if (c >= 0x20 && c <= 0x7e) {
+      *q++ = c;
+    } else {
+      return seFail(ctx);           /* deparse1() may not spell it this way */
+    }
+  }
+  *q++ = '"';
+  *q = '\0';
+  return out;
+}
+
 /* sub("[(]rx_SymPy_Res_", "(", .ret) -- first match only, as sub() is */
 static const char *seUnRes(seCtx *ctx, const char *s) {
   const char *p = strstr(s, "(rx_SymPy_Res_");

--- a/src/seFromSEnames.h
+++ b/src/seFromSEnames.h
@@ -214,9 +214,40 @@ static int seHexDigit(char c) {
   return -1;
 }
 
+/* one decoded byte of the escaped body, advancing *i past what it consumed.
+   A "_" not followed by two hex digits cannot come from .rxStrEncode(), so it
+   is taken literally rather than guessed at. */
+static char seRxQByte(const char *body, size_t bn, size_t *i) {
+  char c = body[*i];
+  if (c == '_' && *i + 2 < bn) {
+    int hi = seHexDigit(body[*i + 1]), lo = seHexDigit(body[*i + 2]);
+    if (hi >= 0 && lo >= 0) {
+      *i += 3;
+      return (char)((hi << 4) | lo);
+    }
+  }
+  (*i)++;
+  return c;
+}
+
+/* deparse1()'s spelling of one byte inside a quoted string; 0 when it is not a
+   byte this emitter reproduces */
+static int seRxQEmitByte(char c, char **q) {
+  if (c == '\\' || c == '"') {
+    *(*q)++ = '\\';
+    *(*q)++ = c;
+    return 1;
+  }
+  if (c >= 0x20 && c <= 0x7e) {
+    *(*q)++ = c;
+    return 1;
+  }
+  return 0;
+}
+
 /* NULL: not an encoded literal, carry on with the normal name handling. */
 static const char *seRepRxQ(seCtx *ctx, const char *raw) {
-  size_t n = strlen(raw), bn, i;
+  size_t n = strlen(raw), bn, i = 0;
   const char *body;
   char *out, *q;
   if (n <= 10 || strncmp(raw, "rxQ__", 5) != 0) return NULL;
@@ -226,28 +257,9 @@ static const char *seRepRxQ(seCtx *ctx, const char *raw) {
   if (out == NULL) return "";
   q = out;
   *q++ = '"';
-  i = 0;
   while (i < bn) {
-    char c = body[i];
-    if (c == '_' && i + 2 < bn) {
-      int hi = seHexDigit(body[i + 1]), lo = seHexDigit(body[i + 2]);
-      if (hi >= 0 && lo >= 0) {
-        c = (char)((hi << 4) | lo);
-        i += 3;
-      } else {
-        i++;
-      }
-    } else {
-      i++;
-    }
-    if (c == '\\' || c == '"') {
-      *q++ = '\\';
-      *q++ = c;
-    } else if (c >= 0x20 && c <= 0x7e) {
-      *q++ = c;
-    } else {
-      return seFail(ctx);           /* deparse1() may not spell it this way */
-    }
+    /* deparse1() may not spell it this way -- hand it back to the R walker */
+    if (!seRxQEmitByte(seRxQByte(body, bn, &i), &q)) return seFail(ctx);
   }
   *q++ = '"';
   *q = '\0';

--- a/tests/testthat/test-build-lock.R
+++ b/tests/testthat/test-build-lock.R
@@ -1,0 +1,58 @@
+rxTest({
+  # rxTempDir() exports itself with Sys.setenv(), so every subprocess -- a
+  # testthat parallel worker, for one -- inherits ONE shared build directory.
+  # The build lock therefore has to actually exclude, and it did not: it was
+  # file.exists() followed by sink(), a check-then-create pair, so two
+  # processes could both see no lock and both build the same artifact into the
+  # same directory.  The losing write surfaced as "error building model",
+  # "cannot open the connection" or "cannot change working directory".
+  #
+  # Atomicity itself is dir.create()'s contract (it creates the directory or
+  # returns FALSE, never both).  What is testable here without a second
+  # process is the two ways a lock can be left behind.
+
+  .lockOf <- function(ui) {
+    # the .c the model compiles to, whose sibling <name>.lock is the lock
+    .f <- rxode2::rxDll(ui)
+    sub("\\.[^.]+$", ".c.lock", .f)
+  }
+
+  test_that("a stale FILE lock does not wedge the build", {
+    skip_on_cran()
+    # An rxode2 that predates this wrote the lock as a FILE.  Nothing removes
+    # it, so the old `while (file.exists(.lock))` wait never returned -- the
+    # build hung rather than failed.
+    .m <- rxode2::rxode2("d/dt(sLockA) <- -sLockA\nyLockA <- sLockA * 2")
+    .lock <- .lockOf(.m)
+    rxode2::rxDelete(.m)
+    writeLines("", .lock)
+    on.exit(unlink(.lock, recursive = TRUE), add = TRUE)
+    expect_true(file.exists(.lock) && !dir.exists(.lock))
+    .m2 <- withr::with_options(
+      list(rxode2.buildLockTimeout = 2),
+      rxode2::rxode2("d/dt(sLockA) <- -sLockA\nyLockA <- sLockA * 2"))
+    expect_s3_class(.m2, "rxode2")
+    expect_false(file.exists(.lock))
+  })
+
+  test_that("an abandoned DIRECTORY lock is taken over once the wait expires", {
+    skip_on_cran()
+    # A builder killed mid-compile leaves the lock directory behind.  It must
+    # be reclaimed rather than block this model's build for the rest of time.
+    .m <- rxode2::rxode2("d/dt(sLockB) <- -sLockB\nyLockB <- sLockB * 3")
+    .lock <- .lockOf(.m)
+    rxode2::rxDelete(.m)
+    dir.create(.lock, showWarnings = FALSE)
+    on.exit(unlink(.lock, recursive = TRUE), add = TRUE)
+    expect_true(dir.exists(.lock))
+    .m2 <- withr::with_options(
+      list(rxode2.buildLockTimeout = 1),
+      suppressMessages(
+        rxode2::rxode2("d/dt(sLockB) <- -sLockB\nyLockB <- sLockB * 3")))
+    expect_s3_class(.m2, "rxode2")
+    # solving proves the takeover produced a real dll, not just a file
+    .s <- rxode2::rxSolve(.m2, rxode2::et(0:3), c(sLockB = 1),
+                          returnType = "data.frame")
+    expect_equal(.s$yLockB, .s$sLockB * 3)
+  })
+})

--- a/tests/testthat/test-symengine-rxq-string.R
+++ b/tests/testthat/test-symengine-rxq-string.R
@@ -1,0 +1,55 @@
+rxTest({
+  # A character literal reaches symengine as the SYMBOL rxQ__<esc>__rxQ
+  # (.rxStrEncode()); .rxFromSE() turns it back into a quoted string.  The C
+  # emitter did not, so a model comparing a string covariate translated to
+  # `LowID==rxQ__Yes__rxQ` and the solve then failed with
+  # "parameter(s) are required for solving: rxQ__Yes__rxQ".  Only symengine's
+  # own underscore naming reached it -- the bracket form declines to C and
+  # falls back to R -- which is why the translate fixture never caught it.
+
+  .rTxt <- function(s) {
+    .rxFromSE(eval(parse(text = paste0("quote({", s, "})"))))
+  }
+
+  test_that("the C emitter decodes an encoded character literal", {
+    .cases <- c(
+      "rxEq(LowID,rxQ__Yes__rxQ)",
+      "rxNeq(LowID,rxQ__Yes__rxQ)",
+      "rxEq(LowID,rxQ__A_20B__rxQ)",
+      "rxEq(LowID,rxQ__a_2Db_2Ec__rxQ)",
+      # the form nlmixr2est's FOCEi inner model actually hits
+      "exp(ETA_2_+THETA_2_+rxEq(LowID,rxQ__Yes__rxQ)*THETA_4_)"
+    )
+    for (.s in .cases) {
+      .c <- .rxFromSEC(.s, 1L)
+      # declining is always allowed; disagreeing is not
+      if (is.na(.c)) next
+      expect_false(grepl("rxQ__", .c, fixed = TRUE), label = .s)
+      expect_equal(.c, .rTxt(.s), label = .s)
+    }
+  })
+
+  test_that("the C emitter declines a literal deparse1() may spell differently", {
+    # a tab is not printable ASCII, so the C path must hand it back rather
+    # than guess at deparse1()'s escaping
+    expect_true(is.na(.rxFromSEC("rxEq(LowID,rxQ__a_09b__rxQ)", 1L)))
+    expect_equal(.rTxt("rxEq(LowID,rxQ__a_09b__rxQ)"), "(LowID==\"a\\tb\")")
+  })
+
+  test_that("a string comparison survives the rxToSE()/rxFromSE() round trip", {
+    .se <- rxToSE("LowID == \"Yes\"")
+    expect_equal(.se, "rxEq(LowID,rxQ__Yes__rxQ)")
+    expect_equal(rxFromSE(.se), "(LowID==\"Yes\")")
+  })
+
+  test_that("a string covariate reaches the solve as a comparison, not a parameter", {
+    # the end-to-end shape of the original report: the encoded symbol must not
+    # become a model parameter
+    .m <- rxode2({
+      cl <- exp(1 + 0.5 * (LowID == "Yes"))
+      d/dt(center) <- -cl * center
+    })
+    expect_false(any(grepl("rxQ__", rxModelVars(.m)$params, fixed = TRUE)))
+    expect_true("LowID" %in% rxModelVars(.m)$params)
+  })
+})


### PR DESCRIPTION
Two independent bugs, both found while running the `nlmixr2est` suite.

---

## 1. The C translator drops a character literal

A model that compares a string covariate against a literal fails to solve:

```r
cl <- exp(tcl + eta.cl + cllow * (LowID == "Yes"))
```

```
Error: Could not fit data
  The following parameter(s) are required for solving: rxQ__Yes__rxQ
```

A character literal reaches symengine as the **symbol** `rxQ__<escaped>__rxQ`
(`.rxStrEncode()`). The R translator decodes it back to a quoted string
(`.rxFromSE()` -> `.rxRepRxQ()` -> `.rxStrDecode()` -> `deparse1()`); the C
translator added in 5.1.7 has no equivalent step, so `seEmitSymbol()` runs the
symbol through the mangling chain and emits it verbatim.

```r
s <- "exp(ETA_2_+THETA_2_+rxEq(LowID,rxQ__Yes__rxQ)*THETA_4_)"

rxode2:::.rxFromSEC(s, 1L)
#> "exp(ETA[2]+THETA[2]+(LowID==rxQ__Yes__rxQ)*THETA[4])"   # C -- wrong
rxode2:::.rxFromSE(eval(parse(text = paste0("quote({", s, "})"))))
#> "exp(ETA[2]+THETA[2]+(LowID==\"Yes\")*THETA[4])"         # R -- right
```

**Why it went unnoticed.** Only symengine's underscore naming reaches the C
path; the bracket form (`ETA[2]`) makes the C emitter decline and fall back to
the R walker, which decodes correctly. So ad-hoc character-input tests all look
fine, and `symengine-translate-fixture.rds` has no encoded-literal case.

**Fix.** `seRepRxQ()` (`src/seFromSEnames.h`), called first from
`seEmitSymbol()` -- an encoded literal is neither a reserved name nor a number.
The length/prefix test mirrors `.rxRepRxQ()` exactly. `deparse1()`'s escaping is
not reproduced in full: printable ASCII is decoded, and any other byte sets
`ctx->failed` so the expression goes back to the R walker, per
`seFromSEemit.h`'s rule that declining is safe and guessing is not.

---

## 2. The model build lock does not lock

`rxTempDir()` exports itself with `Sys.setenv()`, so every subprocess -- a
`testthat` parallel worker, for one -- inherits **one shared build directory**.
The lock meant to keep two processes from building the same artifact into it
was acquired as

```r
if (file.exists(.lock)) { wait } else { sink(.lock); ...build... }
```

a check-then-create pair, which does not exclude. Both processes can see no
lock and both compile the same `.c`/`.o`/`.so`. The losing write surfaced as
`error building model`, `cannot open the connection`, or `cannot change working
directory`, depending on which step lost -- a different message most runs,
which is what made it look like three unrelated flakes.

**The worse half:** nothing ever removed a lock whose owner had been killed,
and the wait was unbounded, so a single interrupted compile wedged that model
for the life of the cache:

```r
while (file.exists(.lock)) Sys.sleep(0.5)   # nothing removes it
```

Measured against the released build, a leftover lock file hangs `rxode2()`
indefinitely (killed by SIGTERM at 30s). With this branch the same script
completes. Any user who interrupts a compile hits this, and the only way out is
to find and delete the lock by hand.

**Fix.** `dir.create()` -- the portable atomic test-and-set, which creates the
directory or returns `FALSE`, never both. The wait for another builder is
bounded by `options(rxode2.buildLockTimeout=)` (300s default), after which the
abandoned lock is reclaimed; a stale FILE lock from an older rxode2 is removed
rather than waited on.

---

## Verification

- `tests/testthat/test-symengine-rxq-string.R` (16 assertions): C matches the R
  walker for plain, space- and punctuation-escaped literals and the nested form
  a FOCEi inner model hits; a tab-bearing literal must decline to `NA` rather
  than guess; `rxToSE()`/`rxFromSE()` round trip; the encoded symbol must not
  reach `rxModelVars()$params`. All fail on `main`.
- `tests/testthat/test-build-lock.R` (6 assertions): a stale FILE lock and an
  abandoned DIRECTORY lock both let the build proceed. Both **hang** on `main`
  rather than fail, so they are forward regression tests.
- 70 files / 8499 assertions clean across the parse/translate/solve/lincmt/
  sens/cov/compile slice, including `test-symengine-translate-fixture.R`, which
  pins C-vs-R agreement over the whole recorded corpus.
- End to end: the `nlmixr2est` model above, which errors on `main`, now fits;
  and an `nlmixr2est` test chunk that fails under its parallel harness (always
  in a different place) is clean with fix 2.
