### PR TITLE
fix(solve): restore ind->idx on updateRate()'s error paths; pair _getDur()'s infusion scans on the event type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -701,6 +701,21 @@
 
 ## Bug fixes
 
+- `updateRate()` no longer leaves `ind->idx` pointing at the dose record when a
+  modeled `rate()` evaluates to zero or less.  Both of its error returns skipped
+  the trailing restore of the saved index, so the corrupted value stayed live
+  solver state until the error was picked up after the integration step.  The
+  restore now happens before the checks, as it already did in `updateDur()`.
+
+- The internal `_getDur()` backward scan now pairs an infusion end with a start
+  of the same event type, not merely one of the opposite amount, so a bolus of
+  `+amt` can no longer be mistaken for the start of an infusion of `-amt`; this
+  matches the pairing `handleInfusionGetEndOfInfusionIndex()` already did.  An
+  orphaned infusion end sitting at dose index 0 also reports the missing start
+  instead of falling through to the forward scan and returning a negated
+  duration.  Both paths are reached through the `t_getDur` slot handed to
+  generated model code and downstream packages (nlmixr2/rxode2#1322).
+
 - An `integer` or `logical` covariate column no longer makes `rxSolve()`
   quadratic in the number of rows.  While building the solving data set each
   covariate column was coerced to double once per output row; for a column

--- a/NEWS.md
+++ b/NEWS.md
@@ -716,7 +716,11 @@
   the same internal event id as its start, so the scans now compare that too --
   the pairing `handleInfusionGetEndOfInfusionIndex()` already performed.  An
   overlapping 100 mg and 50 mg infusion both run at 10 mg/hr reported
-  `dose() = 60` for the first; it now reports 100.  Separately, an orphaned
+  `dose() = 60` for the first; it now reports 100.  A steady state infusion
+  with a modeled `alag()` reported `dose() = 0` for the same reason and now
+  reports the whole dose, and before the lagged dose lands `dose()`, `tad()`
+  and `tlast()` are `NA` -- what a plain lagged infusion has always reported.
+  Separately, an orphaned
   infusion end sitting at dose index 0 reports the missing start instead of
   falling through to the forward scan and returning a negated duration
   (nlmixr2/rxode2#1322).

--- a/NEWS.md
+++ b/NEWS.md
@@ -707,14 +707,19 @@
   solver state until the error was picked up after the integration step.  The
   restore now happens before the checks, as it already did in `updateDur()`.
 
-- The internal `_getDur()` backward scan now pairs an infusion end with a start
-  of the same event type, not merely one of the opposite amount, so a bolus of
-  `+amt` can no longer be mistaken for the start of an infusion of `-amt`; this
-  matches the pairing `handleInfusionGetEndOfInfusionIndex()` already did.  An
-  orphaned infusion end sitting at dose index 0 also reports the missing start
-  instead of falling through to the forward scan and returning a negated
-  duration.  Both paths are reached through the `t_getDur` slot handed to
-  generated model code and downstream packages (nlmixr2/rxode2#1322).
+- `dose()` and `tad()` no longer read the wrong infusion when two infusions run
+  at the same rate into different compartments.  The internal `_getDur()` scan
+  that recovers an infusion's duration paired records by amount alone, so an
+  infusion of `+rate` matched the first `-rate` it found, which may belong to
+  another compartment's infusion (or, in the backward direction, be a bolus of
+  the same amount).  A fixed rate/duration infusion emits its stop record with
+  the same internal event id as its start, so the scans now compare that too --
+  the pairing `handleInfusionGetEndOfInfusionIndex()` already performed.  An
+  overlapping 100 mg and 50 mg infusion both run at 10 mg/hr reported
+  `dose() = 60` for the first; it now reports 100.  Separately, an orphaned
+  infusion end sitting at dose index 0 reports the missing start instead of
+  falling through to the forward scan and returning a negated duration
+  (nlmixr2/rxode2#1322).
 
 - An `integer` or `logical` covariate column no longer makes `rxSolve()`
   quadratic in the number of rows.  While building the solving data set each

--- a/R/intern.R
+++ b/R/intern.R
@@ -39,3 +39,27 @@
 ## .calcDerived <- function(ncmtSXP, transSXP, inp, sigdigSXP) {
 ##   .Call(`_calcDerived`, ncmtSXP, transSXP, inp, sigdigSXP)
 ## }
+
+#' Test-only driver for the internal `_getDur()` infusion-duration lookup
+#'
+#' Builds a minimal solving structure from the supplied dose records and calls
+#' `_getDur()` directly.  `backward` is 1 (scan back for the infusion start), 2
+#' (scan forward, return `NA` when the end is missing) or anything else (scan
+#' forward, error when the end is missing).
+#'
+#' @param time numeric vector of record times
+#' @param dose numeric vector of record amounts
+#' @param evid integer vector of record event ids
+#' @param idose integer vector of 0-based indices into `time`/`dose`/`evid` that
+#'   hold the dose records
+#' @param l 0-based dose index to look up
+#' @param backward scan direction, see above
+#' @return numeric of length 2: the duration and the paired dose index found
+#' @author Matthew L. Fidler
+#' @keywords internal
+#' @noRd
+.getDurTest <- function(time, dose, evid, idose, l, backward) {
+  .Call(`_rxode2_getDurTest`, as.double(time), as.double(dose),
+        as.integer(evid), as.integer(idose), as.integer(l),
+        as.integer(backward))
+}

--- a/inst/include/rxode2parseGetTime.h
+++ b/inst/include/rxode2parseGetTime.h
@@ -143,6 +143,9 @@ static inline void updateRate(int idx, rx_solving_options_ind *ind, double *yp) 
   double dur, rate, amt;
   amt  = getAmt(ind, ind->id, ind->cmt, getDose(ind,idx), t, yp);
   rate  = getRate(ind, ind->id, ind->cmt, amt, t, yp);
+  // restore before the checks below so every return path leaves ind->idx alone
+  // (mirrors updateDur() above)
+  ind->idx=oldIdx;
   if (rate > 0){
     dur = amt/rate; // mg/hr
     setDoseP1(ind, idx, -rate);
@@ -150,7 +153,6 @@ static inline void updateRate(int idx, rx_solving_options_ind *ind, double *yp) 
       double _laggedStart = getLag(ind, ind->id, ind->cmt, t, yp);
       setAllTimesP1(ind, idx, (ISNA(_laggedStart) ? t : _laggedStart) + dur);
     }
-    ind->idx=oldIdx;
   } else {
     rx_solve *rx = (ind->rx ? ind->rx : &rx_global);
     rx_solving_options *op = (ind->op ? ind->op : &op_global);
@@ -169,7 +171,6 @@ static inline void updateRate(int idx, rx_solving_options_ind *ind, double *yp) 
       }
     }
   }
-  ind->idx=oldIdx;
 }
 
 static inline void handleTurnOffModeledDuration(int idx, rx_solve *rx, rx_solving_options *op, rx_solving_options_ind *ind) {

--- a/src/handle_evid.cpp
+++ b/src/handle_evid.cpp
@@ -56,11 +56,16 @@ extern "C" double _getDur(int l, rx_solving_options_ind *ind, int backward, unsi
                    "infusion end cannot be found (l >= ndoses)");
   }
   double dose = getDoseNumber(ind, l);
+  // Pair on the event type as well as the amount.  getDoseNumber() returns the
+  // amount alone, so a bolus of +amt matches an infusion end of -amt, and two
+  // concurrent infusions running at the same rate into different compartments
+  // match each other's ends.  A fixed rate/duration infusion -- the only kind
+  // that reaches here, see handleTlastInlineUpateDosingInformation() -- emits
+  // its stop record with the SAME internal evid as its start, so comparing the
+  // evid rejects those pairings and keeps every real one.  This is the pairing
+  // handleInfusionGetEndOfInfusionIndex() already performs.
+  int curEvid = getEvid(ind, ind->idose[l]);
   if (backward==1){
-    // Pair on the event type as well as the amount; getDoseNumber() alone lets a
-    // bolus of +amt match an infusion end of -amt.  This matches the pairing in
-    // handleInfusionGetEndOfInfusionIndex(): same evid, opposite amount.
-    int curEvid = getEvid(ind, ind->idose[l]);
     p[0] = 0;
     if (l != 0) {
       p[0] = l-1;
@@ -86,13 +91,16 @@ extern "C" double _getDur(int l, rx_solving_options_ind *ind, int backward, unsi
     return getAllTimes(ind, ind->idose[l]) - getAllTimes(ind, ind->idose[p[0]]);
   } else {
     p[0] = l+1;
-    while (p[0] < ind->ndoses && getDoseNumber(ind, p[0]) != -dose){
+    while (p[0] < ind->ndoses &&
+           (getDoseNumber(ind, p[0]) != -dose ||
+            getEvid(ind, ind->idose[p[0]]) != curEvid)){
       p[0]++;
     }
     // A scan that ran off the end must not be re-read: idose only holds ndoses
     // entries for this subject, so idose[ndoses] belongs to the next subject
     // (or is past gidose entirely for the last one) and can spuriously match.
-    if (p[0] >= ind->ndoses || getDoseNumber(ind, p[0]) != -dose){
+    if (p[0] >= ind->ndoses || getDoseNumber(ind, p[0]) != -dose ||
+        getEvid(ind, ind->idose[p[0]]) != curEvid){
       if (backward==2) return(NA_REAL);
       rx_solving_options *op = (ind->op ? ind->op : &op_global);
       if (omp_in_parallel()) {
@@ -117,6 +125,25 @@ extern "C" double _getDur(int l, rx_solving_options_ind *ind, int backward, unsi
 // of both branches can be tested directly (nlmixr2/rxode2#1322).
 extern "C" SEXP _rxode2_getDurTest(SEXP timeS, SEXP doseS, SEXP evidS,
                                    SEXP idoseS, SEXP lS, SEXP backwardS) {
+  if (TYPEOF(timeS) != REALSXP || TYPEOF(doseS) != REALSXP ||
+      TYPEOF(evidS) != INTSXP || TYPEOF(idoseS) != INTSXP ||
+      TYPEOF(lS) != INTSXP || TYPEOF(backwardS) != INTSXP) {
+    (Rf_errorcall)(R_NilValue, "'getDurTest' argument types are wrong");
+  }
+  int nRec = Rf_length(timeS);
+  int nDose = Rf_length(idoseS);
+  if (Rf_length(doseS) != nRec || Rf_length(evidS) != nRec ||
+      Rf_length(lS) != 1 || Rf_length(backwardS) != 1) {
+    (Rf_errorcall)(R_NilValue, "'getDurTest' argument lengths are wrong");
+  }
+  // this driver has no extra-dose pools, so a negative idose entry (which the
+  // getDose()/getEvid() macros redirect into those pools) would dereference NULL
+  int *idose = INTEGER(idoseS);
+  for (int i = 0; i < nDose; ++i) {
+    if (idose[i] < 0 || idose[i] >= nRec) {
+      (Rf_errorcall)(R_NilValue, "'getDurTest' 'idose' is out of range");
+    }
+  }
   rx_solving_options_ind ind;
   rx_solving_options op;
   memset(&ind, 0, sizeof(rx_solving_options_ind));
@@ -125,9 +152,9 @@ extern "C" SEXP _rxode2_getDurTest(SEXP timeS, SEXP doseS, SEXP evidS,
   ind.all_times = REAL(timeS);
   ind.dose = REAL(doseS);
   ind.evid = INTEGER(evidS);
-  ind.idose = INTEGER(idoseS);
-  ind.n_all_times = Rf_length(timeS);
-  ind.ndoses = Rf_length(idoseS);
+  ind.idose = idose;
+  ind.n_all_times = nRec;
+  ind.ndoses = nDose;
   unsigned int p = 0;
   double dur = _getDur(INTEGER(lS)[0], &ind, INTEGER(backwardS)[0], &p);
   SEXP ret = Rf_protect(Rf_allocVector(REALSXP, 2));

--- a/src/handle_evid.cpp
+++ b/src/handle_evid.cpp
@@ -6,6 +6,7 @@
 #include "rxomp.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 #include "strncmp.h"
 #define _(String) (String)
@@ -55,12 +56,24 @@ extern "C" double _getDur(int l, rx_solving_options_ind *ind, int backward, unsi
                    "infusion end cannot be found (l >= ndoses)");
   }
   double dose = getDoseNumber(ind, l);
-  if (backward==1 && l != 0){
-    p[0] = l-1;
-    while (p[0] > 0 && getDoseNumber(ind, p[0]) != -dose){
-      p[0]--;
+  if (backward==1){
+    // Pair on the event type as well as the amount; getDoseNumber() alone lets a
+    // bolus of +amt match an infusion end of -amt.  This matches the pairing in
+    // handleInfusionGetEndOfInfusionIndex(): same evid, opposite amount.
+    int curEvid = getEvid(ind, ind->idose[l]);
+    p[0] = 0;
+    if (l != 0) {
+      p[0] = l-1;
+      while (p[0] > 0 &&
+             (getDoseNumber(ind, p[0]) != -dose ||
+              getEvid(ind, ind->idose[p[0]]) != curEvid)){
+        p[0]--;
+      }
     }
-    if (getDoseNumber(ind, p[0]) != -dose){
+    // l == 0 has no earlier record to pair with, so the start is missing; it
+    // must not fall through to the forward scan below.
+    if (l == 0 || getDoseNumber(ind, p[0]) != -dose ||
+        getEvid(ind, ind->idose[p[0]]) != curEvid){
       rx_solving_options *op = (ind->op ? ind->op : &op_global);
       if (omp_in_parallel()) {
         int newBadSolve = 1;
@@ -92,4 +105,34 @@ extern "C" double _getDur(int l, rx_solving_options_ind *ind, int backward, unsi
     }
     return getAllTimes(ind, ind->idose[p[0]]) - getAllTimes(ind, ind->idose[l]);
   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Test-only entry point for _getDur()
+//
+// _getDur()'s `backward == 1` branch is not reachable from inside rxode2 (the
+// one internal caller always passes 2); it is only used through the `t_getDur`
+// slot handed to generated model code and downstream packages.  This wrapper
+// builds a minimal rx_solving_options_ind from R vectors so the pairing rules
+// of both branches can be tested directly (nlmixr2/rxode2#1322).
+extern "C" SEXP _rxode2_getDurTest(SEXP timeS, SEXP doseS, SEXP evidS,
+                                   SEXP idoseS, SEXP lS, SEXP backwardS) {
+  rx_solving_options_ind ind;
+  rx_solving_options op;
+  memset(&ind, 0, sizeof(rx_solving_options_ind));
+  memset(&op, 0, sizeof(rx_solving_options));
+  ind.op = &op;
+  ind.all_times = REAL(timeS);
+  ind.dose = REAL(doseS);
+  ind.evid = INTEGER(evidS);
+  ind.idose = INTEGER(idoseS);
+  ind.n_all_times = Rf_length(timeS);
+  ind.ndoses = Rf_length(idoseS);
+  unsigned int p = 0;
+  double dur = _getDur(INTEGER(lS)[0], &ind, INTEGER(backwardS)[0], &p);
+  SEXP ret = Rf_protect(Rf_allocVector(REALSXP, 2));
+  REAL(ret)[0] = dur;
+  REAL(ret)[1] = (double)p;
+  Rf_unprotect(1);
+  return ret;
 }

--- a/src/init.c
+++ b/src/init.c
@@ -437,6 +437,9 @@ SEXP _rxode2_linCmtBSensTypesSeen(SEXP);
 SEXP _rxode2_linCmtCarryLiveTest(SEXP, SEXP, SEXP, SEXP, SEXP,
                                  SEXP, SEXP, SEXP, SEXP, SEXP);
 
+// test-only driver for _getDur() (see src/handle_evid.cpp)
+SEXP _rxode2_getDurTest(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+
 SEXP _rxode2_linCmtCarrySetFast(SEXP);
 SEXP _rxode2_linCmtCarrySentinelMax(void);
 SEXP _rxode2_linCmtCarryFastStats(SEXP);
@@ -895,6 +898,7 @@ void R_init_rxode2(DllInfo *info){
     {"_rxode2_linCmtDeltaMemo", (DL_FUNC) &_rxode2_linCmtDeltaMemo, 1},
     {"_rxode2_linCmtBSensTypesSeen", (DL_FUNC) &_rxode2_linCmtBSensTypesSeen, 1},
     {"_rxode2_linCmtCarryLiveTest", (DL_FUNC) &_rxode2_linCmtCarryLiveTest, 10},
+    {"_rxode2_getDurTest", (DL_FUNC) &_rxode2_getDurTest, 6},
     {"_rxode2_linCmtCarrySetFast", (DL_FUNC) &_rxode2_linCmtCarrySetFast, 1},
     {"_rxode2_linCmtCarrySentinelMax", (DL_FUNC) &_rxode2_linCmtCarrySentinelMax, 0},
     {"_rxode2_linCmtCarryFastStats", (DL_FUNC) &_rxode2_linCmtCarryFastStats, 1},

--- a/tests/testthat/test-getdur-1322.R
+++ b/tests/testthat/test-getdur-1322.R
@@ -1,13 +1,18 @@
 rxTest({
 
+  # The record-pairing rules of the internal _getDur() scans, driven through the
+  # test-only C driver .getDurTest().  Their solver-level consequences are in
+  # test-infusion-duration-1322.R.
+  #
   # _getDur()'s `backward == 1` branch has no call site inside rxode2 (the one
   # internal caller always passes 2); it is reachable only through the
   # `t_getDur` slot handed to generated model code and downstream packages.
-  # .getDurTest() drives it directly.  Only equality of the evid values matters
-  # to the pairing, so plain distinct integers stand in for real event ids.
+  # Only equality of the evid values matters to the pairing, so plain distinct
+  # integers stand in for real event ids.
   .evidInf <- 10101L
   .evidInf2 <- 10201L
   .evidBolus <- 101L
+
 
   test_that("backward scan finds the matching infusion start", {
     d <- .getDurTest(time = c(0, 5), dose = c(100, -100),
@@ -61,63 +66,6 @@ rxTest({
                      idose = c(0L, 1L, 2L, 3L), l = 0L, backward = 2L)
     expect_equal(d[1], 10)
     expect_equal(d[2], 3)
-  })
-
-  test_that("dose() reports the whole infusion amount when a same-rate infusion overlaps (#1322)", {
-    # the end-to-end shape of the scan above: _getDur() recovers the amount from
-    # the rate for tad()/dose(), so the mispairing reported 6 * 10 = 60 here.
-    mod <- rxode2({
-      d/dt(a) <- -0.1 * a
-      d/dt(b) <- -0.1 * b
-      dd <- dose()
-    })
-
-    ev <- et(amt = 100, rate = 10, cmt = "a") |>
-      et(amt = 50, rate = 10, cmt = "b", time = 1) |>
-      et(seq(0, 15, by = 1))
-
-    s <- rxSolve(mod, ev)
-    expect_equal(s$dd[s$time == 0], 100)
-    expect_equal(s$dd[s$time == 1], 50)
-  })
-
-  test_that("a steady state infusion with a modeled lag reports the whole dose (#1322)", {
-    # the steady state path pushes the lagged infusion's start and stop records
-    # into the extra-dose pool, and the amount-only scan paired the start with a
-    # stop at its own time, so dose() came out as 0 * rate for every row.
-    mod <- rxode2({
-      cl <- 1
-      v <- 20
-      d/dt(central) <- -(cl / v) * central
-      alag(central) <- lg
-      dd <- dose()
-      tl <- tad()
-    })
-
-    ev <- et(amt = 100, rate = 100 / 8, ss = 1, ii = 12) |> et(seq(0, 24, by = 2))
-
-    s0 <- rxSolve(mod, ev, c(lg = 0))
-    expect_equal(unique(s0$dd), 100)
-
-    # before the lagged dose lands there is no dose yet, which is what a plain
-    # (non steady state) lagged infusion has always reported
-    s2 <- rxSolve(mod, ev, c(lg = 2))
-    expect_true(is.na(s2$dd[s2$time == 0]))
-    expect_true(is.na(s2$tl[s2$time == 0]))
-    expect_equal(unique(s2$dd[s2$time > 0]), 100)
-
-    ref <- rxSolve(mod, et(amt = 100, rate = 100 / 8) |> et(seq(0, 24, by = 2)),
-                   c(lg = 2))
-    expect_true(is.na(ref$dd[ref$time == 0]))
-
-    # a steady state infusion with no modeled lag was already right
-    modNoLag <- rxode2({
-      cl <- 1
-      v <- 20
-      d/dt(central) <- -(cl / v) * central
-      dd <- dose()
-    })
-    expect_equal(unique(rxSolve(modNoLag, ev)$dd), 100)
   })
 
   test_that("forward scan finds the infusion end", {
@@ -177,44 +125,6 @@ rxTest({
                              evid = c(.evidInf, .evidInf),
                              idose = c(0L, 1L), l = -1L, backward = 1L),
                  "infusion start cannot be found")
-  })
-
-  test_that("a modeled rate of zero or less still errors and leaves the solver usable (#1322)", {
-    # updateRate() returned from these two paths without restoring ind->idx.
-    mod <- rxode2({
-      a <- 6
-      b <- 0.6
-      ri <- 10
-      d/dt(intestine) <- -a * intestine
-      rate(intestine) <- ri
-      d/dt(blood) <- a * intestine - b * blood
-    })
-
-    ev <- et() |>
-      et(amt = 2 / 24, rate = -1, time = 0, addl = 9, ii = 1) |>
-      et(seq(0, 10, by = 1 / 24))
-
-    good <- rxSolve(mod, ev, c(ri = 2))
-
-    expect_error(rxSolve(mod, ev, c(ri = 0)))
-    expect_error(rxSolve(mod, ev, c(ri = -1)))
-
-    # the failed solves must not leave anything behind
-    expect_equal(as.data.frame(rxSolve(mod, ev, c(ri = 2))),
-                 as.data.frame(good))
-
-    # the other error return: the data asks for a modeled rate but the model
-    # only supplies a modeled duration
-    modDur <- rxode2({
-      a <- 6
-      b <- 0.6
-      di <- 3
-      d/dt(intestine) <- -a * intestine
-      dur(intestine) <- di
-      d/dt(blood) <- a * intestine - b * blood
-    })
-
-    expect_error(rxSolve(modDur, ev, c(di = 3)))
   })
 
 })

--- a/tests/testthat/test-getdur-1322.R
+++ b/tests/testthat/test-getdur-1322.R
@@ -6,6 +6,7 @@ rxTest({
   # .getDurTest() drives it directly.  Only equality of the evid values matters
   # to the pairing, so plain distinct integers stand in for real event ids.
   .evidInf <- 10101L
+  .evidInf2 <- 10201L
   .evidBolus <- 101L
 
   test_that("backward scan finds the matching infusion start", {
@@ -51,6 +52,35 @@ rxTest({
                  "infusion start cannot be found")
   })
 
+  test_that("forward scan does not pair with another infusion's end (#1322)", {
+    # two infusions running at the same rate into different compartments: the
+    # first record's end is dose 3, but dose 2 (the other compartment's end)
+    # carries the same amount and was matched first.
+    d <- .getDurTest(time = c(0, 1, 6, 10), dose = c(10, 10, -10, -10),
+                     evid = c(.evidInf, .evidInf2, .evidInf2, .evidInf),
+                     idose = c(0L, 1L, 2L, 3L), l = 0L, backward = 2L)
+    expect_equal(d[1], 10)
+    expect_equal(d[2], 3)
+  })
+
+  test_that("dose() reports the whole infusion amount when a same-rate infusion overlaps (#1322)", {
+    # the end-to-end shape of the scan above: _getDur() recovers the amount from
+    # the rate for tad()/dose(), so the mispairing reported 6 * 10 = 60 here.
+    mod <- rxode2({
+      d/dt(a) <- -0.1 * a
+      d/dt(b) <- -0.1 * b
+      dd <- dose()
+    })
+
+    ev <- et(amt = 100, rate = 10, cmt = "a") |>
+      et(amt = 50, rate = 10, cmt = "b", time = 1) |>
+      et(seq(0, 15, by = 1))
+
+    s <- rxSolve(mod, ev)
+    expect_equal(s$dd[s$time == 0], 100)
+    expect_equal(s$dd[s$time == 1], 50)
+  })
+
   test_that("forward scan finds the infusion end", {
     d <- .getDurTest(time = c(0, 5), dose = c(100, -100),
                      evid = c(.evidInf, .evidInf), idose = c(0L, 1L),
@@ -67,6 +97,33 @@ rxTest({
                              evid = c(.evidInf, .evidInf),
                              idose = c(0L, 1L), l = 0L, backward = 0L),
                  "infusion end cannot be found")
+  })
+
+  test_that("forward scan errors when only a different-evid end is available (#1322)", {
+    expect_true(is.na(.getDurTest(time = c(0, 5), dose = c(10, -10),
+                                  evid = c(.evidInf, .evidInf2),
+                                  idose = c(0L, 1L), l = 0L, backward = 2L)[1]))
+    expect_error(.getDurTest(time = c(0, 5), dose = c(10, -10),
+                             evid = c(.evidInf, .evidInf2),
+                             idose = c(0L, 1L), l = 0L, backward = 0L),
+                 "infusion end cannot be found")
+  })
+
+  test_that("the test driver rejects arguments it cannot safely read", {
+    expect_error(.getDurTest(time = c(0, 5), dose = 100,
+                             evid = c(.evidInf, .evidInf),
+                             idose = c(0L, 1L), l = 0L, backward = 2L),
+                 "lengths are wrong")
+    # a negative or past-the-end idose entry would be redirected into the
+    # extra-dose pools, which this driver does not have
+    expect_error(.getDurTest(time = c(0, 5), dose = c(100, -100),
+                             evid = c(.evidInf, .evidInf),
+                             idose = c(-1L, 1L), l = 1L, backward = 1L),
+                 "out of range")
+    expect_error(.getDurTest(time = c(0, 5), dose = c(100, -100),
+                             evid = c(.evidInf, .evidInf),
+                             idose = c(0L, 2L), l = 0L, backward = 2L),
+                 "out of range")
   })
 
   test_that("an out of range dose index is caught before idose is read", {
@@ -106,6 +163,19 @@ rxTest({
     # the failed solves must not leave anything behind
     expect_equal(as.data.frame(rxSolve(mod, ev, c(ri = 2))),
                  as.data.frame(good))
+
+    # the other error return: the data asks for a modeled rate but the model
+    # only supplies a modeled duration
+    modDur <- rxode2({
+      a <- 6
+      b <- 0.6
+      di <- 3
+      d/dt(intestine) <- -a * intestine
+      dur(intestine) <- di
+      d/dt(blood) <- a * intestine - b * blood
+    })
+
+    expect_error(rxSolve(modDur, ev, c(di = 3)))
   })
 
 })

--- a/tests/testthat/test-getdur-1322.R
+++ b/tests/testthat/test-getdur-1322.R
@@ -81,6 +81,45 @@ rxTest({
     expect_equal(s$dd[s$time == 1], 50)
   })
 
+  test_that("a steady state infusion with a modeled lag reports the whole dose (#1322)", {
+    # the steady state path pushes the lagged infusion's start and stop records
+    # into the extra-dose pool, and the amount-only scan paired the start with a
+    # stop at its own time, so dose() came out as 0 * rate for every row.
+    mod <- rxode2({
+      cl <- 1
+      v <- 20
+      d/dt(central) <- -(cl / v) * central
+      alag(central) <- lg
+      dd <- dose()
+      tl <- tad()
+    })
+
+    ev <- et(amt = 100, rate = 100 / 8, ss = 1, ii = 12) |> et(seq(0, 24, by = 2))
+
+    s0 <- rxSolve(mod, ev, c(lg = 0))
+    expect_equal(unique(s0$dd), 100)
+
+    # before the lagged dose lands there is no dose yet, which is what a plain
+    # (non steady state) lagged infusion has always reported
+    s2 <- rxSolve(mod, ev, c(lg = 2))
+    expect_true(is.na(s2$dd[s2$time == 0]))
+    expect_true(is.na(s2$tl[s2$time == 0]))
+    expect_equal(unique(s2$dd[s2$time > 0]), 100)
+
+    ref <- rxSolve(mod, et(amt = 100, rate = 100 / 8) |> et(seq(0, 24, by = 2)),
+                   c(lg = 2))
+    expect_true(is.na(ref$dd[ref$time == 0]))
+
+    # a steady state infusion with no modeled lag was already right
+    modNoLag <- rxode2({
+      cl <- 1
+      v <- 20
+      d/dt(central) <- -(cl / v) * central
+      dd <- dose()
+    })
+    expect_equal(unique(rxSolve(modNoLag, ev)$dd), 100)
+  })
+
   test_that("forward scan finds the infusion end", {
     d <- .getDurTest(time = c(0, 5), dose = c(100, -100),
                      evid = c(.evidInf, .evidInf), idose = c(0L, 1L),

--- a/tests/testthat/test-getdur-1322.R
+++ b/tests/testthat/test-getdur-1322.R
@@ -1,0 +1,111 @@
+rxTest({
+
+  # _getDur()'s `backward == 1` branch has no call site inside rxode2 (the one
+  # internal caller always passes 2); it is reachable only through the
+  # `t_getDur` slot handed to generated model code and downstream packages.
+  # .getDurTest() drives it directly.  Only equality of the evid values matters
+  # to the pairing, so plain distinct integers stand in for real event ids.
+  .evidInf <- 10101L
+  .evidBolus <- 101L
+
+  test_that("backward scan finds the matching infusion start", {
+    d <- .getDurTest(time = c(0, 5), dose = c(100, -100),
+                     evid = c(.evidInf, .evidInf), idose = c(0L, 1L),
+                     l = 1L, backward = 1L)
+    expect_equal(d[1], 5)
+    expect_equal(d[2], 0)
+  })
+
+  test_that("backward scan does not pair an infusion end with a bolus of the same amount (#1322)", {
+    # dose 1 is a bolus of +100 that sits between the real infusion start
+    # (dose 0) and the infusion end (dose 2).  Pairing on the amount alone
+    # matched the bolus and returned 3 instead of 5.
+    d <- .getDurTest(time = c(0, 2, 5), dose = c(100, 100, -100),
+                     evid = c(.evidInf, .evidBolus, .evidInf),
+                     idose = c(0L, 1L, 2L), l = 2L, backward = 1L)
+    expect_equal(d[1], 5)
+    expect_equal(d[2], 0)
+  })
+
+  test_that("backward scan errors when only a different-evid start is available (#1322)", {
+    expect_error(.getDurTest(time = c(0, 5), dose = c(100, -100),
+                             evid = c(.evidBolus, .evidInf),
+                             idose = c(0L, 1L), l = 1L, backward = 1L),
+                 "infusion start cannot be found")
+  })
+
+  test_that("backward scan errors when the start is missing", {
+    expect_error(.getDurTest(time = c(0, 5), dose = c(50, -100),
+                             evid = c(.evidInf, .evidInf),
+                             idose = c(0L, 1L), l = 1L, backward = 1L),
+                 "infusion start cannot be found")
+  })
+
+  test_that("an orphaned infusion end at dose 0 does not fall into the forward scan (#1322)", {
+    # dose 0 is an infusion end with nothing before it.  The old branch guard
+    # (`backward == 1 && l != 0`) sent this to the forward scan, which paired it
+    # with the later start and returned a negated duration of 3.
+    expect_error(.getDurTest(time = c(5, 8), dose = c(-100, 100),
+                             evid = c(.evidInf, .evidInf),
+                             idose = c(0L, 1L), l = 0L, backward = 1L),
+                 "infusion start cannot be found")
+  })
+
+  test_that("forward scan finds the infusion end", {
+    d <- .getDurTest(time = c(0, 5), dose = c(100, -100),
+                     evid = c(.evidInf, .evidInf), idose = c(0L, 1L),
+                     l = 0L, backward = 2L)
+    expect_equal(d[1], 5)
+    expect_equal(d[2], 1)
+  })
+
+  test_that("forward scan returns NA (backward=2) or errors otherwise when the end is missing", {
+    expect_true(is.na(.getDurTest(time = c(0, 5), dose = c(100, 50),
+                                  evid = c(.evidInf, .evidInf),
+                                  idose = c(0L, 1L), l = 0L, backward = 2L)[1]))
+    expect_error(.getDurTest(time = c(0, 5), dose = c(100, 50),
+                             evid = c(.evidInf, .evidInf),
+                             idose = c(0L, 1L), l = 0L, backward = 0L),
+                 "infusion end cannot be found")
+  })
+
+  test_that("an out of range dose index is caught before idose is read", {
+    expect_true(is.na(.getDurTest(time = c(0, 5), dose = c(100, -100),
+                                  evid = c(.evidInf, .evidInf),
+                                  idose = c(0L, 1L), l = 2L, backward = 2L)[1]))
+    expect_error(.getDurTest(time = c(0, 5), dose = c(100, -100),
+                             evid = c(.evidInf, .evidInf),
+                             idose = c(0L, 1L), l = 2L, backward = 1L),
+                 "infusion end cannot be found")
+    expect_error(.getDurTest(time = c(0, 5), dose = c(100, -100),
+                             evid = c(.evidInf, .evidInf),
+                             idose = c(0L, 1L), l = -1L, backward = 1L),
+                 "infusion start cannot be found")
+  })
+
+  test_that("a modeled rate of zero or less still errors and leaves the solver usable (#1322)", {
+    # updateRate() returned from these two paths without restoring ind->idx.
+    mod <- rxode2({
+      a <- 6
+      b <- 0.6
+      ri <- 10
+      d/dt(intestine) <- -a * intestine
+      rate(intestine) <- ri
+      d/dt(blood) <- a * intestine - b * blood
+    })
+
+    ev <- et() |>
+      et(amt = 2 / 24, rate = -1, time = 0, addl = 9, ii = 1) |>
+      et(seq(0, 10, by = 1 / 24))
+
+    good <- rxSolve(mod, ev, c(ri = 2))
+
+    expect_error(rxSolve(mod, ev, c(ri = 0)))
+    expect_error(rxSolve(mod, ev, c(ri = -1)))
+
+    # the failed solves must not leave anything behind
+    expect_equal(as.data.frame(rxSolve(mod, ev, c(ri = 2))),
+                 as.data.frame(good))
+  })
+
+})

--- a/tests/testthat/test-infusion-duration-1322.R
+++ b/tests/testthat/test-infusion-duration-1322.R
@@ -1,0 +1,103 @@
+rxTest({
+
+  # The solver-level consequences of the _getDur() infusion pairing and the
+  # updateRate() index restore fixed in nlmixr2/rxode2#1322.  The pairing rules
+  # themselves are tested against the C driver in test-getdur-1322.R.
+
+  test_that("dose() reports the whole infusion amount when a same-rate infusion overlaps (#1322)", {
+    # _getDur() recovers the amount from the rate for tad()/dose(), so pairing
+    # the first infusion's start with the other compartment's end reported
+    # 6 * 10 = 60 here.
+    mod <- rxode2({
+      d/dt(a) <- -0.1 * a
+      d/dt(b) <- -0.1 * b
+      dd <- dose()
+    })
+
+    ev <- et(amt = 100, rate = 10, cmt = "a") |>
+      et(amt = 50, rate = 10, cmt = "b", time = 1) |>
+      et(seq(0, 15, by = 1))
+
+    s <- rxSolve(mod, ev)
+    expect_equal(s$dd[s$time == 0], 100)
+    expect_equal(s$dd[s$time == 1], 50)
+  })
+
+  test_that("a steady state infusion with a modeled lag reports the whole dose (#1322)", {
+    # the steady state path pushes the lagged infusion's start and stop records
+    # into the extra-dose pool, and the amount-only scan paired the start with a
+    # stop at its own time, so dose() came out as 0 * rate for every row.
+    mod <- rxode2({
+      cl <- 1
+      v <- 20
+      d/dt(central) <- -(cl / v) * central
+      alag(central) <- lg
+      dd <- dose()
+      tl <- tad()
+    })
+
+    ev <- et(amt = 100, rate = 100 / 8, ss = 1, ii = 12) |> et(seq(0, 24, by = 2))
+
+    s0 <- rxSolve(mod, ev, c(lg = 0))
+    expect_equal(unique(s0$dd), 100)
+
+    # before the lagged dose lands there is no dose yet, which is what a plain
+    # (non steady state) lagged infusion has always reported
+    s2 <- rxSolve(mod, ev, c(lg = 2))
+    expect_true(is.na(s2$dd[s2$time == 0]))
+    expect_true(is.na(s2$tl[s2$time == 0]))
+    expect_equal(unique(s2$dd[s2$time > 0]), 100)
+
+    ref <- rxSolve(mod, et(amt = 100, rate = 100 / 8) |> et(seq(0, 24, by = 2)),
+                   c(lg = 2))
+    expect_true(is.na(ref$dd[ref$time == 0]))
+
+    # a steady state infusion with no modeled lag was already right
+    modNoLag <- rxode2({
+      cl <- 1
+      v <- 20
+      d/dt(central) <- -(cl / v) * central
+      dd <- dose()
+    })
+    expect_equal(unique(rxSolve(modNoLag, ev)$dd), 100)
+  })
+
+  test_that("a modeled rate of zero or less still errors and leaves the solver usable (#1322)", {
+    # updateRate() returned from these two paths without restoring ind->idx.
+    mod <- rxode2({
+      a <- 6
+      b <- 0.6
+      ri <- 10
+      d/dt(intestine) <- -a * intestine
+      rate(intestine) <- ri
+      d/dt(blood) <- a * intestine - b * blood
+    })
+
+    ev <- et() |>
+      et(amt = 2 / 24, rate = -1, time = 0, addl = 9, ii = 1) |>
+      et(seq(0, 10, by = 1 / 24))
+
+    good <- rxSolve(mod, ev, c(ri = 2))
+
+    expect_error(rxSolve(mod, ev, c(ri = 0)))
+    expect_error(rxSolve(mod, ev, c(ri = -1)))
+
+    # the failed solves must not leave anything behind
+    expect_equal(as.data.frame(rxSolve(mod, ev, c(ri = 2))),
+                 as.data.frame(good))
+
+    # the other error return: the data asks for a modeled rate but the model
+    # only supplies a modeled duration
+    modDur <- rxode2({
+      a <- 6
+      b <- 0.6
+      di <- 3
+      d/dt(intestine) <- -a * intestine
+      dur(intestine) <- di
+      d/dt(blood) <- a * intestine - b * blood
+    })
+
+    expect_error(rxSolve(modDur, ev, c(di = 3)))
+  })
+
+})


### PR DESCRIPTION
Fixes #1322.

## 1. `updateRate()` left `ind->idx` corrupted on its error paths

`updateRate()` saved `ind->idx`, overrode it for the `getAmt()`/`getRate()`
calls, and restored it only inside the `rate > 0` branch and at the end of the
function. Both error returns -- a modeled `rate()` of zero or less, with or
without `needSortRate` -- skipped the restore, leaving `ind->idx` pointing at the
dose record as live solver state until the error is picked up after the
integration step.

The restore now happens right after `getRate()`, which is what `updateDur()`
already does, so every return path is safe. Both call sites of the enclosing
`getTime__(idx, ind, 1)` set `ind->idx = idx` immediately before the call, so
`oldIdx == idx` there and the success path is unchanged.

## 2. `_getDur()` paired an infusion end with a start by amount alone

`getDoseNumber()` returns only the amount, so a `+amt` record matched any `-amt`
record. The issue reports this for the backward scan (a bolus of `+amt` matching
an infusion end of `-amt`); the review below found the same in the **forward**
scan, which is live code -- it is what
`handleTlastInlineUpateDosingInformation()` calls to recover an infusion's
duration for `dose()`/`tad()`.

A fixed rate/duration infusion -- the only kind that reaches `_getDur()` --
emits its stop record with the same internal evid as its start (see
`_rxTranslateEvent()`), so both scans now compare the evid as well. This is the
pairing `handleInfusionGetEndOfInfusionIndex()` already performed.

Two user-visible fixes fall out:

- Two infusions running at the same rate into different compartments matched
  each other's stop records. An overlapping 100 mg and 50 mg infusion both at
  10 mg/hr reported `dose() = 60` for the first; it now reports 100.
- A steady state infusion with a modeled `alag()` reported `dose() = 0` for
  every row (the scan matched a stop at the start's own time); it now reports
  the whole dose. With a non-zero lag, the rows before the lagged dose lands go
  from `0/0/0` to `NA/NA/NA` for `dose()`/`tad()`/`tlast()` -- which is exactly
  what a plain, non steady state lagged infusion has always reported there.

## 3. `backward == 1` with `l == 0` fell into the forward scan

The branch guard was `backward == 1 && l != 0`, so an orphaned infusion end at
dose index 0 searched *forward* and returned `t_start - t_end` instead of
reporting the missing start. `l == 0` now reports it.

## Testing

The `backward == 1` branch has no call site inside rxode2 -- it is reached only
through the `t_getDur` slot handed to generated model code and downstream
packages -- so a test-only `.Call` driver (`_rxode2_getDurTest`) builds a
minimal solving structure from R vectors and exercises both scans directly.
Solver-level regressions cover `dose()` through `rxSolve()` for the overlapping
and steady-state-lag cases, plus both `updateRate()` error returns.

Verified by alternating the two builds: nothing else in a grid over no modeled
lag, `ss=1`, `ss=2`, `addl` and a plain infusion moved.

## Review

Reviewed by Antigravity (`gemini-3.1-pro-high`, two rounds) and GitHub Copilot.
Round one found the forward-scan mispairing, which is fixed here. Round two
predicted the evid comparison would break the steady-state lag path; it does
change it, and the change is the `dose() = 0` -> `dose() = 100` fix above.
Copilot's round found no bugs.
