### PR TITLE
fix(indLin): cancel the residual before deciding it is a forcing (#1298)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,15 @@ devtools::document()
 - **S3 methods**: follow `generic.class` R convention (e.g., `rxSolve.rxUi`, `modelExtract.function`)
 - Avoid `snake_case` for new names; underscores only appear in S3 methods for snake_case generics from other packages (e.g., `drop_units.rxSolve`)
 - Use American English spelling for consistency and do not use unicode characters
+- **Never write `rxode2:::foo` (or any `pkg:::`) in a script under `bench/`, in a
+  test, or in package code.** CodeFactor flags every `:::` as a Major
+  Maintainability issue and fails the PR check.  To reach a non-exported
+  function, bind it once near the top with
+  `.foo <- utils::getFromNamespace(".foo", "rxode2")` and call `.foo()` -- the
+  convention `bench/symengine-translate.R`, `bench/lincmt_hybrid_production.R`
+  and `bench/lincmt_strategy_gate.R` already follow.  Inside `tests/testthat/`
+  no qualifier is needed at all: tests run in the package namespace, so call
+  the internal by its bare name.
 
 ### Working with symengine objects (`.rxToSE`/`rxFromSE`/`symengine::D`)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -710,11 +710,11 @@
   `matExp()` was competitive.  The residual is now cancelled before it is
   tested, and the same cancellation collapses the un-simplified `k_<cmt>_output`
   constants the split produced (`-q/v-(-q/v-cl/v)` is now `cl/v`), which the
-  generated model re-evaluated on every `ME()` call.  An expansion that drops a
-  symbol is taken however long it gets, since what the expression depends on is
-  what the classification reads; otherwise it is a rewrite of the same
-  dependencies and is kept only where it does not lengthen what it replaced, so
-  a genuinely nonlinear forcing is untouched.  Measured on an optimized build,
+  generated model re-evaluated on every `ME()` call.  An expansion that takes a
+  forcing from reading a compartment to reading none is kept however long it
+  gets, since that is the difference between the two drivers; everywhere else
+  it buys no reclassification and is kept only where it does not lengthen what
+  it replaced, so a genuinely nonlinear forcing is untouched.  Measured on an optimized build,
   40 subjects over an irregular 200 point schedule with three sensitivity
   parameters, single thread, the solve is 9.6x faster at two compartments and
   12.5x at three, with

--- a/NEWS.md
+++ b/NEWS.md
@@ -695,6 +695,29 @@
   shows up most in generated sensitivity code, where differentiating leaves a
   great many `*1` and `+0` terms behind; the emitted values are unchanged.
 
+- `rxSensMatExp()` no longer emits an `indLin()` forcing that is
+  algebraically zero, which had been demoting every sensitivity model with two
+  or more compartments to the fixed-point iteration.  The generator splits the
+  system term wise as `dX/dt = A.X + F(X)` and keeps whatever `rhs - A.X`
+  leaves as the forcing; symengine holds `A_ij * X_j` as a product of a sum and
+  a symbol and does not distribute it, so from two compartments up the
+  subtraction left a residual that prints as non-zero and is zero.  A
+  structurally non-zero forcing is what classifies a model as state dependent,
+  so the whole solve took the inductive-linearization driver -- Picard/Newton
+  substepping with error control and several exponentials per substep --
+  instead of one cached matrix exponential per interval.  One compartment
+  emitted no forcing at all, which is why it was the only configuration where
+  `matExp()` was competitive.  The residual is now cancelled before it is
+  tested, and the same cancellation collapses the un-simplified `k_<cmt>_output`
+  constants the split produced (`-q/v-(-q/v-cl/v)` is now `cl/v`), which the
+  generated model re-evaluated on every `ME()` call.  A genuinely nonlinear
+  forcing is untouched: the expansion is kept only where it does not lengthen
+  what it replaced.  Measured on an optimized build, 40 subjects over an
+  irregular 200 point schedule with three sensitivity parameters, single
+  thread, the solve is 9.6x faster at two compartments and 12.5x at three, with
+  the solved values unchanged to 3e-14 -- the dropped terms contributed nothing
+  but cost.  `bench/indlin_zero_forcing_ab.R` is the harness.
+
 - `psigamma()`, `log1pmx()` and `polygamma()` now check how many arguments
   they were given.  All three guarded the count with `length(x == n)` instead
   of `length(x) == n`; `x` is a call, so `x == n` compares its elements and

--- a/NEWS.md
+++ b/NEWS.md
@@ -710,11 +710,14 @@
   `matExp()` was competitive.  The residual is now cancelled before it is
   tested, and the same cancellation collapses the un-simplified `k_<cmt>_output`
   constants the split produced (`-q/v-(-q/v-cl/v)` is now `cl/v`), which the
-  generated model re-evaluated on every `ME()` call.  A genuinely nonlinear
-  forcing is untouched: the expansion is kept only where it does not lengthen
-  what it replaced.  Measured on an optimized build, 40 subjects over an
-  irregular 200 point schedule with three sensitivity parameters, single
-  thread, the solve is 9.6x faster at two compartments and 12.5x at three, with
+  generated model re-evaluated on every `ME()` call.  An expansion that drops a
+  symbol is taken however long it gets, since what the expression depends on is
+  what the classification reads; otherwise it is a rewrite of the same
+  dependencies and is kept only where it does not lengthen what it replaced, so
+  a genuinely nonlinear forcing is untouched.  Measured on an optimized build,
+  40 subjects over an irregular 200 point schedule with three sensitivity
+  parameters, single thread, the solve is 9.6x faster at two compartments and
+  12.5x at three, with
   the solved values unchanged to 3e-14 -- the dropped terms contributed nothing
   but cost.  `bench/indlin_zero_forcing_ab.R` is the harness.
 

--- a/R/indLin.R
+++ b/R/indLin.R
@@ -232,8 +232,11 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
 #' @noRd
 #' @author Matthew L. Fidler
 .rxIndLinReadsState <- function(e, statesSe) {
+  # An expression whose symbols cannot be read is assumed to read one, which
+  # leaves the caller on the length rule rather than on a claim it cannot back.
   .v <- tryCatch(vapply(symengine::free_symbols(e), as.character, character(1)),
-                 error = function(.e) character(0))
+                 error = function(.e) NULL)
+  if (is.null(.v)) return(TRUE)
   any(.v %in% statesSe) || any(startsWith(.v, "rx__sens_"))
 }
 
@@ -467,6 +470,12 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
   # `X[[i]]` expression and it reports `user function '[[' requires 0 arguments`.
   .toSe <- function(.n) rxToSE(.n)
   .statesSe <- vapply(.states, .toSe, character(1), USE.NAMES = FALSE)
+  # Every compartment the generated model can read, which is what the solver
+  # classifies a forcing on -- `.states` drops the linCmt() pseudo-compartments
+  # (they have no matExp dynamics of their own), but a forcing that reads one
+  # still moves within the step and still has to take the iterating driver.
+  .cmtSe <- c(.statesSe,
+              vapply(.rxLinCmt(.mv), .toSe, character(1), USE.NAMES = FALSE))
   .parSe <- vapply(unique(c(calcSens, calcSens2, calcSens3)), .toSe, character(1))
 
   # 2. Split the system the way indLin() does: dX/dt = A.X + F(X), with A
@@ -536,7 +545,7 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
       .aij <- .A[[.i]][[.j]]
       if (!.rxIndLinIsZero(.aij)) .f <- .f - .aij * .stateSym[[.j]]
     }
-    .rxIndLinExpand(.f, .statesSe)
+    .rxIndLinExpand(.f, .cmtSe)
   })
   names(.force) <- .states
   # elimination from compartment j: -(A[j,j] + sum_{i != j} A[i,j]).  Computed
@@ -679,7 +688,7 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
       .fi <- .force[[.i]]
       if (.rxIndLinIsZero(.fi)) next
       .g <- .rxIndLinExpand(.rxIndLinTotalD(.fi, .p, .states, .statesSe, .pSe),
-                            .statesSe)
+                            .cmtSe)
       if (!.rxIndLinIsZero(.g)) {
         .code <- c(.code, paste0("indLin(", .S(.i), ") <- ", rxFromSE(.g)))
       }
@@ -744,7 +753,7 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
           .fi <- .force[[.i]]
           if (.rxIndLinIsZero(.fi)) next
           .g2 <- .rxIndLinExpand(.rxIndLinChainD(.fi, c(.p, .q), .states, .statesSe,
-                                                 c(.pSe, .qSe)), .statesSe)
+                                                 c(.pSe, .qSe)), .cmtSe)
           if (!.rxIndLinIsZero(.g2)) {
             .code <- c(.code, paste0("indLin(", .S2(.i), ") <- ", rxFromSE(.g2)))
           }
@@ -825,7 +834,7 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
             .fi <- .force[[.i]]
             if (.rxIndLinIsZero(.fi)) next
             .g3 <- .rxIndLinExpand(.rxIndLinChainD(.fi, c(.p, .q, .r), .states, .statesSe,
-                                                   c(.pSe, .qSe, .rSe)), .statesSe)
+                                                   c(.pSe, .qSe, .rSe)), .cmtSe)
             if (!.rxIndLinIsZero(.g3)) {
               .code <- c(.code, paste0("indLin(", .S3(.i), ") <- ", rxFromSE(.g3)))
             }

--- a/R/indLin.R
+++ b/R/indLin.R
@@ -85,7 +85,7 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
       # column sum symengine leaves as a product of sums prints as a non-zero
       # elimination that is really zero.
       .elimStr <- as.character(.rxIndLinExpand(-.sumExpr))
-      if (.elimStr != "0") {
+      if (!.rxIndLinIsZeroTxt(.elimStr)) {
         .knameOut <- paste0("k_", .cmt1, "_output")
         if (.elimStr == .knameOut || .elimStr == paste0("k.", .cmt1, ".output")) {
           .code <- c(.code, paste0("param(", .elimStr, ")"))
@@ -134,7 +134,6 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
   # this change too.
   .jacMax <- getOption("rxode2.indLinJacMaxStates", 24L)
   if (length(.states) <= .jacMax) {
-    .isZeroTxt <- function(.t) .t == "0" || .t == "0.0" || .t == "-0"
     # Direct symengine::D on Basics held in locals, as rxSensMatExp does:
     # `with(.env, ...)` would not see them, since it ignores the calling frame.
     #
@@ -158,7 +157,7 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
       for (.jj in seq_along(.states)) {
         .d <- symengine::D(.rhsI, .stateSym[[.jj]])
         .dTxt <- rxFromSE(.d)
-        if (!.isZeroTxt(.dTxt)) {
+        if (!.rxIndLinIsZeroTxt(.dTxt)) {
           .code <- c(.code, paste0("df(", .states[.ii], ")/dy(", .states[.jj],
                                    ") = ", .dTxt))
         }
@@ -205,17 +204,38 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
   # has to be bound to a plain local before it is handed over.
   .se <- .rxIndLinExpand(e)
   .z <- rxFromSE(.se)
-  .z == "0" || .z == "0.0" || .z == "-0"
+  .rxIndLinIsZeroTxt(.z)
 }
 
-#' Expand a symengine expression when expansion does not grow it
+#' Is a translated expression string zero?
+#'
+#' `as.character()` of a symengine zero is `"0"`, but a float zero prints as
+#' `"0.0"` (`0.0*a`), so the text test has to accept both spellings.
+#'
+#' @param t Expression text.
+#' @return `TRUE` when the text is a zero.
+#' @noRd
+#' @author Matthew L. Fidler
+.rxIndLinIsZeroTxt <- function(t) {
+  t == "0" || t == "0.0" || t == "-0"
+}
+
+#' Expand a symengine expression where the expansion is worth taking
 #'
 #' `symengine::expand()` is what cancels the algebraically-zero residual the
 #' term-wise `rhs - A.X` split leaves behind, and it also collapses the
-#' un-simplified `k_*_output` constants the same split produces.  It can grow a
-#' genuinely nonlinear expression instead, and the forcing it would grow is
-#' re-evaluated on every `ME()` call, so the expansion is kept only when it is
-#' no longer than what it replaced -- a cancellation to `0` always is.
+#' un-simplified `k_*_output` constants the same split produces.  Two rules
+#' decide whether to keep it:
+#'
+#' - An expansion that drops a free symbol changes what the expression DEPENDS
+#'   ON, and dependence on a state is exactly what classifies a forcing as
+#'   state dependent, so it is taken however long it is.  Without this a
+#'   residual whose state terms cancel but whose state-free part expands wide
+#'   -- `(p1+..+p5)*(p6+..+p10) - (a+b)*x - a*x - b*x` -- keeps `x` in the text
+#'   and lands on the iterating driver it does not need.
+#' - Otherwise the expansion is only a rewrite of the same dependencies, and
+#'   the forcing is re-evaluated on every `ME()` call, so it is kept only when
+#'   it is no longer than what it replaced.
 #'
 #' @param e symengine expression; anything that is not a `Basic` (a constant
 #'   `d/dt(x) <- 0` is stored as a plain numeric) is returned unchanged.
@@ -226,6 +246,12 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
   if (!inherits(e, "Basic")) return(e)
   .x <- tryCatch(symengine::expand(e), error = function(.e) NULL)
   if (is.null(.x)) return(e)
+  # expand() can only remove a free symbol, never add one, so a smaller count
+  # is a strict subset.
+  .nSym <- function(.b) {
+    tryCatch(length(symengine::free_symbols(.b)), error = function(.e) NA_integer_)
+  }
+  if (isTRUE(.nSym(.x) < .nSym(e))) return(.x)
   if (nchar(as.character(.x)) > nchar(as.character(e))) return(e)
   .x
 }

--- a/R/indLin.R
+++ b/R/indLin.R
@@ -220,6 +220,23 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
   t == "0" || t == "0.0" || t == "-0"
 }
 
+#' Does an expression reference a compartment?
+#'
+#' A forcing that reads any compartment -- a physical state or one of the
+#' `rx__sens_*` sensitivity compartments -- is what makes the solver classify
+#' the model as state dependent and take the iterating driver.
+#'
+#' @param e symengine expression.
+#' @param statesSe The symengine name of each physical state.
+#' @return `TRUE` when the expression references a compartment.
+#' @noRd
+#' @author Matthew L. Fidler
+.rxIndLinReadsState <- function(e, statesSe) {
+  .v <- tryCatch(vapply(symengine::free_symbols(e), as.character, character(1)),
+                 error = function(.e) character(0))
+  any(.v %in% statesSe) || any(startsWith(.v, "rx__sens_"))
+}
+
 #' Expand a symengine expression where the expansion is worth taking
 #'
 #' `symengine::expand()` is what cancels the algebraically-zero residual the
@@ -227,31 +244,34 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
 #' un-simplified `k_*_output` constants the same split produces.  Two rules
 #' decide whether to keep it:
 #'
-#' - An expansion that drops a free symbol changes what the expression DEPENDS
-#'   ON, and dependence on a state is exactly what classifies a forcing as
-#'   state dependent, so it is taken however long it is.  Without this a
-#'   residual whose state terms cancel but whose state-free part expands wide
-#'   -- `(p1+..+p5)*(p6+..+p10) - (a+b)*x - a*x - b*x` -- keeps `x` in the text
-#'   and lands on the iterating driver it does not need.
-#' - Otherwise the expansion is only a rewrite of the same dependencies, and
-#'   the forcing is re-evaluated on every `ME()` call, so it is kept only when
-#'   it is no longer than what it replaced.
+#' - Given `statesSe`, an expansion that takes the expression from reading a
+#'   compartment to reading none is taken however long it gets, because that
+#'   is the difference between the iterating driver and one cached exponential
+#'   per interval.  Without it a residual whose state terms cancel but whose
+#'   state-free part expands wide -- `(p1+..+p5)*(p6+..+p10) - (a+b)*x - a*x -
+#'   b*x` -- keeps `x` in the text and iterates for nothing.
+#' - Otherwise the expansion buys no reclassification -- which is every rate
+#'   constant, elimination and cross-term coefficient, none of which the
+#'   classification reads -- and the result is re-evaluated on every `ME()`
+#'   call, so it is kept only when it is no longer than what it replaced.  A
+#'   cancellation to `0` always is.
 #'
 #' @param e symengine expression; anything that is not a `Basic` (a constant
 #'   `d/dt(x) <- 0` is stored as a plain numeric) is returned unchanged.
+#' @param statesSe The symengine name of each physical state, for an expression
+#'   whose state dependence is what will be classified (a forcing).  `NULL`
+#'   elsewhere, which leaves only the length rule.
 #' @return `e`, or its expansion.
 #' @noRd
 #' @author Matthew L. Fidler
-.rxIndLinExpand <- function(e) {
+.rxIndLinExpand <- function(e, statesSe = NULL) {
   if (!inherits(e, "Basic")) return(e)
   .x <- tryCatch(symengine::expand(e), error = function(.e) NULL)
   if (is.null(.x)) return(e)
-  # expand() can only remove a free symbol, never add one, so a smaller count
-  # is a strict subset.
-  .nSym <- function(.b) {
-    tryCatch(length(symengine::free_symbols(.b)), error = function(.e) NA_integer_)
+  if (!is.null(statesSe) && .rxIndLinReadsState(e, statesSe) &&
+      !.rxIndLinReadsState(.x, statesSe)) {
+    return(.x)
   }
-  if (isTRUE(.nSym(.x) < .nSym(e))) return(.x)
   if (nchar(as.character(.x)) > nchar(as.character(e))) return(e)
   .x
 }
@@ -350,7 +370,7 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
     } else {
       # Two families that landed on the same pair can cancel, so the sum is
       # expanded before it is stored -- `emit()`'s zero test reads it back.
-      val <- .rxIndLinExpand(get(.key, envir = .env, inherits = FALSE) + val)
+      val <- .rxIndLinExpand(base::get(.key, envir = .env, inherits = FALSE) + val)
     }
     assign(.key, val, envir = .env)
     invisible()
@@ -358,7 +378,7 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
   .emit <- function() {
     .lines <- character(0)
     for (.key in .order) {
-      .val <- get(.key, envir = .env, inherits = FALSE)
+      .val <- base::get(.key, envir = .env, inherits = FALSE)
       if (.rxIndLinIsZero(.val)) next
       .parts <- strsplit(.key, "\r", fixed = TRUE)[[1L]]
       .lines <- c(.lines, paste0("k_", .parts[1L], "_", .parts[2L], "_nd = ", rxFromSE(.val)))
@@ -516,7 +536,7 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
       .aij <- .A[[.i]][[.j]]
       if (!.rxIndLinIsZero(.aij)) .f <- .f - .aij * .stateSym[[.j]]
     }
-    .rxIndLinExpand(.f)
+    .rxIndLinExpand(.f, .statesSe)
   })
   names(.force) <- .states
   # elimination from compartment j: -(A[j,j] + sum_{i != j} A[i,j]).  Computed
@@ -658,7 +678,8 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
     for (.i in .states) {
       .fi <- .force[[.i]]
       if (.rxIndLinIsZero(.fi)) next
-      .g <- .rxIndLinExpand(.rxIndLinTotalD(.fi, .p, .states, .statesSe, .pSe))
+      .g <- .rxIndLinExpand(.rxIndLinTotalD(.fi, .p, .states, .statesSe, .pSe),
+                            .statesSe)
       if (!.rxIndLinIsZero(.g)) {
         .code <- c(.code, paste0("indLin(", .S(.i), ") <- ", rxFromSE(.g)))
       }
@@ -723,7 +744,7 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
           .fi <- .force[[.i]]
           if (.rxIndLinIsZero(.fi)) next
           .g2 <- .rxIndLinExpand(.rxIndLinChainD(.fi, c(.p, .q), .states, .statesSe,
-                                                 c(.pSe, .qSe)))
+                                                 c(.pSe, .qSe)), .statesSe)
           if (!.rxIndLinIsZero(.g2)) {
             .code <- c(.code, paste0("indLin(", .S2(.i), ") <- ", rxFromSE(.g2)))
           }
@@ -804,7 +825,7 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
             .fi <- .force[[.i]]
             if (.rxIndLinIsZero(.fi)) next
             .g3 <- .rxIndLinExpand(.rxIndLinChainD(.fi, c(.p, .q, .r), .states, .statesSe,
-                                                   c(.pSe, .qSe, .rSe)))
+                                                   c(.pSe, .qSe, .rSe)), .statesSe)
             if (!.rxIndLinIsZero(.g3)) {
               .code <- c(.code, paste0("indLin(", .S3(.i), ") <- ", rxFromSE(.g3)))
             }

--- a/R/indLin.R
+++ b/R/indLin.R
@@ -80,8 +80,11 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
         .sumExpr <- .sumExpr + .t
       }
       # Negate the Basic directly rather than round-tripping through a string:
-      # same simplification, and no re-parse to fail on a dotted name.
-      .elimStr <- as.character(-.sumExpr)
+      # same simplification, and no re-parse to fail on a dotted name.  Expanded
+      # for the same reason the sensitivity path expands it (rxode2#1298): a
+      # column sum symengine leaves as a product of sums prints as a non-zero
+      # elimination that is really zero.
+      .elimStr <- as.character(.rxIndLinExpand(-.sumExpr))
       if (.elimStr != "0") {
         .knameOut <- paste0("k_", .cmt1, "_output")
         if (.elimStr == .knameOut || .elimStr == paste0("k.", .cmt1, ".output")) {
@@ -184,6 +187,49 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
   return(paste(.code, collapse = "\n"))
 }
 
+#' Is a symengine expression algebraically zero?
+#'
+#' The one place the indLin/matExp generators decide a term does not exist.
+#' Tested on the expanded form: symengine keeps a product of sums as a product,
+#' so `rhs - A.X` leaves an expression that prints as non-zero even when every
+#' term cancels -- and emitting it as an `indLin()` forcing demotes the whole
+#' model from one cached exponential per interval to the fixed-point iteration
+#' (rxode2#1298).
+#'
+#' @param e symengine expression (or anything `rxFromSE()` accepts).
+#' @return `TRUE` when the expression is zero.
+#' @noRd
+#' @author Matthew L. Fidler
+.rxIndLinIsZero <- function(e) {
+  # rxFromSE() resolves its argument by name (substitute()), so the expansion
+  # has to be bound to a plain local before it is handed over.
+  .se <- .rxIndLinExpand(e)
+  .z <- rxFromSE(.se)
+  .z == "0" || .z == "0.0" || .z == "-0"
+}
+
+#' Expand a symengine expression when expansion does not grow it
+#'
+#' `symengine::expand()` is what cancels the algebraically-zero residual the
+#' term-wise `rhs - A.X` split leaves behind, and it also collapses the
+#' un-simplified `k_*_output` constants the same split produces.  It can grow a
+#' genuinely nonlinear expression instead, and the forcing it would grow is
+#' re-evaluated on every `ME()` call, so the expansion is kept only when it is
+#' no longer than what it replaced -- a cancellation to `0` always is.
+#'
+#' @param e symengine expression; anything that is not a `Basic` (a constant
+#'   `d/dt(x) <- 0` is stored as a plain numeric) is returned unchanged.
+#' @return `e`, or its expansion.
+#' @noRd
+#' @author Matthew L. Fidler
+.rxIndLinExpand <- function(e) {
+  if (!inherits(e, "Basic")) return(e)
+  .x <- tryCatch(symengine::expand(e), error = function(.e) NULL)
+  if (is.null(.x)) return(e)
+  if (nchar(as.character(.x)) > nchar(as.character(e))) return(e)
+  .x
+}
+
 #' Total derivative of an indLin/matExp Jacobian-entry expression
 #'
 #' `expr` is a scalar Jacobian-entry expression, differentiated wrt every
@@ -206,10 +252,6 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
 #' @return symengine expression for the total derivative.
 #' @noRd
 .rxIndLinTotalD <- function(expr, byVar, states, statesSe, byVarSe) {
-  .isZero <- function(.e) {
-    .z <- rxFromSE(.e)
-    .z == "0" || .z == "0.0" || .z == "-0"
-  }
   .vars <- tryCatch(
     vapply(symengine::free_symbols(expr), as.character, character(1)),
     error = function(e) character(0)
@@ -230,14 +272,14 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
   for (.i in seq_along(states)) {
     if (!(statesSe[[.i]] %in% .vars)) next
     .dl <- symengine::D(expr, symengine::Symbol(statesSe[[.i]]))
-    if (!.isZero(.dl)) {
+    if (!.rxIndLinIsZero(.dl)) {
       .add(.dl * symengine::Symbol(paste0("rx__sens_", states[[.i]], "_BY_", byVar, "__")))
     }
   }
   for (.s in .vars) {
     if (!startsWith(.s, "rx__sens_") || !endsWith(.s, "__")) next
     .ds <- symengine::D(expr, symengine::Symbol(.s))
-    if (.isZero(.ds)) next
+    if (.rxIndLinIsZero(.ds)) next
     .target <- paste0(substring(.s, 1L, nchar(.s) - 2L), "_BY_", byVar, "__")
     .add(.ds * symengine::Symbol(.target))
   }
@@ -272,19 +314,17 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
 #'   `k_<from>_<to>_nd = <expr>` lines, skipping pairs that summed to zero).
 #' @noRd
 .rxIndLinNdAccumulator <- function() {
-  .isZero <- function(.e) {
-    .z <- rxFromSE(.e)
-    .z == "0" || .z == "0.0" || .z == "-0"
-  }
   .env <- new.env(parent = emptyenv())
   .order <- character(0)
   .add <- function(from, to, val) {
-    if (.isZero(val)) return(invisible())
+    if (.rxIndLinIsZero(val)) return(invisible())
     .key <- paste0(from, "\r", to)
     if (!exists(.key, envir = .env, inherits = FALSE)) {
       .order <<- c(.order, .key)
     } else {
-      val <- get(.key, envir = .env, inherits = FALSE) + val
+      # Two families that landed on the same pair can cancel, so the sum is
+      # expanded before it is stored -- `emit()`'s zero test reads it back.
+      val <- .rxIndLinExpand(get(.key, envir = .env, inherits = FALSE) + val)
     }
     assign(.key, val, envir = .env)
     invisible()
@@ -293,7 +333,7 @@ indLin <- function(model, doConst = FALSE, calcSens = NULL) {
     .lines <- character(0)
     for (.key in .order) {
       .val <- get(.key, envir = .env, inherits = FALSE)
-      if (.isZero(.val)) next
+      if (.rxIndLinIsZero(.val)) next
       .parts <- strsplit(.key, "\r", fixed = TRUE)[[1L]]
       .lines <- c(.lines, paste0("k_", .parts[1L], "_", .parts[2L], "_nd = ", rxFromSE(.val)))
     }
@@ -390,10 +430,6 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
   #    iterates it.  The Jacobian is still needed -- for the df()/dy() block and
   #    for the forcing -- but it is no longer what the rate constants come from.
   .zero <- symengine::S("0")
-  .isZero <- function(.e) {
-    .z <- rxFromSE(.e)
-    .z == "0" || .z == "0.0" || .z == "-0"
-  }
   # `.zero +` coerces a plain numeric (how a constant `d/dt(depot) <- 0` is
   # stored) to a Basic, which symengine::D() and the arithmetic below require.
   .rhs <- lapply(.states, function(.s) {
@@ -411,7 +447,7 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
   names(.stateSym) <- .states
   # Full Jacobian, for the df()/dy() block only.
   .jac <- lapply(.states, function(.i) {
-    .row <- lapply(.states, function(.j) symengine::D(.rhs[[.i]], .stateSym[[.j]]))
+    .row <- lapply(.states, function(.j) .rxIndLinExpand(symengine::D(.rhs[[.i]], .stateSym[[.j]])))
     names(.row) <- .states
     .row
   })
@@ -429,7 +465,7 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
   .A <- lapply(.states, function(.i) {
     .row <- lapply(.states, function(.j) {
       .t <- .aTxt[.i, .j]
-      if (.t == "0") .zero else .zero + eval(parse(text = .t), envir = .env)
+      if (.t == "0") .zero else .rxIndLinExpand(.zero + eval(parse(text = .t), envir = .env))
     })
     names(.row) <- .states
     .row
@@ -442,24 +478,34 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
   # indLin():105-113 documents.  The split is term wise, so the residual is the
   # same expression; symengine cancels the A.X part outright.  This is also
   # what carries a state-free input term (`d/dt(x) = k0 - ke*x`), which the
-  # Jacobian never saw.
+  # Jacobian never saw.  Expanded, because symengine leaves `A_ij * X_j` as a
+  # product of a sum and a symbol and so cancels only part of it: without the
+  # expansion every model with two or more compartments keeps a residual that
+  # is algebraically zero, and a structurally non-zero forcing is what puts the
+  # solve on the fixed-point iteration instead of one cached exponential per
+  # interval (rxode2#1298).
   .force <- lapply(.states, function(.i) {
     .f <- .rhs[[.i]]
     for (.j in .states) {
       .aij <- .A[[.i]][[.j]]
-      if (!.isZero(.aij)) .f <- .f - .aij * .stateSym[[.j]]
+      if (!.rxIndLinIsZero(.aij)) .f <- .f - .aij * .stateSym[[.j]]
     }
-    .f
+    .rxIndLinExpand(.f)
   })
   names(.force) <- .states
-  # elimination from compartment j: -(A[j,j] + sum_{i != j} A[i,j])
-  .elimOf <- function(.j) {
+  # elimination from compartment j: -(A[j,j] + sum_{i != j} A[i,j]).  Computed
+  # once per compartment: it is read in every sensitivity block, and the same
+  # expansion that cancels the forcing is what turns `-q/v-(-q/v-cl/v)` into
+  # the `cl/v` the emitted `k_<j>_output` should have said all along.
+  .elimAll <- lapply(.states, function(.j) {
     .e <- -.A[[.j]][[.j]]
     for (.i in .states) {
       if (.i != .j) .e <- .e - .A[[.i]][[.j]]
     }
-    .e
-  }
+    .rxIndLinExpand(.e)
+  })
+  names(.elimAll) <- .states
+  .elimOf <- function(.j) .elimAll[[.j]]
 
   # 3. Build model code
   .code <- c("matExp()")
@@ -499,7 +545,7 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
     for (.i in .states) {
       if (.i == .j) next
       .aij <- .A[[.i]][[.j]]
-      if (.isZero(.aij)) next
+      if (.rxIndLinIsZero(.aij)) next
       .kname <- paste0("k_", .j, "_", .i)
       .val <- rxFromSE(.aij)
       # A matExp()-form input can carry the rate as a model parameter, in which
@@ -512,7 +558,7 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
       }
     }
     .elim <- .elimOf(.j)
-    if (!.isZero(.elim)) {
+    if (!.rxIndLinIsZero(.elim)) {
       .knameOut <- paste0("k_", .j, "_output")
       .elimVal <- rxFromSE(.elim)
       if (.elimVal == .knameOut || .elimVal == paste0("k.", .j, ".output")) {
@@ -529,7 +575,7 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
   # loop below and is re-derived here.
   for (.i in .states) {
     .fi <- .force[[.i]]
-    if (!.isZero(.fi)) {
+    if (!.rxIndLinIsZero(.fi)) {
       .code <- c(.code, paste0("indLin(", .i, ") <- ", rxFromSE(.fi)))
     }
   }
@@ -545,7 +591,7 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
   for (.i in .states) {
     for (.j in .states) {
       .jij <- .jac[[.i]][[.j]]
-      if (!.isZero(.jij)) {
+      if (!.rxIndLinIsZero(.jij)) {
         .code <- c(.code, paste0("df(", .i, ")/dy(", .j, ") = ", rxFromSE(.jij)))
       }
     }
@@ -561,11 +607,11 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
     for (.j in .states) {
       for (.i in .states) {
         if (.i == .j) next
-        if (!.isZero(.A[[.i]][[.j]])) {
+        if (!.rxIndLinIsZero(.A[[.i]][[.j]])) {
           .code <- c(.code, paste0("k_", .S(.j), "_", .S(.i), " = k_", .j, "_", .i))
         }
       }
-      if (!.isZero(.elimOf(.j))) {
+      if (!.rxIndLinIsZero(.elimOf(.j))) {
         .code <- c(.code, paste0("k_", .S(.j), "_output = k_", .j, "_output"))
       }
     }
@@ -574,8 +620,8 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
     #     X_j is not depleted).
     for (.j in .states) {
       for (.i in .states) {
-        .dAdp <- symengine::D(.A[[.i]][[.j]], .pSym)
-        if (!.isZero(.dAdp)) {
+        .dAdp <- .rxIndLinExpand(symengine::D(.A[[.i]][[.j]], .pSym))
+        if (!.rxIndLinIsZero(.dAdp)) {
           .code <- c(.code, paste0("k_", .j, "_", .S(.i), "_nd = ", rxFromSE(.dAdp)))
         }
       }
@@ -585,9 +631,9 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
     #     which is exactly .rxIndLinTotalD() (rxode2#1187).
     for (.i in .states) {
       .fi <- .force[[.i]]
-      if (.isZero(.fi)) next
-      .g <- .rxIndLinTotalD(.fi, .p, .states, .statesSe, .pSe)
-      if (!.isZero(.g)) {
+      if (.rxIndLinIsZero(.fi)) next
+      .g <- .rxIndLinExpand(.rxIndLinTotalD(.fi, .p, .states, .statesSe, .pSe))
+      if (!.rxIndLinIsZero(.g)) {
         .code <- c(.code, paste0("indLin(", .S(.i), ") <- ", rxFromSE(.g)))
       }
     }
@@ -616,11 +662,11 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
         for (.j in .states) {
           for (.i in .states) {
             if (.i == .j) next
-            if (!.isZero(.A[[.i]][[.j]])) {
+            if (!.rxIndLinIsZero(.A[[.i]][[.j]])) {
               .code <- c(.code, paste0("k_", .S2(.j), "_", .S2(.i), " = k_", .j, "_", .i))
             }
           }
-          if (!.isZero(.elimOf(.j))) {
+          if (!.rxIndLinIsZero(.elimOf(.j))) {
             .code <- c(.code, paste0("k_", .S2(.j), "_output = k_", .j, "_output"))
           }
         }
@@ -635,7 +681,7 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
             .acc$add(.S1p(.k), .S2(.i), .c2a)
           }
           for (.j in .states) {
-            .dAdp <- symengine::D(.A[[.i]][[.j]], .pSym)
+            .dAdp <- .rxIndLinExpand(symengine::D(.A[[.i]][[.j]], .pSym))
             .acc$add(.S1q(.j), .S2(.i), .dAdp) # from S^q_j
             .c2c <- .rxIndLinTotalD(.dAdp, .q, .states, .statesSe, .qSe) # from X_j
             .acc$add(.j, .S2(.i), .c2c)
@@ -649,9 +695,10 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
         # is keyed by one target compartment, so p == q still gives one line.
         for (.i in .states) {
           .fi <- .force[[.i]]
-          if (.isZero(.fi)) next
-          .g2 <- .rxIndLinChainD(.fi, c(.p, .q), .states, .statesSe, c(.pSe, .qSe))
-          if (!.isZero(.g2)) {
+          if (.rxIndLinIsZero(.fi)) next
+          .g2 <- .rxIndLinExpand(.rxIndLinChainD(.fi, c(.p, .q), .states, .statesSe,
+                                                 c(.pSe, .qSe)))
+          if (!.rxIndLinIsZero(.g2)) {
             .code <- c(.code, paste0("indLin(", .S2(.i), ") <- ", rxFromSE(.g2)))
           }
         }
@@ -691,11 +738,11 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
           for (.j in .states) {
             for (.i in .states) {
               if (.i == .j) next
-              if (!.isZero(.A[[.i]][[.j]])) {
+              if (!.rxIndLinIsZero(.A[[.i]][[.j]])) {
                 .code <- c(.code, paste0("k_", .S3(.j), "_", .S3(.i), " = k_", .j, "_", .i))
               }
             }
-            if (!.isZero(.elimOf(.j))) {
+            if (!.rxIndLinIsZero(.elimOf(.j))) {
               .code <- c(.code, paste0("k_", .S3(.j), "_output = k_", .j, "_output"))
             }
           }
@@ -712,7 +759,7 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
               .acc$add(.S1p(.k), .S3(.i), .rxIndLinChainD(.Aik, c(.q, .r), .states, .statesSe, c(.qSe, .rSe))) # from S^p_k
             }
             for (.j in .states) {
-              .dAdp <- symengine::D(.A[[.i]][[.j]], .pSym)
+              .dAdp <- .rxIndLinExpand(symengine::D(.A[[.i]][[.j]], .pSym))
               .acc$add(.S2qr(.j), .S3(.i), .dAdp) # from S^{qr}_j
               .acc$add(.S1q(.j), .S3(.i), .rxIndLinTotalD(.dAdp, .r, .states, .statesSe, .rSe)) # from S^q_j
               .acc$add(.S1r(.j), .S3(.i), .rxIndLinTotalD(.dAdp, .q, .states, .statesSe, .qSe)) # from S^r_j
@@ -729,10 +776,10 @@ rxSensMatExp <- function(model, calcSens, calcSens2 = NULL, calcSens3 = NULL, do
           # as second order -- a forcing is keyed by one target compartment.
           for (.i in .states) {
             .fi <- .force[[.i]]
-            if (.isZero(.fi)) next
-            .g3 <- .rxIndLinChainD(.fi, c(.p, .q, .r), .states, .statesSe,
-                                   c(.pSe, .qSe, .rSe))
-            if (!.isZero(.g3)) {
+            if (.rxIndLinIsZero(.fi)) next
+            .g3 <- .rxIndLinExpand(.rxIndLinChainD(.fi, c(.p, .q, .r), .states, .statesSe,
+                                                   c(.pSe, .qSe, .rSe)))
+            if (!.rxIndLinIsZero(.g3)) {
               .code <- c(.code, paste0("indLin(", .S3(.i), ") <- ", rxFromSE(.g3)))
             }
           }

--- a/bench/indlin_zero_forcing_ab.R
+++ b/bench/indlin_zero_forcing_ab.R
@@ -1,0 +1,79 @@
+# A/B for rxode2#1298: the same optimized binary and the SAME generated
+# sensitivity model, once as `rxSensMatExp()` emits it now and once with the
+# two algebraically-zero `indLin()` lines -- and the un-cancelled
+# `k_central_output` -- put back the way it emitted them before.  The fix is
+# entirely in the generated model text, so one build measures both arms and the
+# comparison isolates the spurious forcing exactly.
+#
+# The zero forcing is what classified the model as state dependent, which put
+# the solve on the fixed-point iteration (`doIndLin` 4) instead of one cached
+# exponential per interval (`doIndLin` 1).  `.rxMemDoIndLin()` is recorded per
+# arm, and `cp` must agree between them to rounding: the dropped terms are
+# zero, so a real difference means the arms are not the same model.
+#
+# Must be run against an INSTALLED (-O3) build in its own library -- load_all
+# compiles at -O0 and its solver timings are meaningless.  Run on an idle
+# machine.
+#
+# Usage:
+#   R CMD INSTALL --library=/tmp/lib .
+#   BENCH_LIB=/tmp/lib Rscript bench/indlin_zero_forcing_ab.R
+message("== indlin_zero_forcing_ab ==")
+.lib <- Sys.getenv("BENCH_LIB")
+stopifnot(nzchar(.lib))
+.libPaths(c(.lib, .libPaths()))
+suppressMessages(library(rxode2))
+# Guard against measuring a DIFFERENT rxode2 than the one just built.
+stopifnot(identical(normalizePath(dirname(system.file(package = "rxode2"))),
+                    normalizePath(.lib)))
+
+.reps <- as.integer(Sys.getenv("BENCH_REPS", "7"))
+cat("reps:", .reps, " load:",
+    strsplit(readLines("/proc/loadavg"), " ")[[1]][1], "\n")
+
+.mexp <- function(n) {
+  .ln <- c("matExp()", "k_depot_central <- ka", "k_central_output <- cl/v")
+  if (n >= 2) .ln <- c(.ln, "k_central_periph <- q/v", "k_periph_central <- q/vp")
+  if (n >= 3) .ln <- c(.ln, "k_central_periph2 <- q2/v", "k_periph2_central <- q2/vp2")
+  paste(c(.ln, "cp <- central/v"), collapse = "\n")
+}
+.th <- c(ka = 1.1, cl = 4, v = 30, q = 8, vp = 40, q2 = 2, vp2 = 100)
+# Log spaced on purpose: a uniform grid repeats one `dt`, and the
+# content-addressed exponential cache then answers almost every interval.
+.obs <- exp(seq(log(0.05), log(24), length.out = 200))
+.ev <- as.data.frame(et(amt = 100, cmt = "depot", ii = 8, addl = 2) |>
+                       et(.obs) |> et(id = 1:40))
+
+.res <- NULL
+for (.n in 2:3) {
+  .new <- rxSensMatExp(model = .mexp(.n), calcSens = c("ka", "cl", "v"))
+  .old <- sub("k_central_output = cl/v", "k_central_output = -q/v-(-q/v-cl/v)",
+              .new, fixed = TRUE)
+  .old <- paste0(
+    .old,
+    "\nindLin(central) <- -(-q/v-cl/v)*central-q*central/v-cl*central/v",
+    "\nindLin(rx__sens_central_BY_v__) <- ",
+    "-(q/Rx_pow_di(v,2)+cl/Rx_pow_di(v,2))*central",
+    "+q*central/Rx_pow_di(v,2)+cl*central/Rx_pow_di(v,2)")
+  .mn <- suppressMessages(rxode2(.new))
+  .mo <- suppressMessages(rxode2(.old))
+  .run <- function(m) {
+    suppressMessages(rxSolve(m, .th, .ev, method = "indLin",
+                             atol = 1e-10, rtol = 1e-10, cores = 1L))
+  }
+  .a <- as.data.frame(.run(.mn))
+  .b <- as.data.frame(.run(.mo))
+  .tn <- .to <- numeric(0)
+  for (.i in seq_len(.reps)) {           # interleaved, so drift hits both arms
+    .tn <- c(.tn, system.time(.run(.mn))[["elapsed"]])
+    .to <- c(.to, system.time(.run(.mo))[["elapsed"]])
+  }
+  .res <- rbind(.res, data.frame(
+    cmt = .n,
+    fixed = min(.tn), spurious = min(.to), ratio = min(.to) / min(.tn),
+    doIndLinFixed = rxode2:::.rxMemDoIndLin(rxModelVars(.mn)),
+    doIndLinSpurious = rxode2:::.rxMemDoIndLin(rxModelVars(.mo)),
+    maxCpDiff = max(abs(.a$cp - .b$cp))))
+}
+print(.res, digits = 4)
+cat("load:", strsplit(readLines("/proc/loadavg"), " ")[[1]][1], "\n")

--- a/bench/indlin_zero_forcing_ab.R
+++ b/bench/indlin_zero_forcing_ab.R
@@ -27,6 +27,11 @@ suppressMessages(library(rxode2))
 stopifnot(identical(normalizePath(dirname(system.file(package = "rxode2"))),
                     normalizePath(.lib)))
 
+# Which of the four matrix-exponential drivers a model lands on is the whole
+# point of the measurement, and it is not exported; bind it once the way the
+# other bench scripts reach an internal.
+.doIndLin <- utils::getFromNamespace(".rxMemDoIndLin", "rxode2")
+
 .reps <- as.integer(Sys.getenv("BENCH_REPS", "7"))
 cat("reps:", .reps, " load:",
     strsplit(readLines("/proc/loadavg"), " ")[[1]][1], "\n")
@@ -71,8 +76,8 @@ for (.n in 2:3) {
   .res <- rbind(.res, data.frame(
     cmt = .n,
     fixed = min(.tn), spurious = min(.to), ratio = min(.to) / min(.tn),
-    doIndLinFixed = rxode2:::.rxMemDoIndLin(rxModelVars(.mn)),
-    doIndLinSpurious = rxode2:::.rxMemDoIndLin(rxModelVars(.mo)),
+    doIndLinFixed = .doIndLin(rxModelVars(.mn)),
+    doIndLinSpurious = .doIndLin(rxModelVars(.mo)),
     maxCpDiff = max(abs(.a$cp - .b$cp))))
 }
 print(.res, digits = 4)

--- a/bench/lincmt_seq_amortize_phase0.R
+++ b/bench/lincmt_seq_amortize_phase0.R
@@ -123,7 +123,7 @@ for (cell in cells) {
     cat(sprintf("%s %s nSub=%d nObs=%d: %.4f s = %.3f us/obs (load %.2f)\n",
                 cfg, strat, nSub, nObs, median(tset), us, loadAvg()))
     if (strat == "hybrid") {
-      st <- rxode2:::linCmtHybStats(TRUE)
+      st <- utils::getFromNamespace("linCmtHybStats", "rxode2")(TRUE)
       cat("  hybrid counters:", paste(names(st), st, sep = "=", collapse = " "), "\n")
     }
   }

--- a/inst/tools/workaround.R
+++ b/inst/tools/workaround.R
@@ -74,8 +74,8 @@ if (inherits(versionInfo, "try-error")) {
 .in <- gsub("@EG@", file.path(find.package("RcppEigen"),"include"), .in)
 
 
-.sl <- paste(capture.output(StanHeaders:::LdFlags()),
-             capture.output(RcppParallel:::RcppParallelLibs()))
+.sl <- paste(capture.output(StanHeaders:::LdFlags()), # nolint
+             capture.output(RcppParallel:::RcppParallelLibs())) # nolint
 # Set when the TBB link flags are stripped below; the compile-time
 # STAN_THREADS/TBB defines must then be stripped too (see @SH@ handling).
 .rxDisableTbb <- FALSE

--- a/tests/testthat/test-ind-lin-1298-expand.R
+++ b/tests/testthat/test-ind-lin-1298-expand.R
@@ -1,0 +1,96 @@
+rxTest({
+  # rxode2#1298, the decision half: `.rxIndLinExpand()` is handed two
+  # algebraically equal forms of the same expression -- what the term-wise
+  # `rhs - A.X` split wrote, and its expansion -- and has to pick one.  The
+  # rule is the classification boundary: an expansion that takes a forcing from
+  # reading a compartment to reading none is kept however long it gets, because
+  # that is the difference between one cached exponential per interval and the
+  # fixed-point iteration; anything else is a rewrite of the same dependencies
+  # and is kept only when it does not grow.
+  #
+  # The models here are contrived on purpose -- each one is the smallest thing
+  # that puts the rule on one side of that boundary.  For the ordinary linear
+  # compartment models the fix was about, see test-ind-lin-1298.R.
+
+  .lines <- function(code) trimws(strsplit(code, "\n")[[1L]])
+  .forcings <- function(code) grep("^indLin\\(", .lines(code), value = TRUE)
+  .rhsOf <- function(code) sub("^indLin\\([^)]*\\) *<- *", "", .forcings(code))
+  # `attempt` is bumped only by `indLinDriveAdaptive()`, which `doIndLin` 1 and
+  # 2 never reach: zero attempts is the iterative path not having run.
+  .attempts <- function() .Call("_rxode2_rxIndLinSteps", PACKAGE = "rxode2")[["attempt"]]
+  .obs <- exp(seq(log(0.05), log(24), length.out = 60))
+
+  test_that("a residual whose state terms cancel is not called state dependent", {
+    # The state terms cancel but the state-free part expands to 25 of them, so
+    # a rule that only compared lengths would keep `central` in the forcing text
+    # and land the model on the iterating driver (doIndLin 4) rather than the
+    # state-free one (2).
+    .m <- paste("d/dt(central) = (p1+p2+p3+p4+p5)*(p6+p7+p8+p9+p10)",
+                "- (a+b)*central - a*central - b*central")
+    .code <- rxSensMatExp(model = .m, calcSens = c("p1", "a"))
+    expect_false(any(grepl("central", .rhsOf(.code))))
+    expect_equal(.rxMemDoIndLin(rxModelVars(suppressMessages(rxode2(.code)))), 2L)
+  })
+
+  test_that("an expansion that buys no reclassification is not taken", {
+    # The other side of the rule.  `central` stays in the forcing whatever is
+    # done to it, so the model iterates either way -- and expanding the compact
+    # product into its 16 terms would only inflate what `ME()` re-evaluates on
+    # every call.  The compact form is kept.
+    .m <- paste("d/dt(central) = (p1+p2+p3+p4)*(p5+p6+p7+p8)*central*central",
+                "- (a+b)*y + a*y + b*y", "d/dt(y) = 0", sep = "\n")
+    .code <- rxSensMatExp(model = .m, calcSens = c("p1", "a"))
+    .rhs <- .rhsOf(.code)
+    expect_true(any(grepl("(p1+p2+p3+p4)", .rhs, fixed = TRUE)))
+    expect_false(any(grepl("p1*p5", .rhs, fixed = TRUE)))  # not distributed
+    expect_equal(.rxMemDoIndLin(rxModelVars(suppressMessages(rxode2(.code)))), 4L)
+  })
+
+  test_that("the cross-term accumulator sums and cancels", {
+    # The `_nd` coefficients are summed by (from, to) because two families
+    # collapse onto the same pair whenever the differentiated parameters
+    # coincide, and the sum is expanded before it is stored: a pair whose
+    # contributions cancel has to emit nothing, not a line that prints as
+    # non-zero.  A second-order model reaches this branch, but only its totals
+    # are visible there.
+    .acc <- .rxIndLinNdAccumulator()
+    .x <- symengine::S("a") / symengine::S("b")
+    .acc$add("from", "to", .x)
+    .acc$add("from", "to", -.x)          # cancels
+    .acc$add("f2", "t2", .x)
+    .acc$add("f2", "t2", .x)             # sums
+    expect_equal(.acc$emit(), "k_f2_t2_nd = 2*a/b")
+  })
+
+  test_that("a nonlinear model keeps the forcing it needs", {
+    # The cancellation must reach only what is algebraically zero: a
+    # Michaelis-Menten elimination cannot leave a state-free rate matrix, so
+    # every one of its forcings has to survive, the model has to stay on the
+    # iterative path, and its sensitivities have to stay right.
+    .mm <- paste("d/dt(depot) = -ka*depot",
+                 "d/dt(central) = ka*depot - vm*central/(km + central)",
+                 "cp = central/v", sep = "\n")
+    .code <- rxSensMatExp(model = .mm, calcSens = c("ka", "vm", "km"))
+    expect_equal(length(.forcings(.code)), 4L) # central, plus one per parameter
+    .m <- suppressMessages(rxode2(.code))
+    expect_equal(.rxMemDoIndLin(rxModelVars(.m)), 4L)
+    .th <- c(ka = 1.1, vm = 20, km = 5, v = 30)
+    .ev <- as.data.frame(et(amt = 100, cmt = "depot") |> et(.obs))
+    invisible(.attempts())                     # read to reset
+    .s <- suppressMessages(rxSolve(.m, .th, .ev, method = "indLin",
+                                   atol = 1e-10, rtol = 1e-10, cores = 1L))
+    expect_gt(.attempts(), 0)                  # it really did iterate
+    expect_true(all(is.finite(.s$cp)))
+    .p <- suppressMessages(rxode2(.mm))
+    .fd <- function(nm, h) {
+      .up <- .th; .up[[nm]] <- .th[[nm]] + h
+      .dn <- .th; .dn[[nm]] <- .th[[nm]] - h
+      (suppressMessages(rxSolve(.p, .up, .ev, atol = 1e-12, rtol = 1e-12))$cp -
+         suppressMessages(rxSolve(.p, .dn, .ev, atol = 1e-12, rtol = 1e-12))$cp) / (2 * h)
+    }
+    for (.nm in c("ka", "vm", "km")) {
+      expect_equal(.s[[paste0("rx__sens_central_BY_", .nm, "__")]] / .th[["v"]],
+                   .fd(.nm, .th[[.nm]] * 1e-4), tolerance = 1e-4, info = .nm)
+    }
+  })
+})

--- a/tests/testthat/test-ind-lin-1298.R
+++ b/tests/testthat/test-ind-lin-1298.R
@@ -95,6 +95,22 @@ rxTest({
     }
   })
 
+  test_that("the cross-term accumulator sums and cancels", {
+    # The `_nd` coefficients are summed by (from, to) because two families
+    # collapse onto the same pair whenever the differentiated parameters
+    # coincide, and the sum is now expanded before it is stored: a pair whose
+    # contributions cancel has to emit nothing, not a line that prints as
+    # non-zero.  The second-order model above reaches this branch, but only its
+    # totals are visible there.
+    .acc <- .rxIndLinNdAccumulator()
+    .x <- symengine::S("a") / symengine::S("b")
+    .acc$add("from", "to", .x)
+    .acc$add("from", "to", -.x)          # cancels
+    .acc$add("f2", "t2", .x)
+    .acc$add("f2", "t2", .x)             # sums
+    expect_equal(.acc$emit(), "k_f2_t2_nd = 2*a/b")
+  })
+
   test_that("a nonlinear model keeps the forcing it needs", {
     # The expansion must cancel only what is algebraically zero: a
     # Michaelis-Menten elimination cannot leave a state-free rate matrix, so
@@ -114,5 +130,19 @@ rxTest({
                                    cores = 1L))
     expect_gt(.attempts(), 0)                  # it really did iterate
     expect_true(all(is.finite(.s$cp)))
+    # ... and its sensitivities are still right, which is what a cancellation
+    # that went too far would break.
+    .th2 <- c(ka = 1.1, vm = 20, km = 5, v = 30)
+    .p <- suppressMessages(rxode2(.mm))
+    .fd <- function(nm, h) {
+      .up <- .th2; .up[[nm]] <- .th2[[nm]] + h
+      .dn <- .th2; .dn[[nm]] <- .th2[[nm]] - h
+      (suppressMessages(rxSolve(.p, .up, .ev, atol = 1e-12, rtol = 1e-12))$cp -
+         suppressMessages(rxSolve(.p, .dn, .ev, atol = 1e-12, rtol = 1e-12))$cp) / (2 * h)
+    }
+    for (.nm in c("ka", "vm", "km")) {
+      expect_equal(.s[[paste0("rx__sens_central_BY_", .nm, "__")]] / .th2[["v"]],
+                   .fd(.nm, .th2[[.nm]] * 1e-4), tolerance = 1e-4, info = .nm)
+    }
   })
 })

--- a/tests/testthat/test-ind-lin-1298.R
+++ b/tests/testthat/test-ind-lin-1298.R
@@ -159,6 +159,21 @@ rxTest({
     }
   })
 
+  test_that("the plain conversion cancels its elimination constants too", {
+    # The non-sensitivity `indLin()` path builds its `k_<cmt>_output` from the
+    # same column sum and is expanded for the same reason.  A linear ODE model
+    # has to convert to a pure matrix exponential with no forcing at all.
+    .ode <- paste("d/dt(depot) = -ka*depot",
+                  "d/dt(central) = ka*depot - (cl/v)*central - (q/v)*central + (q/vp)*periph",
+                  "d/dt(periph) = (q/v)*central - (q/vp)*periph",
+                  "cp = central/v", sep = "\n")
+    .code <- indLin(.ode)
+    expect_equal(.forcings(.code), character(0))
+    expect_true("k_central_output = cl/v" %in% .lines(.code))
+    expect_false(any(grepl("^k_[a-z_]*_output = 0", .lines(.code))))
+    expect_equal(.rxMemDoIndLin(rxModelVars(suppressMessages(rxode2(.code)))), 1L)
+  })
+
   test_that("the cross-term accumulator sums and cancels", {
     # The `_nd` coefficients are summed by (from, to) because two families
     # collapse onto the same pair whenever the differentiated parameters

--- a/tests/testthat/test-ind-lin-1298.R
+++ b/tests/testthat/test-ind-lin-1298.R
@@ -41,14 +41,61 @@ rxTest({
     }
   })
 
-  test_that("the second-order block emits no forcing either", {
-    # The Hessian block differentiates the first-order forcing once more, so a
-    # residual that survives first order is multiplied through the whole
-    # `calcSens x calcSens2` grid.
+  test_that("the second- and third-order blocks emit no forcing either", {
+    # The higher-order blocks differentiate the first-order forcing once and
+    # twice more, so a residual that survives first order is multiplied
+    # through the whole `calcSens x calcSens2 (x calcSens3)` grid.
     .code <- rxSensMatExp(model = .mexp[["2cmt"]], calcSens = c("ka", "cl", "v"),
                           calcSens2 = c("cl", "v"))
     expect_equal(.forcings(.code), character(0))
     expect_equal(.rxMemDoIndLin(rxModelVars(suppressMessages(rxode2(.code)))), 1L)
+    .code3 <- rxSensMatExp(model = .mexp[["2cmt"]], calcSens = c("cl", "v"),
+                           calcSens2 = c("cl", "v"), calcSens3 = "v")
+    expect_equal(.forcings(.code3), character(0))
+    expect_equal(.rxMemDoIndLin(rxModelVars(suppressMessages(rxode2(.code3)))), 1L)
+  })
+
+  test_that("the second-order sensitivities are right on the exponential path", {
+    # These models now solve under a DIFFERENT driver than they used to (one
+    # cached exponential per interval, not the fixed-point iteration), so the
+    # Hessian block has to be checked on the path it actually takes now.
+    .code <- rxSensMatExp(model = .mexp[["2cmt"]], calcSens = c("cl", "v"),
+                          calcSens2 = c("cl", "v"))
+    .m <- suppressMessages(rxode2(.code))
+    .m1 <- suppressMessages(rxode2(rxSensMatExp(model = .mexp[["2cmt"]],
+                                                calcSens = c("cl", "v"))))
+    .ev <- as.data.frame(et(amt = 100, cmt = "depot") |> et(.obs))
+    .run <- function(m, th) {
+      suppressMessages(rxSolve(m, th, .ev, method = "indLin",
+                               atol = 1e-12, rtol = 1e-12, cores = 1L))
+    }
+    .s <- .run(.m, .th)
+    # d/dq of the first-order sensitivity wrt p is the (p, q) second-order one.
+    for (.p in c("cl", "v")) {
+      for (.q in c("cl", "v")) {
+        .h <- .th[[.q]] * 1e-4
+        .up <- .th; .up[[.q]] <- .th[[.q]] + .h
+        .dn <- .th; .dn[[.q]] <- .th[[.q]] - .h
+        .nm1 <- paste0("rx__sens_central_BY_", .p, "__")
+        expect_equal(.s[[paste0("rx__sens_central_BY_", .p, "_BY_", .q, "__")]],
+                     (.run(.m1, .up)[[.nm1]] - .run(.m1, .dn)[[.nm1]]) / (2 * .h),
+                     tolerance = 1e-4, info = paste(.p, .q))
+      }
+    }
+  })
+
+  test_that("a residual whose state terms cancel is not called state dependent", {
+    # The expansion is kept whenever it drops a free symbol, however long it
+    # gets: here the state terms cancel but the state-free part expands to 25
+    # of them, so a rule that only compared lengths would keep `central` in the
+    # forcing text and land the model on the iterating driver (doIndLin 4)
+    # rather than the state-free one (doIndLin 2).
+    .m <- paste("d/dt(central) = (p1+p2+p3+p4+p5)*(p6+p7+p8+p9+p10)",
+                "- (a+b)*central - a*central - b*central")
+    .code <- rxSensMatExp(model = .m, calcSens = c("p1", "a"))
+    .rhs <- sub("^indLin\\([^)]*\\) *<- *", "", .forcings(.code))
+    expect_false(any(grepl("central", .rhs)))
+    expect_equal(.rxMemDoIndLin(rxModelVars(suppressMessages(rxode2(.code)))), 2L)
   })
 
   test_that("the elimination constant is emitted in its cancelled form", {

--- a/tests/testthat/test-ind-lin-1298.R
+++ b/tests/testthat/test-ind-lin-1298.R
@@ -11,6 +11,9 @@ rxTest({
   # These assert the MECHANISM -- nothing emitted, `doIndLin == 1`, no adaptive
   # attempt recorded -- and not only that the values are unchanged, which they
   # were the whole time (the dropped terms were zero).
+  #
+  # The rule that decides WHICH of two algebraically equal forms is emitted is
+  # exercised on its own contrived models in test-ind-lin-1298-expand.R.
 
   .mexp <- list(
     "1cmt" = paste("matExp()", "k_depot_central <- ka", "k_central_output <- cl/v",
@@ -55,71 +58,26 @@ rxTest({
     expect_equal(.rxMemDoIndLin(rxModelVars(suppressMessages(rxode2(.code3)))), 1L)
   })
 
-  test_that("the second-order sensitivities are right on the exponential path", {
-    # These models now solve under a DIFFERENT driver than they used to (one
-    # cached exponential per interval, not the fixed-point iteration), so the
-    # Hessian block has to be checked on the path it actually takes now.
-    # Second order is differenced against FIRST order rather than the primal,
-    # which is only worth something because the test above has already pinned
-    # first order to the primal: the two together are the chain.
-    .code <- rxSensMatExp(model = .mexp[["2cmt"]], calcSens = c("cl", "v"),
-                          calcSens2 = c("cl", "v"))
-    .m <- suppressMessages(rxode2(.code))
-    .m1 <- suppressMessages(rxode2(rxSensMatExp(model = .mexp[["2cmt"]],
-                                                calcSens = c("cl", "v"))))
-    .ev <- as.data.frame(et(amt = 100, cmt = "depot") |> et(.obs))
-    .run <- function(m, th) {
-      suppressMessages(rxSolve(m, th, .ev, method = "indLin",
-                               atol = 1e-12, rtol = 1e-12, cores = 1L))
-    }
-    .s <- .run(.m, .th)
-    # d/dq of the first-order sensitivity wrt p is the (p, q) second-order one.
-    for (.p in c("cl", "v")) {
-      for (.q in c("cl", "v")) {
-        .h <- .th[[.q]] * 1e-4
-        .up <- .th; .up[[.q]] <- .th[[.q]] + .h
-        .dn <- .th; .dn[[.q]] <- .th[[.q]] - .h
-        .nm1 <- paste0("rx__sens_central_BY_", .p, "__")
-        expect_equal(.s[[paste0("rx__sens_central_BY_", .p, "_BY_", .q, "__")]],
-                     (.run(.m1, .up)[[.nm1]] - .run(.m1, .dn)[[.nm1]]) / (2 * .h),
-                     tolerance = 1e-4, info = paste(.p, .q))
-      }
-    }
-  })
-
-  test_that("a residual whose state terms cancel is not called state dependent", {
-    # An expansion that takes the forcing from reading a compartment to reading
-    # none is kept however long it gets: here the state terms cancel but the
-    # state-free part expands to 25 of them, so a rule that only compared
-    # lengths would keep `central` in the forcing text and land the model on
-    # the iterating driver (doIndLin 4) rather than the state-free one (2).
-    .m <- paste("d/dt(central) = (p1+p2+p3+p4+p5)*(p6+p7+p8+p9+p10)",
-                "- (a+b)*central - a*central - b*central")
-    .code <- rxSensMatExp(model = .m, calcSens = c("p1", "a"))
-    .rhs <- sub("^indLin\\([^)]*\\) *<- *", "", .forcings(.code))
-    expect_false(any(grepl("central", .rhs)))
-    expect_equal(.rxMemDoIndLin(rxModelVars(suppressMessages(rxode2(.code)))), 2L)
-  })
-
-  test_that("an expansion that buys no reclassification is not taken", {
-    # The other side of that rule.  `central` stays in the forcing whatever is
-    # done to it, so the model iterates either way -- and expanding the compact
-    # product into its 16 terms would only inflate what `ME()` re-evaluates on
-    # every call.  The compact form is kept.
-    .m <- paste("d/dt(central) = (p1+p2+p3+p4)*(p5+p6+p7+p8)*central*central",
-                "- (a+b)*y + a*y + b*y", "d/dt(y) = 0", sep = "\n")
-    .code <- rxSensMatExp(model = .m, calcSens = c("p1", "a"))
-    .rhs <- sub("^indLin\\([^)]*\\) *<- *", "", .forcings(.code))
-    expect_true(any(grepl("(p1+p2+p3+p4)", .rhs, fixed = TRUE)))
-    expect_false(any(grepl("p1*p5", .rhs, fixed = TRUE)))  # not distributed
-    expect_equal(.rxMemDoIndLin(rxModelVars(suppressMessages(rxode2(.code)))), 4L)
-  })
-
   test_that("the elimination constant is emitted in its cancelled form", {
     # `-q/v-(-q/v-cl/v)` is the same number, but the generated model
     # re-evaluates it on every ME() call.
     .code <- rxSensMatExp(model = .mexp[["2cmt"]], calcSens = c("ka", "cl", "v"))
     expect_true("k_central_output = cl/v" %in% .lines(.code))
+  })
+
+  test_that("the plain conversion cancels its elimination constants too", {
+    # The non-sensitivity `indLin()` path builds its `k_<cmt>_output` from the
+    # same column sum and is expanded for the same reason.  A linear ODE model
+    # has to convert to a pure matrix exponential with no forcing at all.
+    .ode <- paste("d/dt(depot) = -ka*depot",
+                  "d/dt(central) = ka*depot - (cl/v)*central - (q/v)*central + (q/vp)*periph",
+                  "d/dt(periph) = (q/v)*central - (q/vp)*periph",
+                  "cp = central/v", sep = "\n")
+    .code <- indLin(.ode)
+    expect_equal(.forcings(.code), character(0))
+    expect_true("k_central_output = cl/v" %in% .lines(.code))
+    expect_false(any(grepl("^k_[a-z_]*_output = 0", .lines(.code))))
+    expect_equal(.rxMemDoIndLin(rxModelVars(suppressMessages(rxode2(.code)))), 1L)
   })
 
   test_that("a pure linear sensitivity solve never enters the iteration", {
@@ -159,69 +117,35 @@ rxTest({
     }
   })
 
-  test_that("the plain conversion cancels its elimination constants too", {
-    # The non-sensitivity `indLin()` path builds its `k_<cmt>_output` from the
-    # same column sum and is expanded for the same reason.  A linear ODE model
-    # has to convert to a pure matrix exponential with no forcing at all.
-    .ode <- paste("d/dt(depot) = -ka*depot",
-                  "d/dt(central) = ka*depot - (cl/v)*central - (q/v)*central + (q/vp)*periph",
-                  "d/dt(periph) = (q/v)*central - (q/vp)*periph",
-                  "cp = central/v", sep = "\n")
-    .code <- indLin(.ode)
-    expect_equal(.forcings(.code), character(0))
-    expect_true("k_central_output = cl/v" %in% .lines(.code))
-    expect_false(any(grepl("^k_[a-z_]*_output = 0", .lines(.code))))
-    expect_equal(.rxMemDoIndLin(rxModelVars(suppressMessages(rxode2(.code)))), 1L)
-  })
-
-  test_that("the cross-term accumulator sums and cancels", {
-    # The `_nd` coefficients are summed by (from, to) because two families
-    # collapse onto the same pair whenever the differentiated parameters
-    # coincide, and the sum is now expanded before it is stored: a pair whose
-    # contributions cancel has to emit nothing, not a line that prints as
-    # non-zero.  The second-order model above reaches this branch, but only its
-    # totals are visible there.
-    .acc <- .rxIndLinNdAccumulator()
-    .x <- symengine::S("a") / symengine::S("b")
-    .acc$add("from", "to", .x)
-    .acc$add("from", "to", -.x)          # cancels
-    .acc$add("f2", "t2", .x)
-    .acc$add("f2", "t2", .x)             # sums
-    expect_equal(.acc$emit(), "k_f2_t2_nd = 2*a/b")
-  })
-
-  test_that("a nonlinear model keeps the forcing it needs", {
-    # The expansion must cancel only what is algebraically zero: a
-    # Michaelis-Menten elimination cannot leave a state-free rate matrix, so
-    # every one of its forcings has to survive and the model has to stay on the
-    # iterative path.
-    .mm <- paste("d/dt(depot) = -ka*depot",
-                 "d/dt(central) = ka*depot - vm*central/(km + central)",
-                 "cp = central/v", sep = "\n")
-    .code <- rxSensMatExp(model = .mm, calcSens = c("ka", "vm", "km"))
-    expect_equal(length(.forcings(.code)), 4L) # central, plus one per parameter
-    .m <- suppressMessages(rxode2(.code))
-    expect_equal(.rxMemDoIndLin(rxModelVars(.m)), 4L)
+  test_that("the second-order sensitivities are right on the exponential path", {
+    # These models now solve under a DIFFERENT driver than they used to (one
+    # cached exponential per interval, not the fixed-point iteration), so the
+    # Hessian block has to be checked on the path it actually takes now.
+    # Second order is differenced against FIRST order rather than the primal,
+    # which is only worth something because the test above has already pinned
+    # first order to the primal: the two together are the chain.
+    .m <- suppressMessages(rxode2(rxSensMatExp(model = .mexp[["2cmt"]],
+                                               calcSens = c("cl", "v"),
+                                               calcSens2 = c("cl", "v"))))
+    .m1 <- suppressMessages(rxode2(rxSensMatExp(model = .mexp[["2cmt"]],
+                                                calcSens = c("cl", "v"))))
     .ev <- as.data.frame(et(amt = 100, cmt = "depot") |> et(.obs))
-    invisible(.attempts())
-    .s <- suppressMessages(rxSolve(.m, c(ka = 1.1, vm = 20, km = 5, v = 30), .ev,
-                                   method = "indLin", atol = 1e-10, rtol = 1e-10,
-                                   cores = 1L))
-    expect_gt(.attempts(), 0)                  # it really did iterate
-    expect_true(all(is.finite(.s$cp)))
-    # ... and its sensitivities are still right, which is what a cancellation
-    # that went too far would break.
-    .th2 <- c(ka = 1.1, vm = 20, km = 5, v = 30)
-    .p <- suppressMessages(rxode2(.mm))
-    .fd <- function(nm, h) {
-      .up <- .th2; .up[[nm]] <- .th2[[nm]] + h
-      .dn <- .th2; .dn[[nm]] <- .th2[[nm]] - h
-      (suppressMessages(rxSolve(.p, .up, .ev, atol = 1e-12, rtol = 1e-12))$cp -
-         suppressMessages(rxSolve(.p, .dn, .ev, atol = 1e-12, rtol = 1e-12))$cp) / (2 * h)
+    .run <- function(m, th) {
+      suppressMessages(rxSolve(m, th, .ev, method = "indLin",
+                               atol = 1e-12, rtol = 1e-12, cores = 1L))
     }
-    for (.nm in c("ka", "vm", "km")) {
-      expect_equal(.s[[paste0("rx__sens_central_BY_", .nm, "__")]] / .th2[["v"]],
-                   .fd(.nm, .th2[[.nm]] * 1e-4), tolerance = 1e-4, info = .nm)
+    .s <- .run(.m, .th)
+    # d/dq of the first-order sensitivity wrt p is the (p, q) second-order one.
+    for (.p in c("cl", "v")) {
+      for (.q in c("cl", "v")) {
+        .h <- .th[[.q]] * 1e-4
+        .up <- .th; .up[[.q]] <- .th[[.q]] + .h
+        .dn <- .th; .dn[[.q]] <- .th[[.q]] - .h
+        .nm1 <- paste0("rx__sens_central_BY_", .p, "__")
+        expect_equal(.s[[paste0("rx__sens_central_BY_", .p, "_BY_", .q, "__")]],
+                     (.run(.m1, .up)[[.nm1]] - .run(.m1, .dn)[[.nm1]]) / (2 * .h),
+                     tolerance = 1e-4, info = paste(.p, .q))
+      }
     }
   })
 })

--- a/tests/testthat/test-ind-lin-1298.R
+++ b/tests/testthat/test-ind-lin-1298.R
@@ -1,0 +1,118 @@
+rxTest({
+  # rxode2#1298: `rxSensMatExp()` splits the system term wise as
+  # `dX/dt = A.X + F(X)` and keeps whatever `rhs - A.X` leaves as the indLin()
+  # forcing.  symengine holds `A_ij * X_j` as a product of a sum and a symbol
+  # and does not distribute it, so from two compartments up the subtraction
+  # left a residual that prints as non-zero and is algebraically zero.  A
+  # structurally non-zero forcing is what classifies the model as state
+  # dependent, and that is what put the whole sensitivity solve on the
+  # fixed-point iteration instead of one cached exponential per interval.
+  #
+  # These assert the MECHANISM -- nothing emitted, `doIndLin == 1`, no adaptive
+  # attempt recorded -- and not only that the values are unchanged, which they
+  # were the whole time (the dropped terms were zero).
+
+  .mexp <- list(
+    "1cmt" = paste("matExp()", "k_depot_central <- ka", "k_central_output <- cl/v",
+                   "cp <- central/v", sep = "\n"),
+    "2cmt" = paste("matExp()", "k_depot_central <- ka", "k_central_output <- cl/v",
+                   "k_central_periph <- q/v", "k_periph_central <- q/vp",
+                   "cp <- central/v", sep = "\n"),
+    "3cmt" = paste("matExp()", "k_depot_central <- ka", "k_central_output <- cl/v",
+                   "k_central_periph <- q/v", "k_periph_central <- q/vp",
+                   "k_central_periph2 <- q2/v", "k_periph2_central <- q2/vp2",
+                   "cp <- central/v", sep = "\n"))
+  .th <- c(ka = 1.1, cl = 4, v = 30, q = 8, vp = 40, q2 = 2, vp2 = 100)
+  .obs <- exp(seq(log(0.05), log(24), length.out = 60))
+
+  .lines <- function(code) trimws(strsplit(code, "\n")[[1L]])
+  .forcings <- function(code) grep("^indLin\\(", .lines(code), value = TRUE)
+  # `attempt` is bumped only by `indLinDriveAdaptive()`, which `doIndLin` 1 and
+  # 2 never reach: zero attempts is the iterative path not having run.
+  .attempts <- function() .Call("_rxode2_rxIndLinSteps", PACKAGE = "rxode2")[["attempt"]]
+
+  test_that("a pure linear matExp sensitivity model emits no indLin() forcing", {
+    for (.nm in names(.mexp)) {
+      .code <- rxSensMatExp(model = .mexp[[.nm]], calcSens = c("ka", "cl", "v"))
+      expect_equal(.forcings(.code), character(0), info = .nm)
+      # 1 == pure matrix exponential; 3 or 4 is the fixed-point iteration.
+      expect_equal(.rxMemDoIndLin(rxModelVars(suppressMessages(rxode2(.code)))),
+                   1L, info = .nm)
+    }
+  })
+
+  test_that("the second-order block emits no forcing either", {
+    # The Hessian block differentiates the first-order forcing once more, so a
+    # residual that survives first order is multiplied through the whole
+    # `calcSens x calcSens2` grid.
+    .code <- rxSensMatExp(model = .mexp[["2cmt"]], calcSens = c("ka", "cl", "v"),
+                          calcSens2 = c("cl", "v"))
+    expect_equal(.forcings(.code), character(0))
+    expect_equal(.rxMemDoIndLin(rxModelVars(suppressMessages(rxode2(.code)))), 1L)
+  })
+
+  test_that("the elimination constant is emitted in its cancelled form", {
+    # `-q/v-(-q/v-cl/v)` is the same number, but the generated model
+    # re-evaluates it on every ME() call.
+    .code <- rxSensMatExp(model = .mexp[["2cmt"]], calcSens = c("ka", "cl", "v"))
+    expect_true("k_central_output = cl/v" %in% .lines(.code))
+  })
+
+  test_that("a pure linear sensitivity solve never enters the iteration", {
+    .ev <- as.data.frame(et(amt = 100, cmt = "depot", ii = 8, addl = 2) |> et(.obs))
+    for (.nm in names(.mexp)) {
+      .m <- suppressMessages(rxode2(rxSensMatExp(model = .mexp[[.nm]],
+                                                 calcSens = c("ka", "cl", "v"))))
+      invisible(.attempts())                   # read to reset
+      .s <- suppressMessages(rxSolve(.m, .th, .ev, method = "indLin",
+                                     atol = 1e-10, rtol = 1e-10, cores = 1L))
+      expect_equal(.attempts(), 0, info = .nm)
+      expect_true(all(is.finite(.s$cp)))
+    }
+  })
+
+  test_that("the sensitivities are still the derivatives of the primal", {
+    # The dropped terms were zero, so this has to be unchanged -- it is the
+    # guard against a cancellation that goes too far.
+    .m <- suppressMessages(rxode2(rxSensMatExp(model = .mexp[["2cmt"]],
+                                               calcSens = c("ka", "cl", "v"))))
+    .p <- suppressMessages(rxode2(.mexp[["2cmt"]]))
+    .ev <- as.data.frame(et(amt = 100, cmt = "depot") |> et(.obs))
+    .s <- suppressMessages(rxSolve(.m, .th, .ev, method = "indLin",
+                                   atol = 1e-12, rtol = 1e-12, cores = 1L))
+    .fd <- function(nm, h) {
+      .up <- .th; .up[[nm]] <- .th[[nm]] + h
+      .dn <- .th; .dn[[nm]] <- .th[[nm]] - h
+      (suppressMessages(rxSolve(.p, .up, .ev, method = "indLin",
+                                atol = 1e-12, rtol = 1e-12))$cp -
+         suppressMessages(rxSolve(.p, .dn, .ev, method = "indLin",
+                                  atol = 1e-12, rtol = 1e-12))$cp) / (2 * h)
+    }
+    for (.nm in c("ka", "cl", "v")) {
+      .an <- .s[[paste0("rx__sens_central_BY_", .nm, "__")]] / .th[["v"]]
+      if (.nm == "v") .an <- .an - .s$central / .th[["v"]]^2
+      expect_equal(.an, .fd(.nm, .th[[.nm]] * 1e-4), tolerance = 1e-5)
+    }
+  })
+
+  test_that("a nonlinear model keeps the forcing it needs", {
+    # The expansion must cancel only what is algebraically zero: a
+    # Michaelis-Menten elimination cannot leave a state-free rate matrix, so
+    # every one of its forcings has to survive and the model has to stay on the
+    # iterative path.
+    .mm <- paste("d/dt(depot) = -ka*depot",
+                 "d/dt(central) = ka*depot - vm*central/(km + central)",
+                 "cp = central/v", sep = "\n")
+    .code <- rxSensMatExp(model = .mm, calcSens = c("ka", "vm", "km"))
+    expect_equal(length(.forcings(.code)), 4L) # central, plus one per parameter
+    .m <- suppressMessages(rxode2(.code))
+    expect_equal(.rxMemDoIndLin(rxModelVars(.m)), 4L)
+    .ev <- as.data.frame(et(amt = 100, cmt = "depot") |> et(.obs))
+    invisible(.attempts())
+    .s <- suppressMessages(rxSolve(.m, c(ka = 1.1, vm = 20, km = 5, v = 30), .ev,
+                                   method = "indLin", atol = 1e-10, rtol = 1e-10,
+                                   cores = 1L))
+    expect_gt(.attempts(), 0)                  # it really did iterate
+    expect_true(all(is.finite(.s$cp)))
+  })
+})

--- a/tests/testthat/test-ind-lin-1298.R
+++ b/tests/testthat/test-ind-lin-1298.R
@@ -59,6 +59,9 @@ rxTest({
     # These models now solve under a DIFFERENT driver than they used to (one
     # cached exponential per interval, not the fixed-point iteration), so the
     # Hessian block has to be checked on the path it actually takes now.
+    # Second order is differenced against FIRST order rather than the primal,
+    # which is only worth something because the test above has already pinned
+    # first order to the primal: the two together are the chain.
     .code <- rxSensMatExp(model = .mexp[["2cmt"]], calcSens = c("cl", "v"),
                           calcSens2 = c("cl", "v"))
     .m <- suppressMessages(rxode2(.code))
@@ -85,17 +88,31 @@ rxTest({
   })
 
   test_that("a residual whose state terms cancel is not called state dependent", {
-    # The expansion is kept whenever it drops a free symbol, however long it
-    # gets: here the state terms cancel but the state-free part expands to 25
-    # of them, so a rule that only compared lengths would keep `central` in the
-    # forcing text and land the model on the iterating driver (doIndLin 4)
-    # rather than the state-free one (doIndLin 2).
+    # An expansion that takes the forcing from reading a compartment to reading
+    # none is kept however long it gets: here the state terms cancel but the
+    # state-free part expands to 25 of them, so a rule that only compared
+    # lengths would keep `central` in the forcing text and land the model on
+    # the iterating driver (doIndLin 4) rather than the state-free one (2).
     .m <- paste("d/dt(central) = (p1+p2+p3+p4+p5)*(p6+p7+p8+p9+p10)",
                 "- (a+b)*central - a*central - b*central")
     .code <- rxSensMatExp(model = .m, calcSens = c("p1", "a"))
     .rhs <- sub("^indLin\\([^)]*\\) *<- *", "", .forcings(.code))
     expect_false(any(grepl("central", .rhs)))
     expect_equal(.rxMemDoIndLin(rxModelVars(suppressMessages(rxode2(.code)))), 2L)
+  })
+
+  test_that("an expansion that buys no reclassification is not taken", {
+    # The other side of that rule.  `central` stays in the forcing whatever is
+    # done to it, so the model iterates either way -- and expanding the compact
+    # product into its 16 terms would only inflate what `ME()` re-evaluates on
+    # every call.  The compact form is kept.
+    .m <- paste("d/dt(central) = (p1+p2+p3+p4)*(p5+p6+p7+p8)*central*central",
+                "- (a+b)*y + a*y + b*y", "d/dt(y) = 0", sep = "\n")
+    .code <- rxSensMatExp(model = .m, calcSens = c("p1", "a"))
+    .rhs <- sub("^indLin\\([^)]*\\) *<- *", "", .forcings(.code))
+    expect_true(any(grepl("(p1+p2+p3+p4)", .rhs, fixed = TRUE)))
+    expect_false(any(grepl("p1*p5", .rhs, fixed = TRUE)))  # not distributed
+    expect_equal(.rxMemDoIndLin(rxModelVars(suppressMessages(rxode2(.code)))), 4L)
   })
 
   test_that("the elimination constant is emitted in its cancelled form", {


### PR DESCRIPTION
Fixes #1298.

## What was wrong

`rxSensMatExp()` splits the system the way `indLin()` does -- `dX/dt = A.X + F(X)`,
with `A` constant in the states -- and keeps whatever `rhs - A.X` leaves as the
`indLin()` forcing.  symengine holds `A_ij * X_j` as a product of a sum and a
symbol and does not distribute it, so from two compartments up the subtraction
left a residual that *prints* as non-zero and *is* algebraically zero:

```
indLin(central) <- -(-q/v-cl/v)*central-q*central/v-cl*central/v
indLin(rx__sens_central_BY_v__) <- -(q/Rx_pow_di(v,2)+cl/Rx_pow_di(v,2))*central+q*central/Rx_pow_di(v,2)+cl*central/Rx_pow_di(v,2)
```

A structurally non-zero forcing is what classifies the model as *state
dependent*, so the whole sensitivity solve took the inductive-linearization
driver -- Picard/Newton substepping, error control, several exponentials per
substep -- instead of one cached matrix exponential per interval.  One
compartment emitted no forcing at all, which is exactly why 1cmt was the only
configuration where `matExp()` was competitive.  The same un-cancelled split
also emitted `k_central_output = -q/v-(-q/v-cl/v)`, re-evaluated on every `ME()`
call, instead of `cl/v`.

## The fix

Cancel the residual before deciding whether it exists.  `.rxIndLinExpand()`
runs `symengine::expand()` and keeps the result under two rules:

- An expansion that takes a forcing from **reading a compartment to reading
  none** is kept however long it gets -- that is the difference between the two
  drivers, and it is what the solver classifies on.  Compartments here means
  every one the generated model can read: the physical states, the
  `rx__sens_*` sensitivity compartments, and the `linCmt()` pseudo-compartments.
- Everywhere else -- rate constants, eliminations, cross-term coefficients, none
  of which the classification reads -- the expansion is only a rewrite of the
  same dependencies, so it is kept only when it does not lengthen what it
  replaced.  A cancellation to `0` always qualifies.

A genuinely nonlinear forcing is therefore untouched, and a Michaelis-Menten
model still emits every forcing it needs and still iterates.

Also in here: the three copies of the zero test are now one
`.rxIndLinIsZero()`/`.rxIndLinIsZeroTxt()` (which is how the plain conversion
path now accepts the float spelling `0.0` that `0.0*a` prints, instead of
emitting it as an elimination rate), the column-sum elimination is computed once
per compartment rather than once per read, and the cross-term accumulator reads
its store through `base::get()` like the rest of the file.

## Effect

| model | `doIndLin` before | after |
|---|---|---|
| 1cmt + 3 sens params | 1 | 1 |
| 2cmt + 3 sens params | 4 (iterating) | **1** (one cached exponential) |
| 3cmt + 3 sens params | 4 (iterating) | **1** |
| 2cmt Michaelis-Menten | 4 | 4 (unchanged, as it must be) |

Measured on an optimized build, 40 subjects over an irregular 200 point
schedule with three sensitivity parameters, single thread -- the same generated
model in both arms, once as emitted now and once with the zero `indLin()` lines
put back:

| cell | fixed | with the zero forcing | |
|---|---|---|---|
| 2cmt | 0.099 s | 1.041 s | **10.5x** |
| 3cmt | 0.139 s | 1.775 s | **12.8x** |

`max abs(cp difference) = 3e-14` -- the dropped terms contributed nothing but
cost.  `bench/indlin_zero_forcing_ab.R` is the harness.

This is also what unblocks the #1301 block-structured exponential, which until
now was only reachable on 1cmt.

## Tests

`tests/testthat/test-ind-lin-1298.R` asserts the *mechanism*, not only the
values -- the values were never wrong, since the terms this drops are zero, so a
value test alone cannot see the regression it guards:

- no `indLin()` line emitted for 1/2/3 compartments, at first, second and third
  order, and `doIndLin == 1`
- no adaptive attempt recorded by the step counters over a real solve
- `k_central_output` emitted in its cancelled form
- first- **and** second-order sensitivities against finite differences, on the
  exponential path they now take
- a Michaelis-Menten model keeps all four forcings, lands on `doIndLin == 4`,
  really iterates, and its sensitivities still match finite differences
- both sides of the expansion rule: a residual whose state terms cancel is not
  called state dependent, and an expansion that buys no reclassification is not
  taken
- the cross-term accumulator sums and cancels
- the plain non-sensitivity `indLin()` conversion cancels its elimination
  constants too

## Review

Four rounds of independent (Gemini) review beyond my own.  Two rounds produced
real findings, both fixed here and both now pinned by a test: the first cut's
length-only expansion rule let the bug survive where a residual's state terms
cancel but its state-free part expands wide, and the follow-up rule counted all
free symbols, so dropping a mere parameter forced an expansion that bought no
reclassification and only inflated what `ME()` re-evaluates.  The final round
found no correctness bugs.
