### PR TITLE
Point the sigma stream divergence at its issue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1107,7 +1107,8 @@ mod |> ini(prior(eta.cl, eta.v) ~ invWishart(4))
   residual draw, so from study 2 on a chunked solve draws different etas than
   the unchunked one.  Each study's etas still come from that study's omega --
   the simulation is right, it is simply not the same draw -- and this is
-  unchanged from before, but it reaches any model with an error term.
+  unchanged from before, but it reaches any model with an error term
+  (#1339).
 
 - A chunked solve is no longer refused outright for a prior written in
   `ini({})`.  A prior on the population parameters is a `thetaMat`, which the


### PR DESCRIPTION
The NEWS entry from #1334 describes the `sigma` random-stream divergence a chunked solve has but had no issue to point at. It is now #1339, so name it.

NEWS only; no code change.