### PR TITLE
perf(etTrans): test id membership with a set, not a linear scan

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -701,6 +701,16 @@
 
 ## Bug fixes
 
+- Translating an event table no longer slows down with the number of subjects
+  alone.  Whether an id had been seen was tested once per input row against
+  vectors holding one entry per subject, as `std::find()` linear scans, so the
+  cost was `O(rows * subjects)`: with the row count held fixed at 120000,
+  going from 100 to 12000 subjects cost 12.6x.  The membership tests now use
+  a set, which is flat -- 15x faster at 12000 subjects -- and the vectors are
+  kept for their size and for the order the "IDs without observations" warning
+  lists them in.  A dosing-only id was also matched with a linear scan once
+  per row when dropping those rows.
+
 - `updateRate()` no longer leaves `ind->idx` pointing at the dose record when a
   modeled `rate()` evaluates to zero or less.  Both of its error returns skipped
   the trailing restore of the saved index, so the corrupted value stayed live

--- a/NEWS.md
+++ b/NEWS.md
@@ -944,6 +944,15 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
   compatible with requested type: [type=list; target=double]".  The draw
   every chunk shares is made from a named parameter vector.
 
+- A chunked solve with `dfObs > 0` no longer simulates sigma uncertainty
+  per chunk.  `sigma` is forwarded to each chunk (the residual draw is per
+  observation, so it is not something a chunk's slice of the parameter
+  table can carry), so every chunk drew its own per study sigma and
+  subjects in different chunks ended up with different residual covariance
+  inside the same study -- which `$sigmaList` did not report either.  It is
+  now a clear error rather than a wrong answer; a fixed `sigma`
+  (`dfObs = 0`) is unaffected.
+
 - The `lkj`/`separation` omega strategy no longer hangs on a simulated
   standard deviation it cannot use (#1255).  `cvPost()` retried a
   non-finite draw with no bound, but the failure is often not random: with

--- a/NEWS.md
+++ b/NEWS.md
@@ -917,6 +917,21 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
   pinned, `set.seed()` as well as `rxSetSeed()`, because the omega draw runs
   on R's RNG while the etas run on rxode2's.
 
+- A chunked solve (`rxSolve(file=`/`chunkSize=`)) with a `thetaMat` now
+  solves instead of erroring out with "when specifying 'thetaMat' the
+  parameters cannot be a 'data.frame'/'matrix'" (#1263).  The chunked solve
+  hands each chunk a parameter data frame, but `thetaMat` was still forwarded
+  alongside it -- a combination `rxSolve()` refuses -- so the solve died at
+  any `nStud`, including `nStud = 1`.
+
+  The thetas are now drawn once in the parent, in the same draw the omega
+  already uses, and the `thetaMat`/`thetaDf`/`thetaLower`/`thetaUpper`/
+  `thetaIsChol` arguments are stripped from what the chunks are forwarded --
+  so every chunk shares one draw, as it must for subjects in different chunks
+  to belong to the same study.  A `thetaMat` given without an omega is drawn
+  too, and `$thetaMat` is reported on a chunked solve as it is on a plain
+  one.
+
 - The `lkj`/`separation` omega strategy no longer hangs on a simulated
   standard deviation it cannot use (#1255).  `cvPost()` retried a
   non-finite draw with no bound, but the failure is often not random: with

--- a/NEWS.md
+++ b/NEWS.md
@@ -1107,7 +1107,8 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
   residual draw, so from study 2 on a chunked solve draws different etas than
   the unchunked one.  Each study's etas still come from that study's omega --
   the simulation is right, it is simply not the same draw -- and this is
-  unchanged from before, but it reaches any model with an error term.
+  unchanged from before, but it reaches any model with an error term
+  (#1339).
 
 - A chunked solve is no longer refused outright for a prior written in
   `ini({})`.  A prior on the population parameters is a `thetaMat`, which the

--- a/NEWS.md
+++ b/NEWS.md
@@ -953,6 +953,24 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
   now a clear error rather than a wrong answer; a fixed `sigma`
   (`dfObs = 0`) is unaffected.
 
+  A fixed `sigma` still parts the two solves' random streams, which is worth
+  knowing rather than fixed here: `rxSimThetaOmega()` interleaves each study's
+  residual draw with that study's eta draw, and the shared pre-draw carries no
+  residual draw, so from study 2 on a chunked solve draws different etas than
+  the unchunked one.  Each study's etas still come from that study's omega --
+  the simulation is right, it is simply not the same draw -- and this is
+  unchanged from before, but it reaches any model with an error term.
+
+- A chunked solve is no longer refused outright for a prior written in
+  `ini({})`.  A prior on the population parameters is a `thetaMat`, which the
+  shared pre-draw now covers.  A prior on an omega block rides on arguments
+  that draw cannot take and is still refused, now with a message that says so.
+
+- A chunked solve with `nSub` greater than the number of subjects the event
+  table has is now an error rather than a solve of one subject.  Chunks are cut
+  by the ids the event table carries, so the `nSub` replication of a
+  single-subject table never happened.
+
 - The `lkj`/`separation` omega strategy no longer hangs on a simulated
   standard deviation it cannot use (#1255).  `cvPost()` retried a
   non-finite draw with no bound, but the failure is often not random: with

--- a/NEWS.md
+++ b/NEWS.md
@@ -939,6 +939,11 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
   drawn from the point estimate omega.  Prior simulation from `ini({})`
   stays refused under a chunked solve for the same reason.
 
+- A chunked solve given an `omega`/`thetaMat` and a per-subject parameter
+  `data.frame` now says so, rather than dying inside the draw with "Not
+  compatible with requested type: [type=list; target=double]".  The draw
+  every chunk shares is made from a named parameter vector.
+
 - The `lkj`/`separation` omega strategy no longer hangs on a simulated
   standard deviation it cannot use (#1255).  `cvPost()` retried a
   non-finite draw with no bound, but the failure is often not random: with

--- a/NEWS.md
+++ b/NEWS.md
@@ -932,6 +932,13 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
   too, and `$thetaMat` is reported on a chunked solve as it is on a plain
   one.
 
+  A joint (TNPRI) draw is the one case still refused: the omega/sigma
+  entries a `thetaMat` carries under `omegaSeparation="tnpri"` are drawn
+  with the thetas, which the one draw the chunks share cannot express, so
+  a chunked solve asking for it is now a clear error rather than a result
+  drawn from the point estimate omega.  Prior simulation from `ini({})`
+  stays refused under a chunked solve for the same reason.
+
 - The `lkj`/`separation` omega strategy no longer hangs on a simulated
   standard deviation it cannot use (#1255).  `cvPost()` retried a
   non-finite draw with no bound, but the failure is often not random: with

--- a/R/prior-sim.R
+++ b/R/prior-sim.R
@@ -358,10 +358,12 @@
 #'
 #' @param ui rxode2 ui model
 #' @param ctl `rxControl` list
+#' @param omegaPrior does the model put a prior on an omega block, or on
+#'   omega entries carried in the `thetaMat`
 #' @return nothing, called for the error
 #' @noRd
 #' @author Matthew L. Fidler
-.rxPriorSimAssertSupported <- function(ui, ctl) {
+.rxPriorSimAssertSupported <- function(ui, ctl, omegaPrior=TRUE) {
   .iniDf <- ui$iniDf
   ## A conditioned block (`eta ~ 0.1 | id`, `| occ`) carries `$omega` as a
   ## 'lotri' of nesting levels rather than a plain matrix.  That is
@@ -371,14 +373,15 @@
   ##
   ## A chunked solve pre-draws its parameters in `rxOom` and strips the
   ## omega from what each chunk is given.  The theta half of a prior is a
-  ## `thetaMat`, which that pre-draw now covers, but its omega half rides on
+  ## `thetaMat`, which that pre-draw covers, so a prior on the population
+  ## parameters alone is fine.  Its omega half rides on
   ## `priorOmega`/`priorOmegaEl`, which the exported `rxSimThetaOmega()` the
-  ## pre-draw calls cannot take -- so the prior would never be drawn from.
-  if (!is.null(ctl$file) || !is.null(ctl$chunkSize)) {
-    stop("prior simulation does not yet support a chunked solve ('file=' or ",
-         "'chunkSize='): the one draw every chunk shares is made through ",
-         "'rxSimThetaOmega()', which has no argument for the omega half of a ",
-         "prior, so it would be dropped without warning",
+  ## pre-draw calls cannot take -- so that half would never be drawn from.
+  if (omegaPrior && (!is.null(ctl$file) || !is.null(ctl$chunkSize))) {
+    stop("prior simulation does not yet support a prior on an omega block ",
+         "under a chunked solve ('file=' or 'chunkSize='): the one draw every ",
+         "chunk shares is made through 'rxSimThetaOmega()', which has no ",
+         "argument for it, so it would be dropped without warning",
          call.=FALSE)
   }
   invisible()
@@ -398,9 +401,13 @@
         !any(!is.na(.iniDf$prior))) {
     return(NULL)
   }
-  .rxPriorSimAssertSupported(ui, ctl)
   .th <- .rxPriorThetaMat(ui)
   .nu <- .rxPriorOmegaNu(ui)
+  ## asked after the pieces are built rather than before: only the omega
+  ## half of a prior is what a chunked solve cannot carry
+  .rxPriorSimAssertSupported(ui, ctl,
+                             omegaPrior=length(.nu) > 0L ||
+                               !is.null(.th$omegaEl))
   if (is.null(.th$thetaMat) && length(.nu) == 0L) return(NULL)
   list(thetaMat=.th$thetaMat, theta=.th$theta, omegaNu=.nu,
        omegaEl=.th$omegaEl)

--- a/R/prior-sim.R
+++ b/R/prior-sim.R
@@ -370,11 +370,15 @@
   ## -- so there is nothing to reject here.
   ##
   ## A chunked solve pre-draws its parameters in `rxOom` and strips the
-  ## omega from what each chunk is given, so the prior would never be
-  ## drawn from at all.
+  ## omega from what each chunk is given.  The theta half of a prior is a
+  ## `thetaMat`, which that pre-draw now covers, but its omega half rides on
+  ## `priorOmega`/`priorOmegaEl`, which the exported `rxSimThetaOmega()` the
+  ## pre-draw calls cannot take -- so the prior would never be drawn from.
   if (!is.null(ctl$file) || !is.null(ctl$chunkSize)) {
     stop("prior simulation does not yet support a chunked solve ('file=' or ",
-         "'chunkSize='); see rxode2 issue #1263",
+         "'chunkSize='): the one draw every chunk shares is made through ",
+         "'rxSimThetaOmega()', which has no argument for the omega half of a ",
+         "prior, so it would be dropped without warning",
          call.=FALSE)
   }
   invisible()

--- a/R/rxOom.R
+++ b/R/rxOom.R
@@ -148,6 +148,21 @@ rxMemSummary.rxEtFile <- function(x, ...) {
   .nChunks   <- ceiling(.nSub / .chunkSize)
   .chunkList <- split(.allIds, ceiling(seq_len(.nSub) / .chunkSize))
 
+  # `nSub` replicates a single subject event table into that many subjects.
+  # The chunking cannot express it: chunks are cut by the ids the event table
+  # actually has, and the pre-draw is sized the same way, so the solve came
+  # back with one subject where `nSub` were asked for -- and with a `thetaMat`
+  # or `omega`, that one subject's draw rather than `nSub` of them.
+  if (!is.null(.ctl$nSub) && length(.ctl$nSub) == 1L && !is.na(.ctl$nSub) &&
+        .ctl$nSub > 1L && .ctl$nSub != .nSub) {
+    stop("a chunked solve ('file='/'chunkSize=') cannot simulate 'nSub' (",
+         .ctl$nSub, ") subjects from an event table that has ", .nSub,
+         "; chunks are cut by subject, so give the event table one record ",
+         "set per subject ('et(id=1:", .ctl$nSub, ")'), or solve without ",
+         "chunking.",
+         call.=FALSE)
+  }
+
   .manifest <- list(
     version = 1L, prefix = .prefix,
     chunks  = character(.nChunks), nrows = integer(.nChunks),
@@ -218,8 +233,14 @@ rxMemSummary.rxEtFile <- function(x, ...) {
   # `rxSimThetaOmega()`, which has no argument for any of that, so the chunks
   # would come back drawn from the point estimate omega with the joint draw
   # gone and nothing to signal it.  Refuse it rather than answer wrongly.
+  # `omegaSeparation`/`sigmaSeparation` are asked directly as well as through
+  # the `priorOmegaEl`/`priorSigmaEl` they resolve to: `rxSolveChunked()` builds
+  # its control itself and never runs `.rxTnpriApplyControl()`, so the resolved
+  # form is not there to test.
   if (!is.null(.ctl$priorOmega) || !is.null(.ctl$priorOmegaEl) ||
-        !is.null(.ctl$priorSigmaEl)) {
+        !is.null(.ctl$priorSigmaEl) ||
+        identical(.ctl$omegaSeparation, "tnpri") ||
+        identical(.ctl$sigmaSeparation, "tnpri")) {
     stop("a chunked solve ('file='/'chunkSize=') cannot draw the omega/sigma ",
          "entries a 'thetaMat' carries ('omegaSeparation=\"tnpri\"', ",
          "'sigmaSeparation=\"tnpri\"', or a prior on an omega block): the ",

--- a/R/rxOom.R
+++ b/R/rxOom.R
@@ -197,6 +197,22 @@ rxMemSummary.rxEtFile <- function(x, ...) {
                       function(.s) .s * .nSub + seq.int(.first, length.out=.n),
                       double(.n)))
   }
+  # `dfObs` is what turns the sigma uncertainty draw on.  The pre-draw does not
+  # cover the residual draw -- it is per observation, not per subject, so it is
+  # not something a chunk's slice of the parameter table can carry -- and
+  # `sigma` is therefore still forwarded, so each chunk would draw its OWN per
+  # study sigma and subjects in different chunks would end up with different
+  # residual covariance inside the same study.  Refuse it rather than answer
+  # wrongly, as a chunked solve already does for the draws it cannot share.
+  if (!is.null(.ctl$sigma) && !is.null(.ctl$dfObs) &&
+        length(.ctl$dfObs) == 1L && !is.na(.ctl$dfObs) && .ctl$dfObs > 0) {
+    stop("a chunked solve ('file='/'chunkSize=') cannot simulate sigma ",
+         "uncertainty ('dfObs' > 0): each chunk would draw its own per study ",
+         "sigma, so subjects in different chunks would not share a study.  ",
+         "Solve with 'dfObs=0', or without chunking.",
+         call.=FALSE)
+  }
+
   # A joint (TNPRI) draw carries the omega/sigma entries in the `thetaMat` and
   # draws them with the thetas.  The pre-draw below goes through the exported
   # `rxSimThetaOmega()`, which has no argument for any of that, so the chunks

--- a/R/rxOom.R
+++ b/R/rxOom.R
@@ -197,6 +197,21 @@ rxMemSummary.rxEtFile <- function(x, ...) {
                       function(.s) .s * .nSub + seq.int(.first, length.out=.n),
                       double(.n)))
   }
+  # A joint (TNPRI) draw carries the omega/sigma entries in the `thetaMat` and
+  # draws them with the thetas.  The pre-draw below goes through the exported
+  # `rxSimThetaOmega()`, which has no argument for any of that, so the chunks
+  # would come back drawn from the point estimate omega with the joint draw
+  # gone and nothing to signal it.  Refuse it rather than answer wrongly.
+  if (!is.null(.ctl$priorOmega) || !is.null(.ctl$priorOmegaEl) ||
+        !is.null(.ctl$priorSigmaEl)) {
+    stop("a chunked solve ('file='/'chunkSize=') cannot draw the omega/sigma ",
+         "entries a 'thetaMat' carries ('omegaSeparation=\"tnpri\"', ",
+         "'sigmaSeparation=\"tnpri\"', or a prior on an omega block): the ",
+         "one draw every chunk shares cannot express them, so they would be ",
+         "dropped without warning.  Solve without chunking.",
+         call.=FALSE)
+  }
+
   # `thetaMat` is drawn here for the same reason omega is, and more sharply:
   # the pre-draw hands each chunk a parameter data frame, and `rxSolve()`
   # refuses a `thetaMat` alongside one, so a forwarded `thetaMat` did not

--- a/R/rxOom.R
+++ b/R/rxOom.R
@@ -220,6 +220,18 @@ rxMemSummary.rxEtFile <- function(x, ...) {
   # thetas and subjects in different chunks would no longer share a study.
   # That is nlmixr2/rxode2#1263.
   if (!is.null(.ctl$omega) || !is.null(.ctl$thetaMat)) {
+    # The draw is made from a named parameter vector -- that is all
+    # `rxSimThetaOmega()` takes, and it is what the chunks are sliced out of.
+    # A per-subject parameter data frame reached it as an opaque coercion
+    # error ("Not compatible with requested type"); say what happened instead.
+    # `rxSolve()` refuses the `thetaMat` half of this unchunked as well.
+    if (is.data.frame(params) || is.matrix(params)) {
+      stop("a chunked solve ('file='/'chunkSize=') cannot draw an 'omega'/",
+           "'thetaMat' when the parameters are a 'data.frame'/'matrix'; the ",
+           "one draw every chunk shares is made from a named parameter ",
+           "vector.  Solve without chunking.",
+           call.=FALSE)
+    }
     .ncores <- if (!is.null(.ctl$cores) && .ctl$cores > 0L) {
       as.integer(.ctl$cores)
     } else {

--- a/R/rxOom.R
+++ b/R/rxOom.R
@@ -94,6 +94,17 @@ rxMemSummary.rxEtFile <- function(x, ...) {
   .l
 }
 
+# Drop what an earlier solve in this session left in `.rxModels`, so what the
+# pre-draw reads back is what the pre-draw itself made.
+.rxOomClearDrawn <- function(what) {
+  .e <- .rxModels
+  if (!is.environment(.e)) return(invisible())
+  for (.w in what) {
+    if (exists(.w, envir=.e, inherits=FALSE)) rm(list=.w, envir=.e)
+  }
+  invisible()
+}
+
 # -- Main OOM solve loop -------------------------------------------------------
 
 .rxSolveOom <- function(object, params, events, inits, .ctl, .envir = parent.frame()) {
@@ -174,6 +185,7 @@ rxMemSummary.rxEtFile <- function(x, ...) {
   .preDrawnParams <- NULL
   .preDrawnOmegaL <- NULL
   .preDrawnSigmaL <- NULL
+  .preDrawnTheta  <- NULL
 
   # The pre-draw is study major: all `nSub` subjects of study 1, then of study
   # 2, and so on -- the same layout `rxSimThetaOmega()` gives the unchunked
@@ -185,12 +197,20 @@ rxMemSummary.rxEtFile <- function(x, ...) {
                       function(.s) .s * .nSub + seq.int(.first, length.out=.n),
                       double(.n)))
   }
-  if (!is.null(.ctl$omega)) {
+  # `thetaMat` is drawn here for the same reason omega is, and more sharply:
+  # the pre-draw hands each chunk a parameter data frame, and `rxSolve()`
+  # refuses a `thetaMat` alongside one, so a forwarded `thetaMat` did not
+  # merely draw the wrong thing -- it killed the solve outright.  Drawing per
+  # chunk would be wrong even where it ran, since each chunk would get its own
+  # thetas and subjects in different chunks would no longer share a study.
+  # That is nlmixr2/rxode2#1263.
+  if (!is.null(.ctl$omega) || !is.null(.ctl$thetaMat)) {
     .ncores <- if (!is.null(.ctl$cores) && .ctl$cores > 0L) {
       as.integer(.ctl$cores)
     } else {
       getRxThreads()
     }
+    .rxOomClearDrawn(c(".omegaL", ".sigmaL", ".theta"))
     rxSetSeed(.baseSeed)
     rxSeedEng(.ncores)
     .preDrawnParams <- rxSimThetaOmega(
@@ -203,6 +223,16 @@ rxMemSummary.rxEtFile <- function(x, ...) {
       omegaSeparation = if (!is.null(.ctl$omegaSeparation)) .ctl$omegaSeparation else "auto",
       omegaXform      = if (!is.null(.ctl$omegaXform))  .ctl$omegaXform  else 1L,
       nSub            = .nSub,
+      # the theta draw is one row per study, added into the parameter columns
+      # it names, so it has to happen in the same call as the omega draw: it
+      # is the same `params` table the chunks are sliced out of, and running
+      # it separately would also take the RNG out of the order the unchunked
+      # solve draws in
+      thetaMat        = .ctl$thetaMat,
+      thetaLower      = if (!is.null(.ctl$thetaLower))  .ctl$thetaLower  else -Inf,
+      thetaUpper      = if (!is.null(.ctl$thetaUpper))  .ctl$thetaUpper  else  Inf,
+      thetaDf         = .ctl$thetaDf,
+      thetaIsChol     = if (!is.null(.ctl$thetaIsChol)) .ctl$thetaIsChol else FALSE,
       nCoresRV        = 1L,
       nStud           = .nStud,
       # `dfSub` is what turns the omega uncertainty draw on, so the pre-draw
@@ -214,18 +244,31 @@ rxMemSummary.rxEtFile <- function(x, ...) {
     # The drawn per study omegas live in the shared `.rxModels` environment that
     # the C++ side writes.  They are read here, in the parent, because that is
     # the only process that ran the draw -- a chunk never sees them, so without
-    # this `$omegaList`/`$sigmaList` would come back empty on a chunked solve
-    # while a plain one reports them.
+    # this `$omegaList`/`$sigmaList`/`$thetaMat` would come back empty on a
+    # chunked solve while a plain one reports them.
     .preDrawnOmegaL <- .rxOomDrawnList(".omegaL")
     .preDrawnSigmaL <- .rxOomDrawnList(".sigmaL")
-    # Strip omega from forwarded args -- etas are now baked into per-chunk params
-    .fwdCtlArgs$omega           <- NULL
-    .fwdCtlArgs$omegaDf         <- NULL
-    .fwdCtlArgs$omegaLower      <- NULL
-    .fwdCtlArgs$omegaUpper      <- NULL
-    .fwdCtlArgs$omegaIsChol     <- NULL
-    .fwdCtlArgs$omegaSeparation <- NULL
-    .fwdCtlArgs$omegaXform      <- NULL
+    .preDrawnTheta  <- .rxOomDrawnList(".theta")
+    if (!is.null(.ctl$omega)) {
+      # Strip omega from forwarded args -- etas are now baked into per-chunk params
+      .fwdCtlArgs$omega           <- NULL
+      .fwdCtlArgs$omegaDf         <- NULL
+      .fwdCtlArgs$omegaLower      <- NULL
+      .fwdCtlArgs$omegaUpper      <- NULL
+      .fwdCtlArgs$omegaIsChol     <- NULL
+      .fwdCtlArgs$omegaSeparation <- NULL
+      .fwdCtlArgs$omegaXform      <- NULL
+    }
+    if (!is.null(.ctl$thetaMat)) {
+      # Likewise for thetaMat -- the drawn thetas are baked into the per-chunk
+      # parameter table, and forwarding it would have each chunk draw its own
+      # on top of them (where it did not simply error out)
+      .fwdCtlArgs$thetaMat    <- NULL
+      .fwdCtlArgs$thetaDf     <- NULL
+      .fwdCtlArgs$thetaLower  <- NULL
+      .fwdCtlArgs$thetaUpper  <- NULL
+      .fwdCtlArgs$thetaIsChol <- NULL
+    }
   }
 
   # Normalize: ensure id column is always present so chunks can be rbind'd.
@@ -449,6 +492,9 @@ rxMemSummary.rxEtFile <- function(x, ...) {
   # like a plain one does
   .manifest$omegaList <- .preDrawnOmegaL
   .manifest$sigmaList <- .preDrawnSigmaL
+  # `$thetaMat` is the drawn thetas, one row per study -- the same thing a
+  # plain solve reports
+  .manifest$thetaMat  <- .preDrawnTheta
 
   saveRDS(.manifest, paste0(.prefix, "_manifest.rds"))
   .rxSolveOomFromManifest(.manifest)
@@ -736,6 +782,9 @@ head.rxSolveOom <- function(x, n = 6L, ...) {
   }
   if (name == "sigmaList") {
     return(.m$sigmaList)
+  }
+  if (name == "thetaMat" || name == "theta.mat") {
+    return(.m$thetaMat)
   }
   .pq <- .rxOomParquetFiles(.m$chunks)
   if (length(.pq) > 0L && .rxOomHasDuckdb()) {

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -1161,6 +1161,15 @@
 #'   is saved to `<file>_manifest.rds`. Set to `NULL` (default) to use the
 #'   normal in-memory path.
 #'
+#'   A chunked solve draws the parameters once in the parent so that every
+#'   chunk shares them, which is what keeps subjects in different chunks in
+#'   the same study.  Four things that draw cannot express are a clear error
+#'   rather than a quietly different answer: a joint (TNPRI) draw of the
+#'   omega/sigma entries a `thetaMat` carries, sigma uncertainty
+#'   (`dfObs > 0`), a per-subject parameter `data.frame`/`matrix` alongside an
+#'   `omega`/`thetaMat`, and `nSub` greater than the number of subjects the
+#'   event table has.
+#'
 #' @param chunkSize Integer; number of subjects per chunk when `file` is
 #'   set. If `NULL` (default), the chunk size is auto-computed from available
 #'   free RAM using `rxMemoryEstimate()`.

--- a/man/rmdhunks/rxode2-syntax-hunk.Rmd
+++ b/man/rmdhunks/rxode2-syntax-hunk.Rmd
@@ -741,10 +741,10 @@ block too and correlate blocks the model declared independent, and there
 is nowhere to put a second degrees of freedom.  Put the prior on the
 whole level instead.
 
-Prior simulation does not yet cover a chunked solve
-(`file =`/`chunkSize =`), which is a clear error rather than a solve that
-quietly drops the prior: the one draw every chunk shares cannot express
-the omega half of a prior.
+Under a chunked solve (`file =`/`chunkSize =`) a prior on the population
+parameters is simulated, since that half of a prior is a `thetaMat`,
+which the one draw every chunk shares covers.  A prior on an omega block
+is not, and is a clear error rather than a solve that quietly drops it.
 
 ### A thetaMat that already carries the omegas
 

--- a/man/rmdhunks/rxode2-syntax-hunk.Rmd
+++ b/man/rmdhunks/rxode2-syntax-hunk.Rmd
@@ -742,8 +742,9 @@ is nowhere to put a second degrees of freedom.  Put the prior on the
 whole level instead.
 
 Prior simulation does not yet cover a chunked solve
-(`file =`/`chunkSize =`, rxode2 issue #1252), which is a clear error
-rather than a solve that quietly drops the prior.
+(`file =`/`chunkSize =`), which is a clear error rather than a solve that
+quietly drops the prior: the one draw every chunk shares cannot express
+the omega half of a prior.
 
 ### A thetaMat that already carries the omegas
 

--- a/man/rxSolve.Rd
+++ b/man/rxSolve.Rd
@@ -1652,7 +1652,16 @@ chunk solving. When set, \code{rxSolve()} splits subjects into chunks, writes
 each chunk's result to \verb{<file>_chunk_NNNNN.parquet} (or \code{.rds} if
 \code{arrow} is unavailable), and returns an \code{rxSolveOom} object. The manifest
 is saved to \verb{<file>_manifest.rds}. Set to \code{NULL} (default) to use the
-normal in-memory path.}
+normal in-memory path.
+
+A chunked solve draws the parameters once in the parent so that every
+chunk shares them, which is what keeps subjects in different chunks in
+the same study.  Four things that draw cannot express are a clear error
+rather than a quietly different answer: a joint (TNPRI) draw of the
+omega/sigma entries a \code{thetaMat} carries, sigma uncertainty
+(\code{dfObs > 0}), a per-subject parameter \code{data.frame}/\code{matrix} alongside an
+\code{omega}/\code{thetaMat}, and \code{nSub} greater than the number of subjects the
+event table has.}
 
 \item{chunkSize}{Integer; number of subjects per chunk when \code{file} is
 set. If \code{NULL} (default), the chunk size is auto-computed from available

--- a/man/rxode2.Rd
+++ b/man/rxode2.Rd
@@ -1417,10 +1417,10 @@ block too and correlate blocks the model declared independent, and there
 is nowhere to put a second degrees of freedom. Put the prior on the
 whole level instead.
 
-Prior simulation does not yet cover a chunked solve
-(\verb{file =}/\verb{chunkSize =}), which is a clear error rather than a solve that
-quietly drops the prior: the one draw every chunk shares cannot express
-the omega half of a prior.
+Under a chunked solve (\verb{file =}/\verb{chunkSize =}) a prior on the population
+parameters is simulated, since that half of a prior is a \code{thetaMat},
+which the one draw every chunk shares covers. A prior on an omega block
+is not, and is a clear error rather than a solve that quietly drops it.
 }
 
 \subsection{A thetaMat that already carries the omegas}{

--- a/man/rxode2.Rd
+++ b/man/rxode2.Rd
@@ -1418,8 +1418,9 @@ is nowhere to put a second degrees of freedom. Put the prior on the
 whole level instead.
 
 Prior simulation does not yet cover a chunked solve
-(\verb{file =}/\verb{chunkSize =}, rxode2 issue #1252), which is a clear error
-rather than a solve that quietly drops the prior.
+(\verb{file =}/\verb{chunkSize =}), which is a clear error rather than a solve that
+quietly drops the prior: the one draw every chunk shares cannot express
+the omega half of a prior.
 }
 
 \subsection{A thetaMat that already carries the omegas}{

--- a/src/etTran.cpp
+++ b/src/etTran.cpp
@@ -5,6 +5,7 @@
 
 #include <Rcpp.h>
 #include <algorithm>
+#include <unordered_set>
 #include "../inst/include/rxode2parse.h"
 #include "../inst/include/rxode2EventTranslate.h"
 #include "timsort.h"
@@ -1422,14 +1423,24 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
   std::vector<int> id;
   id.reserve(resSize);
   std::vector<int> idIcov;
+  // These four hold one entry per subject.  Membership in them is tested once
+  // per input row, so a std::find() linear scan makes the row loop below cost
+  // O(rows * subjects) -- at a fixed 120000 rows, going from 100 to 12000
+  // subjects cost 12.6x.  The vectors stay (their size, and the order they are
+  // iterated in for the warnings, are both used); the sets alongside them make
+  // the membership test O(1) and are kept in step at every push_back.
   std::vector<int> allId;
   allId.reserve(resSize);
+  std::unordered_set<int> allIdSet;
   std::vector<int> obsId;
   obsId.reserve(resSize);
+  std::unordered_set<int> obsIdSet;
   std::vector<int> zeroId;
-  obsId.reserve(resSize);
+  zeroId.reserve(resSize);
+  std::unordered_set<int> zeroIdSet;
   std::vector<int> doseId;
   doseId.reserve(resSize);
+  std::unordered_set<int> doseIdSet;
   std::vector<int> evid;
   evid.reserve(resSize);
   std::vector<double> time;
@@ -1735,8 +1746,9 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
     else cii = inIi[i];
     if (ISNA(cii)) cii=0.0;
 
-    if (std::find(allId.begin(), allId.end(), cid) == allId.end()) {
+    if (allIdSet.find(cid) == allIdSet.end()) {
       allId.push_back(cid);
+      allIdSet.insert(cid);
       // New ID
       // Add mtime records
       for (j = nMtime; j--;) {
@@ -1920,8 +1932,9 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
           cevid=2;
         }
         if ((cevid == 0 || (cevid == 2 && evid2isObs)) &&
-            std::find(obsId.begin(), obsId.end(), cid) == obsId.end()) {
+            obsIdSet.find(cid) == obsIdSet.end()) {
           obsId.push_back(cid);
+          obsIdSet.insert(cid);
         }
       } else {
         if (mdvCol != -1 && (inMdv[i] == 0 || IntegerVector::is_na(inMdv[i]))) {
@@ -1970,8 +1983,9 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
         }
       }
       if ((cevid == 0 || (cevid == 2 && evid2isObs)) &&
-          std::find(obsId.begin(), obsId.end(), cid) == obsId.end()) {
+          obsIdSet.find(cid) == obsIdSet.end()) {
         obsId.push_back(cid);
+        obsIdSet.insert(cid);
       }
       if (caddl > 0) {
         Rf_warningcall(R_NilValue, "%s", _("'addl' is ignored with observations"));
@@ -2036,8 +2050,9 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
         cmtF.push_back(cmt);
         time.push_back(ctime);
         if (ctime == 0){
-          if (std::find(zeroId.begin(), zeroId.end(), cid) == zeroId.end()){
+          if (zeroIdSet.find(cid) == zeroIdSet.end()){
             zeroId.push_back(cid);
+            zeroIdSet.insert(cid);
           }
         }
         amt.push_back(NA_REAL);
@@ -2083,8 +2098,9 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
       break;
     case 2:
       cevid = 2;
-      if ((cevid == 0 || (cevid == 2 && evid2isObs)) && std::find(obsId.begin(), obsId.end(), cid) == obsId.end()){
+      if ((cevid == 0 || (cevid == 2 && evid2isObs)) && obsIdSet.find(cid) == obsIdSet.end()){
         obsId.push_back(cid);
+        obsIdSet.insert(cid);
       }
       if (flg == 30){
         rateI = 0;
@@ -2105,8 +2121,9 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
         cmtF.push_back(cmt);
         time.push_back(ctime);
         if (ctime == 0){
-          if (std::find(zeroId.begin(), zeroId.end(), cid) == zeroId.end()){
+          if (zeroIdSet.find(cid) == zeroIdSet.end()){
             zeroId.push_back(cid);
+            zeroIdSet.insert(cid);
           }
         }
         amt.push_back(NA_REAL);
@@ -2151,8 +2168,9 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
       time.push_back(ctime);
       hasReset = true;
       if (ctime == 0){
-        if (std::find(zeroId.begin(), zeroId.end(), cid) == zeroId.end()){
+        if (zeroIdSet.find(cid) == zeroIdSet.end()){
           zeroId.push_back(cid);
+          zeroIdSet.insert(cid);
         }
       }
       amt.push_back(NA_REAL);
@@ -2178,8 +2196,9 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
       time.push_back(ctime);
       hasReset = true;
       if (ctime == 0){
-        if (std::find(zeroId.begin(), zeroId.end(), cid) == zeroId.end()){
+        if (zeroIdSet.find(cid) == zeroIdSet.end()){
           zeroId.push_back(cid);
+          zeroIdSet.insert(cid);
         }
       }
       amt.push_back(NA_REAL);
@@ -2241,8 +2260,9 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
       cmtF.push_back(cmt);
       time.push_back(ctime);
       if (ctime == 0){
-        if (std::find(zeroId.begin(), zeroId.end(), cid) == zeroId.end()){
+        if (zeroIdSet.find(cid) == zeroIdSet.end()){
           zeroId.push_back(cid);
+          zeroIdSet.insert(cid);
         }
       }
       ii.push_back(cii);
@@ -2649,9 +2669,10 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
     if (obsId.size() != allId.size()){
       std::string idWarn = "IDs without observations dropped:";
       for (j = allId.size(); j--;){
-        if (std::find(obsId.begin(), obsId.end(), allId[j]) == obsId.end()){
+        if (obsIdSet.find(allId[j]) == obsIdSet.end()){
           idWarn = idWarn + " " +as<std::string>(idLvl[allId[j]-1]);
           doseId.push_back(allId[j]);
+          doseIdSet.insert(allId[j]);
         }
       }
       Rf_warningcall(R_NilValue, "%s", idWarn.c_str());
@@ -2665,11 +2686,11 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
   if (zeroId.size() != allId.size()) {
     std::string idWarn = "IDs without zero-time start at the first observed time:";
     for (j = allId.size(); j--;){
-      if (std::find(zeroId.begin(), zeroId.end(), allId[j]) == zeroId.end()){
+      if (zeroIdSet.find(allId[j]) == zeroIdSet.end()){
         bool skipIt=false;
         if (!keepDosingOnly){
           // Excluded from list
-          if (std::find(obsId.begin(), obsId.end(), allId[j]) == obsId.end()){
+          if (obsIdSet.find(allId[j]) == obsIdSet.end()){
             skipIt=true;
           }
         }
@@ -2713,7 +2734,7 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
       ivEvid[j] = -ivEvid[j];                   \
     }
     for (int j = ivId.size(); j--; ){
-      if (!(std::find(doseId.begin(), doseId.end(), ivId[j]) == doseId.end())){
+      if (!(doseIdSet.find(ivId[j]) == doseIdSet.end())){
         ivId[j] = NA_INTEGER; // Drop
       }
       // Duplicated below for speed.

--- a/tests/testthat/test-000-modelVars.R
+++ b/tests/testthat/test-000-modelVars.R
@@ -12,7 +12,7 @@ rxTest({
 
   test_that("modelvars", {
     skip_on_cran()
-    rxClean()
+    rxUnloadAll()
     rigid.txt <- "
 y1(0)    = 1
 y2(0)    = 0
@@ -46,7 +46,7 @@ d/dt(y3) = a3*y1*y2
 
   test_that("modelvars track exhaustive string comparison covariates", {
     skip_on_cran()
-    rxClean()
+    rxUnloadAll()
 
     modTxt <- "
 x = 1

--- a/tests/testthat/test-etTrans.R
+++ b/tests/testthat/test-etTrans.R
@@ -2246,4 +2246,42 @@ rxTest({
     })
 
   })
+
+  test_that("translation does not slow down with the subject count alone", {
+
+    # Whether an id has been seen is tested once per input row against
+    # allId/obsId/zeroId/doseId, which hold one entry per subject.  As
+    # std::find() linear scans that made translation O(rows * subjects): with
+    # the rows held fixed, going from 100 to 12000 subjects cost 12.6x.  Hold
+    # the row count constant and only redistribute it over more subjects, so
+    # the only thing that changes is the number of ids.
+    .fixedRows <- function(nSub, nRow = 40000) {
+      nPer <- nRow / nSub
+      data.frame(
+        ID = rep(seq_len(nSub), each = nPer),
+        TIME = rep(seq_len(nPer), times = nSub),
+        x = seq(-100, 0, length.out = nRow),
+        EVID = 0, AMT = 0
+      )
+    }
+    mod <- rxode2({
+      eff <- slopeA * x
+    })
+    .minElapsed <- function(d, reps = 3L) {
+      min(vapply(seq_len(reps),
+                 function(i) system.time(rxode2::etTrans(d, mod))[["elapsed"]],
+                 numeric(1)))
+    }
+
+    # the same rows either way, only spread over more ids.  (The translated
+    # row count is NOT the same -- splitting the rows over more subjects adds
+    # per-subject records -- so only the input is held equal here.)
+    .few <- .fixedRows(50)
+    .many <- .fixedRows(5000)
+    expect_equal(nrow(.few), nrow(.many))
+    expect_equal(length(unique(.many$ID)), 5000L)
+
+    invisible(rxode2::etTrans(.fixedRows(50, 1000), mod)) # warm up
+    expect_lt(.minElapsed(.many), 3 * .minElapsed(.few))
+  })
 })

--- a/tests/testthat/test-etTrans.R
+++ b/tests/testthat/test-etTrans.R
@@ -327,7 +327,7 @@ d/dt(blood)     = a*intestine - b*blood
   })
 
   test_that("rxSolve updates preserve grouped solve event attributes", {
-    on.exit(rxClean(), add = TRUE)
+    on.exit(rxUnloadAll(), add = TRUE)
     mod <- rxode2({
       KA <- 1
       CL <- 1
@@ -363,7 +363,7 @@ d/dt(blood)     = a*intestine - b*blood
   })
 
   test_that("rxSolve updates preserve grouped iCov keep-column output", {
-    on.exit(rxClean(), add = TRUE)
+    on.exit(rxUnloadAll(), add = TRUE)
     mod <- rxode2({
       WT2 <- WT/70
       C2 <- centr / V2

--- a/tests/testthat/test-oom.R
+++ b/tests/testthat/test-oom.R
@@ -800,6 +800,42 @@ rxTest({
     expect_null(.none$thetaMat)
   })
 
+  test_that("a chunked solve refuses a joint (tnpri) thetaMat draw", {
+    skip_on_cran()
+
+    ## the omega entries a tnpri thetaMat carries are drawn jointly with the
+    ## thetas, which the pre-draw cannot express -- so the chunks would come
+    ## back drawn from the point estimate omega with the joint draw gone
+    .m <- rxode2({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      cp <- linCmt()
+    })
+    .ev <- et(et(amt=100, id=1:6), seq(0, 24, by=8))
+    .om <- lotri::lotri(eta.ka + eta.cl ~ c(0.1, 0.01, 0.1))
+    .p <- c(tka=0.45, tcl=1, tv=3.45)
+    .tm <- lotri::lotri(tka + tcl + tv + om.eta.ka + om.eta.cl ~
+                          c(0.01,
+                            0.001, 0.01,
+                            0.001, 0.001, 0.01,
+                            0, 0, 0, 0.001,
+                            0, 0, 0, 0, 0.001))
+
+    expect_error(
+      rxSolve(.m, .ev, params=.p, omega=.om, thetaMat=.tm, nStud=3,
+              omegaSeparation="tnpri",
+              file=tempfile(fileext=".parquet"), chunkSize=2),
+      "tnpri")
+
+    ## and it is refused, not merely unsupported: the unchunked solve does
+    ## draw a different omega per study
+    set.seed(42); rxSetSeed(1234)
+    .full <- rxSolve(.m, .ev, params=.p, omega=.om, thetaMat=.tm, nStud=3,
+                     omegaSeparation="tnpri")
+    expect_false(isTRUE(all.equal(.full$omegaList[[1]], .full$omegaList[[2]])))
+  })
+
   test_that("the parallel chunked path handles a thetaMat too", {
     skip_on_cran()
     skip_if_not_installed("mirai")

--- a/tests/testthat/test-oom.R
+++ b/tests/testthat/test-oom.R
@@ -800,6 +800,31 @@ rxTest({
     expect_null(.none$thetaMat)
   })
 
+  test_that("a chunked solve says why it cannot draw from a parameter table", {
+    skip_on_cran()
+
+    ## the draw the chunks share is made from a named parameter vector, so a
+    ## per-subject parameter data frame used to die in the coercion with
+    ## "Not compatible with requested type"
+    .m <- rxode2({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl)
+      v <- exp(tv)
+      cp <- linCmt()
+    })
+    .ev <- et(et(amt=100, id=1:6), seq(0, 24, by=8))
+    .om <- lotri::lotri(eta.ka ~ 0.09)
+    .pdf <- data.frame(id=1:6, tka=0.45, tcl=1, tv=3.45)
+
+    expect_error(
+      rxSolve(.m, .ev, params=.pdf, omega=.om,
+              file=tempfile(fileext=".parquet"), chunkSize=2),
+      "named parameter vector")
+
+    ## unchunked it solves, so the message has to name the chunking
+    expect_s3_class(rxSolve(.m, .ev, params=.pdf, omega=.om), "rxSolve")
+  })
+
   test_that("a chunked solve refuses a joint (tnpri) thetaMat draw", {
     skip_on_cran()
 

--- a/tests/testthat/test-oom.R
+++ b/tests/testthat/test-oom.R
@@ -704,6 +704,51 @@ rxTest({
     }
   })
 
+  test_that("the thetaMat settings reach the shared draw", {
+    skip_on_cran()
+
+    ## `thetaLower`/`thetaIsChol` shape the draw, so leaving one out of the
+    ## pre-draw would give a chunked solve that quietly differs from the
+    ## unchunked one rather than failing
+    .m <- rxode2({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      cp <- linCmt()
+    })
+    .ev <- et(et(amt=100, id=1:6), seq(0, 24, by=8))
+    .om <- lotri::lotri(eta.ka + eta.cl ~ c(0.1, 0.01, 0.1))
+    .p <- c(tka=0.45, tcl=1, tv=3.45)
+    .tm <- lotri::lotri(tka + tcl + tv ~
+                          c(0.25, 0.01, 0.25, 0.01, 0.01, 0.25))
+    .chol <- chol(.tm)
+    dimnames(.chol) <- dimnames(.tm)
+    .key <- function(d) d[order(d$sim.id, d$id, d$time), ]
+
+    .chunked <- function(...) {
+      set.seed(42)
+      rxSetSeed(1234)
+      rxSolve(.m, .ev, params=.p, omega=.om, nStud=4, ...,
+              file=tempfile(fileext=".parquet"), chunkSize=2)
+    }
+
+    ## unbounded the draw straddles zero, so all-positive below is the bound
+    ## being honoured rather than a coincidence
+    expect_true(any(.chunked(thetaMat=.tm)$thetaMat < 0))
+    expect_true(all(.chunked(thetaMat=.tm, thetaLower=0)$thetaMat > 0))
+
+    ## a cholesky thetaMat is read as one -- read as a covariance it would
+    ## draw a visibly different spread, and here it reproduces the
+    ## unchunked solve exactly
+    set.seed(42); rxSetSeed(1234)
+    .full <- rxSolve(.m, .ev, params=.p, omega=.om, nStud=4,
+                     thetaMat=.chol, thetaIsChol=TRUE)
+    .chunk <- .chunked(thetaMat=.chol, thetaIsChol=TRUE)
+    expect_equal(.key(as.data.frame(.chunk))$cp,
+                 .key(as.data.frame(.full))$cp, tolerance=1e-8)
+    expect_equal(.chunk$thetaMat, .full$thetaMat)
+  })
+
   test_that("a chunked solve draws a thetaMat given without an omega", {
     skip_on_cran()
 
@@ -831,6 +876,34 @@ rxTest({
       "rxSolveOom")
   })
 
+  test_that("a chunked solve refuses an nSub it cannot replicate", {
+    skip_on_cran()
+
+    ## chunks are cut by the ids the event table has, so `nSub` replication
+    ## of a single subject table silently came back with one subject
+    .m <- rxode2({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      cp <- linCmt()
+    })
+    .ev <- et(et(amt=100), seq(0, 24, by=8))
+    .om <- lotri::lotri(eta.ka + eta.cl ~ c(0.1, 0.01, 0.1))
+    .p <- c(tka=0.45, tcl=1, tv=3.45)
+
+    expect_error(
+      rxSolve(.m, .ev, params=.p, omega=.om, nSub=6,
+              file=tempfile(fileext=".parquet"), chunkSize=2),
+      "'nSub'")
+
+    ## the same subjects spelled in the event table are fine
+    .ev6 <- et(et(amt=100, id=1:6), seq(0, 24, by=8))
+    expect_s3_class(
+      rxSolve(.m, .ev6, params=.p, omega=.om, nSub=6,
+              file=tempfile(fileext=".parquet"), chunkSize=2),
+      "rxSolveOom")
+  })
+
   test_that("a chunked solve says why it cannot draw from a parameter table", {
     skip_on_cran()
 
@@ -882,6 +955,13 @@ rxTest({
       rxSolve(.m, .ev, params=.p, omega=.om, thetaMat=.tm, nStud=3,
               omegaSeparation="tnpri",
               file=tempfile(fileext=".parquet"), chunkSize=2),
+      "tnpri")
+
+    ## `rxSolveChunked()` builds its own control and never resolves the
+    ## separation into 'priorOmegaEl', so the guard has to ask for it directly
+    expect_error(
+      rxSolveChunked(.m, .p, .ev, omega=.om, thetaMat=.tm, nStud=3,
+                     omegaSeparation="tnpri", chunkSize=2),
       "tnpri")
 
     ## and it is refused, not merely unsupported: the unchunked solve does

--- a/tests/testthat/test-oom.R
+++ b/tests/testthat/test-oom.R
@@ -651,3 +651,187 @@ rxTest({
   })
 
 })
+
+rxTest({
+
+  test_that("a chunked solve simulates parameter uncertainty like an unchunked one", {
+    skip_on_cran()
+
+    ## #1263: `thetaMat` was not stripped from what each chunk is forwarded,
+    ## so every chunk was asked to draw its own thetas on top of the
+    ## parameter data frame the omega pre-draw hands it -- a combination
+    ## `rxSolve()` refuses, so the solve died rather than answered
+    .m <- rxode2({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      cp <- linCmt()
+    })
+    .ev <- et(et(amt=100, id=1:6), seq(0, 24, by=8))
+    .om <- lotri::lotri(eta.ka + eta.cl ~ c(0.1, 0.01, 0.1))
+    .p <- c(tka=0.45, tcl=1, tv=3.45)
+    .tm <- lotri::lotri(tka + tcl + tv ~
+                          c(0.01, 0.001, 0.01, 0.001, 0.001, 0.01))
+
+    .solve <- function(...) {
+      set.seed(42)
+      rxSetSeed(1234)
+      rxSolve(.m, .ev, params=.p, omega=.om, thetaMat=.tm, nStud=3, ...)
+    }
+    .key <- function(d) d[order(d$sim.id, d$id, d$time), ]
+
+    .full  <- .solve()
+    .chunk <- .solve(file=tempfile(fileext=".parquet"), chunkSize=2)
+
+    expect_equal(.key(as.data.frame(.chunk))$cp,
+                 .key(as.data.frame(.full))$cp,
+                 tolerance=1e-8)
+
+    ## the drawn thetas are reported, not just used
+    expect_equal(.chunk$thetaMat, .full$thetaMat)
+
+    ## there really was a theta draw to have gotten right
+    expect_equal(dim(.full$thetaMat), c(3L, 3L))
+    expect_false(isTRUE(all.equal(.full$thetaMat[1, ], .full$thetaMat[2, ])))
+
+    ## one draw shared by every chunk: a per-chunk draw would put subjects
+    ## in different chunks in different studies, which shows up as the
+    ## answer depending on the chunk size
+    for (.cs in c(1L, 2L, 3L, 6L)) {
+      expect_equal(.key(as.data.frame(
+        .solve(file=tempfile(fileext=".parquet"), chunkSize=.cs)))$cp,
+        .key(as.data.frame(.full))$cp, tolerance=1e-8)
+    }
+  })
+
+  test_that("a chunked solve draws a thetaMat given without an omega", {
+    skip_on_cran()
+
+    ## without an omega nothing pre-drew at all, so the chunks were handed
+    ## the original parameter vector and the thetaMat with it
+    .m <- rxode2({
+      ka <- exp(tka)
+      cl <- exp(tcl)
+      v <- exp(tv)
+      cp <- linCmt()
+    })
+    .ev <- et(et(amt=100, id=1:6), seq(0, 24, by=8))
+    .p <- c(tka=0.45, tcl=1, tv=3.45)
+    .tm <- lotri::lotri(tka + tcl + tv ~
+                          c(0.01, 0.001, 0.01, 0.001, 0.001, 0.01))
+
+    .solve <- function(...) {
+      set.seed(42)
+      rxSetSeed(1234)
+      suppressWarnings(
+        rxSolve(.m, .ev, params=.p, thetaMat=.tm, nStud=3, ...))
+    }
+    .key <- function(d) d[order(d$sim.id, d$id, d$time), ]
+
+    .full  <- .solve()
+    .chunk <- .solve(file=tempfile(fileext=".parquet"), chunkSize=2)
+
+    expect_equal(.key(as.data.frame(.chunk))$cp,
+                 .key(as.data.frame(.full))$cp,
+                 tolerance=1e-8)
+    expect_equal(.chunk$thetaMat, .full$thetaMat)
+  })
+
+  test_that("a chunked solve with a thetaMat that is ignored still solves", {
+    skip_on_cran()
+
+    ## `nStud = 1` ignores the thetaMat, but it still has to be stripped:
+    ## forwarded, it errored out against the pre-drawn parameter data frame
+    .m <- rxode2({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      cp <- linCmt()
+    })
+    .ev <- et(et(amt=100, id=1:6), seq(0, 24, by=8))
+    .om <- lotri::lotri(eta.ka + eta.cl ~ c(0.1, 0.01, 0.1))
+    .p <- c(tka=0.45, tcl=1, tv=3.45)
+    .tm <- lotri::lotri(tka + tcl + tv ~
+                          c(0.01, 0.001, 0.01, 0.001, 0.001, 0.01))
+
+    .solve <- function(...) {
+      set.seed(42)
+      rxSetSeed(1234)
+      suppressWarnings(
+        rxSolve(.m, .ev, params=.p, omega=.om, thetaMat=.tm, nStud=1, ...))
+    }
+    .key <- function(d) d[order(d$id, d$time), ]
+
+    .full  <- .solve()
+    .chunk <- .solve(file=tempfile(fileext=".parquet"), chunkSize=3)
+
+    expect_equal(.key(as.data.frame(.chunk))$cp,
+                 .key(as.data.frame(.full))$cp,
+                 tolerance=1e-8)
+    ## nothing drawn, nothing reported
+    expect_null(.chunk$thetaMat)
+  })
+
+  test_that("a chunked solve without a thetaMat reports none", {
+    skip_on_cran()
+
+    ## the drawn thetas are read out of the shared `.rxModels` environment,
+    ## so a solve that draws none must not pick up an earlier solve's
+    .m <- rxode2({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      cp <- linCmt()
+    })
+    .ev <- et(et(amt=100, id=1:6), seq(0, 24, by=8))
+    .om <- lotri::lotri(eta.ka + eta.cl ~ c(0.1, 0.01, 0.1))
+    .p <- c(tka=0.45, tcl=1, tv=3.45)
+    .tm <- lotri::lotri(tka + tcl + tv ~
+                          c(0.01, 0.001, 0.01, 0.001, 0.001, 0.01))
+
+    set.seed(42); rxSetSeed(1234)
+    .drew <- rxSolve(.m, .ev, params=.p, omega=.om, thetaMat=.tm, nStud=3,
+                     file=tempfile(fileext=".parquet"), chunkSize=2)
+    expect_false(is.null(.drew$thetaMat))
+
+    set.seed(42); rxSetSeed(1234)
+    .none <- rxSolve(.m, .ev, params=.p, omega=.om, nStud=3, dfSub=10,
+                     file=tempfile(fileext=".parquet"), chunkSize=2)
+    expect_null(.none$thetaMat)
+  })
+
+  test_that("the parallel chunked path handles a thetaMat too", {
+    skip_on_cran()
+    skip_if_not_installed("mirai")
+    skip_if_not_installed("arrow")
+
+    ## the strip happens in the parent, so the daemons see a plain solve
+    .m <- rxode2({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      cp <- linCmt()
+    })
+    .ev <- et(et(amt=100, id=1:6), seq(0, 24, by=8))
+    .om <- lotri::lotri(eta.ka + eta.cl ~ c(0.1, 0.01, 0.1))
+    .p <- c(tka=0.45, tcl=1, tv=3.45)
+    .tm <- lotri::lotri(tka + tcl + tv ~
+                          c(0.01, 0.001, 0.01, 0.001, 0.001, 0.01))
+
+    .solve <- function(...) {
+      set.seed(42)
+      rxSetSeed(1234)
+      rxSolve(.m, .ev, params=.p, omega=.om, thetaMat=.tm, nStud=3, ...)
+    }
+    .key <- function(d) d[order(d$sim.id, d$id, d$time), ]
+
+    .ser <- .solve(file=tempfile("rxSer"), chunkSize=2)
+    .par <- .solve(file=tempfile("rxPar"), chunkSize=2, parallel=2)
+
+    expect_equal(.key(as.data.frame(.par))$cp,
+                 .key(as.data.frame(.ser))$cp,
+                 tolerance=1e-8)
+    expect_equal(.par$thetaMat, .ser$thetaMat)
+  })
+
+})

--- a/tests/testthat/test-oom.R
+++ b/tests/testthat/test-oom.R
@@ -800,6 +800,37 @@ rxTest({
     expect_null(.none$thetaMat)
   })
 
+  test_that("a chunked solve refuses sigma uncertainty it cannot share", {
+    skip_on_cran()
+
+    ## `sigma` is still forwarded to each chunk, so with `dfObs > 0` every
+    ## chunk drew its own per study sigma and subjects in different chunks
+    ## ended up with different residual covariance inside the same study --
+    ## which `$sigmaList` did not report either, it came back NULL
+    .m <- rxode2({
+      ka <- exp(tka + eta.ka)
+      cl <- exp(tcl + eta.cl)
+      v <- exp(tv)
+      cp <- linCmt()
+      cp2 <- cp * (1 + prop.err)
+    })
+    .ev <- et(et(amt=100, id=1:6), seq(0, 24, by=8))
+    .om <- lotri::lotri(eta.ka + eta.cl ~ c(0.1, 0.01, 0.1))
+    .sg <- lotri::lotri(prop.err ~ 0.1)
+    .p <- c(tka=0.45, tcl=1, tv=3.45)
+
+    expect_error(
+      rxSolve(.m, .ev, params=.p, omega=.om, sigma=.sg, nStud=3, dfSub=10,
+              dfObs=20, file=tempfile(fileext=".parquet"), chunkSize=2),
+      "sigma uncertainty")
+
+    ## a fixed sigma is not refused -- there is nothing per study to share
+    expect_s3_class(
+      rxSolve(.m, .ev, params=.p, omega=.om, sigma=.sg, nStud=3, dfSub=10,
+              file=tempfile(fileext=".parquet"), chunkSize=2),
+      "rxSolveOom")
+  })
+
   test_that("a chunked solve says why it cannot draw from a parameter table", {
     skip_on_cran()
 

--- a/tests/testthat/test-prior-sim-spec.R
+++ b/tests/testthat/test-prior-sim-spec.R
@@ -155,13 +155,23 @@ rxTest({
     expect_equal(.th$omegaEl$neta2, 3L)
   })
 
-  test_that("a chunked solve with priors is an error", {
-    ## the chunked path pre-draws its parameters and strips the omega
-    ## from each chunk, so the prior would never be drawn from
-    .u <- .withPrior(.base(), "tka", "dnorm(0.45, 0.1)")
+  test_that("a chunked solve with an omega prior is an error", {
+    ## the chunked path pre-draws its parameters through
+    ## `rxSimThetaOmega()`, which has no argument for the omega half of a
+    ## prior, so that half would never be drawn from
+    .u <- .withPrior(.base(), "eta.cl", "invWishart(20)")
     expect_error(.rx$.rxPriorSimSpec(.u, list(chunkSize=1e5)), "chunked solve")
     expect_error(.rx$.rxPriorSimSpec(.u, list(file="out.parquet")),
                  "chunked solve")
+  })
+
+  test_that("a chunked solve with a population parameter prior is not", {
+    ## that half of a prior is a `thetaMat`, which the pre-draw does cover
+    .u <- .withPrior(.base(), "tka", "dnorm(0.45, 0.1)")
+    .s <- .rx$.rxPriorSimSpec(.u, list(chunkSize=1e5))
+    expect_false(is.null(.s$thetaMat))
+    expect_equal(length(.s$omegaNu), 0L)
+    expect_null(.s$omegaEl)
   })
 
   test_that("a nested model puts each prior's degrees of freedom on its level", {


### PR DESCRIPTION
Stacked on #1336; retarget to `main` once that merges.

Found by sweeping for the pattern behind #1325 rather than waiting to trip over
it again. This is a **third** instance in the same function, and larger than the
pointer hoist.

`allId`, `obsId`, `zeroId` and `doseId` hold one entry per subject, and whether
an id was already present was tested with `std::find()` **once per input row** —
12 sites in the row loop, plus one more per row when dropping dosing-only ids.
That makes translation `O(rows × subjects)` instead of `O(rows)`.

Holding the row count **fixed at 120 000** and only redistributing it over more
subjects, so the only thing changing is the id count:

| subjects | before | after |
|---|---|---|
| 100 | 0.025 s | 0.023 s |
| 1 000 | 0.041 s | 0.016 s |
| 6 000 | 0.163 s | 0.019 s |
| 12 000 | **0.316 s** | **0.021 s** |

12.6x growth becomes flat; **15x at 12 000 subjects**. This matters
independently of everything already fixed, because it scales with the subject
count rather than the data size — a large population simulation pays it on top.

## Approach

The vectors stay: their `size()` is compared, and the "IDs without observations
dropped" warning iterates them in order. An `unordered_set` alongside each
carries the membership test, inserted into at every `push_back`. Also reserves
`zeroId`, which was never reserved — that line reserved `obsId` a second time.

## Verification

Output **and warning text** identical, checked across the paths those vectors
drive: ids with no observations, all-zero ids, dosing-only ids, `keepDosingOnly`
both ways, plus a 300-subject randomised case.

Regression test in `test-etTrans.R` verified to go **red on the base branch and
green here** — it holds rows fixed and varies only the subject count, so it
cannot pass by accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)