### PR TITLE
test: unload models instead of wiping the shared cache

### DIFF
--- a/tests/testthat/test-000-modelVars.R
+++ b/tests/testthat/test-000-modelVars.R
@@ -12,7 +12,7 @@ rxTest({
 
   test_that("modelvars", {
     skip_on_cran()
-    rxClean()
+    rxUnloadAll()
     rigid.txt <- "
 y1(0)    = 1
 y2(0)    = 0
@@ -46,7 +46,7 @@ d/dt(y3) = a3*y1*y2
 
   test_that("modelvars track exhaustive string comparison covariates", {
     skip_on_cran()
-    rxClean()
+    rxUnloadAll()
 
     modTxt <- "
 x = 1

--- a/tests/testthat/test-etTrans.R
+++ b/tests/testthat/test-etTrans.R
@@ -327,7 +327,7 @@ d/dt(blood)     = a*intestine - b*blood
   })
 
   test_that("rxSolve updates preserve grouped solve event attributes", {
-    on.exit(rxClean(), add = TRUE)
+    on.exit(rxUnloadAll(), add = TRUE)
     mod <- rxode2({
       KA <- 1
       CL <- 1
@@ -363,7 +363,7 @@ d/dt(blood)     = a*intestine - b*blood
   })
 
   test_that("rxSolve updates preserve grouped iCov keep-column output", {
-    on.exit(rxClean(), add = TRUE)
+    on.exit(rxUnloadAll(), add = TRUE)
     mod <- rxode2({
       WT2 <- WT/70
       C2 <- centr / V2


### PR DESCRIPTION
Four-line change that makes the test suite safe to run concurrently.

Four tests reached for `rxClean()` — two to start from a clean slate, two as
`on.exit()` cleanup. None of them test `rxClean()`; they want its process-local
half.

`rxClean()` is `rxUnloadAll()` **plus** `unlink(rxTempDir())`, and `rxTempDir()`
exports itself with `Sys.setenv()`, so every process inheriting the environment
shares one model build directory. Wiping it deletes the directory another
process is compiling into — which is why the suite could not be run in
parallel. `rxUnloadAll()` unloads this process's DLLs and never touches the
directory, which is what all four wanted.

`rxClean()` itself is **not** changed: wiping the cache is exactly its contract.
The problem was tests using it as a sledgehammer for "give me a clean slate".

## Verification

Same 40 files, 8 workers, one shared cache:

| tree | errors | passed |
|---|---|---|
| before | **2** (`test-alag.R`, `test-adjoint-sens.R`) | 4 863 |
| after | **0** | 4 973 |

Both failing files pass on their own — the failures were purely concurrency,
surfacing as `cannot open file '.../Makevars'` and `error building model`.

## Not included, deliberately

`Config/testthat/parallel` is **not** set here. It ships in `DESCRIPTION`, so it
would also apply on CI, where the runners have 2 cores — 8 workers each loading
a large package with OpenMP underneath. Parallelism is better enabled per
machine: `TESTTHAT_PARALLEL` (env var) overrides `DESCRIPTION` and
`getOption("Ncpus")` sets the worker count, so a developer can opt in without
the package carrying the decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)