### PR TITLE
fix: remove code that can never run, and one result that was always discarded

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -719,6 +719,13 @@
   double covariate at 20000 subjects.  The columns are now coerced once, as
   above.
 
+- `rxDfdy()` (and `rxModelVars()$dfdy`) report an ETA derivative as
+  `df(A)/dy(ETA[1])` instead of leaking the internal name
+  `df(A)/dy(_ETA_1_)`.  Both `THETA[n]` and `ETA[n]` are translated back from
+  their internal spellings for display, but the ETA translation was written
+  into the buffer and then unconditionally overwritten, so only `THETA[n]`
+  survived.
+
 - Building a model no longer hangs forever on a lock left behind by an
   interrupted session, and two processes no longer build the same model at
   once.  `rxTempDir()` exports itself with `Sys.setenv()`, so every subprocess

--- a/R/rudf.R
+++ b/R/rudf.R
@@ -516,5 +516,4 @@ rxRmFunParse <- function(name) {
   }
   stop(paste0(.udfCallFunArg(fun, args), "needs to return a length 1 numeric"),
        call.=FALSE)
-  .ret
 }

--- a/src/etTran.cpp
+++ b/src/etTran.cpp
@@ -3202,7 +3202,12 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
                 int idxOut = i;
                 int idxIn = i;
                 double vCur = curCovD[idxInput[idxOutput[i]]];
-                // Could be NA, look for non NA value OR beginning of subject
+                // Could be NA, look for non NA value OR beginning of subject.
+                // The enclosing loop walks the output rows backwards, so addId
+                // is set on a subject's LAST row and walking iCur down from
+                // there covers every one of that subject's rows.  Searching
+                // forwards as well would only reach the next subject, which
+                // the lastId guard rejects.
                 while (ISNA(vCur) && iCur != 0 &&
                        id.size() > (idxOut = idxOutput[iCur]) &&
                        idxOut >= 0 &&
@@ -3212,18 +3217,6 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
                        idxIn >= 0) {
                   vCur = curCovD[idxIn];
                   iCur--;
-                }
-                if (ISNA(vCur)) iCur = i;
-                while (ISNA(vCur) && iCur+1 != (int)(covCol.size()) &&
-                       idxOutput.size() < iCur+1 &&
-                       id.size() > (idxOut = idxOutput[iCur+1]) &&
-                       idxOut >= 0 &&
-                       lastId == id[idxOut] &&
-                       idxInput.size() > idxOut &&
-                       curCovDn > (idxIn = idxInput[idxOut]) &&
-                       idxIn >= 0) {
-                  vCur = curCovD[idxIn];
-                  iCur++;
                 }
                 if (ISNA(vCur)) {
                   Rf_warningcall(R_NilValue,

--- a/src/genModelVars.h
+++ b/src/genModelVars.h
@@ -590,6 +590,8 @@ static inline void populateDfdy(SEXP dfdy) {
         sPrint(&_bufw,"_ETA_%d_",j);
         if (!strcmp(dy,_bufw.s)){
           sPrint(&_bufw,"ETA[%d]",j);
+          foundIt=1;
+          break;
         }
       }
     }

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -2013,7 +2013,6 @@ extern "C" double *rxGetErrs(){
   if (_rxModels.exists(".sigma")){
     NumericMatrix sigma = _rxModels[".sigma"];
     if (_rxGetErrs == NULL){
-      if (_rxGetErrs != NULL) free(_rxGetErrs);
       _rxGetErrs = (double*)calloc(sigma.ncol()*sigma.nrow(), sizeof(double));
       if (_rxGetErrs == NULL) {
         rxSolveFree();

--- a/tests/testthat/test-cov.R
+++ b/tests/testthat/test-cov.R
@@ -853,4 +853,40 @@ rxTest({
     .d <- .cmtData(20000, 3)
     expect_lt(.minElapsed(modCmt, .d), 2 * .minElapsed(modDbl, .d))
   })
+
+  test_that("an NA covariate resolves from anywhere in the subject", {
+
+    # A subject's invariant covariate value is filled by scanning that
+    # subject's rows for a non-NA one.  The scan starts at the subject's LAST
+    # row and walks backwards, so it has to reach a value that sits at the
+    # subject's FIRST rows -- id 3 below is the case that pins that down.
+    mod <- rxode2({
+      eff <- 10 * flag
+    })
+    d <- data.frame(
+      ID = rep(1:3, each = 4),
+      TIME = rep(1:4, times = 3),
+      flag = c(
+        NA, NA, NA, NA, # nothing to find -> NA, with a warning
+        NA, NA, 7, 7,   # value at the last rows  -> found immediately
+        5, 5, NA, NA    # value at the FIRST rows -> found by walking back
+      ),
+      EVID = 0, AMT = 0
+    )
+
+    expect_warning(
+      .r <- rxSolve(mod, events = d, returnType = "data.frame"),
+      "column 'flag' has only 'NA' values for id '1'"
+    )
+    expect_equal(.r$eff[.r$id == 1], rep(0, 4)) # warned about, then solved as 0
+    expect_equal(.r$eff[.r$id == 2], rep(70, 4))
+    expect_equal(.r$eff[.r$id == 3], rep(50, 4))
+
+    # the per-id covariate table keeps the unresolvable value as NA
+    expect_warning(
+      .tr <- rxode2::etTrans(d, mod),
+      "column 'flag' has only 'NA' values for id '1'"
+    )
+    expect_equal(attr(class(.tr), ".rxode2.lst")$cov1$flag, c(NA, 7, 5))
+  })
 })

--- a/tests/testthat/test-dfdy.R
+++ b/tests/testthat/test-dfdy.R
@@ -290,4 +290,25 @@ d/dt(cen) = ka*depot-k*cen
       "cen(0)=0\ndf(cen)/dy(x1)=0\ndf(cen)/dy(THETA[1])=0\ndf(cen)/dy(THETA[2])=0\n",
       "df(cen)/dy(THETA[3])=0\ny=cen\ntad=t-tlast()\n")))
   })
+
+  test_that("dfdy names report ETA[n] and THETA[n], not the internal names", {
+
+    # THETA and ETA both reach populateDfdy() under their internal spellings
+    # (_THETA_1_, _ETA_1_) and are translated back for display.  The ETA half
+    # of that translation used to be discarded, so an ETA derivative reported
+    # the internal name while a THETA derivative next to it did not.
+    mod <- rxode2({
+      d / dt(A) <- -(CL / V) * A + THETA[1] * ETA[1]
+      df(A) / dy(A) <- -(CL / V)
+      df(A) / dy(THETA[1]) <- ETA[1]
+      df(A) / dy(ETA[1]) <- THETA[1]
+    })
+
+    expect_equal(
+      rxDfdy(mod),
+      c("df(A)/dy(A)", "df(A)/dy(THETA[1])", "df(A)/dy(ETA[1])")
+    )
+    expect_false(any(grepl("_ETA_", rxDfdy(mod), fixed = TRUE)))
+    expect_false(any(grepl("_THETA_", rxDfdy(mod), fixed = TRUE)))
+  })
 })


### PR DESCRIPTION
Stacked on #<PR 1>. Base is `fix/covariate-int-logical-perf-1325`; retarget to
`main` after that merges.

Found while fixing #1325 — the covariate loop had a second row-scan whose guard
could never be true. Sweeping for the same shape (cppcheck across the C/C++
sources, `lintr::unreachable_code_linter` across `R/`) turned up 43 candidates,
of which 4 were genuine. The sweep is worth a note: the site that started this
was **not** among cppcheck's findings, because it cannot prove
`iCur+1 <= idxOutput.size()` statically; and 25 of its 36 hits were one
ABI-constrained pattern that should not be touched. The tools narrowed the
search, they did not do the triage.

## The one that changes behaviour

`populateDfdy()` translates both `_THETA_n_` and `_ETA_n_` back to their
displayed spellings, but only the THETA loop set `foundIt`. The ETA loop wrote
`ETA[n]` into the buffer and the next `if (!foundIt)` overwrote it with the raw
internal name:

```r
rxDfdy(mod)
#> "df(A)/dy(A)"  "df(A)/dy(THETA[1])"  "df(A)/dy(_ETA_1_)"
#>                                                ^^^^^^^ leaked internal name
```

Not dead code — code whose result was unconditionally discarded. Fixed by
setting `foundIt` in the ETA loop (and breaking once it matches). Nothing parses
these names back; `rxDfdy()` returns them to the user, so this only changes what
is displayed. No existing test locked the buggy form.

## The three that cannot be observed

- **`etTrans()`** searched a subject's rows for a non-NA covariate value twice:
  backwards, then forwards. The forward search was guarded by
  `idxOutput.size() < iCur+1` — never true, since `iCur < idxOutput.size()` —
  and by `iCur+1 != covCol.size()`, comparing a row index against the covariate
  count. **Repairing both guards would not help.** The enclosing loop walks the
  output rows backwards, so `addId` is set on a subject's *last* row and the
  backward search already covers every row of that subject; the forward search
  would only reach the next subject and be rejected by the `lastId` guard.
  Removed rather than repaired.
- **`rxGetErrs()`** called `free(_rxGetErrs)` inside a branch entered only when
  `_rxGetErrs` is `NULL`.
- **`.udfCallCheckNumeric()`** ended with a value expression after `stop()`.

## Tests

- `test-dfdy.R` — a real gate: **2 failures before the fix, 0 after.**
- `test-cov.R` — a *characterization* test for the `etTrans()` removal, not a
  gate. It pins the behaviour that has to survive: a subject whose covariate is
  present only in its **first** rows (`5, 5, NA, NA`) still resolves to `5`,
  which is precisely the case a forward scan would have existed to handle. It
  passes on both builds — that is the point. It proves the removal is lossless.

## Deliberately left alone

- `if (!iniSubject(...))` at ~25 solver call sites is genuinely always-false
  today (`iniSubject` has a single `return 1`), but `iniSubjectE` is published
  at slot 6 of the cross-package pointer vector and typed `int (*)(...)` in
  `inst/include/rxode2ptr.h`. Removing the checks would bake "this cannot fail"
  into code consuming a contract that says otherwise. Changing that is an ABI
  decision, not a cleanup.
- `localAbort2 == 0` / `la2 == 0` in the adjoint drivers — cppcheck does not
  model the `#pragma omp atomic write` from sibling threads.
- `j >= op->minSS` (×5), `_t < 0`, `nOrd > 0`, `omp_get_thread_num() != 0` —
  redundant-but-executing guards, or OpenMP/defensive checks where removal
  trades safety for tidiness.
- `stop()` in `switch()` defaults in `rxRaw.R`, and `with(..., return())` in
  `rxode2.R` — lintr false positives.

## Verification

Full suite on Linux / R 4.6.1: **0 failures, 0 errors, 39 269 passing, 5
skipped**, and no warnings leaked from the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)