### PR TITLE
perf: coerce covariate columns to double once, not once per row

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -701,6 +701,17 @@
 
 ## Bug fixes
 
+- An `integer` or `logical` covariate column no longer makes `rxSolve()`
+  quadratic in the number of rows.  While building the solving data set each
+  covariate column was coerced to double once per output row; for a column
+  that is already double that coercion is free, but for an integer or logical
+  column it allocated and converted a copy of the whole column on every row.
+  The result was correct but progressively slower -- roughly 14x a double
+  column at 20000 rows and 90x at 160000 -- and the only hint was the timing,
+  since a logical covariate arises naturally from ordinary R code such as
+  `flag = x == "value"`.  Each covariate column is now coerced once, so every
+  storage mode solves at the speed a double column always did.
+
 - Building a model no longer hangs forever on a lock left behind by an
   interrupted session, and two processes no longer build the same model at
   once.  `rxTempDir()` exports itself with `Sys.setenv()`, so every subprocess

--- a/NEWS.md
+++ b/NEWS.md
@@ -712,6 +712,13 @@
   `flag = x == "value"`.  Each covariate column is now coerced once, so every
   storage mode solves at the speed a double column always did.
 
+- A model that reads `CMT` as a covariate no longer slows down with the number
+  of subjects.  `CMT` is carried as an integer column, and the copy of each
+  covariate into the solving buffer -- done once per subject -- coerced the
+  whole column to double every time, costing about 3x an otherwise identical
+  double covariate at 20000 subjects.  The columns are now coerced once, as
+  above.
+
 - Building a model no longer hangs forever on a lock left behind by an
   interrupted session, and two processes no longer build the same model at
   once.  `rxTempDir()` exports itself with `Sys.setenv()`, so every subprocess

--- a/src/etTran.cpp
+++ b/src/etTran.cpp
@@ -3065,6 +3065,35 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
       stop(_("the columns that are kept must be either an underlying logical, string, factor, integer number, or real number"));
     }
   }
+  // The row loop below reads every covariate column once per output row.
+  // Coercing to double there costs a whole-column allocation and copy for each
+  // integer or logical column on each row, which makes the loop quadratic in
+  // the number of rows.  Coerce each column to double once, here, and keep the
+  // coerced columns alive in covD so covDp[] stays valid for the loop.  A
+  // column that is already double is not copied at all.
+  List covD(covCol.size());
+  std::vector<double*> covDp(covCol.size(), NULL);
+  std::vector<R_xlen_t> covDn(covCol.size(), 0);
+  for (j = 0; j < (int)(covCol.size()); j++) {
+    int covColj = covCol[j];
+    // cmt is carried as an integer compartment column, not a double covariate
+    if (hasCmt && covColj >= 0 && j == cmtI) continue;
+    SEXP curCov;
+    if (covColj >= 0) {
+      // This comes from the original data
+      curCov = inData[covColj];
+    } else {
+      // this comes from the individual covariate table
+      curCov = iCov_[-covColj-1];
+    }
+    if (!Rf_isNull(inDataF[j])) {
+      curCov = inDataF[j];
+    }
+    NumericVector curCovD = as<NumericVector>(curCov);
+    covD[j]  = curCovD;
+    covDp[j] = REAL(curCovD);
+    covDn[j] = curCovD.size();
+  }
   int maxItemsPerId = 0;
   int curItems = 0;
   for (i =idxOutput.size(); i--;){
@@ -3149,48 +3178,39 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
             // These should be ignored for interpolation.
             nvTmp[jj] = NA_REAL;
           } else {
-            // These covariates are added.
-            SEXP cur;
-            if (covColj >= 0) {
-              // This comes from the original data
-              cur = inData[covColj];
-            } else {
-              // this comes from the individual covariate table
-              cur = iCov_[-covColj-1];
-            }
-            if (!Rf_isNull(inDataF[j])) {
-              cur = inDataF[j];
-            }
-            nvTmp2   = as<NumericVector>(cur);
+            // These covariates are added; covDp[j] is the column already
+            // coerced to double above.
+            double *curCovD = covDp[j];
+            R_xlen_t curCovDn = covDn[j];
             if (covColj < 0) {
               // By definition, not time varying, no need to check
-              // nvTmp2 in this case is the column sorted by id
+              // curCovD in this case is the column sorted by id
               // so we get the current
               // idx1 = the index of the current id
               if (allTimeVar) {
-                nvTmp[jj] = nvTmp2[idxIcov[idx1]];
+                nvTmp[jj] = curCovD[idxIcov[idx1]];
               }
               // nvTmp = as<NumericVector>(lst1[1+j]);
-              // double vCur = nvTmp2[idx1];
+              // double vCur = curCovD[idx1];
               // nvTmp[idx1] = vCur;
               // fPars[idx1*pars.size()+covParPos[j]] = nvTmp[idx1];
             } else {
-              nvTmp[jj] = nvTmp2[idxInput[idxOutput[i]]];
+              nvTmp[jj] = curCovD[idxInput[idxOutput[i]]];
               if (addId) {
                 nvTmp = as<NumericVector>(lst1[1+j]);
                 int iCur = i;
                 int idxOut = i;
                 int idxIn = i;
-                double vCur = nvTmp2[idxInput[idxOutput[i]]];
+                double vCur = curCovD[idxInput[idxOutput[i]]];
                 // Could be NA, look for non NA value OR beginning of subject
                 while (ISNA(vCur) && iCur != 0 &&
                        id.size() > (idxOut = idxOutput[iCur]) &&
                        idxOut >= 0 &&
                        lastId == id[idxOut] &&
                        idxInput.size() > idxOut &&
-                       nvTmp2.size() > (idxIn = idxInput[idxOut]) &&
+                       curCovDn > (idxIn = idxInput[idxOut]) &&
                        idxIn >= 0) {
-                  vCur = nvTmp2[idxIn];
+                  vCur = curCovD[idxIn];
                   iCur--;
                 }
                 if (ISNA(vCur)) iCur = i;
@@ -3200,9 +3220,9 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
                        idxOut >= 0 &&
                        lastId == id[idxOut] &&
                        idxInput.size() > idxOut &&
-                       nvTmp2.size() > (idxIn = idxInput[idxOut]) &&
+                       curCovDn > (idxIn = idxInput[idxOut]) &&
                        idxIn >= 0) {
-                  vCur = nvTmp2[idxIn];
+                  vCur = curCovD[idxIn];
                   iCur++;
                 }
                 if (ISNA(vCur)) {
@@ -3216,7 +3236,7 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
               } else if (sub1[1+j]) {
                 nvTmp = as<NumericVector>(lst1[1+j]);
                 //double cur1 = nvTmp[idx1];
-                double cur2 = nvTmp2[idxInput[idxOutput[i]]];
+                double cur2 = curCovD[idxInput[idxOutput[i]]];
                 if (!ISNA(cur2) && nvTmp[idx1] != cur2){
                   sub0[baseSize+j] = true;
                   sub1[1+j] = false;

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -4449,6 +4449,19 @@ static inline void rxSolve_datSetupHmax(const RObject &obj, const List &rxContro
     op->par_cov_interp = &(_globals.gpar_covInterp[0]);
     op->ncov=ncov;
     op->do_par_cov = (ncov > 0);
+    // Each covariate column is copied out of dataf once per subject below.
+    // Coerce every column to double once, here, so the copies read a plain
+    // pointer.  A column that is already double is not copied at all, but an
+    // integer column -- CMT, when the model reads it as a covariate -- would
+    // otherwise be converted in full for each subject.  covD keeps the coerced
+    // columns alive so covDp[] stays valid for the copies below.
+    List covD(ncov);
+    std::vector<double*> covDp(ncov, NULL);
+    for (int ic = 0; ic < ncov; ic++) {
+      NumericVector curCovD = as<NumericVector>(dataf[covPos[ic]]);
+      covD[ic]  = curCovD;
+      covDp[ic] = REAL(curCovD);
+    }
     // Make sure the covariates are a #ncov * all times size
     int ids = id.size();
     // Get the number of subjects
@@ -4470,8 +4483,8 @@ static inline void rxSolve_datSetupHmax(const RObject &obj, const List &rxContro
         int groupNAll = ndoses + nobs;
         double *groupCov = &(_globals.gcov[curcovi]);
         for (ii = 0; ii < ncov; ii++){
-          NumericVector cur = as<NumericVector>(dataf[covPos[ii]]);
-          std::copy(cur.begin()+lasti, cur.begin()+lasti+groupNAll,
+          double *cur = covDp[ii];
+          std::copy(cur+lasti, cur+lasti+groupNAll,
                     _globals.gcov+curcovi);
           curcovi += groupNAll;
         }
@@ -4619,8 +4632,8 @@ static inline void rxSolve_datSetupHmax(const RObject &obj, const List &rxContro
             if (ind->n_all_times > rx->maxAllTimes) rx->maxAllTimes= ind->n_all_times;
             ind->cov_ptr = &(_globals.gcov[curcovi]);
             for (ii = 0; ii < ncov; ii++){
-              NumericVector cur = as<NumericVector>(dataf[covPos[ii]]);
-              std::copy(cur.begin()+lasti, cur.begin()+lasti+ind->n_all_times,
+              double *cur = covDp[ii];
+              std::copy(cur+lasti, cur+lasti+ind->n_all_times,
                         _globals.gcov+curcovi);
               curcovi += ind->n_all_times;
             }
@@ -4726,8 +4739,8 @@ static inline void rxSolve_datSetupHmax(const RObject &obj, const List &rxContro
       if (ind->n_all_times > rx->maxAllTimes) rx->maxAllTimes= ind->n_all_times;
       ind->cov_ptr = &(_globals.gcov[curcovi]);
       for (ii = 0; ii < ncov; ii++){
-        NumericVector cur = as<NumericVector>(dataf[covPos[ii]]);
-        std::copy(cur.begin()+lasti, cur.begin()+lasti+ind->n_all_times,
+        double *cur = covDp[ii];
+        std::copy(cur+lasti, cur+lasti+ind->n_all_times,
                   _globals.gcov+curcovi);
         curcovi += ind->n_all_times;
       }

--- a/tests/testthat/test-cov.R
+++ b/tests/testthat/test-cov.R
@@ -705,4 +705,111 @@ rxTest({
     x2 <- rxSolve(mod2, dfadvan, keep = "CL")
     expect_equal(x1$CL, x2$CL)
   })
+
+  test_that("covariate columns behave the same in every storage mode (#1325)", {
+
+    .covFlagData <- function(nRow, type) {
+      flag <- rep(c(0, 1), length.out = nRow)
+      data.frame(
+        ID = rep(seq_len(nRow / 50), each = 50),
+        TIME = rep(seq_len(50), times = nRow / 50),
+        x = seq(-100, 0, length.out = nRow),
+        flag = switch(type,
+          double = as.double(flag),
+          integer = as.integer(flag),
+          logical = as.logical(flag)
+        ),
+        EVID = 0, AMT = 0
+      )
+    }
+
+    mod <- rxode2({
+      slope <- slopeA * (1 - flag) + slopeB * flag
+      eff <- slope * x
+    })
+    .pars <- c(slopeA = -0.9, slopeB = -1.29)
+    .solve <- function(d) {
+      rxSolve(mod, params = .pars, events = d, returnType = "data.frame")
+    }
+
+    # etTrans() carries every covariate as a double, whatever the column's
+    # storage mode in the input data
+    .trDouble <- rxode2::etTrans(.covFlagData(200, "double"), mod)
+    expect_equal(typeof(.trDouble$flag), "double")
+    for (.ty in c("integer", "logical")) {
+      .tr <- rxode2::etTrans(.covFlagData(200, .ty), mod)
+      expect_equal(typeof(.tr$flag), "double")
+      expect_equal(.tr$flag, .trDouble$flag)
+    }
+
+    # ...and the model therefore sees identical values
+    .refSolve <- .solve(.covFlagData(1000, "double"))
+    for (.ty in c("integer", "logical")) {
+      .cur <- .solve(.covFlagData(1000, .ty))
+      expect_equal(.cur$slope, .refSolve$slope)
+      expect_equal(.cur$eff, .refSolve$eff)
+    }
+
+    # the NA carry-forward/carry-back that fills a subject's first covariate
+    # value reads the same coerced column, so an NA in an integer or logical
+    # column resolves the same way an NA in a double column does
+    .naData <- function(type) {
+      d <- .covFlagData(200, type)
+      d$flag[c(1, 2, 51)] <- NA
+      d
+    }
+    .refNa <- .solve(.naData("double"))
+    for (.ty in c("integer", "logical")) {
+      expect_equal(.solve(.naData(.ty))$eff, .refNa$eff)
+    }
+  })
+
+  test_that("non-double covariate columns stay linear in row count (#1325)", {
+
+    # etTrans() used to coerce a covariate column to double once per output
+    # row.  For an integer or logical column that is a whole-column allocation
+    # and copy per row, which made rxSolve() quadratic in rows -- 20000 rows
+    # cost ~14x a double column and 160000 rows ~90x.  A double column was
+    # never copied, so it is the reference the other modes are held to.
+    #
+    # The threshold is deliberately loose (timing on a shared CI runner is
+    # noisy) but the defect it guards against is an order of magnitude past
+    # it; taking the minimum of a few repeats keeps a stray GC pause from
+    # failing the check.
+    .covFlagData <- function(nRow, type) {
+      flag <- rep(c(0, 1), length.out = nRow)
+      data.frame(
+        ID = rep(seq_len(nRow / 50), each = 50),
+        TIME = rep(seq_len(50), times = nRow / 50),
+        x = seq(-100, 0, length.out = nRow),
+        flag = switch(type,
+          double = as.double(flag),
+          integer = as.integer(flag),
+          logical = as.logical(flag)
+        ),
+        EVID = 0, AMT = 0
+      )
+    }
+
+    mod <- rxode2({
+      slope <- slopeA * (1 - flag) + slopeB * flag
+      eff <- slope * x
+    })
+    .pars <- c(slopeA = -0.9, slopeB = -1.29)
+    .solve <- function(d) {
+      rxSolve(mod, params = .pars, events = d, returnType = "data.frame")
+    }
+    .minElapsed <- function(d, reps = 3L) {
+      min(vapply(seq_len(reps),
+                 function(i) system.time(.solve(d))[["elapsed"]],
+                 numeric(1)))
+    }
+
+    invisible(.solve(.covFlagData(1000, "double"))) # compile the model first
+
+    .nRow <- 20000
+    .tDouble <- .minElapsed(.covFlagData(.nRow, "double"))
+    expect_lt(.minElapsed(.covFlagData(.nRow, "integer")), 4 * .tDouble)
+    expect_lt(.minElapsed(.covFlagData(.nRow, "logical")), 4 * .tDouble)
+  })
 })

--- a/tests/testthat/test-cov.R
+++ b/tests/testthat/test-cov.R
@@ -812,4 +812,45 @@ rxTest({
     expect_lt(.minElapsed(.covFlagData(.nRow, "integer")), 4 * .tDouble)
     expect_lt(.minElapsed(.covFlagData(.nRow, "logical")), 4 * .tDouble)
   })
+
+  test_that("a CMT covariate stays linear in subject count (#1325)", {
+
+    # CMT is the one covariate rxSolve() receives as an integer column, and the
+    # per-subject copy into the solving buffer used to coerce the whole column
+    # to double for each subject.  Hold it to an otherwise identical double
+    # covariate: the two now run the same code, so the threshold only has to
+    # absorb timing noise, and the defect it guards against was 3x or more.
+    .cmtData <- function(nSub, nPer) {
+      n <- nSub * nPer
+      data.frame(
+        ID = rep(seq_len(nSub), each = nPer),
+        TIME = rep(seq_len(nPer), times = nSub),
+        x = seq(-100, 0, length.out = n),
+        zz = 1.0, CMT = 1L, EVID = 0, AMT = 0
+      )
+    }
+    modCmt <- rxode2({
+      eff <- slopeA * x + CMT
+    })
+    modDbl <- rxode2({
+      eff <- slopeA * x + zz
+    })
+    .solve <- function(m, d) {
+      rxSolve(m, params = c(slopeA = -0.9), events = d, returnType = "data.frame")
+    }
+    .minElapsed <- function(m, d, reps = 3L) {
+      min(vapply(seq_len(reps),
+                 function(i) system.time(.solve(m, d))[["elapsed"]],
+                 numeric(1)))
+    }
+
+    # CMT reaches the model as the compartment number it holds
+    .small <- .cmtData(4, 3)
+    expect_equal(.solve(modCmt, .small)$eff, -0.9 * .small$x + 1)
+
+    invisible(.solve(modDbl, .cmtData(4, 3))) # compile both models first
+
+    .d <- .cmtData(20000, 3)
+    expect_lt(.minElapsed(modCmt, .d), 2 * .minElapsed(modDbl, .d))
+  })
 })


### PR DESCRIPTION
Fixes #1325.

## The defect

`etTrans()` builds the solving data set one output row at a time, and for each
row it did this per covariate:

```cpp
nvTmp2 = as<NumericVector>(cur);   // cur = inData[covColj]
```

For a column that is already `double` that returns the same vector and costs
nothing — which is why the problem was invisible in the common case. For an
`integer` or `logical` column it calls `Rf_coerceVector`, allocating and
converting a copy of the **whole column**, on **every row**. The loop was
therefore quadratic in rows, with correct results throughout.

Each covariate column is now coerced once, before the loop, and the loop reads
it through a plain pointer. A column that is already double is still not
copied at all.

| rows | `double` | `integer` | `logical` |
|---|---|---|---|
| before, 20k | 0.12 s | 1.68 s | 2.06 s |
| before, 160k | 1.10 s | 81.5 s | 100.9 s |
| after, 160k | 1.12 s | **1.01 s** | **1.08 s** |

This matters because a logical covariate arises from ordinary R code —
`flag = x == "value"`, or a `data.frame(is_a = c(FALSE, TRUE))` crossed into a
simulation grid. The failure mode was silent: correct answers, quietly up to
90x slower.

## Second commit: the same defect in `rxSolve()`

The copy of each covariate into the solving buffer runs once per subject, and
each copy coerced its column first (`src/rxData.cpp`, three sites). Those
columns come from `etTrans()` and are almost all double — except `CMT`, which
is carried as an integer column. So a model that reads `CMT` as a covariate
re-converted the whole column for every subject: O(nsub × nrow).

Measured with 20 000 subjects / 60 000 rows, against an otherwise identical
double covariate: **3.35x before, 0.93x after**.

## Tests

Three regression tests in `tests/testthat/test-cov.R`, each verified to go
**red on the unfixed build and green on the fixed one** — a timing test that
cannot fail is worse than no test:

- `etTrans()` carries every covariate as a double whatever the input storage
  mode, the model sees identical values, and an `NA` in an integer or logical
  column resolves the same way an `NA` in a double column does (exact
  equality — these are strict).
- Integer and logical covariates stay within 4x a double covariate at
  20 000 rows (was ~14x).
- A `CMT` covariate stays within 2x an equivalent double covariate at
  20 000 subjects (was 3.35x).

The timing thresholds are loose on purpose — timing on a shared runner is
noisy — but the defects they guard against are an order of magnitude past
them, and each measurement is the minimum of three repeats so a stray GC pause
cannot fail the check.

## Verification

Full suite on Linux / R 4.6.1: **0 failures, 0 errors, 39 261 passing, 5
skipped.** No new compiler warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)