### PR TITLE
etTrans follow-ups: dead code, dfdy ETA names, output-pointer hoist, iCov allocation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -814,6 +814,11 @@
   The pointers are taken once instead, which is 2.7x on `etTrans()` alone and
   2.8-3.8x on a solve at 160000-320000 rows.
 
+- `etTrans(allTimeVar = TRUE)` no longer errors when an `iCov` covariate is
+  supplied.  Under `allTimeVar` every covariate is emitted as a per-row
+  column, but the column for an `iCov` covariate was never allocated, so
+  taking it failed instead of returning the covariate.
+
 - `rxDfdy()` (and `rxModelVars()$dfdy`) report an ETA derivative as
   `df(A)/dy(ETA[1])` instead of leaking the internal name
   `df(A)/dy(_ETA_1_)`.  Both `THETA[n]` and `ETA[n]` are translated back from

--- a/NEWS.md
+++ b/NEWS.md
@@ -806,6 +806,14 @@
   double covariate at 20000 subjects.  The columns are now coerced once, as
   above.
 
+- Translating an event table no longer re-wraps its own output columns once
+  per row.  The row loop in `etTrans()` took each output column as a fresh
+  `Rcpp` vector on every row -- a no-op cast, since the columns were
+  allocated as the right type, but one that still paid Rcpp's
+  preserve/release bookkeeping at every one of roughly nine sites per row.
+  The pointers are taken once instead, which is 2.7x on `etTrans()` alone and
+  2.8-3.8x on a solve at 160000-320000 rows.
+
 - `rxDfdy()` (and `rxModelVars()$dfdy`) report an ETA derivative as
   `df(A)/dy(ETA[1])` instead of leaking the internal name
   `df(A)/dy(_ETA_1_)`.  Both `THETA[n]` and `ETA[n]` are translated back from

--- a/NEWS.md
+++ b/NEWS.md
@@ -806,6 +806,13 @@
   double covariate at 20000 subjects.  The columns are now coerced once, as
   above.
 
+- `rxDfdy()` (and `rxModelVars()$dfdy`) report an ETA derivative as
+  `df(A)/dy(ETA[1])` instead of leaking the internal name
+  `df(A)/dy(_ETA_1_)`.  Both `THETA[n]` and `ETA[n]` are translated back from
+  their internal spellings for display, but the ETA translation was written
+  into the buffer and then unconditionally overwritten, so only `THETA[n]`
+  survived.
+
 - Building a model no longer hangs forever on a lock left behind by an
   interrupted session, and two processes no longer build the same model at
   once.  `rxTempDir()` exports itself with `Sys.setenv()`, so every subprocess

--- a/R/rudf.R
+++ b/R/rudf.R
@@ -516,5 +516,4 @@ rxRmFunParse <- function(name) {
   }
   stop(paste0(.udfCallFunArg(fun, args), "needs to return a length 1 numeric"),
        call.=FALSE)
-  .ret
 }

--- a/src/etTran.cpp
+++ b/src/etTran.cpp
@@ -3202,7 +3202,12 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
                 int idxOut = i;
                 int idxIn = i;
                 double vCur = curCovD[idxInput[idxOutput[i]]];
-                // Could be NA, look for non NA value OR beginning of subject
+                // Could be NA, look for non NA value OR beginning of subject.
+                // The enclosing loop walks the output rows backwards, so addId
+                // is set on a subject's LAST row and walking iCur down from
+                // there covers every one of that subject's rows.  Searching
+                // forwards as well would only reach the next subject, which
+                // the lastId guard rejects.
                 while (ISNA(vCur) && iCur != 0 &&
                        id.size() > (idxOut = idxOutput[iCur]) &&
                        idxOut >= 0 &&
@@ -3212,18 +3217,6 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
                        idxIn >= 0) {
                   vCur = curCovD[idxIn];
                   iCur--;
-                }
-                if (ISNA(vCur)) iCur = i;
-                while (ISNA(vCur) && iCur+1 != (int)(covCol.size()) &&
-                       idxOutput.size() < iCur+1 &&
-                       id.size() > (idxOut = idxOutput[iCur+1]) &&
-                       idxOut >= 0 &&
-                       lastId == id[idxOut] &&
-                       idxInput.size() > idxOut &&
-                       curCovDn > (idxIn = idxInput[idxOut]) &&
-                       idxIn >= 0) {
-                  vCur = curCovD[idxIn];
-                  iCur++;
                 }
                 if (ISNA(vCur)) {
                   Rf_warningcall(R_NilValue,

--- a/src/etTran.cpp
+++ b/src/etTran.cpp
@@ -3094,13 +3094,40 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
     covDp[j] = REAL(curCovD);
     covDn[j] = curCovD.size();
   }
+  // The output columns below are ours -- allocated above as IntegerVector /
+  // NumericVector -- so re-wrapping them per row only pays Rcpp's
+  // preserve/release bookkeeping.  Take the pointers once.
+  int    *outId    = INTEGER(lst[0]);
+  int    *outId1   = INTEGER(lst1[0]);
+  double *outTime  = REAL(lst[1]);
+  int    *outEvid  = INTEGER(lst[2]);
+  double *outAmt   = REAL(lst[3]);
+  double *outIi    = REAL(lst[4]);
+  double *outDv    = REAL(lst[5]);
+  int    *outCmt   = cmtAdd  ? INTEGER(lst[6])              : NULL;
+  int    *outCens  = censAdd ? INTEGER(lst[6+cmtAdd])       : NULL;
+  double *outLimit = limitAdd? REAL(lst[6+cmtAdd+censAdd])  : NULL;
+  std::vector<double*> keepP(keepCol.size(), NULL);
+  for (j = 0; j < (int)(keepCol.size()); j++) keepP[j] = REAL(keepL[j]);
+  // covariate output columns; the cmt covariate is the one integer column
+  std::vector<double*> covOutP(covCol.size(), NULL);
+  std::vector<int*>    covOutI(covCol.size(), NULL);
+  std::vector<double*> cov1P(covCol.size(), NULL);
+  for (j = 0; j < (int)(covCol.size()); j++) {
+    if (hasCmt && covCol[j] >= 0 && j == cmtI) {
+      covOutI[j] = INTEGER(lst[baseSize+j]);
+      continue;
+    }
+    if (!allTimeVar && covCol[j] < 0) continue;
+    covOutP[j] = REAL(lst[baseSize+j]);
+    cov1P[j]   = REAL(lst1[1+j]);
+  }
   int maxItemsPerId = 0;
   int curItems = 0;
   for (i =idxOutput.size(); i--;){
     if (idxOutput[i] != -1) {
       jj--;
-      ivTmp = as<IntegerVector>(lst[0]);
-      ivTmp[jj] = id[idxOutput[i]];
+      outId[jj] = id[idxOutput[i]];
       if (lastId != id[idxOutput[i]]) {
         maxItemsPerId = max2(curItems, maxItemsPerId);
         curItems=0;
@@ -3108,62 +3135,35 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
         idx1--;
         if (idx1 < 0) stop(_("number of individuals not calculated correctly"));
         // Add ID
-        ivTmp = as<IntegerVector>(lst1[0]);
-        ivTmp[idx1] = id[idxOutput[i]];
+        outId1[idx1] = id[idxOutput[i]];
         lastId=id[idxOutput[i]];
       }
       // retId[i]=id[idxOutput[i]];
-      nvTmp = as<NumericVector>(lst[1]);
-      // retTime[i]=time[idxOutput[i]];
-      nvTmp[jj] = time[idxOutput[i]];
-      ivTmp = as<IntegerVector>(lst[2]);
-      ivTmp[jj] = evid[idxOutput[i]];
-      // retEvid[i]=evid[idxOutput[i]];
-      nvTmp = as<NumericVector>(lst[3]);
-      // retAmt[i]=amt[idxOutput[i]];
-      nvTmp[jj] = amt[idxOutput[i]];
-      nvTmp = as<NumericVector>(lst[4]);
-      nvTmp[jj]=ii[idxOutput[i]];
-      nvTmp = as<NumericVector>(lst[5]);
-      nvTmp[jj]=dv[idxOutput[i]];
-      kk = 6;
-      if (cmtAdd){
-        ivTmp = as<IntegerVector>(lst[kk]);
-        ivTmp[jj] = cmtF[idxOutput[i]];
-        kk++;
-      }
-      if (censAdd){
-        ivTmp = as<IntegerVector>(lst[kk]);
-        ivTmp[jj] = cens[idxOutput[i]];
-        kk++;
-      }
-      if (limitAdd){
-        nvTmp = as<NumericVector>(lst[kk]);
-        nvTmp[jj] = limit[idxOutput[i]];
-        kk++;
-      }
+      outTime[jj] = time[idxOutput[i]];
+      outEvid[jj] = evid[idxOutput[i]];
+      outAmt[jj] = amt[idxOutput[i]];
+      outIi[jj] = ii[idxOutput[i]];
+      outDv[jj] = dv[idxOutput[i]];
+      if (cmtAdd)  outCmt[jj]   = cmtF[idxOutput[i]];
+      if (censAdd) outCens[jj]  = cens[idxOutput[i]];
+      if (limitAdd) outLimit[jj] = limit[idxOutput[i]];
       // Now add the other items.
       added=false;
       if (idxInput[idxOutput[i]] == -1) {
         // not in data
         for (j = 0; j < (int)(keepCol.size()); j++){
-          nvTmp = as<NumericVector>(keepL[j]);
-          nvTmp[jj] = NA_REAL;
+          keepP[j][jj] = NA_REAL;
         }
       } else {
         for (j = 0; j < (int)(keepCol.size()); j++){
-          // idxOutput is the output id
-          nvTmp = as<NumericVector>(keepL[j]);
           // These keep variables are added.
-          SEXP cur = inDataFK[j];
-          nvTmp[jj] = REAL(cur)[idxInput[idxOutput[i]]];
+          keepP[j][jj] = REAL(inDataFK[j])[idxInput[idxOutput[i]]];
         }
       }
       for (j = 0; j < (int)(covCol.size()); j++){
         int covColj = covCol[j];
         if (hasCmt && covColj >= 0 &&j == cmtI) {
-          ivTmp = as<IntegerVector>(lst[baseSize+j]);
-          ivTmp[jj] = cmtF[idxOutput[i]];
+          covOutI[j][jj] = cmtF[idxOutput[i]];
           if (!cmtFadd){
             sub0[baseSize+j] = true;
             sub1[1+j] = false;
@@ -3173,10 +3173,10 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
           }
         } else {
           if (!allTimeVar && covColj < 0) continue;
-          nvTmp = as<NumericVector>(lst[baseSize+j]);
+          double *covOut = covOutP[j];
           if (idxInput[idxOutput[i]] == -1){
             // These should be ignored for interpolation.
-            nvTmp[jj] = NA_REAL;
+            covOut[jj] = NA_REAL;
           } else {
             // These covariates are added; covDp[j] is the column already
             // coerced to double above.
@@ -3188,16 +3188,16 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
               // so we get the current
               // idx1 = the index of the current id
               if (allTimeVar) {
-                nvTmp[jj] = curCovD[idxIcov[idx1]];
+                covOut[jj] = curCovD[idxIcov[idx1]];
               }
               // nvTmp = as<NumericVector>(lst1[1+j]);
               // double vCur = curCovD[idx1];
               // nvTmp[idx1] = vCur;
               // fPars[idx1*pars.size()+covParPos[j]] = nvTmp[idx1];
             } else {
-              nvTmp[jj] = curCovD[idxInput[idxOutput[i]]];
+              covOut[jj] = curCovD[idxInput[idxOutput[i]]];
               if (addId) {
-                nvTmp = as<NumericVector>(lst1[1+j]);
+                double *cov1 = cov1P[j];
                 int iCur = i;
                 int idxOut = i;
                 int idxIn = i;
@@ -3223,14 +3223,13 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
                                  "column '%s' has only 'NA' values for id '%s'" , CHAR(nme1[1+j]),
                                  CHAR(idLvl[((inId.size() == 0) ? 1 : lastId)-1]));
                 }
-                nvTmp[idx1] = vCur;
-                fPars[idx1*pars.size()+covParPos[j]] = nvTmp[idx1];
+                cov1[idx1] = vCur;
+                fPars[idx1*pars.size()+covParPos[j]] = cov1[idx1];
                 added = true;
               } else if (sub1[1+j]) {
-                nvTmp = as<NumericVector>(lst1[1+j]);
-                //double cur1 = nvTmp[idx1];
+                double *cov1 = cov1P[j];
                 double cur2 = curCovD[idxInput[idxOutput[i]]];
-                if (!ISNA(cur2) && nvTmp[idx1] != cur2){
+                if (!ISNA(cur2) && cov1[idx1] != cur2){
                   sub0[baseSize+j] = true;
                   sub1[1+j] = false;
                   fPars[idx1*pars.size()+covParPos[j]] = NA_REAL;

--- a/src/etTran.cpp
+++ b/src/etTran.cpp
@@ -2860,9 +2860,11 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
       nvTmp = NumericVector(nid);
       nme[baseSize+j] = pars[covParPos[j]];
       if (covColj < 0) {
-        // invariant covariates so don't allocate space
+        // An 'iCov' covariate is invariant within an id, so the per-row column
+        // is a zero-length placeholder -- except under 'allTimeVar', where the
+        // row loop writes it for every output row and it must be full length.
         if (allTimeVar) {
-          lst1[1+j] = NumericVector(nid);
+          lst[baseSize+j] = NumericVector(idxOutput.size()-rmAmt);
         } else {
           lst[baseSize+j] = NumericVector(0);
         }

--- a/src/genModelVars.h
+++ b/src/genModelVars.h
@@ -590,6 +590,8 @@ static inline void populateDfdy(SEXP dfdy) {
         sPrint(&_bufw,"_ETA_%d_",j);
         if (!strcmp(dy,_bufw.s)){
           sPrint(&_bufw,"ETA[%d]",j);
+          foundIt=1;
+          break;
         }
       }
     }

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -2013,7 +2013,6 @@ extern "C" double *rxGetErrs(){
   if (_rxModels.exists(".sigma")){
     NumericMatrix sigma = _rxModels[".sigma"];
     if (_rxGetErrs == NULL){
-      if (_rxGetErrs != NULL) free(_rxGetErrs);
       _rxGetErrs = (double*)calloc(sigma.ncol()*sigma.nrow(), sizeof(double));
       if (_rxGetErrs == NULL) {
         rxSolveFree();

--- a/tests/testthat/test-cov.R
+++ b/tests/testthat/test-cov.R
@@ -853,4 +853,40 @@ rxTest({
     .d <- .cmtData(20000, 3)
     expect_lt(.minElapsed(modCmt, .d), 2 * .minElapsed(modDbl, .d))
   })
+
+  test_that("an NA covariate resolves from anywhere in the subject", {
+
+    # A subject's invariant covariate value is filled by scanning that
+    # subject's rows for a non-NA one.  The scan starts at the subject's LAST
+    # row and walks backwards, so it has to reach a value that sits at the
+    # subject's FIRST rows -- id 3 below is the case that pins that down.
+    mod <- rxode2({
+      eff <- 10 * flag
+    })
+    d <- data.frame(
+      ID = rep(1:3, each = 4),
+      TIME = rep(1:4, times = 3),
+      flag = c(
+        NA, NA, NA, NA, # nothing to find -> NA, with a warning
+        NA, NA, 7, 7,   # value at the last rows  -> found immediately
+        5, 5, NA, NA    # value at the FIRST rows -> found by walking back
+      ),
+      EVID = 0, AMT = 0
+    )
+
+    expect_warning(
+      .r <- rxSolve(mod, events = d, returnType = "data.frame"),
+      "column 'flag' has only 'NA' values for id '1'"
+    )
+    expect_equal(.r$eff[.r$id == 1], rep(0, 4)) # warned about, then solved as 0
+    expect_equal(.r$eff[.r$id == 2], rep(70, 4))
+    expect_equal(.r$eff[.r$id == 3], rep(50, 4))
+
+    # the per-id covariate table keeps the unresolvable value as NA
+    expect_warning(
+      .tr <- rxode2::etTrans(d, mod),
+      "column 'flag' has only 'NA' values for id '1'"
+    )
+    expect_equal(attr(class(.tr), ".rxode2.lst")$cov1$flag, c(NA, 7, 5))
+  })
 })

--- a/tests/testthat/test-dfdy.R
+++ b/tests/testthat/test-dfdy.R
@@ -290,4 +290,25 @@ d/dt(cen) = ka*depot-k*cen
       "cen(0)=0\ndf(cen)/dy(x1)=0\ndf(cen)/dy(THETA[1])=0\ndf(cen)/dy(THETA[2])=0\n",
       "df(cen)/dy(THETA[3])=0\ny=cen\ntad=t-tlast()\n")))
   })
+
+  test_that("dfdy names report ETA[n] and THETA[n], not the internal names", {
+
+    # THETA and ETA both reach populateDfdy() under their internal spellings
+    # (_THETA_1_, _ETA_1_) and are translated back for display.  The ETA half
+    # of that translation used to be discarded, so an ETA derivative reported
+    # the internal name while a THETA derivative next to it did not.
+    mod <- rxode2({
+      d / dt(A) <- -(CL / V) * A + THETA[1] * ETA[1]
+      df(A) / dy(A) <- -(CL / V)
+      df(A) / dy(THETA[1]) <- ETA[1]
+      df(A) / dy(ETA[1]) <- THETA[1]
+    })
+
+    expect_equal(
+      rxDfdy(mod),
+      c("df(A)/dy(A)", "df(A)/dy(THETA[1])", "df(A)/dy(ETA[1])")
+    )
+    expect_false(any(grepl("_ETA_", rxDfdy(mod), fixed = TRUE)))
+    expect_false(any(grepl("_THETA_", rxDfdy(mod), fixed = TRUE)))
+  })
 })

--- a/tests/testthat/test-iCov.R
+++ b/tests/testthat/test-iCov.R
@@ -170,4 +170,29 @@ rxTest({
     expect_equal(as.numeric(tmp2$cov1$cov), c(2, 3, 1))
     expect_equal(as.numeric(tmp2$pars["cov", ]), c(2, 3, 1))
   })
+
+  test_that("'allTimeVar=TRUE' emits an 'iCov' covariate as a per-row column", {
+    # the per-row column for an 'iCov' covariate was never allocated under
+    # 'allTimeVar', so taking it errored instead of returning the covariate
+    mod <- rxode2({
+      d/dt(center) <- -(cl / v) * center
+      cp <- center / v + wt * 0
+    })
+
+    ev <- as.data.frame(et(amt = 100) |> et(seq(0, 24, 4)) |> et(id = 1:3))
+    ic <- data.frame(id = 1:3, wt = c(70, 80, 90))
+
+    tmp <- as.data.frame(etTrans(ev, mod, allTimeVar = TRUE, iCov = ic))
+    expect_equal(vapply(split(tmp$wt, tmp$ID),
+                        function(x) unique(x[!is.na(x)]), double(1),
+                        USE.NAMES = FALSE),
+                 c(70, 80, 90))
+
+    # 'allTimeVar=FALSE' keeps the covariate on the per-id table only
+    tmp2 <- etTrans(ev, mod, allTimeVar = FALSE, iCov = ic)
+    expect_false("wt" %in% names(as.data.frame(tmp2)))
+    .lst <- attr(class(tmp2), ".rxode2.lst")
+    class(.lst) <- NULL
+    expect_equal(.lst$cov1$wt, c(70, 80, 90))
+  })
 })


### PR DESCRIPTION
Re-lands four commits that were reviewed and approved in #1327 and #1328 but
never reached `main`. Both PRs targeted `fix/covariate-int-logical-perf-1325`
rather than `main`, and #1326 had already merged that branch, so their commits
ended up stranded on it with no open PR. Cherry-picked onto current `main`;
content is unchanged from what was reviewed, and mattfidler's commit keeps his
authorship.

| commit | what |
|---|---|
| `refactor:` | three blocks that can never execute |
| `fix(dfdy):` | report `ETA[n]`, not the internal `_ETA_n_` |
| `perf(etTrans):` | take the output column pointers once, not once per row |
| `fix(etTrans):` | allocate the per-row `iCov` column under `allTimeVar` |

## Dead code

`etTrans()` searched a subject's rows for a non-NA covariate twice — backwards,
then forwards. The forward search was guarded by `idxOutput.size() < iCur+1`,
never true because `iCur < idxOutput.size()`, and by
`iCur+1 != covCol.size()`, comparing a row index against the covariate count.
**Repairing both guards would not help**: the enclosing loop walks rows
backwards, so `addId` fires on a subject's *last* row and the backward search
already covers the whole subject; the forward search would only reach the next
subject and be rejected by the `lastId` guard. Removed rather than repaired.
Also a `free()` inside a branch entered only when the pointer is `NULL`, and a
value expression after `stop()`.

## dfdy — the one with user-visible output

`populateDfdy()` translates `_THETA_n_` and `_ETA_n_` back for display, but
only the THETA loop set `foundIt`, so the ETA loop's result was overwritten by
the next `if (!foundIt)`:

```r
rxDfdy(mod)
#> "df(A)/dy(A)"  "df(A)/dy(THETA[1])"  "df(A)/dy(_ETA_1_)"
#>                                                ^^^^^^^ internal name leaked
```

Nothing parses these names back, and no test locked the buggy form.

## Pointer hoist

The row loop re-wrapped **its own output columns** every row — 16 sites, ~8–9
per row. Not coercions: the vectors were allocated as the right type a few
lines above, so each was a no-op cast still paying Rcpp's preserve/release
bookkeeping.

| | before | after | |
|---|---|---|---|
| solve, 160k rows | 1.068 s | 0.284 s | **3.8x** |
| `etTrans()` alone, 320k rows | 1.232 s | 0.455 s | **2.7x** |

## Verification

Output identical across double / time-varying-with-`NA` / integer / logical
covariates, a `keep` column and 200 subjects. Full suite green when this was
reviewed.

Re-checked on current `main`: `test-ss-extra-dose-duration.R` has 3 failures,
but they reproduce on **clean `origin/main`** — pre-existing and unrelated to
this PR, though worth knowing `main` is red there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)