### PR TITLE
Prevent transformation on variables during confint plot

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -384,7 +384,7 @@ plot.rxSolve <- function(x, y, ..., log = "", xlab = "Time", ylab = "") {
 #' @export
 plot.rxSolveConfint1 <- function(x, y, ..., xlab = "Time", ylab = "", log = "") {
   .data <- NULL
-  .y <- as.character(substitute(y))
+  .y <- all.vars(substitute(y))
   .call0 <- match.call()[-(1:2)]
   .call <- as.list(.call0)
   .w <- which(names(.call) %in% c("x", "y", "log", "xlab", "ylab"))
@@ -392,7 +392,7 @@ plot.rxSolveConfint1 <- function(x, y, ..., xlab = "Time", ylab = "", log = "") 
     .call <- .call[-.w]
   }
   .cmts <- c(
-    as.character(substitute(y)),
+    .y,
     names(vapply(as.character(.call), `c`, character(1), USE.NAMES=FALSE)),
     as.character(unlist(.call))
   )
@@ -415,6 +415,13 @@ plot.rxSolveConfint1 <- function(x, y, ..., xlab = "Time", ylab = "", log = "") 
   .logx <- .lst[["logx"]]
   .logy <- .lst[["logy"]]
   .dat <- .lst[["dat"]]
+  # Apply transformation if expression was more than just a variable name
+  .yExpr <- substitute(y)
+  if (!identical(.yExpr, as.name(.y[1])) && length(.y) == 1) {
+    .tempDat <- .dat
+    .tempDat[[.y[1]]] <- .dat$eff
+    .dat$eff <- eval(.yExpr, envir = .tempDat)
+  }
   if (length(.parm) > 1) {
     if (length(.by) > 0) {
       .facet <- eval(str2lang(paste0("facet_wrap(~", paste(c("trt", .by), collapse="+"),
@@ -465,7 +472,7 @@ plot.rxSolveConfint1 <- function(x, y, ..., xlab = "Time", ylab = "", log = "") 
 #' @export
 plot.rxSolveConfint2 <- function(x, y, ..., xlab = "Time", ylab = "", log = "") {
   .data <- NULL
-  .y <- as.character(substitute(y))
+  .y <- all.vars(substitute(y))
   .call0 <- match.call()[-(1:2)]
   .call <- as.list(.call0)
   .w <- which(names(.call) %in% c("x", "y", "log", "xlab", "ylab"))
@@ -473,7 +480,7 @@ plot.rxSolveConfint2 <- function(x, y, ..., xlab = "Time", ylab = "", log = "") 
     .call <- .call[-.w]
   }
   .cmts <- c(
-    as.character(substitute(y)),
+    .y,
     names(vapply(as.character(.call), `c`, character(1), USE.NAMES=FALSE)),
     as.character(unlist(.call))
   )
@@ -502,6 +509,18 @@ plot.rxSolveConfint2 <- function(x, y, ..., xlab = "Time", ylab = "", log = "") 
   .logx <- .lst[["logx"]]
   .logy <- .lst[["logy"]]
   .dat <- .lst[["dat"]]
+  # Apply transformation if expression was more than just a variable name
+  .yExpr <- substitute(y)
+  if (!identical(.yExpr, as.name(.y[1])) && length(.y) == 1) {
+    .tempDat <- .dat
+    .tempDat[[.y[1]]] <- .dat$p50
+    .transformed <- eval(.yExpr, envir = .tempDat)
+    # Apply transformation to all percentile columns
+    for (.pctile in .ci) {
+      .tempDat[[.y[1]]] <- .dat[[.pctile]]
+      .dat[[.pctile]] <- eval(.yExpr, envir = .tempDat)
+    }
+  }
   if (length(.parm) > 1) {
     if (length(.by) > 0) {
       .facet <- eval(str2lang(paste0("facet_wrap(~", paste(c("trt", .by), collapse="+"),

--- a/R/plot.R
+++ b/R/plot.R
@@ -384,7 +384,11 @@ plot.rxSolve <- function(x, y, ..., log = "", xlab = "Time", ylab = "") {
 #' @export
 plot.rxSolveConfint1 <- function(x, y, ..., xlab = "Time", ylab = "", log = "") {
   .data <- NULL
-  .y <- all.vars(substitute(y))
+  .y <- as.character(substitute(y))
+  if (length(.y) != 1){
+    stop("Only a single response variable is allowed with no transformations")
+  }
+  
   .call0 <- match.call()[-(1:2)]
   .call <- as.list(.call0)
   .w <- which(names(.call) %in% c("x", "y", "log", "xlab", "ylab"))
@@ -415,13 +419,6 @@ plot.rxSolveConfint1 <- function(x, y, ..., xlab = "Time", ylab = "", log = "") 
   .logx <- .lst[["logx"]]
   .logy <- .lst[["logy"]]
   .dat <- .lst[["dat"]]
-  # Apply transformation if expression was more than just a variable name
-  .yExpr <- substitute(y)
-  if (!identical(.yExpr, as.name(.y[1])) && length(.y) == 1) {
-    .tempDat <- .dat
-    .tempDat[[.y[1]]] <- .dat$eff
-    .dat$eff <- eval(.yExpr, envir = .tempDat)
-  }
   if (length(.parm) > 1) {
     if (length(.by) > 0) {
       .facet <- eval(str2lang(paste0("facet_wrap(~", paste(c("trt", .by), collapse="+"),
@@ -472,7 +469,10 @@ plot.rxSolveConfint1 <- function(x, y, ..., xlab = "Time", ylab = "", log = "") 
 #' @export
 plot.rxSolveConfint2 <- function(x, y, ..., xlab = "Time", ylab = "", log = "") {
   .data <- NULL
-  .y <- all.vars(substitute(y))
+  .y <- as.character(substitute(y))
+  if (length(.y) != 1) {
+    stop("Only a single response variable is allowed with no transformations")
+  }
   .call0 <- match.call()[-(1:2)]
   .call <- as.list(.call0)
   .w <- which(names(.call) %in% c("x", "y", "log", "xlab", "ylab"))
@@ -509,18 +509,6 @@ plot.rxSolveConfint2 <- function(x, y, ..., xlab = "Time", ylab = "", log = "") 
   .logx <- .lst[["logx"]]
   .logy <- .lst[["logy"]]
   .dat <- .lst[["dat"]]
-  # Apply transformation if expression was more than just a variable name
-  .yExpr <- substitute(y)
-  if (!identical(.yExpr, as.name(.y[1])) && length(.y) == 1) {
-    .tempDat <- .dat
-    .tempDat[[.y[1]]] <- .dat$p50
-    .transformed <- eval(.yExpr, envir = .tempDat)
-    # Apply transformation to all percentile columns
-    for (.pctile in .ci) {
-      .tempDat[[.y[1]]] <- .dat[[.pctile]]
-      .dat[[.pctile]] <- eval(.yExpr, envir = .tempDat)
-    }
-  }
   if (length(.parm) > 1) {
     if (length(.by) > 0) {
       .facet <- eval(str2lang(paste0("facet_wrap(~", paste(c("trt", .by), collapse="+"),

--- a/R/plot.R
+++ b/R/plot.R
@@ -109,7 +109,7 @@ rxTheme <- function(base_size = 11, base_family = "",
   if (inherits(x, "units")) {
     return(units::drop_units(x))
   }
-  return(x)
+  x
 }
 
 .plotTime <- function(.dat, xlab) {
@@ -133,7 +133,7 @@ rxTheme <- function(base_size = 11, base_family = "",
         .timex <- .timex[-.w]
       }
     }
-    return(.timex)
+    .timex
   }
   if (inherits(.dat$time, "units")) {
     .unit <- as.character(units(.dat$time))
@@ -461,7 +461,7 @@ plot.rxSolveConfint1 <- function(x, y, ..., xlab = "Time", ylab = "", log = "") 
     .ylab +
     .theme ->
   .ret
-  return(.ret)
+  .ret
 }
 
 #' @rdname plot.rxSolve
@@ -565,5 +565,5 @@ plot.rxSolveConfint2 <- function(x, y, ..., xlab = "Time", ylab = "", log = "") 
   ## if (getOption("rxode2.theme_bw", TRUE)){
   ##     .ret <- .ret + ggplot2::theme_bw()
   ## }
-  return(.ret)
+  .ret
 }

--- a/tests/testthat/test-confint.R
+++ b/tests/testthat/test-confint.R
@@ -164,15 +164,11 @@ rxTest({
     .ci <- suppressMessages(confint(.s, "cp", level=0.95, ci=FALSE))
 
     .p <- plot(.ci, cp)
-    .p2 <- plot(.ci, cp/10)
-    .p3 <- plot(.ci, log(cp))
+      expect_true(inherits(.p, "ggplot"))
 
-    expect_true(inherits(.p, "ggplot"))
-    expect_true(inherits(.p2, "ggplot"))
-    expect_true(inherits(.p3, "ggplot"))
-    
-    expect_equal(as.list(.p)$data$eff, as.list(.p2)$data$eff * 10)
-    expect_equal(as.list(.p)$data$eff, exp(as.list(.p3)$data$eff))
+    .p2 <- plot(.ci, cp/10) |> expect_error("Only a single response")
+    .p3 <- plot(.ci, log(cp)) |> expect_error("Only a single response")
+
 
   })
 

--- a/tests/testthat/test-confint.R
+++ b/tests/testthat/test-confint.R
@@ -158,9 +158,8 @@ rxTest({
 
   
   test_that("plot.rxSolveConfint1 works with output tranformation", {
-    rxSetSeed(42)
-    .s <- suppressMessages(rxSolve(.ciModel, .ciEt, thetaMat=.ciThetaMat,
-                                  nStud=1, nSub=10))
+    .s <- rxWithSeed(42, suppressMessages(rxSolve(.ciModel, .ciEt, thetaMat=.ciThetaMat,
+                                                  nStud=1, nSub=10)))
     .ci <- suppressMessages(confint(.s, "cp", level=0.95, ci=FALSE))
 
     .p <- plot(.ci, cp)

--- a/tests/testthat/test-confint.R
+++ b/tests/testthat/test-confint.R
@@ -156,4 +156,26 @@ rxTest({
     expect_true(all(c("p1", "eff") %in% names(.ci)))
   })
 
+  
+  test_that("plot.rxSolveConfint1 works with output tranformation", {
+    rxSetSeed(42)
+    .s <- suppressMessages(rxSolve(.ciModel, .ciEt, thetaMat=.ciThetaMat,
+                                  nStud=1, nSub=10))
+    .ci <- suppressMessages(confint(.s, "cp", level=0.95, ci=FALSE))
+
+    .p <- plot(.ci, cp)
+    .p2 <- plot(.ci, cp/10)
+    .p3 <- plot(.ci, log(cp))
+
+    expect_true(inherits(.p, "ggplot"))
+    expect_true(inherits(.p2, "ggplot"))
+    expect_true(inherits(.p3, "ggplot"))
+    
+    expect_equal(as.list(.p)$data$eff, as.list(.p2)$data$eff * 10)
+    expect_equal(as.list(.p)$data$eff, exp(as.list(.p3)$data$eff))
+
+  })
+
+
+
 })


### PR DESCRIPTION
`plot.rxSolveConfint` allows for unquoted simulated variable name. Unexpected results happens if a user tries to apply transformation on that variable, which is intuitive. To avoid that issue, this PR enforces no transformation at this step all together. 