### PR TITLE
Fix rxMemoryEstimate() double-counting gsolve_n0, plus five more defects in $total (#1241)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -729,6 +729,15 @@
   `rxControl(resample=)` asks for covariate resampling, and counts the
   per-thread pointer table that accompanies the `gInfusionRate` buffers.
 
+- `rxMemoryEstimate()` now charges the two per-individual history buffers:
+  the `delay()` dense history (`ind$delayHist`) and the `linCmtB()` output-time
+  rate history (`ind$linCmtRateHist`), neither of which was counted at all.
+  Both grow by doubling inside the solve rather than being sized up front, so
+  unlike every other component these are a documented BOUND rather than a
+  mirror of a `calloc`: the capacity the doubling reaches at roughly one stored
+  step per event, floored at the initial allocation.  They are zero for a model
+  that uses neither.
+
 - `rxMemoryEstimate()` no longer returns `NA` for very large event counts.  The
   per-subject event totals were summed in integer arithmetic, so a solve past
   2^31 events -- exactly the size this estimate exists to judge -- overflowed

--- a/NEWS.md
+++ b/NEWS.md
@@ -695,6 +695,18 @@
   fits is no longer refused and chunks are no longer about half the size they
   should be.
 
+- `rxMemoryEstimate()` now counts the per-individual event and solve arrays.
+  When `op$indOwnAlloc` is set -- which `rxSolve()` defaults to the model's
+  `evid_` parser flag, so any dose-pushing model (`bolus()`, `obs()`) gets it,
+  as does anyone passing `rxSolve(..., indOwnAlloc = TRUE)` -- `rxAllocInd()`
+  gives every individual its own `dose`/`ii`/`all_times`/`timeThread`/`evid`/
+  `ix`/`idose`/`solve` arrays, and `gsolve` is still allocated at its full size
+  regardless, so those arrays are memory on top of it.  The estimate ignored
+  them entirely, which understated `total` -- the direction that makes an
+  out-of-memory guard useless.  They are now reported as an `indOwnAlloc`
+  component, computed by `rxFillIndAllocTotal()` in `inst/include/rxMemoryCalc.h`
+  alongside the rest of the layout.
+
 - Parsing a model no longer corrupts the caller's `PROTECT` stack.  The
   translation table and `_goodFuns` were claimed on the protect stack by one
   function and released by another, with the whole parse in between; an

--- a/NEWS.md
+++ b/NEWS.md
@@ -684,6 +684,17 @@
 
 ## Bug fixes
 
+- `rxMemoryEstimate()` no longer double-counts the ODE state output matrix.
+  `gsolve_n0` is a piece of `gsolve`, not a sibling of it -- `rxFillMemLayout()`
+  adds `n0` into `gsolve_total` -- but `total` summed every reported element, so
+  it counted the single largest allocation of an ordinary solve twice and could
+  approach double the real figure.  `gsolve_n0` is still reported (and still
+  printed indented under `gsolve`), it is just no longer added to `total`.  The
+  out-of-memory guard in `rxSolve()` and the chunk sizing in
+  `.rxOomChunkSize()`/`rxSolveChunked()` both act on `total`, so a solve that
+  fits is no longer refused and chunks are no longer about half the size they
+  should be.
+
 - Parsing a model no longer corrupts the caller's `PROTECT` stack.  The
   translation table and `_goodFuns` were claimed on the protect stack by one
   function and released by another, with the whole parse in between; an

--- a/NEWS.md
+++ b/NEWS.md
@@ -707,6 +707,33 @@
   component, computed by `rxFillIndAllocTotal()` in `inst/include/rxMemoryCalc.h`
   alongside the rest of the layout.
 
+- `rxMemoryEstimate()` now scales the event-indexed buffers with `nSub`,
+  `nStud` and `nsim`.  The replicated subject count was applied to the subject
+  total but never to the event total, so `rxControl(nSub = 100)` on a
+  one-subject table reported the one-subject figure for `gsolve_n0`,
+  `gall_times`, `gevid` and `gpars` -- an undercount of the largest allocation
+  by the full replicate factor, and again in the direction that makes the
+  out-of-memory guard useless.  `nsub` and `nsim` now mean to the estimate what
+  they mean in `rxData.cpp`: `nsub` is the subjects of ONE simulation and
+  `nsim` is how many times that block is replicated, so `nStud` lands in `nsim`
+  (where it also correctly pays for the extra-simulation copies in
+  `gall_timesS`) and `nSub` grows the events of a single simulation.
+  `effectiveSubs` still reports the total individual count.
+
+- `rxMemoryEstimate()` sizes `ordId` by individuals rather than events.
+  `rx$ordId` is the solve ORDER over individuals -- `nsub * nsim` ints -- but
+  the estimate charged one int per event, overstating it by the number of
+  events per subject.
+
+- `rxMemoryEstimate()` now reports `gSampleCov`, allocated when
+  `rxControl(resample=)` asks for covariate resampling, and counts the
+  per-thread pointer table that accompanies the `gInfusionRate` buffers.
+
+- `rxMemoryEstimate()` no longer returns `NA` for very large event counts.  The
+  per-subject event totals were summed in integer arithmetic, so a solve past
+  2^31 events -- exactly the size this estimate exists to judge -- overflowed
+  and then failed with "missing value where TRUE/FALSE needed".
+
 - Parsing a model no longer corrupts the caller's `PROTECT` stack.  The
   translation table and `_goodFuns` were claimed on the protect stack by one
   function and released by another, with the whole parse in between; an

--- a/NEWS.md
+++ b/NEWS.md
@@ -725,6 +725,11 @@
   the estimate charged one int per event, overstating it by the number of
   events per subject.
 
+- `rxMemoryEstimate()` now reports `gEtaPre`, the pre-generated eta draws.
+  `rxPreGenEta()` mallocs `nsim * nsub * neta` doubles before the parallel
+  solve loop whenever the model has etas and a nonzero omega, and none of it
+  was counted.
+
 - `rxMemoryEstimate()` now reports `gSampleCov`, allocated when
   `rxControl(resample=)` asks for covariate resampling, and counts the
   per-thread pointer table that accompanies the `gInfusionRate` buffers.

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -1087,7 +1087,11 @@ rxSymInvCholEnvCalculate <- function(obj, what, theta = NULL) {
 #' @param numLin    Number of linear compartment terms (FOCEi mixed models).
 #' @param nsub      Number of subjects.
 #' @param nallTotal Total events across all subjects (sum of obs + doses).
+#' @param ndosesTotal Total dose events across all subjects.
 #' @param maxAllTimes Maximum events for any single subject.
+#' @param indOwnAlloc 1 if every individual gets its own event/solve arrays
+#'   (\code{op$indOwnAlloc}), else 0.  These are allocated ON TOP of
+#'   \code{gsolve}, whose \code{n0} region then goes unused.
 #' @param stiff     The solving method (\code{op$stiff}); only 3
 #'   (\code{"indLin"}) allocates anything extra here.
 #' @param doIndLin  Which matrix-exponential driver runs: 0 not a
@@ -1098,8 +1102,8 @@ rxSymInvCholEnvCalculate <- function(obj, what, theta = NULL) {
 #'   Also includes \code{sizeofInd} (bytes per \code{rx_solving_options_ind}
 #'   struct) and \code{rxLlikSaveSize} (the compile-time constant).
 #' @noRd
-rxMemoryComponents_ <- function(neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, maxAllTimes, stiff, doIndLin) {
-    .Call(`_rxode2_rxMemoryComponents_`, neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, maxAllTimes, stiff, doIndLin)
+rxMemoryComponents_ <- function(neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, ndosesTotal, maxAllTimes, stiff, doIndLin, indOwnAlloc) {
+    .Call(`_rxode2_rxMemoryComponents_`, neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, ndosesTotal, maxAllTimes, stiff, doIndLin, indOwnAlloc)
 }
 
 rxOptRep_ <- function(input) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -1085,13 +1085,16 @@ rxSymInvCholEnvCalculate <- function(obj, what, theta = NULL) {
 #' @param nIndSim   Per-individual simulation count (typically \code{neta+neps}).
 #' @param numLinSens Number of linear sensitivity parameters (FOCEi mixed models).
 #' @param numLin    Number of linear compartment terms (FOCEi mixed models).
-#' @param nsub      Number of subjects.
+#' @param nsub      Number of subjects in ONE simulation (\code{rx$nsub});
+#'   the total individual count is \code{nsub * nsim}.
 #' @param nallTotal Total events across all subjects (sum of obs + doses).
 #' @param ndosesTotal Total dose events across all subjects.
 #' @param maxAllTimes Maximum events for any single subject.
 #' @param indOwnAlloc 1 if every individual gets its own event/solve arrays
 #'   (\code{op$indOwnAlloc}), else 0.  These are allocated ON TOP of
 #'   \code{gsolve}, whose \code{n0} region then goes unused.
+#' @param sample 1 when \code{rxControl(resample=)} asks for covariate
+#'   resampling, which allocates \code{gSampleCov}; else 0.
 #' @param stiff     The solving method (\code{op$stiff}); only 3
 #'   (\code{"indLin"}) allocates anything extra here.
 #' @param doIndLin  Which matrix-exponential driver runs: 0 not a
@@ -1102,8 +1105,8 @@ rxSymInvCholEnvCalculate <- function(obj, what, theta = NULL) {
 #'   Also includes \code{sizeofInd} (bytes per \code{rx_solving_options_ind}
 #'   struct) and \code{rxLlikSaveSize} (the compile-time constant).
 #' @noRd
-rxMemoryComponents_ <- function(neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, ndosesTotal, maxAllTimes, stiff, doIndLin, indOwnAlloc) {
-    .Call(`_rxode2_rxMemoryComponents_`, neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, ndosesTotal, maxAllTimes, stiff, doIndLin, indOwnAlloc)
+rxMemoryComponents_ <- function(neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, ndosesTotal, maxAllTimes, stiff, doIndLin, indOwnAlloc, sample) {
+    .Call(`_rxode2_rxMemoryComponents_`, neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, ndosesTotal, maxAllTimes, stiff, doIndLin, indOwnAlloc, sample)
 }
 
 rxOptRep_ <- function(input) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -1095,6 +1095,11 @@ rxSymInvCholEnvCalculate <- function(obj, what, theta = NULL) {
 #'   \code{gsolve}, whose \code{n0} region then goes unused.
 #' @param sample 1 when \code{rxControl(resample=)} asks for covariate
 #'   resampling, which allocates \code{gSampleCov}; else 0.
+#' @param nDelayState Number of ODE states \code{delay()} looks back on
+#'   (\code{op$nDelayState}); 0 for a model without \code{delay()}.  Drives
+#'   the per-individual dense-history bound.
+#'   The \code{linCmtB(which1 = -3)} rate history is charged at
+#'   \code{numLin} wide, which is the width \code{linCmtBRateSlot()} uses.
 #' @param stiff     The solving method (\code{op$stiff}); only 3
 #'   (\code{"indLin"}) allocates anything extra here.
 #' @param doIndLin  Which matrix-exponential driver runs: 0 not a
@@ -1105,8 +1110,8 @@ rxSymInvCholEnvCalculate <- function(obj, what, theta = NULL) {
 #'   Also includes \code{sizeofInd} (bytes per \code{rx_solving_options_ind}
 #'   struct) and \code{rxLlikSaveSize} (the compile-time constant).
 #' @noRd
-rxMemoryComponents_ <- function(neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, ndosesTotal, maxAllTimes, stiff, doIndLin, indOwnAlloc, sample) {
-    .Call(`_rxode2_rxMemoryComponents_`, neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, ndosesTotal, maxAllTimes, stiff, doIndLin, indOwnAlloc, sample)
+rxMemoryComponents_ <- function(neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, ndosesTotal, maxAllTimes, stiff, doIndLin, indOwnAlloc, sample, nDelayState) {
+    .Call(`_rxode2_rxMemoryComponents_`, neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, ndosesTotal, maxAllTimes, stiff, doIndLin, indOwnAlloc, sample, nDelayState)
 }
 
 rxOptRep_ <- function(input) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -1106,6 +1106,13 @@ rxSymInvCholEnvCalculate <- function(obj, what, theta = NULL) {
 #'   \code{matExp()} model, 1 pure matrix exponential, 2 plus a state-free
 #'   \code{indLin()} forcing, 3/4 true inductive linearization (the adaptive,
 #'   iterating driver).  These cost very different amounts.
+#' Not counted: a handful of fixed-size index tables whose sizes depend on
+#' values only the solver has (\code{gParPos}, the \code{gevid} tail holding
+#' \code{gpar_cov}/\code{glhs_str}, \code{gdelayCol}/\code{gdelayState},
+#' \code{gindLin}, \code{splitBolus}).  Each is tens to hundreds of ints and
+#' none scales with subjects or events, so they are left out rather than
+#' folded into a component whose scaling law is the useful part of it.
+#'
 #' @return Named numeric vector; each element is bytes for that allocation.
 #'   Also includes \code{sizeofInd} (bytes per \code{rx_solving_options_ind}
 #'   struct) and \code{rxLlikSaveSize} (the compile-time constant).

--- a/R/rxMemoryEstimate.R
+++ b/R/rxMemoryEstimate.R
@@ -778,6 +778,7 @@ print.rxMemoryEstimate <- function(x, ...) {
     indLinWork    = "indLinWork (per-thread indLin scratch)",
     indOwnAlloc   = "indOwnAlloc (per-individual event/solve arrays)",
     gSampleCov    = "gSampleCov (resampled covariate index)",
+    gEtaPre       = "gEtaPre (pre-generated eta draws)",
     delayHist     = "delayHist (per-individual delay() history, bound)",
     linCmtRateHist = "linCmtRateHist (per-individual linCmt rates, bound)",
     outputData    = "outputData (estimated returned data)"

--- a/R/rxMemoryEstimate.R
+++ b/R/rxMemoryEstimate.R
@@ -211,7 +211,10 @@ rxMemSummary <- function(nobs, ndoses, id = seq_along(nobs)) {
     nMtime    = as.integer(.mv[["nMtime"]]),
     nLlik     = as.integer(.flags["nLlik"]),
     nIndSim   = as.integer(.flags["nIndSim"]),
-    doIndLin  = .rxMemDoIndLin(.mv)
+    doIndLin  = .rxMemDoIndLin(.mv),
+    # op->indOwnAlloc defaults to this parser flag (src/rxData.cpp), so the
+    # MODEL decides it unless the control says otherwise
+    indOwnAlloc = as.integer(.flags["evid_"])
   )
 }
 #' Which matrix-exponential driver a model will run under
@@ -254,8 +257,12 @@ rxMemSummary <- function(nobs, ndoses, id = seq_along(nobs)) {
   .nSub  <- if (is.null(ctrl$nSub))  1L else as.integer(ctrl$nSub)
   .nStud <- if (is.null(ctrl$nStud)) 1L else as.integer(ctrl$nStud)
   .stiff <- if (is.null(ctrl$method)) NA_integer_ else as.integer(ctrl$method)
+  # rxControl() stores -1 for "not set"; rxSolve() then takes the model's flag
+  .indOwn <- if (is.null(ctrl$indOwnAlloc)) NA_integer_ else as.integer(ctrl$indOwnAlloc)
+  if (!is.na(.indOwn) && .indOwn < 0L) .indOwn <- NA_integer_
   list(
     cores      = .cores,
+    indOwnAlloc = .indOwn,
     nsim       = .nsim,
     neta       = as.integer(.neta),
     neps       = as.integer(.neps),
@@ -444,6 +451,11 @@ rxMemSummary <- function(nobs, ndoses, id = seq_along(nobs)) {
 #'   \code{control} when given, and overridden to \code{3} for any
 #'   \code{matExp()} model, since \code{rxSolve()} force-selects that method
 #'   for one whatever the control says.
+#' @param indOwnAlloc \code{TRUE}/\code{1} when every individual gets its
+#'   own event and solve arrays rather than pointing into the global
+#'   buffers.  These are allocated on top of \code{gsolve}, so they are real
+#'   extra memory.  Taken from the model's \code{evid_} flag when \code{model}
+#'   is given, and overridden by \code{control$indOwnAlloc} when that is set.
 #' @param doIndLin Which matrix-exponential driver runs: \code{0} not a
 #'   \code{matExp()} model, \code{1} pure matrix exponential, \code{2} plus a
 #'   state-free \code{indLin()} forcing, \code{3}/\code{4} true inductive
@@ -503,7 +515,8 @@ rxMemoryEstimate <- function(
   numLinSens = 0L,
   numLin    = 0L,
   stiff     = NA_integer_,
-  doIndLin  = 0L) {
+  doIndLin  = 0L,
+  indOwnAlloc = 0L) {
   .resolved <- .rxMemResolveInput(dat, control)
   dat <- .resolved$dat
   control <- .resolved$control
@@ -530,6 +543,7 @@ rxMemoryEstimate <- function(
     nMtime    <- .mi$nMtime
     nLlik     <- .mi$nLlik
     doIndLin  <- .mi$doIndLin
+    indOwnAlloc <- .mi$indOwnAlloc
     if (is.null(nIndSim)) nIndSim <- .mi$nIndSim
   }
 
@@ -542,7 +556,9 @@ rxMemoryEstimate <- function(
     if (.ci$neps > 0L) neps <- .ci$neps
     if (!is.null(.ci$nLlikAlloc)) nLlik <- max(nLlik, as.integer(.ci$nLlikAlloc))
     if (!is.na(.ci$stiff)) stiff <- .ci$stiff
+    if (!is.na(.ci$indOwnAlloc)) indOwnAlloc <- .ci$indOwnAlloc
   }
+  indOwnAlloc <- as.integer(isTRUE(as.logical(indOwnAlloc)))
   if (cores <= 0L) {
     cores <- 1L
   }
@@ -567,6 +583,9 @@ rxMemoryEstimate <- function(
   .nsub        <- nrow(.summary)
   .nobsTotal   <- sum(.summary$nobs)
   .nallTotal   <- sum(.nallVec)
+  # dose share of the events, so the dose count follows whatever rescaling the
+  # solve-layout / nSub / nStud branches below do to the event count
+  .doseFrac    <- if (.nallTotal > 0) sum(.summary$ndoses) / .nallTotal else 0
   .maxAllTimes <- max(.nallVec)
   .solveStats  <- .rxMemSolveLayoutStats(dat, control, model)
   .solveNallTotal <- .nallTotal
@@ -603,9 +622,11 @@ rxMemoryEstimate <- function(
     numLin     = as.integer(numLin),
     nsub       = as.integer(.nsub),
     nallTotal  = as.double(.solveNallTotal),
+    ndosesTotal = as.double(.doseFrac * .solveNallTotal),
     maxAllTimes = as.double(.solveMaxAllTimes),
     stiff      = as.integer(stiff),
-    doIndLin   = as.integer(doIndLin)
+    doIndLin   = as.integer(doIndLin),
+    indOwnAlloc = as.integer(indOwnAlloc)
   )
 
   .meta    <- c("sizeofInd", "rxLlikSaveSize")
@@ -683,12 +704,14 @@ print.rxMemoryEstimate <- function(x, ...) {
   .nm  <- names(.comps)[order(.bytes, decreasing = TRUE)]
   .nm  <- .nm[!.nm %in% names(.rxMemSubItems)]
   .tot <- sum(.bytes[.nm])
-  for (.s in names(.rxMemSubItems)) {
-    if (!(.s %in% names(.comps))) next
-    # `nomatch` keeps an orphan sub-item visible at the end rather than
-    # dropping it, should its parent ever stop being reported
-    .nm <- append(.nm, .s,
-                  after = match(.rxMemSubItems[[.s]], .nm, nomatch = length(.nm)))
+  for (.p in unique(unname(.rxMemSubItems))) {
+    # insert a parent's sub-items as one block so several of them keep the
+    # order they are declared in; `nomatch` keeps an orphan visible at the end
+    # rather than dropping it, should its parent ever stop being reported
+    .kids <- names(.rxMemSubItems)[.rxMemSubItems == .p]
+    .kids <- .kids[.kids %in% names(.comps)]
+    if (length(.kids) == 0L) next
+    .nm <- append(.nm, .kids, after = match(.p, .nm, nomatch = length(.nm)))
   }
   .sz  <- .bytes[.nm]
 
@@ -708,6 +731,7 @@ print.rxMemoryEstimate <- function(x, ...) {
     inds_global   = "inds_global (per-subject structs)",
     indLinExpCache = "indLinExpCache (per-thread exponential cache)",
     indLinWork    = "indLinWork (per-thread indLin scratch)",
+    indOwnAlloc   = "indOwnAlloc (per-individual event/solve arrays)",
     outputData    = "outputData (estimated returned data)"
   )
 

--- a/R/rxMemoryEstimate.R
+++ b/R/rxMemoryEstimate.R
@@ -258,11 +258,12 @@ rxMemSummary <- function(nobs, ndoses, id = seq_along(nobs)) {
   .nStud <- if (is.null(ctrl$nStud)) 1L else as.integer(ctrl$nStud)
   .stiff <- if (is.null(ctrl$method)) NA_integer_ else as.integer(ctrl$method)
   # rxControl() stores -1 for "not set"; rxSolve() then takes the model's flag
-  .indOwn <- if (is.null(ctrl$indOwnAlloc)) NA_integer_ else as.integer(ctrl$indOwnAlloc)
+  .indOwn <- if (is.null(ctrl[["indOwnAlloc"]])) NA_integer_ else as.integer(ctrl[["indOwnAlloc"]])
   if (!is.na(.indOwn) && .indOwn < 0L) .indOwn <- NA_integer_
   list(
     cores      = .cores,
     indOwnAlloc = .indOwn,
+    sample     = as.integer(!is.null(ctrl[["resample"]])),
     nsim       = .nsim,
     neta       = as.integer(.neta),
     neps       = as.integer(.neps),
@@ -433,7 +434,8 @@ rxMemSummary <- function(nobs, ndoses, id = seq_along(nobs)) {
 #' @param neta Number of random effects (etas).
 #' @param neps Number of residual-error levels (epsilons).
 #' @param ncov Number of time-varying covariates.
-#' @param nsim Number of simulations.
+#' @param nsim Number of simulations.  \code{nStud} from \code{control} is
+#'   the replicate count, so it lands here rather than in the subject count.
 #' @param cores Number of parallel OMP threads.
 #' @param nMtime Number of model measurement times.
 #' @param extraCmt Extra compartments (0, 1 = depot, 2 =
@@ -548,6 +550,7 @@ rxMemoryEstimate <- function(
   }
 
   .ci <- NULL
+  .sample <- 0L
   if (!is.null(control)) {
     .ci   <- .rxMemExtractControl(control)
     cores <- .ci$cores
@@ -557,6 +560,7 @@ rxMemoryEstimate <- function(
     if (!is.null(.ci$nLlikAlloc)) nLlik <- max(nLlik, as.integer(.ci$nLlikAlloc))
     if (!is.na(.ci$stiff)) stiff <- .ci$stiff
     if (!is.na(.ci$indOwnAlloc)) indOwnAlloc <- .ci$indOwnAlloc
+    .sample <- .ci$sample
   }
   indOwnAlloc <- as.integer(isTRUE(as.logical(indOwnAlloc)))
   if (cores <= 0L) {
@@ -579,25 +583,40 @@ rxMemoryEstimate <- function(
   if (stiff == 3L && doIndLin == 0L) doIndLin <- 3L
   if (is.null(nIndSim)) nIndSim <- neta + neps
 
-  .nallVec     <- .summary$nobs + .summary$ndoses
+  # doubles throughout: integer `sum()` returns NA past 2^31, and a solve big
+  # enough to overflow it is exactly the one this estimate exists to size
+  .nallVec     <- as.numeric(.summary$nobs) + as.numeric(.summary$ndoses)
   .nsub        <- nrow(.summary)
-  .nobsTotal   <- sum(.summary$nobs)
+  .nobsTotal   <- sum(as.numeric(.summary$nobs))
   .nallTotal   <- sum(.nallVec)
   # dose share of the events, so the dose count follows whatever rescaling the
   # solve-layout / nSub / nStud branches below do to the event count
-  .doseFrac    <- if (.nallTotal > 0) sum(.summary$ndoses) / .nallTotal else 0
+  .doseFrac    <- if (.nallTotal > 0) sum(as.numeric(.summary$ndoses)) / .nallTotal else 0
   .maxAllTimes <- max(.nallVec)
   .solveStats  <- .rxMemSolveLayoutStats(dat, control, model)
   .solveNallTotal <- .nallTotal
   .solveMaxAllTimes <- .maxAllTimes
 
+  # `nsub` and `nsim` mean to the ALLOCATOR what they mean in rxData.cpp:
+  # `nsub` is the subjects of ONE simulation and `nsim` is how many times that
+  # block is replicated (rx->nsim = nPopPar / rx->nsub), so `nall` is the
+  # events of one simulation too.  nStud is the replicate count, so it belongs
+  # in `nsim`; nSub replaces the data's subject count within a simulation.
+  # `.nsub` stays the TOTAL individual count, which is what `effectiveSubs`
+  # reports and what `.rxOomChunkSize()` divides by.
+  .nsubPerSim <- .nsub
   if (!is.null(.ci) && (.ci$nSub > 1L || .ci$nStud > 1L)) {
     .subPerStudy <- if (.ci$nSub > 1L) .ci$nSub else .nsub
     .meanObsTimes <- .nobsTotal / .nsub
     .meanAllTimes <- .nallTotal / .nsub
+    .nsubPerSim <- .subPerStudy
+    nsim       <- .ci$nStud
     .nsub      <- .subPerStudy * .ci$nStud
-    .nobsTotal <- .meanObsTimes * .nsub
-    .nallTotal <- .meanAllTimes * .nsub
+    # per-simulation totals: the components multiply these back up by `nsim`
+    .nobsTotal <- .meanObsTimes * .nsubPerSim
+    .nallTotal <- .meanAllTimes * .nsubPerSim
+    .solveNallTotal <- .nallTotal
+    .solveMaxAllTimes <- .maxAllTimes
   } else if (!is.null(.solveStats)) {
     .solveNallTotal <- .solveStats$nallTotal
     .solveMaxAllTimes <- .solveStats$maxAllTimes
@@ -620,13 +639,14 @@ rxMemoryEstimate <- function(
     nIndSim    = as.integer(nIndSim),
     numLinSens = as.integer(numLinSens),
     numLin     = as.integer(numLin),
-    nsub       = as.integer(.nsub),
+    nsub       = as.integer(.nsubPerSim),
     nallTotal  = as.double(.solveNallTotal),
     ndosesTotal = as.double(.doseFrac * .solveNallTotal),
     maxAllTimes = as.double(.solveMaxAllTimes),
     stiff      = as.integer(stiff),
     doIndLin   = as.integer(doIndLin),
-    indOwnAlloc = as.integer(indOwnAlloc)
+    indOwnAlloc = as.integer(indOwnAlloc),
+    sample     = as.integer(.sample)
   )
 
   .meta    <- c("sizeofInd", "rxLlikSaveSize")
@@ -732,6 +752,7 @@ print.rxMemoryEstimate <- function(x, ...) {
     indLinExpCache = "indLinExpCache (per-thread exponential cache)",
     indLinWork    = "indLinWork (per-thread indLin scratch)",
     indOwnAlloc   = "indOwnAlloc (per-individual event/solve arrays)",
+    gSampleCov    = "gSampleCov (resampled covariate index)",
     outputData    = "outputData (estimated returned data)"
   )
 

--- a/R/rxMemoryEstimate.R
+++ b/R/rxMemoryEstimate.R
@@ -212,10 +212,28 @@ rxMemSummary <- function(nobs, ndoses, id = seq_along(nobs)) {
     nLlik     = as.integer(.flags["nLlik"]),
     nIndSim   = as.integer(.flags["nIndSim"]),
     doIndLin  = .rxMemDoIndLin(.mv),
+    nDelayState = .rxMemNDelayState(.mv),
     # op->indOwnAlloc defaults to this parser flag (src/rxData.cpp), so the
     # MODEL decides it unless the control says otherwise
     indOwnAlloc = as.integer(.flags["evid_"])
   )
+}
+#' How many ODE states delay() looks back on
+#'
+#' Mirrors the `op->nDelayState` build in `src/rxData.cpp`: the states carrying
+#' the `propDelay` bit in `stateProp`, falling back to every state when
+#' `hasDelay` is set but no state carried the bit.
+#'
+#' @param mv `rxModelVars()` of the model.
+#' @return Number of dense-history columns; 0 for a model without `delay()`.
+#' @noRd
+#' @author Matthew L. Fidler
+.rxMemNDelayState <- function(mv) {
+  if (!isTRUE(as.integer(mv[["flags"]]["hasDelay"]) > 0L)) return(0L)
+  .sp <- mv[["stateProp"]]
+  if (length(.sp) == 0L) return(0L)
+  .n <- sum(bitwAnd(as.integer(.sp), 262144L) != 0L)  # propDelay, src/tran.h
+  if (.n == 0L) length(.sp) else as.integer(.n)
 }
 #' Which matrix-exponential driver a model will run under
 #'
@@ -458,6 +476,10 @@ rxMemSummary <- function(nobs, ndoses, id = seq_along(nobs)) {
 #'   buffers.  These are allocated on top of \code{gsolve}, so they are real
 #'   extra memory.  Taken from the model's \code{evid_} flag when \code{model}
 #'   is given, and overridden by \code{control$indOwnAlloc} when that is set.
+#' @param nDelayState Number of ODE states \code{delay()} looks back on.
+#'   Drives the per-individual dense-history buffer, which grows by doubling
+#'   inside the solve, so it is charged as a documented bound rather than an
+#'   exact mirror.  Taken from \code{model} when given.
 #' @param doIndLin Which matrix-exponential driver runs: \code{0} not a
 #'   \code{matExp()} model, \code{1} pure matrix exponential, \code{2} plus a
 #'   state-free \code{indLin()} forcing, \code{3}/\code{4} true inductive
@@ -518,7 +540,8 @@ rxMemoryEstimate <- function(
   numLin    = 0L,
   stiff     = NA_integer_,
   doIndLin  = 0L,
-  indOwnAlloc = 0L) {
+  indOwnAlloc = 0L,
+  nDelayState = 0L) {
   .resolved <- .rxMemResolveInput(dat, control)
   dat <- .resolved$dat
   control <- .resolved$control
@@ -546,6 +569,7 @@ rxMemoryEstimate <- function(
     nLlik     <- .mi$nLlik
     doIndLin  <- .mi$doIndLin
     indOwnAlloc <- .mi$indOwnAlloc
+    nDelayState <- .mi$nDelayState
     if (is.null(nIndSim)) nIndSim <- .mi$nIndSim
   }
 
@@ -646,7 +670,8 @@ rxMemoryEstimate <- function(
     stiff      = as.integer(stiff),
     doIndLin   = as.integer(doIndLin),
     indOwnAlloc = as.integer(indOwnAlloc),
-    sample     = as.integer(.sample)
+    sample     = as.integer(.sample),
+    nDelayState = as.integer(nDelayState)
   )
 
   .meta    <- c("sizeofInd", "rxLlikSaveSize")
@@ -753,6 +778,8 @@ print.rxMemoryEstimate <- function(x, ...) {
     indLinWork    = "indLinWork (per-thread indLin scratch)",
     indOwnAlloc   = "indOwnAlloc (per-individual event/solve arrays)",
     gSampleCov    = "gSampleCov (resampled covariate index)",
+    delayHist     = "delayHist (per-individual delay() history, bound)",
+    linCmtRateHist = "linCmtRateHist (per-individual linCmt rates, bound)",
     outputData    = "outputData (estimated returned data)"
   )
 

--- a/R/rxMemoryEstimate.R
+++ b/R/rxMemoryEstimate.R
@@ -277,6 +277,19 @@ rxMemSummary <- function(nobs, ndoses, id = seq_along(nobs)) {
   NA_real_
 }
 
+#' Reported components that are already part of another component
+#'
+#' \code{gsolve_n0} is the ODE state output matrix, which
+#' \code{rxFillMemLayout()} adds INTO \code{gsolve_total}; it is reported
+#' because it is normally the single largest piece of the solve, but summing it
+#' alongside \code{gsolve} would double-count it.  \code{total} therefore
+#' means "bytes actually allocated", not "sum of everything printed".
+#'
+#' Names are the sub-item; values are the parent component they belong to.
+#' @noRd
+#' @author Matthew L. Fidler
+.rxMemSubItems <- c(gsolve_n0 = "gsolve")
+
 .rxMemEstimateOutputData <- function(dat, summary, control, neq, nlhs, ncov,
                                      nsim, nsub, nobsTotal, nallTotal) {
   .addCov       <- TRUE
@@ -439,7 +452,10 @@ rxMemSummary <- function(nobs, ndoses, id = seq_along(nobs)) {
 #' @return A named list of class \code{"rxMemoryEstimate"} whose
 #'   elements are raw byte counts plus \code{outputData},
 #'   \code{ramBytes}, \code{freeRamBytes}, \code{total},
-#'   \code{sizeofInd}, and \code{rxLlikSaveSize}.
+#'   \code{sizeofInd}, and \code{rxLlikSaveSize}.  \code{total} is the
+#'   number of bytes actually allocated, so it excludes \code{gsolve_n0}
+#'   (the ODE state output matrix), which is reported separately but is
+#'   already part of \code{gsolve}.
 #' @export
 #'
 #' @examples
@@ -610,7 +626,9 @@ rxMemoryEstimate <- function(
   .wrapped <- lapply(.sizes, function(bytes) {
     structure(bytes, class = "rxRawBytes")
   })
-  .total   <- Reduce(`+`, .wrapped)
+  # Sub-items (see `.rxMemSubItems`) are still reported, but they are pieces of
+  # a component that is already in the sum, so they are left out of it.
+  .total   <- Reduce(`+`, .wrapped[!names(.wrapped) %in% names(.rxMemSubItems)])
 
   .ret <- c(list(total = .total), .wrapped,
             list(sizeofInd      = .raw[["sizeofInd"]],
@@ -659,10 +677,20 @@ print.rxMemoryEstimate <- function(x, ...) {
 
   .bytes <- vapply(.comps, as.numeric, numeric(1))
 
-  .ord <- order(.bytes, decreasing = TRUE)
-  .nm  <- names(.comps)[.ord]
-  .sz  <- .bytes[.ord]
-  .tot <- sum(.sz)
+  # Sub-items are not ranked by size; they are printed indented directly under
+  # the component they are part of, and left out of the percentage base (they
+  # are already counted inside their parent).
+  .nm  <- names(.comps)[order(.bytes, decreasing = TRUE)]
+  .nm  <- .nm[!.nm %in% names(.rxMemSubItems)]
+  .tot <- sum(.bytes[.nm])
+  for (.s in names(.rxMemSubItems)) {
+    if (!(.s %in% names(.comps))) next
+    # `nomatch` keeps an orphan sub-item visible at the end rather than
+    # dropping it, should its parent ever stop being reported
+    .nm <- append(.nm, .s,
+                  after = match(.rxMemSubItems[[.s]], .nm, nomatch = length(.nm)))
+  }
+  .sz  <- .bytes[.nm]
 
   .labels <- c(
     gsolve        = "gsolve (double buffer total)",

--- a/inst/include/rxMemoryCalc.h
+++ b/inst/include/rxMemoryCalc.h
@@ -118,4 +118,51 @@ static inline void rxFillMemLayout(
   out->gon_total = out->n3a_c + out->n3 + (int64_t)4 * out->nSize + nall * nsim;
 }
 
+/* ---------------------------------------------------------------------------
+ * rx_ind_alloc / rxFillIndAllocTotal
+ *
+ * When op->indOwnAlloc is set, rxAllocInd() (src/rxData.cpp) gives every
+ * individual its OWN dose/ii/all_times/timeThread/evid/ix/idose/solve arrays
+ * instead of pointing them into the global buffers.  gsolve is still calloc'd
+ * at gsolve_total, so its n0 region simply goes unused -- the per-individual
+ * solve arrays are memory ON TOP of it, not instead of it.  An estimate that
+ * ignores them undercounts, which is the direction that makes an
+ * out-of-memory guard useless.
+ *
+ * op->indOwnAlloc is NOT the same as method="indLin"; it defaults to the
+ * model's evid_ parser flag (dose-pushing models) and can be forced with
+ * rxSolve(..., indOwnAlloc = TRUE).
+ * --------------------------------------------------------------------------- */
+#ifndef EVID_EXTRA_SIZE
+#define EVID_EXTRA_SIZE 16
+#endif
+
+typedef struct {
+  int64_t dbl;  /* doubles: solve + dose + ii + all_times + timeThread */
+  int64_t i32;  /* ints:    evid + ix + idose                          */
+} rx_ind_alloc;
+
+/* Summed over every individual (nsub * nsim of them).  `nall` and `ndoses` are
+   totals across all subjects for ONE simulation; the per-individual guard
+   elements (+1) and the solve slack (EVID_EXTRA_SIZE) are charged per
+   individual, matching rxAllocInd() exactly. */
+static inline void rxFillIndAllocTotal(
+  int     neq,
+  int64_t nall,
+  int64_t ndoses,
+  int     nsub,
+  int     nsim,
+  rx_ind_alloc *out)
+{
+  int64_t nind = (int64_t)nsub * nsim;   /* individuals rxAllocInd() runs for */
+  int64_t nat  = nall * nsim;            /* events across all of them         */
+  int64_t nd   = ndoses * nsim;
+  /* newSolve is neq * (nat + EVID_EXTRA_SIZE) per individual */
+  out->dbl = (int64_t)neq * (nat + (int64_t)EVID_EXTRA_SIZE * nind) +
+    /* newDose, newIi, newAT, newTT: each nat + 1 per individual */
+    4 * (nat + nind);
+  /* newEvid, newIx: each nat + 1 per individual; newIdose: nd + 1 */
+  out->i32 = 2 * (nat + nind) + (nd + nind);
+}
+
 #endif /* RXODE2_MEMORY_CALC_H */

--- a/inst/include/rxMemoryCalc.h
+++ b/inst/include/rxMemoryCalc.h
@@ -165,4 +165,40 @@ static inline void rxFillIndAllocTotal(
   out->i32 = 2 * (nat + nind) + (nd + nind);
 }
 
+/* ---------------------------------------------------------------------------
+ * rxDelayHistCap / rxLinCmtRateHistCap
+ *
+ * The two per-individual history buffers grow by DOUBLING rather than being
+ * sized up front, so unlike everything above these cannot be mirrored from a
+ * calloc expression: `delayHistCap` starts at 256 and doubles once per
+ * accepted dense step, and how many of those a solve takes depends on
+ * stiffness and tolerances, not on anything known before solving.
+ *
+ * These return a documented BOUND, not a mirror: the capacity the doubling
+ * reaches at roughly one stored step per event, floored at the initial
+ * allocation every individual takes as soon as it stores anything.  A stiff
+ * solve taking many steps between outputs can still exceed it; an estimate
+ * that guesses low is the useless kind, so round up rather than down.
+ * --------------------------------------------------------------------------- */
+static inline int64_t rxPow2AtLeast(int64_t n, int64_t start) {
+  int64_t cap = start;
+  while (cap < n && cap < ((int64_t)1 << 40)) cap *= 2;
+  return cap;
+}
+
+/* Per individual, in DOUBLES.  n = events for that individual, nDelayState =
+   the states delay() looks back on (op->nDelayState).  Stride is
+   RX_DELAY_STRIDE(nDelayState) = 8*nDelayState + 3 (src/par_solve.cpp). */
+static inline int64_t rxDelayHistCap(int64_t n, int nDelayState) {
+  if (nDelayState <= 0) return 0;
+  return rxPow2AtLeast(n, 256) * (8 * (int64_t)nDelayState + 3);
+}
+
+/* Per individual, in DOUBLES.  linCmtBRateSlot() grows to hold one row of
+   `width` per output index (src/linCmt.cpp), starting at 64. */
+static inline int64_t rxLinCmtRateHistCap(int64_t n, int width) {
+  if (width <= 0) return 0;
+  return rxPow2AtLeast(n, 64) * (int64_t)width;
+}
+
 #endif /* RXODE2_MEMORY_CALC_H */

--- a/inst/include/rxode2_RcppExports.h
+++ b/inst/include/rxode2_RcppExports.h
@@ -1112,17 +1112,17 @@ namespace rxode2 {
         return Rcpp::as<RObject >(rcpp_result_gen);
     }
 
-    inline NumericVector rxMemoryComponents_(int neq, int stateSize, int nlhs, int npars, int neta, int neps, int ncov, int nsim, int cores, int nMtime, int extraCmt, int linB, int nLlik, int nIndSim, int numLinSens, int numLin, int nsub, double nallTotal, double ndosesTotal, double maxAllTimes, int stiff, int doIndLin, int indOwnAlloc) {
-        typedef SEXP(*Ptr_rxMemoryComponents_)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
+    inline NumericVector rxMemoryComponents_(int neq, int stateSize, int nlhs, int npars, int neta, int neps, int ncov, int nsim, int cores, int nMtime, int extraCmt, int linB, int nLlik, int nIndSim, int numLinSens, int numLin, int nsub, double nallTotal, double ndosesTotal, double maxAllTimes, int stiff, int doIndLin, int indOwnAlloc, int sample) {
+        typedef SEXP(*Ptr_rxMemoryComponents_)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
         static Ptr_rxMemoryComponents_ p_rxMemoryComponents_ = NULL;
         if (p_rxMemoryComponents_ == NULL) {
-            validateSignature("NumericVector(*rxMemoryComponents_)(int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,double,double,double,int,int,int)");
+            validateSignature("NumericVector(*rxMemoryComponents_)(int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,double,double,double,int,int,int,int)");
             p_rxMemoryComponents_ = (Ptr_rxMemoryComponents_)R_GetCCallable("rxode2", "_rxode2_rxMemoryComponents_");
         }
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_rxMemoryComponents_(Shield<SEXP>(Rcpp::wrap(neq)), Shield<SEXP>(Rcpp::wrap(stateSize)), Shield<SEXP>(Rcpp::wrap(nlhs)), Shield<SEXP>(Rcpp::wrap(npars)), Shield<SEXP>(Rcpp::wrap(neta)), Shield<SEXP>(Rcpp::wrap(neps)), Shield<SEXP>(Rcpp::wrap(ncov)), Shield<SEXP>(Rcpp::wrap(nsim)), Shield<SEXP>(Rcpp::wrap(cores)), Shield<SEXP>(Rcpp::wrap(nMtime)), Shield<SEXP>(Rcpp::wrap(extraCmt)), Shield<SEXP>(Rcpp::wrap(linB)), Shield<SEXP>(Rcpp::wrap(nLlik)), Shield<SEXP>(Rcpp::wrap(nIndSim)), Shield<SEXP>(Rcpp::wrap(numLinSens)), Shield<SEXP>(Rcpp::wrap(numLin)), Shield<SEXP>(Rcpp::wrap(nsub)), Shield<SEXP>(Rcpp::wrap(nallTotal)), Shield<SEXP>(Rcpp::wrap(ndosesTotal)), Shield<SEXP>(Rcpp::wrap(maxAllTimes)), Shield<SEXP>(Rcpp::wrap(stiff)), Shield<SEXP>(Rcpp::wrap(doIndLin)), Shield<SEXP>(Rcpp::wrap(indOwnAlloc)));
+            rcpp_result_gen = p_rxMemoryComponents_(Shield<SEXP>(Rcpp::wrap(neq)), Shield<SEXP>(Rcpp::wrap(stateSize)), Shield<SEXP>(Rcpp::wrap(nlhs)), Shield<SEXP>(Rcpp::wrap(npars)), Shield<SEXP>(Rcpp::wrap(neta)), Shield<SEXP>(Rcpp::wrap(neps)), Shield<SEXP>(Rcpp::wrap(ncov)), Shield<SEXP>(Rcpp::wrap(nsim)), Shield<SEXP>(Rcpp::wrap(cores)), Shield<SEXP>(Rcpp::wrap(nMtime)), Shield<SEXP>(Rcpp::wrap(extraCmt)), Shield<SEXP>(Rcpp::wrap(linB)), Shield<SEXP>(Rcpp::wrap(nLlik)), Shield<SEXP>(Rcpp::wrap(nIndSim)), Shield<SEXP>(Rcpp::wrap(numLinSens)), Shield<SEXP>(Rcpp::wrap(numLin)), Shield<SEXP>(Rcpp::wrap(nsub)), Shield<SEXP>(Rcpp::wrap(nallTotal)), Shield<SEXP>(Rcpp::wrap(ndosesTotal)), Shield<SEXP>(Rcpp::wrap(maxAllTimes)), Shield<SEXP>(Rcpp::wrap(stiff)), Shield<SEXP>(Rcpp::wrap(doIndLin)), Shield<SEXP>(Rcpp::wrap(indOwnAlloc)), Shield<SEXP>(Rcpp::wrap(sample)));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();

--- a/inst/include/rxode2_RcppExports.h
+++ b/inst/include/rxode2_RcppExports.h
@@ -1112,17 +1112,17 @@ namespace rxode2 {
         return Rcpp::as<RObject >(rcpp_result_gen);
     }
 
-    inline NumericVector rxMemoryComponents_(int neq, int stateSize, int nlhs, int npars, int neta, int neps, int ncov, int nsim, int cores, int nMtime, int extraCmt, int linB, int nLlik, int nIndSim, int numLinSens, int numLin, int nsub, double nallTotal, double ndosesTotal, double maxAllTimes, int stiff, int doIndLin, int indOwnAlloc, int sample) {
-        typedef SEXP(*Ptr_rxMemoryComponents_)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
+    inline NumericVector rxMemoryComponents_(int neq, int stateSize, int nlhs, int npars, int neta, int neps, int ncov, int nsim, int cores, int nMtime, int extraCmt, int linB, int nLlik, int nIndSim, int numLinSens, int numLin, int nsub, double nallTotal, double ndosesTotal, double maxAllTimes, int stiff, int doIndLin, int indOwnAlloc, int sample, int nDelayState) {
+        typedef SEXP(*Ptr_rxMemoryComponents_)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
         static Ptr_rxMemoryComponents_ p_rxMemoryComponents_ = NULL;
         if (p_rxMemoryComponents_ == NULL) {
-            validateSignature("NumericVector(*rxMemoryComponents_)(int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,double,double,double,int,int,int,int)");
+            validateSignature("NumericVector(*rxMemoryComponents_)(int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,double,double,double,int,int,int,int,int)");
             p_rxMemoryComponents_ = (Ptr_rxMemoryComponents_)R_GetCCallable("rxode2", "_rxode2_rxMemoryComponents_");
         }
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_rxMemoryComponents_(Shield<SEXP>(Rcpp::wrap(neq)), Shield<SEXP>(Rcpp::wrap(stateSize)), Shield<SEXP>(Rcpp::wrap(nlhs)), Shield<SEXP>(Rcpp::wrap(npars)), Shield<SEXP>(Rcpp::wrap(neta)), Shield<SEXP>(Rcpp::wrap(neps)), Shield<SEXP>(Rcpp::wrap(ncov)), Shield<SEXP>(Rcpp::wrap(nsim)), Shield<SEXP>(Rcpp::wrap(cores)), Shield<SEXP>(Rcpp::wrap(nMtime)), Shield<SEXP>(Rcpp::wrap(extraCmt)), Shield<SEXP>(Rcpp::wrap(linB)), Shield<SEXP>(Rcpp::wrap(nLlik)), Shield<SEXP>(Rcpp::wrap(nIndSim)), Shield<SEXP>(Rcpp::wrap(numLinSens)), Shield<SEXP>(Rcpp::wrap(numLin)), Shield<SEXP>(Rcpp::wrap(nsub)), Shield<SEXP>(Rcpp::wrap(nallTotal)), Shield<SEXP>(Rcpp::wrap(ndosesTotal)), Shield<SEXP>(Rcpp::wrap(maxAllTimes)), Shield<SEXP>(Rcpp::wrap(stiff)), Shield<SEXP>(Rcpp::wrap(doIndLin)), Shield<SEXP>(Rcpp::wrap(indOwnAlloc)), Shield<SEXP>(Rcpp::wrap(sample)));
+            rcpp_result_gen = p_rxMemoryComponents_(Shield<SEXP>(Rcpp::wrap(neq)), Shield<SEXP>(Rcpp::wrap(stateSize)), Shield<SEXP>(Rcpp::wrap(nlhs)), Shield<SEXP>(Rcpp::wrap(npars)), Shield<SEXP>(Rcpp::wrap(neta)), Shield<SEXP>(Rcpp::wrap(neps)), Shield<SEXP>(Rcpp::wrap(ncov)), Shield<SEXP>(Rcpp::wrap(nsim)), Shield<SEXP>(Rcpp::wrap(cores)), Shield<SEXP>(Rcpp::wrap(nMtime)), Shield<SEXP>(Rcpp::wrap(extraCmt)), Shield<SEXP>(Rcpp::wrap(linB)), Shield<SEXP>(Rcpp::wrap(nLlik)), Shield<SEXP>(Rcpp::wrap(nIndSim)), Shield<SEXP>(Rcpp::wrap(numLinSens)), Shield<SEXP>(Rcpp::wrap(numLin)), Shield<SEXP>(Rcpp::wrap(nsub)), Shield<SEXP>(Rcpp::wrap(nallTotal)), Shield<SEXP>(Rcpp::wrap(ndosesTotal)), Shield<SEXP>(Rcpp::wrap(maxAllTimes)), Shield<SEXP>(Rcpp::wrap(stiff)), Shield<SEXP>(Rcpp::wrap(doIndLin)), Shield<SEXP>(Rcpp::wrap(indOwnAlloc)), Shield<SEXP>(Rcpp::wrap(sample)), Shield<SEXP>(Rcpp::wrap(nDelayState)));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();

--- a/inst/include/rxode2_RcppExports.h
+++ b/inst/include/rxode2_RcppExports.h
@@ -1112,17 +1112,17 @@ namespace rxode2 {
         return Rcpp::as<RObject >(rcpp_result_gen);
     }
 
-    inline NumericVector rxMemoryComponents_(int neq, int stateSize, int nlhs, int npars, int neta, int neps, int ncov, int nsim, int cores, int nMtime, int extraCmt, int linB, int nLlik, int nIndSim, int numLinSens, int numLin, int nsub, double nallTotal, double maxAllTimes, int stiff, int doIndLin) {
-        typedef SEXP(*Ptr_rxMemoryComponents_)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
+    inline NumericVector rxMemoryComponents_(int neq, int stateSize, int nlhs, int npars, int neta, int neps, int ncov, int nsim, int cores, int nMtime, int extraCmt, int linB, int nLlik, int nIndSim, int numLinSens, int numLin, int nsub, double nallTotal, double ndosesTotal, double maxAllTimes, int stiff, int doIndLin, int indOwnAlloc) {
+        typedef SEXP(*Ptr_rxMemoryComponents_)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
         static Ptr_rxMemoryComponents_ p_rxMemoryComponents_ = NULL;
         if (p_rxMemoryComponents_ == NULL) {
-            validateSignature("NumericVector(*rxMemoryComponents_)(int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,double,double,int,int)");
+            validateSignature("NumericVector(*rxMemoryComponents_)(int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,double,double,double,int,int,int)");
             p_rxMemoryComponents_ = (Ptr_rxMemoryComponents_)R_GetCCallable("rxode2", "_rxode2_rxMemoryComponents_");
         }
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_rxMemoryComponents_(Shield<SEXP>(Rcpp::wrap(neq)), Shield<SEXP>(Rcpp::wrap(stateSize)), Shield<SEXP>(Rcpp::wrap(nlhs)), Shield<SEXP>(Rcpp::wrap(npars)), Shield<SEXP>(Rcpp::wrap(neta)), Shield<SEXP>(Rcpp::wrap(neps)), Shield<SEXP>(Rcpp::wrap(ncov)), Shield<SEXP>(Rcpp::wrap(nsim)), Shield<SEXP>(Rcpp::wrap(cores)), Shield<SEXP>(Rcpp::wrap(nMtime)), Shield<SEXP>(Rcpp::wrap(extraCmt)), Shield<SEXP>(Rcpp::wrap(linB)), Shield<SEXP>(Rcpp::wrap(nLlik)), Shield<SEXP>(Rcpp::wrap(nIndSim)), Shield<SEXP>(Rcpp::wrap(numLinSens)), Shield<SEXP>(Rcpp::wrap(numLin)), Shield<SEXP>(Rcpp::wrap(nsub)), Shield<SEXP>(Rcpp::wrap(nallTotal)), Shield<SEXP>(Rcpp::wrap(maxAllTimes)), Shield<SEXP>(Rcpp::wrap(stiff)), Shield<SEXP>(Rcpp::wrap(doIndLin)));
+            rcpp_result_gen = p_rxMemoryComponents_(Shield<SEXP>(Rcpp::wrap(neq)), Shield<SEXP>(Rcpp::wrap(stateSize)), Shield<SEXP>(Rcpp::wrap(nlhs)), Shield<SEXP>(Rcpp::wrap(npars)), Shield<SEXP>(Rcpp::wrap(neta)), Shield<SEXP>(Rcpp::wrap(neps)), Shield<SEXP>(Rcpp::wrap(ncov)), Shield<SEXP>(Rcpp::wrap(nsim)), Shield<SEXP>(Rcpp::wrap(cores)), Shield<SEXP>(Rcpp::wrap(nMtime)), Shield<SEXP>(Rcpp::wrap(extraCmt)), Shield<SEXP>(Rcpp::wrap(linB)), Shield<SEXP>(Rcpp::wrap(nLlik)), Shield<SEXP>(Rcpp::wrap(nIndSim)), Shield<SEXP>(Rcpp::wrap(numLinSens)), Shield<SEXP>(Rcpp::wrap(numLin)), Shield<SEXP>(Rcpp::wrap(nsub)), Shield<SEXP>(Rcpp::wrap(nallTotal)), Shield<SEXP>(Rcpp::wrap(ndosesTotal)), Shield<SEXP>(Rcpp::wrap(maxAllTimes)), Shield<SEXP>(Rcpp::wrap(stiff)), Shield<SEXP>(Rcpp::wrap(doIndLin)), Shield<SEXP>(Rcpp::wrap(indOwnAlloc)));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();

--- a/man/rxMemoryEstimate.Rd
+++ b/man/rxMemoryEstimate.Rd
@@ -26,7 +26,8 @@ rxMemoryEstimate(
   numLin = 0L,
   stiff = NA_integer_,
   doIndLin = 0L,
-  indOwnAlloc = 0L
+  indOwnAlloc = 0L,
+  nDelayState = 0L
 )
 }
 \arguments{
@@ -103,6 +104,11 @@ own event and solve arrays rather than pointing into the global
 buffers.  These are allocated on top of \code{gsolve}, so they are real
 extra memory.  Taken from the model's \code{evid_} flag when \code{model}
 is given, and overridden by \code{control$indOwnAlloc} when that is set.}
+
+\item{nDelayState}{Number of ODE states \code{delay()} looks back on.
+Drives the per-individual dense-history buffer, which grows by doubling
+inside the solve, so it is charged as a documented bound rather than an
+exact mirror.  Taken from \code{model} when given.}
 }
 \value{
 A named list of class \code{"rxMemoryEstimate"} whose

--- a/man/rxMemoryEstimate.Rd
+++ b/man/rxMemoryEstimate.Rd
@@ -100,7 +100,10 @@ different amounts, so it is worth getting right.}
 A named list of class \code{"rxMemoryEstimate"} whose
 elements are raw byte counts plus \code{outputData},
 \code{ramBytes}, \code{freeRamBytes}, \code{total},
-\code{sizeofInd}, and \code{rxLlikSaveSize}.
+\code{sizeofInd}, and \code{rxLlikSaveSize}.  \code{total} is the
+number of bytes actually allocated, so it excludes \code{gsolve_n0}
+(the ODE state output matrix), which is reported separately but is
+already part of \code{gsolve}.
 }
 \description{
 Accepts either a pre-summarized per-ID table (an \code{\link{rxMemSummary}}

--- a/man/rxMemoryEstimate.Rd
+++ b/man/rxMemoryEstimate.Rd
@@ -63,7 +63,8 @@ models.  Defaults to \code{neq}.}
 
 \item{ncov}{Number of time-varying covariates.}
 
-\item{nsim}{Number of simulations.}
+\item{nsim}{Number of simulations.  \code{nStud} from \code{control} is
+the replicate count, so it lands here rather than in the subject count.}
 
 \item{cores}{Number of parallel OMP threads.}
 

--- a/man/rxMemoryEstimate.Rd
+++ b/man/rxMemoryEstimate.Rd
@@ -25,7 +25,8 @@ rxMemoryEstimate(
   numLinSens = 0L,
   numLin = 0L,
   stiff = NA_integer_,
-  doIndLin = 0L
+  doIndLin = 0L,
+  indOwnAlloc = 0L
 )
 }
 \arguments{
@@ -95,6 +96,12 @@ for one whatever the control says.}
 state-free \code{indLin()} forcing, \code{3}/\code{4} true inductive
 linearization.  Taken from \code{model} when given.  These cost very
 different amounts, so it is worth getting right.}
+
+\item{indOwnAlloc}{\code{TRUE}/\code{1} when every individual gets its
+own event and solve arrays rather than pointing into the global
+buffers.  These are allocated on top of \code{gsolve}, so they are real
+extra memory.  Taken from the model's \code{evid_} flag when \code{model}
+is given, and overridden by \code{control$indOwnAlloc} when that is set.}
 }
 \value{
 A named list of class \code{"rxMemoryEstimate"} whose

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2349,8 +2349,8 @@ RcppExport SEXP _rxode2_rxSymInvCholEnvCalculate(SEXP objSEXP, SEXP whatSEXP, SE
     return rcpp_result_gen;
 }
 // rxMemoryComponents_
-NumericVector rxMemoryComponents_(int neq, int stateSize, int nlhs, int npars, int neta, int neps, int ncov, int nsim, int cores, int nMtime, int extraCmt, int linB, int nLlik, int nIndSim, int numLinSens, int numLin, int nsub, double nallTotal, double ndosesTotal, double maxAllTimes, int stiff, int doIndLin, int indOwnAlloc, int sample);
-static SEXP _rxode2_rxMemoryComponents__try(SEXP neqSEXP, SEXP stateSizeSEXP, SEXP nlhsSEXP, SEXP nparsSEXP, SEXP netaSEXP, SEXP nepsSEXP, SEXP ncovSEXP, SEXP nsimSEXP, SEXP coresSEXP, SEXP nMtimeSEXP, SEXP extraCmtSEXP, SEXP linBSEXP, SEXP nLlikSEXP, SEXP nIndSimSEXP, SEXP numLinSensSEXP, SEXP numLinSEXP, SEXP nsubSEXP, SEXP nallTotalSEXP, SEXP ndosesTotalSEXP, SEXP maxAllTimesSEXP, SEXP stiffSEXP, SEXP doIndLinSEXP, SEXP indOwnAllocSEXP, SEXP sampleSEXP) {
+NumericVector rxMemoryComponents_(int neq, int stateSize, int nlhs, int npars, int neta, int neps, int ncov, int nsim, int cores, int nMtime, int extraCmt, int linB, int nLlik, int nIndSim, int numLinSens, int numLin, int nsub, double nallTotal, double ndosesTotal, double maxAllTimes, int stiff, int doIndLin, int indOwnAlloc, int sample, int nDelayState);
+static SEXP _rxode2_rxMemoryComponents__try(SEXP neqSEXP, SEXP stateSizeSEXP, SEXP nlhsSEXP, SEXP nparsSEXP, SEXP netaSEXP, SEXP nepsSEXP, SEXP ncovSEXP, SEXP nsimSEXP, SEXP coresSEXP, SEXP nMtimeSEXP, SEXP extraCmtSEXP, SEXP linBSEXP, SEXP nLlikSEXP, SEXP nIndSimSEXP, SEXP numLinSensSEXP, SEXP numLinSEXP, SEXP nsubSEXP, SEXP nallTotalSEXP, SEXP ndosesTotalSEXP, SEXP maxAllTimesSEXP, SEXP stiffSEXP, SEXP doIndLinSEXP, SEXP indOwnAllocSEXP, SEXP sampleSEXP, SEXP nDelayStateSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< int >::type neq(neqSEXP);
@@ -2377,15 +2377,16 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type doIndLin(doIndLinSEXP);
     Rcpp::traits::input_parameter< int >::type indOwnAlloc(indOwnAllocSEXP);
     Rcpp::traits::input_parameter< int >::type sample(sampleSEXP);
-    rcpp_result_gen = Rcpp::wrap(rxMemoryComponents_(neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, ndosesTotal, maxAllTimes, stiff, doIndLin, indOwnAlloc, sample));
+    Rcpp::traits::input_parameter< int >::type nDelayState(nDelayStateSEXP);
+    rcpp_result_gen = Rcpp::wrap(rxMemoryComponents_(neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, ndosesTotal, maxAllTimes, stiff, doIndLin, indOwnAlloc, sample, nDelayState));
     return rcpp_result_gen;
 END_RCPP_RETURN_ERROR
 }
-RcppExport SEXP _rxode2_rxMemoryComponents_(SEXP neqSEXP, SEXP stateSizeSEXP, SEXP nlhsSEXP, SEXP nparsSEXP, SEXP netaSEXP, SEXP nepsSEXP, SEXP ncovSEXP, SEXP nsimSEXP, SEXP coresSEXP, SEXP nMtimeSEXP, SEXP extraCmtSEXP, SEXP linBSEXP, SEXP nLlikSEXP, SEXP nIndSimSEXP, SEXP numLinSensSEXP, SEXP numLinSEXP, SEXP nsubSEXP, SEXP nallTotalSEXP, SEXP ndosesTotalSEXP, SEXP maxAllTimesSEXP, SEXP stiffSEXP, SEXP doIndLinSEXP, SEXP indOwnAllocSEXP, SEXP sampleSEXP) {
+RcppExport SEXP _rxode2_rxMemoryComponents_(SEXP neqSEXP, SEXP stateSizeSEXP, SEXP nlhsSEXP, SEXP nparsSEXP, SEXP netaSEXP, SEXP nepsSEXP, SEXP ncovSEXP, SEXP nsimSEXP, SEXP coresSEXP, SEXP nMtimeSEXP, SEXP extraCmtSEXP, SEXP linBSEXP, SEXP nLlikSEXP, SEXP nIndSimSEXP, SEXP numLinSensSEXP, SEXP numLinSEXP, SEXP nsubSEXP, SEXP nallTotalSEXP, SEXP ndosesTotalSEXP, SEXP maxAllTimesSEXP, SEXP stiffSEXP, SEXP doIndLinSEXP, SEXP indOwnAllocSEXP, SEXP sampleSEXP, SEXP nDelayStateSEXP) {
     SEXP rcpp_result_gen;
     {
         Rcpp::RNGScope rcpp_rngScope_gen;
-        rcpp_result_gen = PROTECT(_rxode2_rxMemoryComponents__try(neqSEXP, stateSizeSEXP, nlhsSEXP, nparsSEXP, netaSEXP, nepsSEXP, ncovSEXP, nsimSEXP, coresSEXP, nMtimeSEXP, extraCmtSEXP, linBSEXP, nLlikSEXP, nIndSimSEXP, numLinSensSEXP, numLinSEXP, nsubSEXP, nallTotalSEXP, ndosesTotalSEXP, maxAllTimesSEXP, stiffSEXP, doIndLinSEXP, indOwnAllocSEXP, sampleSEXP));
+        rcpp_result_gen = PROTECT(_rxode2_rxMemoryComponents__try(neqSEXP, stateSizeSEXP, nlhsSEXP, nparsSEXP, netaSEXP, nepsSEXP, ncovSEXP, nsimSEXP, coresSEXP, nMtimeSEXP, extraCmtSEXP, linBSEXP, nLlikSEXP, nIndSimSEXP, numLinSensSEXP, numLinSEXP, nsubSEXP, nallTotalSEXP, ndosesTotalSEXP, maxAllTimesSEXP, stiffSEXP, doIndLinSEXP, indOwnAllocSEXP, sampleSEXP, nDelayStateSEXP));
     }
     Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
     if (rcpp_isInterrupt_gen) {
@@ -3162,7 +3163,7 @@ static int _rxode2_RcppExport_validate(const char* sig) {
         signatures.insert("NumericVector(*rxInv)(SEXP)");
         signatures.insert("RObject(*rxSymInvChol)(RObject,Nullable<NumericVector>,std::string,int)");
         signatures.insert("RObject(*rxSymInvCholEnvCalculate)(List,std::string,Nullable<NumericVector>)");
-        signatures.insert("NumericVector(*rxMemoryComponents_)(int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,double,double,double,int,int,int,int)");
+        signatures.insert("NumericVector(*rxMemoryComponents_)(int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,double,double,double,int,int,int,int,int)");
         signatures.insert("SEXP(*rxSaveState_)()");
         signatures.insert("bool(*rxIsSerializeFile_)(SEXP)");
         signatures.insert("SEXP(*rxRestoreState_)(SEXP)");

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2349,8 +2349,8 @@ RcppExport SEXP _rxode2_rxSymInvCholEnvCalculate(SEXP objSEXP, SEXP whatSEXP, SE
     return rcpp_result_gen;
 }
 // rxMemoryComponents_
-NumericVector rxMemoryComponents_(int neq, int stateSize, int nlhs, int npars, int neta, int neps, int ncov, int nsim, int cores, int nMtime, int extraCmt, int linB, int nLlik, int nIndSim, int numLinSens, int numLin, int nsub, double nallTotal, double maxAllTimes, int stiff, int doIndLin);
-static SEXP _rxode2_rxMemoryComponents__try(SEXP neqSEXP, SEXP stateSizeSEXP, SEXP nlhsSEXP, SEXP nparsSEXP, SEXP netaSEXP, SEXP nepsSEXP, SEXP ncovSEXP, SEXP nsimSEXP, SEXP coresSEXP, SEXP nMtimeSEXP, SEXP extraCmtSEXP, SEXP linBSEXP, SEXP nLlikSEXP, SEXP nIndSimSEXP, SEXP numLinSensSEXP, SEXP numLinSEXP, SEXP nsubSEXP, SEXP nallTotalSEXP, SEXP maxAllTimesSEXP, SEXP stiffSEXP, SEXP doIndLinSEXP) {
+NumericVector rxMemoryComponents_(int neq, int stateSize, int nlhs, int npars, int neta, int neps, int ncov, int nsim, int cores, int nMtime, int extraCmt, int linB, int nLlik, int nIndSim, int numLinSens, int numLin, int nsub, double nallTotal, double ndosesTotal, double maxAllTimes, int stiff, int doIndLin, int indOwnAlloc);
+static SEXP _rxode2_rxMemoryComponents__try(SEXP neqSEXP, SEXP stateSizeSEXP, SEXP nlhsSEXP, SEXP nparsSEXP, SEXP netaSEXP, SEXP nepsSEXP, SEXP ncovSEXP, SEXP nsimSEXP, SEXP coresSEXP, SEXP nMtimeSEXP, SEXP extraCmtSEXP, SEXP linBSEXP, SEXP nLlikSEXP, SEXP nIndSimSEXP, SEXP numLinSensSEXP, SEXP numLinSEXP, SEXP nsubSEXP, SEXP nallTotalSEXP, SEXP ndosesTotalSEXP, SEXP maxAllTimesSEXP, SEXP stiffSEXP, SEXP doIndLinSEXP, SEXP indOwnAllocSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< int >::type neq(neqSEXP);
@@ -2371,18 +2371,20 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type numLin(numLinSEXP);
     Rcpp::traits::input_parameter< int >::type nsub(nsubSEXP);
     Rcpp::traits::input_parameter< double >::type nallTotal(nallTotalSEXP);
+    Rcpp::traits::input_parameter< double >::type ndosesTotal(ndosesTotalSEXP);
     Rcpp::traits::input_parameter< double >::type maxAllTimes(maxAllTimesSEXP);
     Rcpp::traits::input_parameter< int >::type stiff(stiffSEXP);
     Rcpp::traits::input_parameter< int >::type doIndLin(doIndLinSEXP);
-    rcpp_result_gen = Rcpp::wrap(rxMemoryComponents_(neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, maxAllTimes, stiff, doIndLin));
+    Rcpp::traits::input_parameter< int >::type indOwnAlloc(indOwnAllocSEXP);
+    rcpp_result_gen = Rcpp::wrap(rxMemoryComponents_(neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, ndosesTotal, maxAllTimes, stiff, doIndLin, indOwnAlloc));
     return rcpp_result_gen;
 END_RCPP_RETURN_ERROR
 }
-RcppExport SEXP _rxode2_rxMemoryComponents_(SEXP neqSEXP, SEXP stateSizeSEXP, SEXP nlhsSEXP, SEXP nparsSEXP, SEXP netaSEXP, SEXP nepsSEXP, SEXP ncovSEXP, SEXP nsimSEXP, SEXP coresSEXP, SEXP nMtimeSEXP, SEXP extraCmtSEXP, SEXP linBSEXP, SEXP nLlikSEXP, SEXP nIndSimSEXP, SEXP numLinSensSEXP, SEXP numLinSEXP, SEXP nsubSEXP, SEXP nallTotalSEXP, SEXP maxAllTimesSEXP, SEXP stiffSEXP, SEXP doIndLinSEXP) {
+RcppExport SEXP _rxode2_rxMemoryComponents_(SEXP neqSEXP, SEXP stateSizeSEXP, SEXP nlhsSEXP, SEXP nparsSEXP, SEXP netaSEXP, SEXP nepsSEXP, SEXP ncovSEXP, SEXP nsimSEXP, SEXP coresSEXP, SEXP nMtimeSEXP, SEXP extraCmtSEXP, SEXP linBSEXP, SEXP nLlikSEXP, SEXP nIndSimSEXP, SEXP numLinSensSEXP, SEXP numLinSEXP, SEXP nsubSEXP, SEXP nallTotalSEXP, SEXP ndosesTotalSEXP, SEXP maxAllTimesSEXP, SEXP stiffSEXP, SEXP doIndLinSEXP, SEXP indOwnAllocSEXP) {
     SEXP rcpp_result_gen;
     {
         Rcpp::RNGScope rcpp_rngScope_gen;
-        rcpp_result_gen = PROTECT(_rxode2_rxMemoryComponents__try(neqSEXP, stateSizeSEXP, nlhsSEXP, nparsSEXP, netaSEXP, nepsSEXP, ncovSEXP, nsimSEXP, coresSEXP, nMtimeSEXP, extraCmtSEXP, linBSEXP, nLlikSEXP, nIndSimSEXP, numLinSensSEXP, numLinSEXP, nsubSEXP, nallTotalSEXP, maxAllTimesSEXP, stiffSEXP, doIndLinSEXP));
+        rcpp_result_gen = PROTECT(_rxode2_rxMemoryComponents__try(neqSEXP, stateSizeSEXP, nlhsSEXP, nparsSEXP, netaSEXP, nepsSEXP, ncovSEXP, nsimSEXP, coresSEXP, nMtimeSEXP, extraCmtSEXP, linBSEXP, nLlikSEXP, nIndSimSEXP, numLinSensSEXP, numLinSEXP, nsubSEXP, nallTotalSEXP, ndosesTotalSEXP, maxAllTimesSEXP, stiffSEXP, doIndLinSEXP, indOwnAllocSEXP));
     }
     Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
     if (rcpp_isInterrupt_gen) {
@@ -3159,7 +3161,7 @@ static int _rxode2_RcppExport_validate(const char* sig) {
         signatures.insert("NumericVector(*rxInv)(SEXP)");
         signatures.insert("RObject(*rxSymInvChol)(RObject,Nullable<NumericVector>,std::string,int)");
         signatures.insert("RObject(*rxSymInvCholEnvCalculate)(List,std::string,Nullable<NumericVector>)");
-        signatures.insert("NumericVector(*rxMemoryComponents_)(int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,double,double,int,int)");
+        signatures.insert("NumericVector(*rxMemoryComponents_)(int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,double,double,double,int,int,int)");
         signatures.insert("SEXP(*rxSaveState_)()");
         signatures.insert("bool(*rxIsSerializeFile_)(SEXP)");
         signatures.insert("SEXP(*rxRestoreState_)(SEXP)");

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2349,8 +2349,8 @@ RcppExport SEXP _rxode2_rxSymInvCholEnvCalculate(SEXP objSEXP, SEXP whatSEXP, SE
     return rcpp_result_gen;
 }
 // rxMemoryComponents_
-NumericVector rxMemoryComponents_(int neq, int stateSize, int nlhs, int npars, int neta, int neps, int ncov, int nsim, int cores, int nMtime, int extraCmt, int linB, int nLlik, int nIndSim, int numLinSens, int numLin, int nsub, double nallTotal, double ndosesTotal, double maxAllTimes, int stiff, int doIndLin, int indOwnAlloc);
-static SEXP _rxode2_rxMemoryComponents__try(SEXP neqSEXP, SEXP stateSizeSEXP, SEXP nlhsSEXP, SEXP nparsSEXP, SEXP netaSEXP, SEXP nepsSEXP, SEXP ncovSEXP, SEXP nsimSEXP, SEXP coresSEXP, SEXP nMtimeSEXP, SEXP extraCmtSEXP, SEXP linBSEXP, SEXP nLlikSEXP, SEXP nIndSimSEXP, SEXP numLinSensSEXP, SEXP numLinSEXP, SEXP nsubSEXP, SEXP nallTotalSEXP, SEXP ndosesTotalSEXP, SEXP maxAllTimesSEXP, SEXP stiffSEXP, SEXP doIndLinSEXP, SEXP indOwnAllocSEXP) {
+NumericVector rxMemoryComponents_(int neq, int stateSize, int nlhs, int npars, int neta, int neps, int ncov, int nsim, int cores, int nMtime, int extraCmt, int linB, int nLlik, int nIndSim, int numLinSens, int numLin, int nsub, double nallTotal, double ndosesTotal, double maxAllTimes, int stiff, int doIndLin, int indOwnAlloc, int sample);
+static SEXP _rxode2_rxMemoryComponents__try(SEXP neqSEXP, SEXP stateSizeSEXP, SEXP nlhsSEXP, SEXP nparsSEXP, SEXP netaSEXP, SEXP nepsSEXP, SEXP ncovSEXP, SEXP nsimSEXP, SEXP coresSEXP, SEXP nMtimeSEXP, SEXP extraCmtSEXP, SEXP linBSEXP, SEXP nLlikSEXP, SEXP nIndSimSEXP, SEXP numLinSensSEXP, SEXP numLinSEXP, SEXP nsubSEXP, SEXP nallTotalSEXP, SEXP ndosesTotalSEXP, SEXP maxAllTimesSEXP, SEXP stiffSEXP, SEXP doIndLinSEXP, SEXP indOwnAllocSEXP, SEXP sampleSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< int >::type neq(neqSEXP);
@@ -2376,15 +2376,16 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type stiff(stiffSEXP);
     Rcpp::traits::input_parameter< int >::type doIndLin(doIndLinSEXP);
     Rcpp::traits::input_parameter< int >::type indOwnAlloc(indOwnAllocSEXP);
-    rcpp_result_gen = Rcpp::wrap(rxMemoryComponents_(neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, ndosesTotal, maxAllTimes, stiff, doIndLin, indOwnAlloc));
+    Rcpp::traits::input_parameter< int >::type sample(sampleSEXP);
+    rcpp_result_gen = Rcpp::wrap(rxMemoryComponents_(neq, stateSize, nlhs, npars, neta, neps, ncov, nsim, cores, nMtime, extraCmt, linB, nLlik, nIndSim, numLinSens, numLin, nsub, nallTotal, ndosesTotal, maxAllTimes, stiff, doIndLin, indOwnAlloc, sample));
     return rcpp_result_gen;
 END_RCPP_RETURN_ERROR
 }
-RcppExport SEXP _rxode2_rxMemoryComponents_(SEXP neqSEXP, SEXP stateSizeSEXP, SEXP nlhsSEXP, SEXP nparsSEXP, SEXP netaSEXP, SEXP nepsSEXP, SEXP ncovSEXP, SEXP nsimSEXP, SEXP coresSEXP, SEXP nMtimeSEXP, SEXP extraCmtSEXP, SEXP linBSEXP, SEXP nLlikSEXP, SEXP nIndSimSEXP, SEXP numLinSensSEXP, SEXP numLinSEXP, SEXP nsubSEXP, SEXP nallTotalSEXP, SEXP ndosesTotalSEXP, SEXP maxAllTimesSEXP, SEXP stiffSEXP, SEXP doIndLinSEXP, SEXP indOwnAllocSEXP) {
+RcppExport SEXP _rxode2_rxMemoryComponents_(SEXP neqSEXP, SEXP stateSizeSEXP, SEXP nlhsSEXP, SEXP nparsSEXP, SEXP netaSEXP, SEXP nepsSEXP, SEXP ncovSEXP, SEXP nsimSEXP, SEXP coresSEXP, SEXP nMtimeSEXP, SEXP extraCmtSEXP, SEXP linBSEXP, SEXP nLlikSEXP, SEXP nIndSimSEXP, SEXP numLinSensSEXP, SEXP numLinSEXP, SEXP nsubSEXP, SEXP nallTotalSEXP, SEXP ndosesTotalSEXP, SEXP maxAllTimesSEXP, SEXP stiffSEXP, SEXP doIndLinSEXP, SEXP indOwnAllocSEXP, SEXP sampleSEXP) {
     SEXP rcpp_result_gen;
     {
         Rcpp::RNGScope rcpp_rngScope_gen;
-        rcpp_result_gen = PROTECT(_rxode2_rxMemoryComponents__try(neqSEXP, stateSizeSEXP, nlhsSEXP, nparsSEXP, netaSEXP, nepsSEXP, ncovSEXP, nsimSEXP, coresSEXP, nMtimeSEXP, extraCmtSEXP, linBSEXP, nLlikSEXP, nIndSimSEXP, numLinSensSEXP, numLinSEXP, nsubSEXP, nallTotalSEXP, ndosesTotalSEXP, maxAllTimesSEXP, stiffSEXP, doIndLinSEXP, indOwnAllocSEXP));
+        rcpp_result_gen = PROTECT(_rxode2_rxMemoryComponents__try(neqSEXP, stateSizeSEXP, nlhsSEXP, nparsSEXP, netaSEXP, nepsSEXP, ncovSEXP, nsimSEXP, coresSEXP, nMtimeSEXP, extraCmtSEXP, linBSEXP, nLlikSEXP, nIndSimSEXP, numLinSensSEXP, numLinSEXP, nsubSEXP, nallTotalSEXP, ndosesTotalSEXP, maxAllTimesSEXP, stiffSEXP, doIndLinSEXP, indOwnAllocSEXP, sampleSEXP));
     }
     Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
     if (rcpp_isInterrupt_gen) {
@@ -3161,7 +3162,7 @@ static int _rxode2_RcppExport_validate(const char* sig) {
         signatures.insert("NumericVector(*rxInv)(SEXP)");
         signatures.insert("RObject(*rxSymInvChol)(RObject,Nullable<NumericVector>,std::string,int)");
         signatures.insert("RObject(*rxSymInvCholEnvCalculate)(List,std::string,Nullable<NumericVector>)");
-        signatures.insert("NumericVector(*rxMemoryComponents_)(int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,double,double,double,int,int,int)");
+        signatures.insert("NumericVector(*rxMemoryComponents_)(int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,double,double,double,int,int,int,int)");
         signatures.insert("SEXP(*rxSaveState_)()");
         signatures.insert("bool(*rxIsSerializeFile_)(SEXP)");
         signatures.insert("SEXP(*rxRestoreState_)(SEXP)");

--- a/src/init.c
+++ b/src/init.c
@@ -849,7 +849,7 @@ SEXP _rxode2_mexpit(SEXP p);
 SEXP _rxode2_dmexpit(SEXP p);
 SEXP _rxode2_mlogit_f(SEXP x, SEXP p);
 SEXP _rxode2_mlogit_j(SEXP x);
-SEXP _rxode2_rxMemoryComponents_(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
+SEXP _rxode2_rxMemoryComponents_(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
 SEXP _rxode2_rxRamBytes_(void);
 SEXP _rxode2_rxSolveSetCurObj_(SEXP);
 
@@ -1079,7 +1079,7 @@ void R_init_rxode2(DllInfo *info){
     {"_rxSetSeed", (DL_FUNC) _rxode2_rxSetSeed, 1},
     {"_rxode2_rxordSelect", (DL_FUNC) _rxode2_rxordSelect, 2},
     {"_rxode2_rxErf", (DL_FUNC) &_rxode2_rxErf, 1},
-    {"_rxode2_rxMemoryComponents_", (DL_FUNC) &_rxode2_rxMemoryComponents_, 24},
+    {"_rxode2_rxMemoryComponents_", (DL_FUNC) &_rxode2_rxMemoryComponents_, 25},
     {"_rxode2_rxRamBytes_", (DL_FUNC) &_rxode2_rxRamBytes_, 0},
     {"_rxode2_rxSaveState_", (DL_FUNC) _rxode2_rxSaveState_, 0},
     {"_rxode2_rxIsSerializeFile_", (DL_FUNC) _rxode2_rxIsSerializeFile_, 1},

--- a/src/init.c
+++ b/src/init.c
@@ -849,7 +849,7 @@ SEXP _rxode2_mexpit(SEXP p);
 SEXP _rxode2_dmexpit(SEXP p);
 SEXP _rxode2_mlogit_f(SEXP x, SEXP p);
 SEXP _rxode2_mlogit_j(SEXP x);
-SEXP _rxode2_rxMemoryComponents_(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
+SEXP _rxode2_rxMemoryComponents_(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
 SEXP _rxode2_rxRamBytes_(void);
 SEXP _rxode2_rxSolveSetCurObj_(SEXP);
 
@@ -1079,7 +1079,7 @@ void R_init_rxode2(DllInfo *info){
     {"_rxSetSeed", (DL_FUNC) _rxode2_rxSetSeed, 1},
     {"_rxode2_rxordSelect", (DL_FUNC) _rxode2_rxordSelect, 2},
     {"_rxode2_rxErf", (DL_FUNC) &_rxode2_rxErf, 1},
-    {"_rxode2_rxMemoryComponents_", (DL_FUNC) &_rxode2_rxMemoryComponents_, 21},
+    {"_rxode2_rxMemoryComponents_", (DL_FUNC) &_rxode2_rxMemoryComponents_, 23},
     {"_rxode2_rxRamBytes_", (DL_FUNC) &_rxode2_rxRamBytes_, 0},
     {"_rxode2_rxSaveState_", (DL_FUNC) _rxode2_rxSaveState_, 0},
     {"_rxode2_rxIsSerializeFile_", (DL_FUNC) _rxode2_rxIsSerializeFile_, 1},

--- a/src/init.c
+++ b/src/init.c
@@ -849,7 +849,7 @@ SEXP _rxode2_mexpit(SEXP p);
 SEXP _rxode2_dmexpit(SEXP p);
 SEXP _rxode2_mlogit_f(SEXP x, SEXP p);
 SEXP _rxode2_mlogit_j(SEXP x);
-SEXP _rxode2_rxMemoryComponents_(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
+SEXP _rxode2_rxMemoryComponents_(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
 SEXP _rxode2_rxRamBytes_(void);
 SEXP _rxode2_rxSolveSetCurObj_(SEXP);
 
@@ -1079,7 +1079,7 @@ void R_init_rxode2(DllInfo *info){
     {"_rxSetSeed", (DL_FUNC) _rxode2_rxSetSeed, 1},
     {"_rxode2_rxordSelect", (DL_FUNC) _rxode2_rxordSelect, 2},
     {"_rxode2_rxErf", (DL_FUNC) &_rxode2_rxErf, 1},
-    {"_rxode2_rxMemoryComponents_", (DL_FUNC) &_rxode2_rxMemoryComponents_, 23},
+    {"_rxode2_rxMemoryComponents_", (DL_FUNC) &_rxode2_rxMemoryComponents_, 24},
     {"_rxode2_rxRamBytes_", (DL_FUNC) &_rxode2_rxRamBytes_, 0},
     {"_rxode2_rxSaveState_", (DL_FUNC) _rxode2_rxSaveState_, 0},
     {"_rxode2_rxIsSerializeFile_", (DL_FUNC) _rxode2_rxIsSerializeFile_, 1},

--- a/src/rxMemoryComponents.cpp
+++ b/src/rxMemoryComponents.cpp
@@ -35,13 +35,16 @@ using namespace Rcpp;
 //' @param nIndSim   Per-individual simulation count (typically \code{neta+neps}).
 //' @param numLinSens Number of linear sensitivity parameters (FOCEi mixed models).
 //' @param numLin    Number of linear compartment terms (FOCEi mixed models).
-//' @param nsub      Number of subjects.
+//' @param nsub      Number of subjects in ONE simulation (\code{rx$nsub});
+//'   the total individual count is \code{nsub * nsim}.
 //' @param nallTotal Total events across all subjects (sum of obs + doses).
 //' @param ndosesTotal Total dose events across all subjects.
 //' @param maxAllTimes Maximum events for any single subject.
 //' @param indOwnAlloc 1 if every individual gets its own event/solve arrays
 //'   (\code{op$indOwnAlloc}), else 0.  These are allocated ON TOP of
 //'   \code{gsolve}, whose \code{n0} region then goes unused.
+//' @param sample 1 when \code{rxControl(resample=)} asks for covariate
+//'   resampling, which allocates \code{gSampleCov}; else 0.
 //' @param stiff     The solving method (\code{op$stiff}); only 3
 //'   (\code{"indLin"}) allocates anything extra here.
 //' @param doIndLin  Which matrix-exponential driver runs: 0 not a
@@ -76,7 +79,8 @@ NumericVector rxMemoryComponents_(
   double maxAllTimes,
   int    stiff,
   int    doIndLin,
-  int    indOwnAlloc)
+  int    indOwnAlloc,
+  int    sample)
 {
   rx_mem_layout _mem;
   rxFillMemLayout(
@@ -103,15 +107,26 @@ NumericVector rxMemoryComponents_(
   double b_gall_times  = 5.0  * nallTotal * sizeof(double);
   double b_gevid       = 3.0  * nallTotal * sizeof(int);
   double b_gcov        = (double)ncov * nallTotal * sizeof(double);
-  double b_gpars       = (double)npars * nsub * sizeof(double);
+  /* gpars is calloc'd at npars*max2(nsub, nPopPar) and inds_global at
+     nPopPar, where nPopPar = nsub*nsim -- both are sized by the TOTAL
+     individual count, not the per-simulation one. */
+  double b_gpars       = (double)npars * nsub * nsim * sizeof(double);
   double b_gomega      = (double)(2 * neta + neta * neta) * sizeof(double);
   double b_gsigma      = (double)(2 * neps + neps * neps) * sizeof(double);
   double b_gall_timesS = (nsim > 1)
                            ? 2.0 * (nsim - 1) * nallTotal * sizeof(double)
                            : 0.0;
-  double b_ordId       = nallTotal * sizeof(int);
-  double b_gInfRate    = (double)cores * (neq + extraCmt) * sizeof(double);
-  double b_inds        = (double)nsub  * sizeof(rx_solving_options_ind);
+  /* rx->ordId is the solve ORDER over individuals, not over events:
+     malloc(rx->nsub * rx->nsim * sizeof(int)) (src/rxData.cpp, where the local
+     is confusingly named `nall`). */
+  double b_ordId       = (double)nsub * nsim * sizeof(int);
+  /* the per-thread pointer table and its length array are allocated alongside
+     the per-thread infusion buffers themselves */
+  double b_gInfRate    = (double)cores * (neq + extraCmt) * sizeof(double) +
+    (double)cores * (sizeof(double*) + sizeof(int));
+  /* gSampleCov: only when rxControl(resample=) asks for it */
+  double b_gSampleCov  = sample ? (double)ncov * nsub * nsim * sizeof(int) : 0.0;
+  double b_inds        = (double)nsub * nsim * sizeof(rx_solving_options_ind);
 
   /* -- method="indLin" (src/expm.cpp) ---------------------------------------
    *
@@ -190,6 +205,7 @@ NumericVector rxMemoryComponents_(
     Named("indLinExpCache")= b_indLinCache,
     Named("indLinWork")    = b_indLinWork,
     Named("indOwnAlloc")   = b_indOwn,
+    Named("gSampleCov")    = b_gSampleCov,
     Named("sizeofInd")    = (double)sizeof(rx_solving_options_ind),
     Named("rxLlikSaveSize")= (double)rxLlikSaveSize);
 

--- a/src/rxMemoryComponents.cpp
+++ b/src/rxMemoryComponents.cpp
@@ -45,6 +45,11 @@ using namespace Rcpp;
 //'   \code{gsolve}, whose \code{n0} region then goes unused.
 //' @param sample 1 when \code{rxControl(resample=)} asks for covariate
 //'   resampling, which allocates \code{gSampleCov}; else 0.
+//' @param nDelayState Number of ODE states \code{delay()} looks back on
+//'   (\code{op$nDelayState}); 0 for a model without \code{delay()}.  Drives
+//'   the per-individual dense-history bound.
+//'   The \code{linCmtB(which1 = -3)} rate history is charged at
+//'   \code{numLin} wide, which is the width \code{linCmtBRateSlot()} uses.
 //' @param stiff     The solving method (\code{op$stiff}); only 3
 //'   (\code{"indLin"}) allocates anything extra here.
 //' @param doIndLin  Which matrix-exponential driver runs: 0 not a
@@ -80,7 +85,8 @@ NumericVector rxMemoryComponents_(
   int    stiff,
   int    doIndLin,
   int    indOwnAlloc,
-  int    sample)
+  int    sample,
+  int    nDelayState)
 {
   rx_mem_layout _mem;
   rxFillMemLayout(
@@ -188,6 +194,24 @@ NumericVector rxMemoryComponents_(
     b_indOwn = (double)_ia.dbl * sizeof(double) + (double)_ia.i32 * sizeof(int);
   }
 
+  /* -- per-individual history buffers (delay() and linCmtB rate history) -----
+   *
+   * Both grow by doubling inside the solve rather than being sized up front,
+   * so these are a documented BOUND rather than a mirror -- see
+   * rxDelayHistCap()/rxLinCmtRateHistCap() in inst/include/rxMemoryCalc.h.
+   * `maxAllTimes` is the busiest individual, so charging every individual at
+   * that capacity is the conservative reading.
+   */
+  double b_delayHist = 0.0;
+  double b_linRateHist = 0.0;
+  {
+    double nind = (double)nsub * nsim;
+    b_delayHist = nind *
+      (double)rxDelayHistCap((int64_t)maxAllTimes, nDelayState) * sizeof(double);
+    b_linRateHist = nind *
+      (double)rxLinCmtRateHistCap((int64_t)maxAllTimes, numLin) * sizeof(double);
+  }
+
   NumericVector out = NumericVector::create(
     Named("gsolve")        = (double)_mem.gsolve_total * sizeof(double),
     Named("gsolve_n0")     = (double)_mem.n0           * sizeof(double),
@@ -206,6 +230,8 @@ NumericVector rxMemoryComponents_(
     Named("indLinWork")    = b_indLinWork,
     Named("indOwnAlloc")   = b_indOwn,
     Named("gSampleCov")    = b_gSampleCov,
+    Named("delayHist")     = b_delayHist,
+    Named("linCmtRateHist")= b_linRateHist,
     Named("sizeofInd")    = (double)sizeof(rx_solving_options_ind),
     Named("rxLlikSaveSize")= (double)rxLlikSaveSize);
 

--- a/src/rxMemoryComponents.cpp
+++ b/src/rxMemoryComponents.cpp
@@ -56,6 +56,13 @@ using namespace Rcpp;
 //'   \code{matExp()} model, 1 pure matrix exponential, 2 plus a state-free
 //'   \code{indLin()} forcing, 3/4 true inductive linearization (the adaptive,
 //'   iterating driver).  These cost very different amounts.
+//' Not counted: a handful of fixed-size index tables whose sizes depend on
+//' values only the solver has (\code{gParPos}, the \code{gevid} tail holding
+//' \code{gpar_cov}/\code{glhs_str}, \code{gdelayCol}/\code{gdelayState},
+//' \code{gindLin}, \code{splitBolus}).  Each is tens to hundreds of ints and
+//' none scales with subjects or events, so they are left out rather than
+//' folded into a component whose scaling law is the useful part of it.
+//'
 //' @return Named numeric vector; each element is bytes for that allocation.
 //'   Also includes \code{sizeofInd} (bytes per \code{rx_solving_options_ind}
 //'   struct) and \code{rxLlikSaveSize} (the compile-time constant).
@@ -132,6 +139,12 @@ NumericVector rxMemoryComponents_(
     (double)cores * (sizeof(double*) + sizeof(int));
   /* gSampleCov: only when rxControl(resample=) asks for it */
   double b_gSampleCov  = sample ? (double)ncov * nsub * nsim * sizeof(int) : 0.0;
+  /* geta_pre_alloc (rxPreGenEta in src/rxthreefry.cpp): every individual's eta
+     draws generated up front, malloc(nsim*nsub*neta doubles), whenever the
+     model has etas and a nonzero omega */
+  double b_gEtaPre     = (neta > 0)
+    ? (double)nsub * nsim * neta * sizeof(double)
+    : 0.0;
   double b_inds        = (double)nsub * nsim * sizeof(rx_solving_options_ind);
 
   /* -- method="indLin" (src/expm.cpp) ---------------------------------------
@@ -230,6 +243,7 @@ NumericVector rxMemoryComponents_(
     Named("indLinWork")    = b_indLinWork,
     Named("indOwnAlloc")   = b_indOwn,
     Named("gSampleCov")    = b_gSampleCov,
+    Named("gEtaPre")       = b_gEtaPre,
     Named("delayHist")     = b_delayHist,
     Named("linCmtRateHist")= b_linRateHist,
     Named("sizeofInd")    = (double)sizeof(rx_solving_options_ind),

--- a/src/rxMemoryComponents.cpp
+++ b/src/rxMemoryComponents.cpp
@@ -37,7 +37,11 @@ using namespace Rcpp;
 //' @param numLin    Number of linear compartment terms (FOCEi mixed models).
 //' @param nsub      Number of subjects.
 //' @param nallTotal Total events across all subjects (sum of obs + doses).
+//' @param ndosesTotal Total dose events across all subjects.
 //' @param maxAllTimes Maximum events for any single subject.
+//' @param indOwnAlloc 1 if every individual gets its own event/solve arrays
+//'   (\code{op$indOwnAlloc}), else 0.  These are allocated ON TOP of
+//'   \code{gsolve}, whose \code{n0} region then goes unused.
 //' @param stiff     The solving method (\code{op$stiff}); only 3
 //'   (\code{"indLin"}) allocates anything extra here.
 //' @param doIndLin  Which matrix-exponential driver runs: 0 not a
@@ -68,9 +72,11 @@ NumericVector rxMemoryComponents_(
   int    numLin,
   int    nsub,
   double nallTotal,
+  double ndosesTotal,
   double maxAllTimes,
   int    stiff,
-  int    doIndLin)
+  int    doIndLin,
+  int    indOwnAlloc)
 {
   rx_mem_layout _mem;
   rxFillMemLayout(
@@ -152,6 +158,21 @@ NumericVector rxMemoryComponents_(
     b_indLinWork = (double)cores * (sq + vec) * sizeof(double);
   }
 
+  /* -- op->indOwnAlloc (rxAllocInd() in src/rxData.cpp) ----------------------
+   *
+   * Each individual gets its own event and solve arrays; gsolve is still
+   * calloc'd at gsolve_total, so this is memory on top of it rather than
+   * instead of it.  Zero for the ordinary case, where ind->solve just points
+   * into gsolve's n0 region.
+   */
+  double b_indOwn = 0.0;
+  if (indOwnAlloc) {
+    rx_ind_alloc _ia;
+    rxFillIndAllocTotal(neq, (int64_t)nallTotal, (int64_t)ndosesTotal,
+                        nsub, nsim, &_ia);
+    b_indOwn = (double)_ia.dbl * sizeof(double) + (double)_ia.i32 * sizeof(int);
+  }
+
   NumericVector out = NumericVector::create(
     Named("gsolve")        = (double)_mem.gsolve_total * sizeof(double),
     Named("gsolve_n0")     = (double)_mem.n0           * sizeof(double),
@@ -168,6 +189,7 @@ NumericVector rxMemoryComponents_(
     Named("inds_global")   = b_inds,
     Named("indLinExpCache")= b_indLinCache,
     Named("indLinWork")    = b_indLinWork,
+    Named("indOwnAlloc")   = b_indOwn,
     Named("sizeofInd")    = (double)sizeof(rx_solving_options_ind),
     Named("rxLlikSaveSize")= (double)rxLlikSaveSize);
 

--- a/tests/testthat/test-rxMemoryEstimate.R
+++ b/tests/testthat/test-rxMemoryEstimate.R
@@ -731,6 +731,22 @@ rxTest({
     expect_gt(as.numeric(.est(.memIl)$indLinWork), as.numeric(.pure$indLinWork))
   })
 
+  test_that("indLinWork matches the scratch formula exactly", {
+    # the sum-identity test below would pass with indLinWork stuck at 0, so pin
+    # the absolute bytes: cores * (sq + vec) * 8, with the fixed-grid driver
+    # holding meOnly()'s rate matrix and its augmented exponential (m = 2*neq
+    # for the state-free forcing) and the iterating one holding the Jacobian,
+    # P(h), its inverse, the ramp and the Richardson table
+    .neq <- length(rxModelVars(.memPure)$state)
+    .m <- .neq + 1                       # doIndLin 1: augmented while infusing
+    .e <- rxMemoryEstimate(.memEv, model = .memPure, control = rxControl(cores = 4L))
+    expect_equal(as.numeric(.e[["indLinWork"]]),
+                 4 * ((.neq * .neq + 2 * .m * .m) + 4 * .neq) * 8)
+    # and it is per thread
+    .e1 <- rxMemoryEstimate(.memEv, model = .memPure, control = rxControl(cores = 1L))
+    expect_equal(as.numeric(.e[["indLinWork"]]), 4 * as.numeric(.e1[["indLinWork"]]))
+  })
+
   test_that("the indLin estimate is per thread, not per subject", {
     .cache <- function(nc) {
       as.numeric(rxMemoryEstimate(.memEv, model = .memIl,

--- a/tests/testthat/test-rxMemoryEstimate.R
+++ b/tests/testthat/test-rxMemoryEstimate.R
@@ -536,6 +536,21 @@ rxTest({
     expect_equal(as.numeric(.on[["linCmtRateHist"]]), 2 * 128 * 3 * 8)
   })
 
+  test_that("gEtaPre charges the pre-generated eta draws", {
+    # rxPreGenEta() mallocs nsim*nsub*neta doubles up front whenever the model
+    # has etas and a nonzero omega
+    .s <- rxMemSummary(nobs = rep(100L, 4L), ndoses = rep(10L, 4L))
+    .none <- rxMemoryEstimate(.s, neq = 2L)
+    .om <- lotri::lotri(eta.ka ~ 0.09, eta.cl ~ 0.04)
+    .eta <- rxMemoryEstimate(.s, neq = 2L, control = rxControl(omega = .om))
+    expect_equal(as.numeric(.none[["gEtaPre"]]), 0)
+    expect_equal(as.numeric(.eta[["gEtaPre"]]), 4 * 1 * 2 * 8)
+    # and it follows the replicate count, like every other per-individual cost
+    .studs <- rxMemoryEstimate(.s, neq = 2L,
+                               control = rxControl(omega = .om, nStud = 10L))
+    expect_equal(as.numeric(.studs[["gEtaPre"]]), 10 * as.numeric(.eta[["gEtaPre"]]))
+  })
+
   test_that("rxMemoryEstimate accepts serialized state files and bundles", {
     skip_on_cran()
     .mod <- rxode2({

--- a/tests/testthat/test-rxMemoryEstimate.R
+++ b/tests/testthat/test-rxMemoryEstimate.R
@@ -315,7 +315,7 @@ rxTest({
         ncov = 0L, nsim = nsim, cores = 1L, nMtime = 0L, extraCmt = 0L, linB = 0L,
         nLlik = 0L, nIndSim = 0L, numLinSens = 0L, numLin = 0L, nsub = 1L,
         nallTotal = 110, ndosesTotal = 10, maxAllTimes = 110, stiff = -1L,
-        doIndLin = 0L, indOwnAlloc = 1L, sample = 0L)[["indOwnAlloc"]])
+        doIndLin = 0L, indOwnAlloc = 1L, sample = 0L, nDelayState = 0L)[["indOwnAlloc"]])
     }
     expect_equal(.c(3L), 3 * .c(1L))
   })
@@ -479,6 +479,11 @@ rxTest({
                              control = rxControl(resample = "WT"))
     expect_equal(as.numeric(.off[["gSampleCov"]]), 0)
     expect_equal(as.numeric(.on[["gSampleCov"]]), 3 * 4 * 1 * 4)
+    # ncov * nsub * nsim: with nsim left at 1 the nsim factor is invisible, so
+    # pin it with a replicate count too
+    .onStud <- rxMemoryEstimate(.s, neq = 2L, ncov = 3L,
+                                control = rxControl(resample = "WT", nStud = 10L))
+    expect_equal(as.numeric(.onStud[["gSampleCov"]]), 3 * 4 * 10 * 4)
   })
 
   test_that("huge event counts do not overflow to NA", {
@@ -488,6 +493,47 @@ rxTest({
     .e <- rxMemoryEstimate(.s, neq = 1L)
     expect_true(is.finite(as.numeric(.e[["total"]])))
     expect_gt(as.numeric(.e[["total"]]), 2^31)
+  })
+
+  test_that("delay() models are charged for the per-individual dense history", {
+    .dde <- rxode2({
+      d/dt(a) <- -a * delay(a, 1)
+    })
+    .ode <- rxode2({
+      d/dt(a) <- -a * a
+    })
+    expect_equal(rxModelVars(.dde)$flags[["hasDelay"]], 1L)
+    expect_equal(rxModelVars(.ode)$flags[["hasDelay"]], 0L)
+    expect_equal(.rxMemNDelayState(rxModelVars(.dde)), 1L)
+    expect_equal(.rxMemNDelayState(rxModelVars(.ode)), 0L)
+
+    .s <- rxMemSummary(nobs = rep(100L, 3L), ndoses = rep(10L, 3L))
+    .eD <- rxMemoryEstimate(.s, model = .dde)
+    .eO <- rxMemoryEstimate(.s, model = .ode)
+    expect_equal(as.numeric(.eO[["delayHist"]]), 0)
+    # a bound, not a mirror: capacity doubles from 256 to at least the busiest
+    # individual's event count, stride 8*nDelayState+3, once per individual
+    expect_equal(as.numeric(.eD[["delayHist"]]), 3 * 256 * (8 * 1 + 3) * 8)
+    expect_gt(as.numeric(.eD[["total"]]), as.numeric(.eO[["total"]]))
+  })
+
+  test_that("the delay history bound follows the doubling past 256", {
+    # 300 events per individual pushes the capacity to the next power of two
+    .s <- rxMemSummary(nobs = 290L, ndoses = 10L)
+    .dde <- rxode2({
+      d/dt(a) <- -a * delay(a, 1)
+    })
+    .e <- rxMemoryEstimate(.s, model = .dde)
+    expect_equal(as.numeric(.e[["delayHist"]]), 512 * (8 * 1 + 3) * 8)
+  })
+
+  test_that("linCmtRateHist is charged at numLin wide, and only when numLin > 0", {
+    .s <- rxMemSummary(nobs = rep(100L, 2L), ndoses = rep(10L, 2L))
+    .off <- rxMemoryEstimate(.s, neq = 2L)
+    .on  <- rxMemoryEstimate(.s, neq = 2L, numLin = 3L)
+    expect_equal(as.numeric(.off[["linCmtRateHist"]]), 0)
+    # capacity doubles from 64 to at least 110 -> 128, width numLin
+    expect_equal(as.numeric(.on[["linCmtRateHist"]]), 2 * 128 * 3 * 8)
   })
 
   test_that("rxMemoryEstimate accepts serialized state files and bundles", {
@@ -700,7 +746,7 @@ rxTest({
         ncov = 0L, nsim = 1L, cores = 4L, nMtime = 0L, extraCmt = 0L, linB = 0L,
         nLlik = 0L, nIndSim = 0L, numLinSens = 0L, numLin = 0L, nsub = 10L,
         nallTotal = 100, ndosesTotal = 10, maxAllTimes = 10, stiff = 3L,
-        doIndLin = doIndLin, indOwnAlloc = 0L, sample = 0L)[["indLinExpCache"]])
+        doIndLin = doIndLin, indOwnAlloc = 0L, sample = 0L, nDelayState = 0L)[["indLinExpCache"]])
     }
     expect_gt(.cache(42L, 3L), .cache(10L, 3L))   # 3*42 = 126, still cached
     expect_lt(.cache(43L, 3L), .cache(42L, 3L))   # 3*43 = 129, over the cap

--- a/tests/testthat/test-rxMemoryEstimate.R
+++ b/tests/testthat/test-rxMemoryEstimate.R
@@ -124,7 +124,9 @@ rxTest({
 
     expect_lt(as.numeric(.grouped$gall_times), as.numeric(.expanded$gall_times))
     expect_lt(as.numeric(.grouped$gevid), as.numeric(.expanded$gevid))
-    expect_lt(as.numeric(.grouped$ordId), as.numeric(.expanded$ordId))
+    # ordId is the solve order over INDIVIDUALS, so grouping -- which shares
+    # event storage, not subjects -- leaves it alone
+    expect_equal(as.numeric(.grouped$ordId), as.numeric(.expanded$ordId))
     expect_equal(as.numeric(.grouped$outputData), as.numeric(.expanded$outputData))
   })
 
@@ -139,7 +141,9 @@ rxTest({
 
     expect_lt(as.numeric(.grouped$gall_times), as.numeric(.expanded$gall_times))
     expect_lt(as.numeric(.grouped$gevid), as.numeric(.expanded$gevid))
-    expect_lt(as.numeric(.grouped$ordId), as.numeric(.expanded$ordId))
+    # ordId is the solve order over INDIVIDUALS, so grouping -- which shares
+    # event storage, not subjects -- leaves it alone
+    expect_equal(as.numeric(.grouped$ordId), as.numeric(.expanded$ordId))
   })
 
   test_that("grouped dose-only rxEt with iCov keep stays compressed in memory estimate", {
@@ -160,7 +164,9 @@ rxTest({
 
     expect_lt(as.numeric(.grouped$gall_times), as.numeric(.expanded$gall_times))
     expect_lt(as.numeric(.grouped$gevid), as.numeric(.expanded$gevid))
-    expect_lt(as.numeric(.grouped$ordId), as.numeric(.expanded$ordId))
+    # ordId is the solve order over INDIVIDUALS, so grouping -- which shares
+    # event storage, not subjects -- leaves it alone
+    expect_equal(as.numeric(.grouped$ordId), as.numeric(.expanded$ordId))
     expect_equal(as.numeric(.grouped$outputData), as.numeric(.expanded$outputData))
   })
 
@@ -309,7 +315,7 @@ rxTest({
         ncov = 0L, nsim = nsim, cores = 1L, nMtime = 0L, extraCmt = 0L, linB = 0L,
         nLlik = 0L, nIndSim = 0L, numLinSens = 0L, numLin = 0L, nsub = 1L,
         nallTotal = 110, ndosesTotal = 10, maxAllTimes = 110, stiff = -1L,
-        doIndLin = 0L, indOwnAlloc = 1L)[["indOwnAlloc"]])
+        doIndLin = 0L, indOwnAlloc = 1L, sample = 0L)[["indOwnAlloc"]])
     }
     expect_equal(.c(3L), 3 * .c(1L))
   })
@@ -405,6 +411,83 @@ rxTest({
     .est  <- rxMemoryEstimate(.s, neq = 2L, control = .ctrl)
     expect_equal(.est$effectiveSubs, 100L)
     expect_gt(.est$total, .base$total)
+  })
+
+  test_that("event-indexed buffers scale with nSub/nStud/nsim", {
+    # `nsub`/`nsim` mean to the components what they mean in rxData.cpp: nSub
+    # replicates subjects WITHIN a simulation, so it grows rx->nall (and with
+    # it gall_times/gevid); nStud replicates the simulation, so it grows n0 and
+    # the extra-sim copies in gall_timesS instead.  Either way the ODE state
+    # matrix has to grow -- it did not before, by a factor of the replicate
+    # count, which is the direction that makes the OOM guard useless.
+    .s <- rxMemSummary(nobs = 100L, ndoses = 10L)          # 1 subject, 110 events
+    .b <- rxMemoryEstimate(.s, neq = 2L)
+    .g <- function(ctrl) rxMemoryEstimate(.s, neq = 2L, control = ctrl)
+    .nStud <- .g(rxControl(nStud = 100L))
+    .nSub  <- .g(rxControl(nSub = 100L))
+    .nsim  <- .g(rxControl(nsim = 100L))
+
+    for (.e in list(.nStud, .nSub, .nsim)) {
+      expect_equal(as.integer(.e[["effectiveSubs"]]), 100L)
+      # the ODE state output matrix is 100 individuals' worth in every form
+      expect_equal(as.numeric(.e[["gsolve_n0"]]),
+                   100 * as.numeric(.b[["gsolve_n0"]]))
+      # so are the per-individual arrays
+      expect_equal(as.numeric(.e[["gpars"]]), 100 * as.numeric(.b[["gpars"]]))
+      expect_equal(as.numeric(.e[["inds_global"]]),
+                   100 * as.numeric(.b[["inds_global"]]))
+      expect_equal(as.numeric(.e[["ordId"]]), 100 * as.numeric(.b[["ordId"]]))
+    }
+
+    # nSub grows the event table of one simulation ...
+    expect_equal(as.numeric(.nSub[["gall_times"]]),
+                 100 * as.numeric(.b[["gall_times"]]))
+    expect_equal(as.numeric(.nSub[["gevid"]]), 100 * as.numeric(.b[["gevid"]]))
+    expect_equal(as.numeric(.nSub[["gall_timesS"]]), 0)
+    # ... while nStud leaves it alone and pays for the replicates in
+    # gall_timesS, which is malloc(2*(nsim-1)*nall) in rxData.cpp
+    expect_equal(as.numeric(.nStud[["gall_times"]]),
+                 as.numeric(.b[["gall_times"]]))
+    expect_equal(as.numeric(.nStud[["gall_timesS"]]), 2 * 99 * 110 * 8)
+    # rxControl(nsim=) is just the nStud form spelled differently
+    expect_equal(as.numeric(.nsim[["total"]]), as.numeric(.nStud[["total"]]))
+  })
+
+  test_that("nSub and nStud compose", {
+    .s <- rxMemSummary(nobs = rep(100L, 5L), ndoses = rep(10L, 5L))
+    .e <- rxMemoryEstimate(.s, neq = 2L, control = rxControl(nSub = 10L, nStud = 5L))
+    .b <- rxMemoryEstimate(.s, neq = 2L)
+    expect_equal(as.integer(.e[["effectiveSubs"]]), 50L)
+    # 50 individuals against the data's 5
+    expect_equal(as.numeric(.e[["gsolve_n0"]]), 10 * as.numeric(.b[["gsolve_n0"]]))
+    expect_equal(as.numeric(.e[["inds_global"]]), 10 * as.numeric(.b[["inds_global"]]))
+    # 10 subjects per simulation against the data's 5
+    expect_equal(as.numeric(.e[["gall_times"]]), 2 * as.numeric(.b[["gall_times"]]))
+  })
+
+  test_that("ordId is sized by individuals, not events", {
+    # rxData.cpp: malloc(rx->nsub * rx->nsim * sizeof(int))
+    .s <- rxMemSummary(nobs = rep(100L, 7L), ndoses = rep(10L, 7L))
+    .e <- rxMemoryEstimate(.s, neq = 2L)
+    expect_equal(as.numeric(.e[["ordId"]]), 7 * 4)
+  })
+
+  test_that("gSampleCov is charged only when resample asks for it", {
+    .s <- rxMemSummary(nobs = rep(100L, 4L), ndoses = rep(10L, 4L))
+    .off <- rxMemoryEstimate(.s, neq = 2L, ncov = 3L)
+    .on  <- rxMemoryEstimate(.s, neq = 2L, ncov = 3L,
+                             control = rxControl(resample = "WT"))
+    expect_equal(as.numeric(.off[["gSampleCov"]]), 0)
+    expect_equal(as.numeric(.on[["gSampleCov"]]), 3 * 4 * 1 * 4)
+  })
+
+  test_that("huge event counts do not overflow to NA", {
+    # integer sum() returns NA past 2^31, and a solve that big is exactly the
+    # one this estimate exists to size
+    .s <- rxMemSummary(nobs = rep(0L, 4L), ndoses = rep(1073741824L, 4L))
+    .e <- rxMemoryEstimate(.s, neq = 1L)
+    expect_true(is.finite(as.numeric(.e[["total"]])))
+    expect_gt(as.numeric(.e[["total"]]), 2^31)
   })
 
   test_that("rxMemoryEstimate accepts serialized state files and bundles", {
@@ -617,7 +700,7 @@ rxTest({
         ncov = 0L, nsim = 1L, cores = 4L, nMtime = 0L, extraCmt = 0L, linB = 0L,
         nLlik = 0L, nIndSim = 0L, numLinSens = 0L, numLin = 0L, nsub = 10L,
         nallTotal = 100, ndosesTotal = 10, maxAllTimes = 10, stiff = 3L,
-        doIndLin = doIndLin, indOwnAlloc = 0L)[["indLinExpCache"]])
+        doIndLin = doIndLin, indOwnAlloc = 0L, sample = 0L)[["indLinExpCache"]])
     }
     expect_gt(.cache(42L, 3L), .cache(10L, 3L))   # 3*42 = 126, still cached
     expect_lt(.cache(43L, 3L), .cache(42L, 3L))   # 3*43 = 129, over the cap

--- a/tests/testthat/test-rxMemoryEstimate.R
+++ b/tests/testthat/test-rxMemoryEstimate.R
@@ -30,15 +30,17 @@ rxTest({
   test_that("gsolve_n0 is reported but not double-counted in total", {
     .s   <- rxMemSummary(nobs = 100L, ndoses = 20L)
     .est <- rxMemoryEstimate(.s, neq = 2L, nlhs = 1L, npars = 3L)
-    # still visible ...
+    # `[[` throughout: `$` partial-matches, so a missing `gsolve` would
+    # silently resolve to `gsolve_n0` and the comparison would pass vacuously
     expect_true("gsolve_n0" %in% names(.est))
-    expect_gt(as.numeric(.est$gsolve_n0), 0)
+    expect_true("gsolve" %in% names(.est))
+    expect_gt(as.numeric(.est[["gsolve_n0"]]), 0)
     # ... and genuinely a piece of gsolve, not a sibling of it
-    expect_lte(as.numeric(.est$gsolve_n0), as.numeric(.est$gsolve))
+    expect_lt(as.numeric(.est[["gsolve_n0"]]), as.numeric(.est[["gsolve"]]))
     # summing every reported element would exceed total by exactly n0
     .meta <- c("total", "sizeofInd", "rxLlikSaveSize", "ramBytes", "freeRamBytes", "effectiveSubs")
     .all  <- sum(vapply(.est[!names(.est) %in% .meta], as.numeric, numeric(1)))
-    expect_equal(.all - as.numeric(.est$gsolve_n0), as.numeric(.est$total))
+    expect_equal(.all - as.numeric(.est[["gsolve_n0"]]), as.numeric(.est[["total"]]))
   })
 
   test_that("every sub-item is smaller than the component it belongs to", {
@@ -48,7 +50,7 @@ rxTest({
       expect_true(.sub %in% names(.est))
       expect_true(.rxMemSubItems[[.sub]] %in% names(.est))
       expect_lte(as.numeric(.est[[.sub]]),
-                 as.numeric(.est[[.rxMemSubItems[[.sub]]]]))
+                 as.numeric(.est[[unname(.rxMemSubItems[[.sub]])]]))
     }
   })
 
@@ -218,10 +220,98 @@ rxTest({
     expect_length(.iN, 1L)
     # the sub-item is printed on the line directly below its parent
     expect_equal(.iN, .iG + 1L)
-    # percentages are a share of `total`, so the non-sub-item lines sum to 100
-    .pct <- as.numeric(sub(".*\\(\\s*([0-9.]+)%\\).*", "\\1",
-                         grep("%\\)", .out[-.iN], value = TRUE)))
-    expect_equal(sum(.pct), 100, tolerance = 0.5)
+    .pctOf <- function(lines) {
+      as.numeric(sub(".*\\(\\s*([0-9.]+)%\\).*", "\\1",
+                     grep("%\\)", lines, value = TRUE)))
+    }
+    # the percentage base excludes sub-items, so the non-sub-item lines sum to 100
+    expect_equal(sum(.pctOf(.out[-.iN])), 100, tolerance = 0.5)
+    # and the sub-item still shows a percentage -- its own share of `total`,
+    # which is what makes it readable as a piece of its parent
+    .n0pct <- .pctOf(.out[.iN])
+    expect_length(.n0pct, 1L)
+    expect_equal(.n0pct,
+                 100 * as.numeric(.est[["gsolve_n0"]]) / as.numeric(.est[["total"]]),
+                 tolerance = 0.05)
+  })
+
+  test_that("indOwnAlloc per-individual arrays are counted, and only when on", {
+    # bolus() sets the evid_ parser flag, which is what rxSolve() defaults
+    # op->indOwnAlloc to -- so the MODEL turns this on, not the method
+    .push <- rxode2({
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      if (t > 10 && cp < 1) {
+        bolus(100, 1, 0, 0, 0)
+      }
+    })
+    .plain <- rxode2({
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+    })
+    expect_equal(rxModelVars(.push)$flags[["evid_"]], 1L)
+    expect_equal(rxModelVars(.plain)$flags[["evid_"]], 0L)
+
+    .s <- rxMemSummary(nobs = 200L, ndoses = 20L)
+    .ePush <- rxMemoryEstimate(.s, model = .push)
+    .ePlain <- rxMemoryEstimate(.s, model = .plain)
+
+    # a plain model points ind->solve into gsolve's n0 region: nothing extra
+    expect_equal(as.numeric(.ePlain[["indOwnAlloc"]]), 0)
+    # a dose-pushing model callocs per-individual arrays ON TOP of gsolve
+    expect_gt(as.numeric(.ePush[["indOwnAlloc"]]), 0)
+
+    # exactly what rxAllocInd() callocs: neq*(nat+EVID_EXTRA_SIZE) doubles for
+    # solve, 4*(nat+1) doubles for dose/ii/all_times/timeThread, 2*(nat+1) ints
+    # for evid/ix, and (nd+1) ints for idose
+    .neq <- 2; .nat <- 220; .nd <- 20
+    expect_equal(as.numeric(.ePush[["indOwnAlloc"]]),
+                 .neq * (.nat + 16) * 8 + 4 * (.nat + 1) * 8 +
+                   2 * (.nat + 1) * 4 + (.nd + 1) * 4)
+  })
+
+  test_that("control$indOwnAlloc overrides the model's evid_ flag", {
+    .plain <- rxode2({
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+    })
+    .s <- rxMemSummary(nobs = 200L, ndoses = 20L)
+    .off <- rxMemoryEstimate(.s, model = .plain,
+                             control = rxControl(indOwnAlloc = FALSE))
+    .on  <- rxMemoryEstimate(.s, model = .plain,
+                             control = rxControl(indOwnAlloc = TRUE))
+    .dflt <- rxMemoryEstimate(.s, model = .plain,
+                              control = rxControl(indOwnAlloc = NA))
+    expect_equal(as.numeric(.off[["indOwnAlloc"]]), 0)
+    expect_gt(as.numeric(.on[["indOwnAlloc"]]), 0)
+    # NA means "let the model decide", and this model says no
+    expect_equal(as.numeric(.dflt[["indOwnAlloc"]]), 0)
+    # and it moves `total`, which is the whole point -- the OOM guard reads it
+    expect_gt(as.numeric(.on[["total"]]), as.numeric(.off[["total"]]))
+  })
+
+  test_that("indOwnAlloc scales with subjects and simulations", {
+    .b <- function(nsub) {
+      .s <- rxMemSummary(nobs = rep(100L, nsub), ndoses = rep(10L, nsub))
+      as.numeric(rxMemoryEstimate(.s, neq = 2L,
+                                  control = rxControl(indOwnAlloc = TRUE))[["indOwnAlloc"]])
+    }
+    expect_equal(.b(4L), 4 * .b(1L))
+
+    # nsim at the component level, where it is unambiguously the simulation
+    # count (rxControl(nsim=) also sets nStud, which rescales nsub)
+    .c <- function(nsim) {
+      unname(rxMemoryComponents_(
+        neq = 2L, stateSize = 2L, nlhs = 0L, npars = 2L, neta = 0L, neps = 0L,
+        ncov = 0L, nsim = nsim, cores = 1L, nMtime = 0L, extraCmt = 0L, linB = 0L,
+        nLlik = 0L, nIndSim = 0L, numLinSens = 0L, numLin = 0L, nsub = 1L,
+        nallTotal = 110, ndosesTotal = 10, maxAllTimes = 110, stiff = -1L,
+        doIndLin = 0L, indOwnAlloc = 1L)[["indOwnAlloc"]])
+    }
+    expect_equal(.c(3L), 3 * .c(1L))
   })
 
   test_that("rxMemoryEstimate scales with subject count", {
@@ -526,8 +616,8 @@ rxTest({
         neq = neq, stateSize = neq, nlhs = 0L, npars = neq, neta = 0L, neps = 0L,
         ncov = 0L, nsim = 1L, cores = 4L, nMtime = 0L, extraCmt = 0L, linB = 0L,
         nLlik = 0L, nIndSim = 0L, numLinSens = 0L, numLin = 0L, nsub = 10L,
-        nallTotal = 100, maxAllTimes = 10, stiff = 3L,
-        doIndLin = doIndLin)[["indLinExpCache"]])
+        nallTotal = 100, ndosesTotal = 10, maxAllTimes = 10, stiff = 3L,
+        doIndLin = doIndLin, indOwnAlloc = 0L)[["indLinExpCache"]])
     }
     expect_gt(.cache(42L, 3L), .cache(10L, 3L))   # 3*42 = 126, still cached
     expect_lt(.cache(43L, 3L), .cache(42L, 3L))   # 3*43 = 129, over the cap

--- a/tests/testthat/test-rxMemoryEstimate.R
+++ b/tests/testthat/test-rxMemoryEstimate.R
@@ -19,12 +19,37 @@ rxTest({
     expect_s3_class(.est, "rxMemoryEstimate")
   })
 
-  test_that("rxMemoryEstimate total equals sum of components", {
+  test_that("rxMemoryEstimate total equals the bytes actually allocated", {
     .s     <- rxMemSummary(nobs = 100L, ndoses = 20L)
     .est   <- rxMemoryEstimate(.s, neq = 2L, nlhs = 1L, npars = 3L)
     .meta  <- c("total", "sizeofInd", "rxLlikSaveSize", "ramBytes", "freeRamBytes", "effectiveSubs")
-    .comps <- .est[!names(.est) %in% .meta]
+    .comps <- .est[!names(.est) %in% c(.meta, names(.rxMemSubItems))]
     expect_equal(as.numeric(.est$total), sum(vapply(.comps, as.numeric, numeric(1))))
+  })
+
+  test_that("gsolve_n0 is reported but not double-counted in total", {
+    .s   <- rxMemSummary(nobs = 100L, ndoses = 20L)
+    .est <- rxMemoryEstimate(.s, neq = 2L, nlhs = 1L, npars = 3L)
+    # still visible ...
+    expect_true("gsolve_n0" %in% names(.est))
+    expect_gt(as.numeric(.est$gsolve_n0), 0)
+    # ... and genuinely a piece of gsolve, not a sibling of it
+    expect_lte(as.numeric(.est$gsolve_n0), as.numeric(.est$gsolve))
+    # summing every reported element would exceed total by exactly n0
+    .meta <- c("total", "sizeofInd", "rxLlikSaveSize", "ramBytes", "freeRamBytes", "effectiveSubs")
+    .all  <- sum(vapply(.est[!names(.est) %in% .meta], as.numeric, numeric(1)))
+    expect_equal(.all - as.numeric(.est$gsolve_n0), as.numeric(.est$total))
+  })
+
+  test_that("every sub-item is smaller than the component it belongs to", {
+    .s   <- rxMemSummary(nobs = 100L, ndoses = 20L)
+    .est <- rxMemoryEstimate(.s, neq = 2L, nlhs = 1L, npars = 3L)
+    for (.sub in names(.rxMemSubItems)) {
+      expect_true(.sub %in% names(.est))
+      expect_true(.rxMemSubItems[[.sub]] %in% names(.est))
+      expect_lte(as.numeric(.est[[.sub]]),
+                 as.numeric(.est[[.rxMemSubItems[[.sub]]]]))
+    }
   })
 
   test_that(".getRamBytes()/.getFreeRamBytes() query RAM natively", {
@@ -181,6 +206,22 @@ rxTest({
     if (!is.na(.est$freeRamBytes) && .est$freeRamBytes > 0) {
       expect_output(print(.est), "available memory")
     }
+  })
+
+  test_that("print.rxMemoryEstimate keeps n0 under gsolve and percents to 100", {
+    .s   <- rxMemSummary(nobs = 500L, ndoses = 50L)
+    .est <- rxMemoryEstimate(.s, neq = 3L, nlhs = 2L, npars = 4L)
+    .out <- utils::capture.output(print(.est))
+    .iG  <- grep("gsolve \\(double buffer total\\)", .out, fixed = FALSE)
+    .iN  <- grep("|_ n0:", .out, fixed = TRUE)
+    expect_length(.iG, 1L)
+    expect_length(.iN, 1L)
+    # the sub-item is printed on the line directly below its parent
+    expect_equal(.iN, .iG + 1L)
+    # percentages are a share of `total`, so the non-sub-item lines sum to 100
+    .pct <- as.numeric(sub(".*\\(\\s*([0-9.]+)%\\).*", "\\1",
+                         grep("%\\)", .out[-.iN], value = TRUE)))
+    expect_equal(sum(.pct), 100, tolerance = 0.5)
   })
 
   test_that("rxMemoryEstimate scales with subject count", {
@@ -469,7 +510,7 @@ rxTest({
     .e <- rxMemoryEstimate(.memEv, model = .memIl, control = rxControl(cores = 4L))
     .meta <- c("total", "sizeofInd", "rxLlikSaveSize", "ramBytes", "freeRamBytes",
                "effectiveSubs")
-    .comps <- .e[!names(.e) %in% .meta]
+    .comps <- .e[!names(.e) %in% c(.meta, names(.rxMemSubItems))]
     expect_true("indLinExpCache" %in% names(.comps))
     expect_true("indLinWork" %in% names(.comps))
     expect_equal(as.numeric(.e$total),


### PR DESCRIPTION
Fixes #1241.

## The reported bug

`gsolve_n0` is a *slice* of `gsolve`, not a sibling allocation: `rxFillMemLayout()`
adds `n0` into `gsolve_total`, and `src/rxData.cpp:7091` callocs that as one buffer
with `gLin = gsolve + n0`. But `rxMemoryEstimate()` summed every non-meta element
into `total`, so the single largest allocation of an ordinary solve was counted
twice and `total` could approach double the real figure.

`total` now means **bytes actually allocated**. Sub-items are excluded from the sum
via a new `.rxMemSubItems` map, the way `sizeofInd`/`rxLlikSaveSize` already were.
`gsolve_n0` is still reported and still printed -- now pinned directly under
`gsolve` rather than landing wherever the size ranking put it, which had made its
`|_` indent misleading -- and it is left out of the percentage base so the printed
shares add to 100.

## Five more defects in the same number

`total` is not just reported: `R/rxsolve.R` refuses a solve when it exceeds 90% of
free RAM, and `.rxOomChunkSize()` divides it by the subject count. Reviewing this
change turned up five further ways it disagreed with what `src/rxData.cpp` actually
allocates. All are fixed here.

| Defect | Direction | Magnitude |
|---|---|---|
| `gsolve_n0` double-counted (**the issue**) | over | up to ~2x |
| `indOwnAlloc` per-individual arrays uncounted | under | largest line for `bolus()`/`obs()` models |
| `nSub`/`nStud`/`nsim` never scaled the event buffers | under | full replicate factor -- 100x at `nSub=100` |
| `ordId` sized by events instead of individuals | over | events-per-subject |
| `gEtaPre`, `gSampleCov`, `delayHist`, `linCmtRateHist`, `gInfusionRate` pointer table | under | material for eta / DDE / linCmtB models |
| integer `sum()` past 2^31 events | `NA`, then a hard error | fatal |

Notes on the two largest:

- **`indOwnAlloc`.** When `op->indOwnAlloc` is set, `rxAllocInd()` gives every
  individual its own `dose`/`ii`/`all_times`/`timeThread`/`evid`/`ix`/`idose`/`solve`
  arrays, and `gsolve` is *still* calloc'd at full size regardless -- so those arrays
  are memory on top of it, and its `n0` region simply goes unused. This is not an
  exotic setting: it defaults to the model's `evid_` parser flag, so any dose-pushing
  model (`bolus()`, `obs()`) has it on. `rxFillIndAllocTotal()` in
  `inst/include/rxMemoryCalc.h` mirrors `rxAllocInd()` element for element.

- **`nSub`/`nStud`.** The replicated subject count was applied to the subject total
  but never to the event total, so `rxControl(nSub = 100)` on a one-subject table
  reported the *one-subject* `gsolve_n0`. `nsub` and `nsim` now carry the meaning
  they have in `rxData.cpp` -- `nsub` is the subjects of one simulation, `nsim` is
  how many times that block is replicated (`rx->nsim = nPopPar / rx->nsub`) -- so
  `nStud` lands in `nsim`, where it also correctly pays for the extra-simulation
  copies in `gall_timesS` (`malloc(2*(nsim-1)*nall)`), and `nSub` grows the events
  of a single simulation. `effectiveSubs` still reports the total individual count.

## Two judgment calls worth a reviewer's eye

- **`delayHist`/`linCmtRateHist` are a bound, not a mirror.** Both grow by *doubling*
  inside the solve (`delayHistCap` starts at 256, doubles per stored dense step), and
  how many steps a solve takes depends on stiffness and tolerances -- nothing known
  beforehand. So `rxDelayHistCap()`/`rxLinCmtRateHistCap()` return a documented bound:
  the capacity the doubling reaches at roughly one stored step per event, floored at
  the initial allocation. Rounding up is deliberate. Both are zero for a model using
  neither feature.

- **Trivial index tables stay uncounted, but are now said out loud.** `gParPos`, the
  `gevid` tail holding `gpar_cov`/`glhs_str`, `gdelayCol`/`gdelayState`, `gindLin` and
  `splitBolus` are each tens to hundreds of ints and none scales with subjects or
  events. I tried folding the two I can compute exactly into `gpars` and `delayHist`
  and backed it out -- it cost those components the clean scaling law that is the
  useful thing about them (`gpars` stopped being a pure multiple of the individual
  count), a bad trade for a hundred bytes. The omission is documented in the
  `rxMemoryComponents_` docs rather than left silent.

## Compatibility

`rxMemoryComponents_()` is internal (`@noRd`, not in NAMESPACE, not in the
`_rxode2_rxode2Ptr()` table); its arity went 21 -> 25, with `src/init.c` hand-updated
alongside `Rcpp::compileAttributes()` as `CLAUDE.md` requires. No exported signature,
`$predDf`/`$iniDf` schema, or pointer-table slot changed.

## Testing

- Full suite from a wiped `src/`: **0 failures**, 5 skips, 33 warnings (all
  pre-existing -- `arrow`/tidyselect deprecations, `ar()` simulation notices,
  snapshot creation).
- `test-rxMemoryEstimate.R` goes from ~40 to 172 tests, pinning exact byte formulas
  and scaling laws rather than only proportionality.
- Three grouped-event-table assertions that `ordId` shrinks under compression were
  updated: that only held because of the `ordId` bug, and grouping shares event
  storage, not subjects.
- `outputData` was checked against `object.size()` on a 200-subject solve and matches
  to the byte (2.43 MB); a chunked solve still round-trips 67400 rows.

Reviewed across five rounds with Antigravity (Gemini) for independence; the last
round found nothing in the code.