### PR TITLE
fix(dose history): look up an extra dose's infusion duration in the extra-dose arrays

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -759,6 +759,18 @@
   `dose()` report the wrong amount.  The duration is now looked up from the
   record being handled.  Solving itself was never affected (#1316).
 
+- The dose history no longer measures an EXTRA dose's infusion against an
+  unrelated dose record.  The steady-state and modeled-lag infusion paths
+  append extra doses whose amount and time live in `ind->extraDose*` rather
+  than in `ind->idose`, so the duration lookup -- an index into `idose` -- had
+  no entry to find and fell back to the solver's running dose counter, reading
+  whichever regular record it happened to point at.  For a steady-state
+  infusion with a modeled `alag()` that produced a duration of 0, entering the
+  infusion into the history with an amount of 0; another arrangement could
+  find no matching off-record at all and drop the dose from the history.  An
+  extra dose's duration is now taken from the matching off-record in the
+  extra-dose arrays (#1321).
+
 - Parsing a model no longer corrupts the caller's `PROTECT` stack.  The
   translation table and `_goodFuns` were claimed on the protect stack by one
   function and released by another, with the whole parse in between; an

--- a/NEWS.md
+++ b/NEWS.md
@@ -769,7 +769,10 @@
   infusion into the history with an amount of 0; another arrangement could
   find no matching off-record at all and drop the dose from the history.  An
   extra dose's duration is now taken from the matching off-record in the
-  extra-dose arrays (#1321).
+  extra-dose arrays, paired from the end of the pool so that an infusion
+  longer than the inter-dose interval -- which overlaps itself, leaving more
+  off records than on records -- is measured against its own off rather than
+  against the one closing an earlier overlapping infusion (#1321).
 
 - Parsing a model no longer corrupts the caller's `PROTECT` stack.  The
   translation table and `_goodFuns` were claimed on the protect stack by one

--- a/inst/include/rxode2parseHandleEvid.h
+++ b/inst/include/rxode2parseHandleEvid.h
@@ -167,7 +167,9 @@ static inline int handleTlastInlineExtraMatches(rx_solving_options_ind *ind, int
 //
 // Returns NA_REAL when there is no off record to pair with (a continuous
 // steady-state infusion never turns off), matching _getDur()'s backward==2
-// contract.
+// contract.  Two steady-state regimens on the same compartment at the same
+// rate share one pool and cannot be told apart here, the same limitation
+// _getDur() has over idose.
 static inline double handleTlastInlineDurExtra(rx_solving_options_ind *ind) {
   if (ind->extraDoseN == NULL) return NA_REAL;
   int trueIdx = -1 - ind->idx;

--- a/inst/include/rxode2parseHandleEvid.h
+++ b/inst/include/rxode2parseHandleEvid.h
@@ -129,8 +129,11 @@ static inline int handleTlastInlineDoseIndex(rx_solving_options_ind *ind) {
   return ind->ixds;
 }
 
-// Is extra dose `a` later than extra dose `b`?  Ties broken by push index, the
-// same (time, index) ordering handleExtraDose() sorts extraDoseTimeIdx by.
+// Is extra dose `a` later than extra dose `b`?  Ties broken by push index.
+// This orders the pool for pairing, not for execution (handleExtraDose() sorts
+// extraDoseTimeIdx by time, then evid, then index): the pairing below only ever
+// compares records carrying the SAME amount, so any strict total order pairs
+// them identically and the evid tier is not needed here.
 static inline int handleTlastInlineExtraIsLater(rx_solving_options_ind *ind, int a, int b) {
   if (ind->extraDoseTime[a] != ind->extraDoseTime[b]) {
     return ind->extraDoseTime[a] > ind->extraDoseTime[b];

--- a/inst/include/rxode2parseHandleEvid.h
+++ b/inst/include/rxode2parseHandleEvid.h
@@ -108,8 +108,8 @@ static inline int getDoseNumberFromIndex(rx_solving_options_ind *ind, int idx) {
 // ixds can point at an unrelated dose there.  Recover the index from ind->idx
 // whenever the record is a real (non-extra) dose, and only fall back to ixds
 // for extra doses (idx < 0).  An extra dose's amount lives in extraDoseDose,
-// not in idose, so there is no dose index to recover for it; it keeps the
-// long-standing ixds behavior.
+// not in idose, so there is no dose index to recover for it; callers that need
+// an extra dose's infusion duration use handleTlastInlineDurExtra() instead.
 static inline int handleTlastInlineDoseIndex(rx_solving_options_ind *ind) {
   if (ind->idx < 0) return ind->ixds;
   int cur = ind->ix[ind->idx];
@@ -127,6 +127,40 @@ static inline int handleTlastInlineDoseIndex(rx_solving_options_ind *ind) {
     if (ind->idose[j] == cur) return j;
   }
   return ind->ixds;
+}
+
+// Infusion duration of an EXTRA dose.
+// Extra doses -- the records pushDosingEvent() appends for the steady-state and
+// modeled-lag infusion paths -- carry ind->idx = -1-trueIdx and live in
+// ind->extraDose*, not in ind->idose, so _getDur()'s scan over idose cannot see
+// them and the ixds fallback measures an unrelated record's infusion.  Find the
+// matching "off" record here instead: same compartment and rate type, the
+// negated amount, the earliest one after this dose.  The extra-dose arrays are
+// in push order rather than time order (extraDoseTimeIdx carries the time
+// ordering), so scan them all rather than walking forward from trueIdx.
+// Returns NA_REAL when no off record exists (a continuous steady-state infusion
+// never turns off), matching _getDur()'s backward==2 contract.
+static inline double handleTlastInlineDurExtra(rx_solving_options_ind *ind) {
+  if (ind->extraDoseN == NULL) return NA_REAL;
+  int trueIdx = -1 - ind->idx;
+  if (trueIdx < 0 || trueIdx >= ind->extraDoseN[0]) return NA_REAL;
+  double curDose = ind->extraDoseDose[trueIdx];
+  double curTime = ind->extraDoseTime[trueIdx];
+  int wh, cmt, wh100, whI, wh0;
+  getWh(ind->extraDoseEvid[trueIdx], &wh, &cmt, &wh100, &whI, &wh0);
+  double offTime = NA_REAL;
+  for (int j = 0; j < ind->extraDoseN[0]; ++j) {
+    if (j == trueIdx || ind->extraDoseTime[j] <= curTime) continue;
+    if (ind->extraDoseDose[j] != -curDose) continue;
+    int whJ, cmtJ, wh100J, whIJ, wh0J;
+    getWh(ind->extraDoseEvid[j], &whJ, &cmtJ, &wh100J, &whIJ, &wh0J);
+    // the on/off pair shares the compartment and the rate type; only the wh0
+    // flag differs (EVID0_REGULAR vs EVID0_RATEADJ), so it is not compared
+    if (cmtJ != cmt || whIJ != whI) continue;
+    if (ISNA(offTime) || ind->extraDoseTime[j] < offTime) offTime = ind->extraDoseTime[j];
+  }
+  if (ISNA(offTime)) return NA_REAL;
+  return offTime - curTime;
 }
 
 static inline int handleTlastInlineUpateDosingInformation(rx_solving_options_ind *ind, double *curDose, double *tinf) {
@@ -147,6 +181,16 @@ static inline int handleTlastInlineUpateDosingInformation(rx_solving_options_ind
   case EVIDF_INF_RATE:
     if (curDose[0] <= 0) {
       return 0;
+    } else if (ind->idx < 0) {
+      // extra dose: it has no idose entry, so its duration comes from the
+      // extra-dose arrays (see handleTlastInlineDurExtra)
+      tinf[0] = handleTlastInlineDurExtra(ind);
+      if (!ISNA(tinf[0])) {
+        curDose[0] = tinf[0] * curDose[0];
+        return 1;
+      } else {
+        return 0;
+      }
     } else {
       // The amt in rxode2 is the infusion rate, but we need the amt
       int doseIdx = handleTlastInlineDoseIndex(ind);

--- a/inst/include/rxode2parseHandleEvid.h
+++ b/inst/include/rxode2parseHandleEvid.h
@@ -152,6 +152,18 @@ static inline int handleTlastInlineExtraMatches(rx_solving_options_ind *ind, int
   return cmtJ == cmt && whIJ == whI;
 }
 
+// How many extra doses carrying `amt` into that compartment come after `ref`?
+static inline int handleTlastInlineExtraCountAfter(rx_solving_options_ind *ind, int ref,
+                                                   int cmt, int whI, double amt) {
+  int n = ind->extraDoseN[0], cnt = 0;
+  for (int j = 0; j < n; ++j) {
+    if (j != ref &&
+        handleTlastInlineExtraMatches(ind, j, cmt, whI, amt) &&
+        handleTlastInlineExtraIsLater(ind, j, ref)) cnt++;
+  }
+  return cnt;
+}
+
 // Infusion duration of an EXTRA dose.
 // Extra doses -- the records pushDosingEvent() appends for the steady-state and
 // modeled-lag infusion paths -- carry ind->idx = -1-trueIdx and live in
@@ -183,29 +195,39 @@ static inline double handleTlastInlineDurExtra(rx_solving_options_ind *ind) {
   int wh, cmt, wh100, whI, wh0;
   getWh(ind->extraDoseEvid[trueIdx], &wh, &cmt, &wh100, &whI, &wh0);
   // how many identical infusions start after this one
-  int nOnAfter = 0;
-  for (int j = 0; j < n; ++j) {
-    if (j != trueIdx &&
-        handleTlastInlineExtraMatches(ind, j, cmt, whI, curDose) &&
-        handleTlastInlineExtraIsLater(ind, j, trueIdx)) nOnAfter++;
-  }
+  int nOnAfter = handleTlastInlineExtraCountAfter(ind, trueIdx, cmt, whI, curDose);
   // this dose ends at the off record that has exactly that many offs after it
   for (int j = 0; j < n; ++j) {
     if (!handleTlastInlineExtraMatches(ind, j, cmt, whI, -curDose)) continue;
     if (!handleTlastInlineExtraIsLater(ind, j, trueIdx)) continue;
-    int nOffAfter = 0;
-    for (int k = 0; k < n; ++k) {
-      if (k != j &&
-          handleTlastInlineExtraMatches(ind, k, cmt, whI, -curDose) &&
-          handleTlastInlineExtraIsLater(ind, k, j)) nOffAfter++;
+    if (handleTlastInlineExtraCountAfter(ind, j, cmt, whI, -curDose) == nOnAfter) {
+      return ind->extraDoseTime[j] - curTime;
     }
-    if (nOffAfter == nOnAfter) return ind->extraDoseTime[j] - curTime;
   }
   return NA_REAL;
 }
 
+// Amount and duration of a fixed rate/duration infusion record.  In rxode2 the
+// amt of such a record is the infusion RATE, so the amount entered into the dose
+// history is rate*duration.  Returns 0 when the record should not be entered.
+static inline int handleTlastInlineInfusion(rx_solving_options_ind *ind, double *curDose, double *tinf) {
+  if (curDose[0] <= 0) return 0;
+  if (ind->idx < 0) {
+    // extra dose: it has no idose entry, so its duration comes from the
+    // extra-dose arrays (see handleTlastInlineDurExtra)
+    tinf[0] = handleTlastInlineDurExtra(ind);
+  } else {
+    unsigned int p;
+    int doseIdx = handleTlastInlineDoseIndex(ind);
+    if (ind->fns->getdur) tinf[0] = ind->fns->getdur(doseIdx, ind, 2, &p);
+    else tinf[0] = _getDur(doseIdx, ind, 2, &p);
+  }
+  if (ISNA(tinf[0])) return 0;
+  curDose[0] = tinf[0] * curDose[0];
+  return 1;
+}
+
 static inline int handleTlastInlineUpateDosingInformation(rx_solving_options_ind *ind, double *curDose, double *tinf) {
-  unsigned int p;
   switch (ind->whI) {
   case EVIDF_MODEL_RATE_ON: // modeled rate.
   case EVIDF_MODEL_DUR_ON: // modeled duration.
@@ -220,30 +242,7 @@ static inline int handleTlastInlineUpateDosingInformation(rx_solving_options_ind
     break;
   case EVIDF_INF_DUR:
   case EVIDF_INF_RATE:
-    if (curDose[0] <= 0) {
-      return 0;
-    } else if (ind->idx < 0) {
-      // extra dose: it has no idose entry, so its duration comes from the
-      // extra-dose arrays (see handleTlastInlineDurExtra)
-      tinf[0] = handleTlastInlineDurExtra(ind);
-      if (!ISNA(tinf[0])) {
-        curDose[0] = tinf[0] * curDose[0];
-        return 1;
-      } else {
-        return 0;
-      }
-    } else {
-      // The amt in rxode2 is the infusion rate, but we need the amt
-      int doseIdx = handleTlastInlineDoseIndex(ind);
-      if (ind->fns->getdur) tinf[0] = ind->fns->getdur(doseIdx, ind, 2, &p);
-      else tinf[0] = _getDur(doseIdx, ind, 2, &p);
-      if (!ISNA(tinf[0])) {
-        curDose[0] = tinf[0] * curDose[0];
-        return 1;
-      } else {
-        return 0;
-      }
-    }
+    return handleTlastInlineInfusion(ind, curDose, tinf);
     break;
   }
   if (ind->wh0 == EVID0_ONDOSE) {

--- a/inst/include/rxode2parseHandleEvid.h
+++ b/inst/include/rxode2parseHandleEvid.h
@@ -129,38 +129,74 @@ static inline int handleTlastInlineDoseIndex(rx_solving_options_ind *ind) {
   return ind->ixds;
 }
 
+// Is extra dose `a` later than extra dose `b`?  Ties broken by push index, the
+// same (time, index) ordering handleExtraDose() sorts extraDoseTimeIdx by.
+static inline int handleTlastInlineExtraIsLater(rx_solving_options_ind *ind, int a, int b) {
+  if (ind->extraDoseTime[a] != ind->extraDoseTime[b]) {
+    return ind->extraDoseTime[a] > ind->extraDoseTime[b];
+  }
+  return a > b;
+}
+
+// Does extra dose `j` carry `amt` into the same compartment with the same rate
+// type?  An on/off pair shares the compartment and whI; only the wh0 flag
+// differs (EVID0_REGULAR vs EVID0_RATEADJ), so it is not compared.
+static inline int handleTlastInlineExtraMatches(rx_solving_options_ind *ind, int j,
+                                                int cmt, int whI, double amt) {
+  if (ind->extraDoseDose[j] != amt) return 0;
+  int whJ, cmtJ, wh100J, whIJ, wh0J;
+  getWh(ind->extraDoseEvid[j], &whJ, &cmtJ, &wh100J, &whIJ, &wh0J);
+  return cmtJ == cmt && whIJ == whI;
+}
+
 // Infusion duration of an EXTRA dose.
 // Extra doses -- the records pushDosingEvent() appends for the steady-state and
 // modeled-lag infusion paths -- carry ind->idx = -1-trueIdx and live in
 // ind->extraDose*, not in ind->idose, so _getDur()'s scan over idose cannot see
-// them and the ixds fallback measures an unrelated record's infusion.  Find the
-// matching "off" record here instead: same compartment and rate type, the
-// negated amount, the earliest one after this dose.  The extra-dose arrays are
-// in push order rather than time order (extraDoseTimeIdx carries the time
-// ordering), so scan them all rather than walking forward from trueIdx.
-// Returns NA_REAL when no off record exists (a continuous steady-state infusion
-// never turns off), matching _getDur()'s backward==2 contract.
+// them and the ixds fallback measures an unrelated record's infusion.  Pair the
+// on record with its off record inside the extra-dose arrays instead.
+//
+// The pairing is done from the END: the last "on" belongs to the last "off",
+// the one before it to the one before that, and so on.  A steady-state infusion
+// longer than the inter-dose interval overlaps itself, so the pool holds more
+// off records than on records -- the leading offs close infusions that started
+// before the pool did.  Matching each on to the nearest following off would
+// hand those to the wrong dose (an ii=12 regimen infusing over 20h reported 8h);
+// counting back from the end pairs them correctly and degenerates to the
+// obvious pairing when the counts are equal.
+//
+// Returns NA_REAL when there is no off record to pair with (a continuous
+// steady-state infusion never turns off), matching _getDur()'s backward==2
+// contract.
 static inline double handleTlastInlineDurExtra(rx_solving_options_ind *ind) {
   if (ind->extraDoseN == NULL) return NA_REAL;
   int trueIdx = -1 - ind->idx;
-  if (trueIdx < 0 || trueIdx >= ind->extraDoseN[0]) return NA_REAL;
+  int n = ind->extraDoseN[0];
+  if (trueIdx < 0 || trueIdx >= n) return NA_REAL;
   double curDose = ind->extraDoseDose[trueIdx];
   double curTime = ind->extraDoseTime[trueIdx];
   int wh, cmt, wh100, whI, wh0;
   getWh(ind->extraDoseEvid[trueIdx], &wh, &cmt, &wh100, &whI, &wh0);
-  double offTime = NA_REAL;
-  for (int j = 0; j < ind->extraDoseN[0]; ++j) {
-    if (j == trueIdx || ind->extraDoseTime[j] <= curTime) continue;
-    if (ind->extraDoseDose[j] != -curDose) continue;
-    int whJ, cmtJ, wh100J, whIJ, wh0J;
-    getWh(ind->extraDoseEvid[j], &whJ, &cmtJ, &wh100J, &whIJ, &wh0J);
-    // the on/off pair shares the compartment and the rate type; only the wh0
-    // flag differs (EVID0_REGULAR vs EVID0_RATEADJ), so it is not compared
-    if (cmtJ != cmt || whIJ != whI) continue;
-    if (ISNA(offTime) || ind->extraDoseTime[j] < offTime) offTime = ind->extraDoseTime[j];
+  // how many identical infusions start after this one
+  int nOnAfter = 0;
+  for (int j = 0; j < n; ++j) {
+    if (j != trueIdx &&
+        handleTlastInlineExtraMatches(ind, j, cmt, whI, curDose) &&
+        handleTlastInlineExtraIsLater(ind, j, trueIdx)) nOnAfter++;
   }
-  if (ISNA(offTime)) return NA_REAL;
-  return offTime - curTime;
+  // this dose ends at the off record that has exactly that many offs after it
+  for (int j = 0; j < n; ++j) {
+    if (!handleTlastInlineExtraMatches(ind, j, cmt, whI, -curDose)) continue;
+    if (!handleTlastInlineExtraIsLater(ind, j, trueIdx)) continue;
+    int nOffAfter = 0;
+    for (int k = 0; k < n; ++k) {
+      if (k != j &&
+          handleTlastInlineExtraMatches(ind, k, cmt, whI, -curDose) &&
+          handleTlastInlineExtraIsLater(ind, k, j)) nOffAfter++;
+    }
+    if (nOffAfter == nOnAfter) return ind->extraDoseTime[j] - curTime;
+  }
+  return NA_REAL;
 }
 
 static inline int handleTlastInlineUpateDosingInformation(rx_solving_options_ind *ind, double *curDose, double *tinf) {

--- a/tests/testthat/test-ss-extra-dose-duration.R
+++ b/tests/testthat/test-ss-extra-dose-duration.R
@@ -84,20 +84,43 @@ rxTest({
     expect_true(all(.r$cen >= .ssRun(20) - 1e-6))
   })
 
+  .histModel <- rxode2({
+    alag(cen) <- 3
+    d / dt(cen) <- -0.1 * cen
+    cd <- dose(cen)
+    dn <- dosenum()
+    ta <- tad(cen)
+  })
+
   test_that("the reported dose history of an ss=1 lagged infusion is the amount", {
-    .e <- et(et(amt = 100, rate = 20, ss = 1, ii = 12, cmt = "cen"),
-             seq(0, 40, by = 4))
-    .m <- rxode2({
-      alag(cen) <- 3
-      d / dt(cen) <- -0.1 * cen
-      cd <- dose(cen)
-      dn <- dosenum()
-    })
-    .r <- rxSolve(.m, .e, returnType = "data.frame")
-    # from the lagged infusion onward the reported dose is the amount, not the
-    # rate and not 0
-    expect_true(all(.r$cd[.r$time >= 3] == 100))
-    expect_true(all(.r$dn >= 1))
+    # dur < ii, dur > ii and dur >> ii: an infusion longer than the inter-dose
+    # interval overlaps itself, which is what makes the on/off pairing in
+    # handleTlastInlineDurExtra() non-trivial
+    for (.rate in c(20, 5, 2.5)) {
+      .e <- et(et(amt = 100, rate = .rate, ss = 1, ii = 12, cmt = "cen"),
+               seq(0, 40, by = 4))
+      .r <- rxSolve(.histModel, .e, returnType = "data.frame")
+      # from the lagged infusion onward the reported dose is the amount, not the
+      # rate and not 0
+      expect_true(all(.r$cd[.r$time >= 3] == 100))
+      expect_true(all(.r$dn >= 1))
+      # the dose lands at the lag time, so time-after-dose counts from there
+      expect_equal(.r$ta[.r$time >= 3], .r$time[.r$time >= 3] - 3)
+    }
+  })
+
+  test_that("the reported dose history of an ss=2 lagged infusion is the amount", {
+    # the ss=2 dose is at 24 rather than at 0 so it is not coincident with the
+    # prior regimen's own lagged dose
+    for (.rate in c(20, 5)) {
+      .e <- et(amt = 50, rate = 10, cmt = "cen") %>%
+        et(amt = 100, rate = .rate, ss = 2, ii = 12, time = 24, cmt = "cen") %>%
+        et(seq(0, 60, by = 4))
+      .r <- rxSolve(.histModel, .e, returnType = "data.frame")
+      expect_true(all(.r$cd[.r$time > 3 & .r$time < 24] == 50))
+      expect_true(all(.r$cd[.r$time > 27] == 100))
+      expect_equal(.r$ta[.r$time > 27], .r$time[.r$time > 27] - 27)
+    }
   })
 
 })

--- a/tests/testthat/test-ss-extra-dose-duration.R
+++ b/tests/testthat/test-ss-extra-dose-duration.R
@@ -74,8 +74,8 @@ rxTest({
   })
 
   test_that("ss=2 infusion with a modeled lag superimposes on a prior regimen", {
-    .e <- et(amt = 50, rate = 10, cmt = "cen") %>%
-      et(amt = 100, rate = 20, ss = 2, ii = 12, time = 0, cmt = "cen") %>%
+    .e <- et(amt = 50, rate = 10, cmt = "cen") |>
+      et(amt = 100, rate = 20, ss = 2, ii = 12, time = 0, cmt = "cen") |>
       et(seq(0, 40, by = 4))
     .r <- rxSolve(.ssLagModel, .e, returnType = "data.frame")
     expect_true(all(is.finite(.r$cen)))
@@ -113,8 +113,8 @@ rxTest({
     # the ss=2 dose is at 24 rather than at 0 so it is not coincident with the
     # prior regimen's own lagged dose
     for (.rate in c(20, 5)) {
-      .e <- et(amt = 50, rate = 10, cmt = "cen") %>%
-        et(amt = 100, rate = .rate, ss = 2, ii = 12, time = 24, cmt = "cen") %>%
+      .e <- et(amt = 50, rate = 10, cmt = "cen") |>
+        et(amt = 100, rate = .rate, ss = 2, ii = 12, time = 24, cmt = "cen") |>
         et(seq(0, 60, by = 4))
       .r <- rxSolve(.histModel, .e, returnType = "data.frame")
       expect_true(all(.r$cd[.r$time > 3 & .r$time < 24] == 50))

--- a/tests/testthat/test-ss-extra-dose-duration.R
+++ b/tests/testthat/test-ss-extra-dose-duration.R
@@ -1,0 +1,103 @@
+rxTest({
+
+  # rxode2 issue #1321 -- the steady-state/modeled-lag infusion paths append
+  # "extra" doses (pushDosingEvent()) whose amounts live in ind->extraDose*, not
+  # in ind->idose.  The dose-history duration lookup used to fall back to an
+  # ind->idose index for those, measuring an unrelated record's infusion; it now
+  # searches the extra-dose arrays for the matching off record.  These regimens
+  # are the ones that push extra doses, so they pin the paths the lookup runs on.
+
+  .ssLagModel <- rxode2({
+    alag(cen) <- 3
+    d / dt(cen) <- -0.1 * cen
+  })
+
+  # true steady state, built by repeating the regimen long enough to converge
+  .longRun <- function(rate, ii = 12, amt = 100, addl = 40) {
+    .e <- et(et(amt = amt, rate = rate, ii = ii, addl = addl, cmt = "cen"),
+             seq(0, 40, by = 4) + addl * ii)
+    .r <- rxSolve(.ssLagModel, .e, returnType = "data.frame")
+    .r <- .r[.r$time >= addl * ii, ]
+    .r$cen
+  }
+
+  .ssRun <- function(rate, ii = 12, amt = 100, ss = 1) {
+    .e <- et(et(amt = amt, rate = rate, ss = ss, ii = ii, cmt = "cen"),
+             seq(0, 40, by = 4))
+    rxSolve(.ssLagModel, .e, returnType = "data.frame")$cen
+  }
+
+  test_that("ss=1 infusion with a modeled lag matches the repeated regimen (dur < ii)", {
+    # amt/rate = 5 < ii = 12
+    expect_equal(.ssRun(20), .longRun(20), tolerance = 1e-4)
+  })
+
+  test_that("ss=1 infusion with a modeled lag matches the repeated regimen (dur > ii)", {
+    # amt/rate = 20 > ii = 12; overlapping infusions
+    expect_equal(.ssRun(5), .longRun(5), tolerance = 1e-4)
+  })
+
+  test_that("ss=1 infusion with a modeled lag holds the plateau (dur == ii)", {
+    # amt/rate = 12 == ii = 12, so steady state is a continuous infusion whose
+    # plateau is rate/kel; it holds for the whole inter-dose interval
+    .e <- et(et(amt = 100, rate = 100 / 12, ss = 1, ii = 12, cmt = "cen"),
+             seq(0, 12, by = 1))
+    .r <- rxSolve(.ssLagModel, .e, returnType = "data.frame")
+    expect_equal(.r$cen, rep((100 / 12) / 0.1, length(.r$cen)), tolerance = 1e-5)
+  })
+
+  test_that("ss=1 modeled-duration infusion with a modeled lag solves", {
+    .m <- rxode2({
+      alag(cen) <- 3
+      dur(cen) <- 5
+      d / dt(cen) <- -0.1 * cen
+    })
+    .e <- et(et(amt = 100, rate = -2, ss = 1, ii = 12, cmt = "cen"),
+             seq(0, 40, by = 4))
+    .r <- rxSolve(.m, .e, returnType = "data.frame")
+    expect_true(all(is.finite(.r$cen)))
+    # same shape as the fixed-duration equivalent
+    expect_equal(.r$cen, .ssRun(20), tolerance = 1e-4)
+  })
+
+  test_that("ss=1 modeled-rate infusion with a modeled lag solves", {
+    .m <- rxode2({
+      alag(cen) <- 3
+      rate(cen) <- 20
+      d / dt(cen) <- -0.1 * cen
+    })
+    .e <- et(et(amt = 100, rate = -1, ss = 1, ii = 12, cmt = "cen"),
+             seq(0, 40, by = 4))
+    .r <- rxSolve(.m, .e, returnType = "data.frame")
+    expect_true(all(is.finite(.r$cen)))
+    expect_equal(.r$cen, .ssRun(20), tolerance = 1e-4)
+  })
+
+  test_that("ss=2 infusion with a modeled lag superimposes on a prior regimen", {
+    .e <- et(amt = 50, rate = 10, cmt = "cen") %>%
+      et(amt = 100, rate = 20, ss = 2, ii = 12, time = 0, cmt = "cen") %>%
+      et(seq(0, 40, by = 4))
+    .r <- rxSolve(.ssLagModel, .e, returnType = "data.frame")
+    expect_true(all(is.finite(.r$cen)))
+    # ss=2 adds the new regimen's steady state on top of the existing one, so it
+    # is everywhere at least the ss=1 solution
+    expect_true(all(.r$cen >= .ssRun(20) - 1e-6))
+  })
+
+  test_that("the reported dose history of an ss=1 lagged infusion is the amount", {
+    .e <- et(et(amt = 100, rate = 20, ss = 1, ii = 12, cmt = "cen"),
+             seq(0, 40, by = 4))
+    .m <- rxode2({
+      alag(cen) <- 3
+      d / dt(cen) <- -0.1 * cen
+      cd <- dose(cen)
+      dn <- dosenum()
+    })
+    .r <- rxSolve(.m, .e, returnType = "data.frame")
+    # from the lagged infusion onward the reported dose is the amount, not the
+    # rate and not 0
+    expect_true(all(.r$cd[.r$time >= 3] == 100))
+    expect_true(all(.r$dn >= 1))
+  })
+
+})


### PR DESCRIPTION
Fixes #1321.

## The bug

Extra doses -- the records `pushDosingEvent()` appends for the steady-state and
modeled-lag infusion paths in `handleSS()` -- carry `ind->idx = -1-trueIdx` and
store their amount and time in `ind->extraDose*`, not in `ind->idose`.  They
still reach the infusion branch of
`handleTlastInlineUpateDosingInformation()`, which asks for the duration with
an index into `idose`; `handleTlastInlineDoseIndex()` has no index to recover
for a negative `idx` and fell back to `ind->ixds`, so `_getDur()` measured an
unrelated regular record's infusion.

For the issue's example -- a steady-state infusion with a modeled `alag()` --
that gave a duration of 0, so the infusion entered the dose history with an
amount of 0.  An arrangement with no matching off-record would drop the dose
from the history entirely.

This is the half of #1316 that #1320 deliberately left alone: that fix repaired
the regular-record path by correcting the *index*, and this one needs a
different *lookup*.

## The fix

`handleTlastInlineDurExtra()` pairs the on record with its off record inside
the extra-dose arrays -- same compartment and rate type, the negated amount.

The pairing counts back from the END of the pool: the last "on" belongs to the
last "off", the one before it to the one before that.  A steady-state infusion
longer than the inter-dose interval overlaps itself, so the pool holds more off
records than on records, and the leading offs close infusions that started
before the pool did.  Matching each on to the nearest following off hands those
to the wrong dose -- an `ii=12` regimen infusing over 20h reported 8h, one over
40h reported 4h.  Counting back from the end pairs them correctly and
degenerates to the obvious pairing when the counts are equal.

## Validation

The branch was instrumented and run over every `pushDosingEvent()` pattern in
`handleSS()`: `dur < ii`, `dur == ii`, `dur > ii` and `dur >> ii`, at modeled
lags of 0, 3, 8, 12, 15 and 27 (`ii = 12`), `ss=1` and `ss=2`, plus two
compartments infused at the same rate.  Every extra-dose on record now reports
its true duration (5, 20, 40) where the previous rule reported 5, 8, 4.

New tests in `tests/testthat/test-ss-extra-dose-duration.R` cover those
regimens and assert the reported dose history (`dose()`, `dosenum()`, `tad()`),
not only the solved state.  Full suite: `FAIL 0 | PASS 40245`.

## Known limit

Two steady-state regimens on the same compartment at the same rate share a
single extra-dose pool and cannot be told apart by the matcher.  That is the
same limitation `_getDur()` has over `idose`, so it is documented in the code
rather than fixed here.

## Scope

As #1321 notes, this is a latent-correctness fix.  The output pass
(`src/rxode2_df.cpp`) re-derives the history by walking the event records, and
extra doses are not records, so the reported `tad`/`dosenum`/`dose` columns
never take this path; and putting `tad()`/`dose()` in an ODE right-hand side
makes any `ss=1` solve fail to converge, which is a separate problem that masks
this one.  The fix is worth making because the fallback silently read an
unrelated dose.

## Review

Reviewed by Antigravity (Gemini) and GitHub Copilot (GPT).  Antigravity's first
round found the overlapping-infusion mis-pairing, which is fixed in the second
commit.  Later rounds from both reviewers converged on the same-rate
same-compartment limitation above; their other findings (non-lagged steady-state
infusions reporting the rate, and `dur == ii` dropping the dose from the
history) were checked against instrumented runs and did not reproduce.
