### PR TITLE
Support the same model variable on multiple residual endpoints

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,29 @@
 
 ## New features
 
+- The same model variable can now be used by more than one residual-error
+  endpoint, as long as each endpoint is named, as in
+  `cp ~ add(add.sd1) | phase1` and `cp ~ add(add.sd2) | phase2`.  rxode2 gives
+  each of those endpoints its own hidden alias (`rx.cp.phase1`,
+  `rx.cp.phase2`, recorded in `$endpointAlias`) when the simulation or
+  estimation model is assembled, so they get separate residual parameters,
+  separate simulated residuals and separate `ar()` state, while the
+  `model({})` block still prints, extracts and pipes as it was written.
+  Previously this needed hand-written aliases (`cp.phase1 <- cp`, ...) and
+  otherwise failed to solve with "The simulated residual errors do not match
+  the model specification".  Two endpoints on the same `linCmt()` are
+  supported the same way.
+
+- Model piping selects one of several endpoints by its condition, as in
+  `model(cp ~ prop(prop.sd) | phase2)`, and drops one with
+  `model(-phase2)`.  Piping an endpoint that shares its variable without
+  naming a condition now says which conditions are available instead of
+  reporting the lhs as duplicated.
+
+- Two endpoints that share a condition (`cp ~ add(a)` written twice) now give
+  a clear error at parse time asking for a `| <name>`, rather than failing
+  later with a confusing message about the additive standard deviation.
+
 - `linCmt()` models can now report a PER-COMPARTMENT dose-time sensitivity.
   `linCmtB(which1 = -3)` differentiates with respect to one delay shared by
   every dose feeding the linear system, so a regimen that doses a lagged
@@ -700,6 +723,19 @@
   reports how many exponentials took it as `blockExp`.
 
 ## Bug fixes
+
+- The "cannot find additive standard deviation" error tested a `$predDf`
+  column that does not exist, so its multiple-endpoint hint was appended even
+  for single-endpoint models.
+
+- A modeled `ar()` correlation on an endpoint written with a condition
+  (`cp ~ add(add.sd) + ar(corv) | phase1`) is now found; the endpoint was
+  matched against the left-hand side, which never carries the condition.
+
+- An endpoint's condition is no longer treated as a residual parameter, so
+  `model(cp ~ add(add.sd) | assay1)` names the endpoint instead of failing with
+  "the following parameter(s) were in the ini block but not in the model block:
+  assay1".
 
 - An `integer` or `logical` covariate column no longer makes `rxSolve()`
   quadratic in the number of rows.  While building the solving data set each

--- a/R/err-foceiBase.R
+++ b/R/err-foceiBase.R
@@ -121,7 +121,7 @@
       .p1 <- str2lang(env$iniDf$name[.w])
     } else {
       stop("cannot find additive standard deviation for '", .cnd, "'",
-           ifelse(length(env$predDf$condition) == 1L, "", "; this parameter could be estimated by another endpoint, to fix move outside of error expression."), call.=FALSE)
+           ifelse(length(env$predDf$cond) == 1L, "", "; this parameter could be estimated by another endpoint, to fix move outside of error expression."), call.=FALSE)
     }
   }
   if (pred1$variance) {

--- a/R/err-sim.R
+++ b/R/err-sim.R
@@ -117,8 +117,6 @@ rxGetDistributionSimulationLines <- function(line) {
   for (.e in .lst) {
     if (is.call(.e) && identical(.e[[1]], quote(`~`)) && length(.e) == 3L) {
       .lhs <- .e[[2]]
-      # strip conditioning (lhs | cond) down to the endpoint variable
-      if (is.call(.lhs) && identical(.lhs[[1]], quote(`|`))) .lhs <- .lhs[[2]]
       # unwrap ll(x)/linCmt() the same way .errHandleLlOrLinCmt() sets the
       # endpoint condition, so ll(cp) ~ ... + ar(corv) still matches cond
       if (is.call(.lhs)) {
@@ -127,6 +125,12 @@ rxGetDistributionSimulationLines <- function(line) {
         } else if (identical(.lhs[[1]], quote(`linCmt`))) {
           .lhs <- quote(`rxLinCmt`)
         }
+      }
+      # `lhs ~ err | cond` puts the condition on the rhs; when it is present it
+      # is the endpoint name, otherwise the lhs is
+      .rhs <- .e[[3]]
+      if (is.call(.rhs) && identical(.rhs[[1]], quote(`|`)) && length(.rhs) == 3L) {
+        .lhs <- .rhs[[3]]
       }
       if (identical(deparse1(.lhs), as.character(cond))) {
         .arg <- .findAr(.e[[3]])
@@ -754,6 +758,11 @@ rxCombineErrorLines <- function(uiModel, errLines=NULL, prefixLines=NULL, params
   .tmp <- .rxFilterOutPropsAndAdjustPredDf(uiModel, predDf=.predDf, lstExpr=lstExpr)
   .predDf <- .tmp$predDf
   .expr <- .tmp$lstExpr
+  # endpoints sharing a model variable get a generated alias; define it just
+  # before the error lines that use it.  A shared linCmt() needs its single
+  # allowed linCmt() call emitted once, outside the CMT branches.
+  .aliasLines <- .rxEndpointAliasLines(uiModel)
+  .aliasLinCmtLine <- .rxEndpointLinCmtLine(uiModel)
 
   .lenLines <- .lenLines + length(.expr) -
     length(.predDf$line) + length(.cmtLines) + length(prefixLines)
@@ -833,6 +842,15 @@ rxCombineErrorLines <- function(uiModel, errLines=NULL, prefixLines=NULL, params
   for (.i in seq_along(.expr)) {
     if (.i %in% .predDf$line) {
       .curErr <- errLines[[.curErrLine]]
+      if (length(.aliasLines) > 0L) {
+        .aw <- match(.predDf$var[.curErrLine], names(.aliasLines))
+        if (!is.na(.aw)) .curErr <- c(list(.aliasLines[[.aw]]), .curErr)
+      }
+      if (!is.null(.aliasLinCmtLine)) {
+        .ret[[.k]] <- .aliasLinCmtLine
+        .k <- .k + 1
+        .aliasLinCmtLine <- NULL
+      }
       if (.if) {
         .ret[[.k]] <- as.call(list(quote(`if`),
                                    as.call(list(quote(`==`), quote(`CMT`),

--- a/R/err.R
+++ b/R/err.R
@@ -1250,10 +1250,13 @@ rxErrTypeCombine <- function(oldErrType, newErrType) {
   .taken <- .errAllModelNames(env)
   .alias <- character(0)
   for (.i in .dup) {
-    .nm <- .errEndpointAliasName(.predDf$var[.i], .predDf$cond[.i],
-                                 c(.taken, names(.alias)))
+    .nm <- .errEndpointAliasName(.predDf$var[.i], .predDf$cond[.i], .taken)
     .alias[.nm] <- .predDf$var[.i]
     .predDf$var[.i] <- .nm
+    # reserve the alias AND everything derived from it: the estimation `ar()`
+    # names are dot-free, so `phase.1` and `phase_1` would otherwise generate
+    # different aliases that collapse to one `rx_arE_*` symbol
+    .taken <- c(.taken, .nm, .errEndpointDerivedNames(.nm))
   }
   env$predDf <- .predDf
   env$endpointAlias <- .alias

--- a/R/err.R
+++ b/R/err.R
@@ -1161,6 +1161,164 @@ rxErrTypeCombine <- function(oldErrType, newErrType) {
   }, character(1), USE.NAMES=FALSE)
 }
 
+#' All identifiers already used by the parsed model
+#'
+#' @param env Parse environment
+#' @return Character vector of names that a generated name must avoid
+#' @author Matthew L. Fidler
+#' @noRd
+.errAllModelNames <- function(env) {
+  unique(c(unlist(lapply(env$lstExpr, allNames), use.names=FALSE),
+           env$df$name, env$iniDf$name,
+           env$predDf$cond, env$predDf$var,
+           "rxLinCmt", "rxLL"))
+}
+
+#' Names derived from an endpoint variable
+#'
+#' The residual innovation and the `ar()` state are named after the endpoint
+#' variable, so a generated alias has to keep those free too -- a user variable
+#' named `rxerr.<alias>` would otherwise take over the endpoint's simulated
+#' residual.
+#'
+#' @param var Endpoint variable
+#' @return Character vector of every name built from `var`
+#' @author Matthew L. Fidler
+#' @noRd
+.errEndpointDerivedNames <- function(var) {
+  .dotFree <- gsub("[^A-Za-z0-9]", "_", var)
+  c(paste0("rxerr.", var),
+    paste0(c("rx.arRes.", "rx.arT.", "rx.arDt.", "rx.arNf.", "rx.arPhi."), var),
+    paste0(c("rx_arE_", "rx_arT_", "rx_arEp_", "rx_arDt_", "rx_arNf_", "rx_arPhi_"),
+           .dotFree))
+}
+
+#' Generate a non-colliding endpoint alias name
+#'
+#' @param var Endpoint variable
+#' @param cond Endpoint condition
+#' @param taken Names that are already used
+#' @return `rx.<var>.<cond>`, suffixed with `.1`, `.2`, ... if needed; the
+#'   names derived from it (see [.errEndpointDerivedNames()]) are free too
+#' @author Matthew L. Fidler
+#' @noRd
+.errEndpointAliasName <- function(var, cond, taken) {
+  .base <- paste0("rx.", gsub("[^A-Za-z0-9._]", ".", var), ".",
+                  gsub("[^A-Za-z0-9._]", ".", cond))
+  .nm <- .base
+  .i <- 1L
+  while (.nm %in% taken ||
+           any(.errEndpointDerivedNames(.nm) %in% taken)) {
+    .nm <- paste0(.base, ".", .i)
+    .i <- .i + 1L
+  }
+  .nm
+}
+
+#' Give each endpoint sharing a variable its own alias
+#'
+#' When the same model variable is used by more than one endpoint (`cp ~
+#' add(a) | phase1` and `cp ~ add(b) | phase2`), `predDf$var` is duplicated and
+#' everything keyed on it collides (`rxerr.<var>`, `rx.ar*.<var>`, the
+#' simulation sigma names).  Rewrite the duplicated rows' `var` to a generated
+#' `rx.<var>.<cond>` and record the mapping in `env$endpointAlias`; the alias
+#' definition is injected where a model is assembled.
+#'
+#' @param env Parse environment
+#' @return Nothing, called for side effects
+#' @author Matthew L. Fidler
+#' @noRd
+.errAssignEndpointAliases <- function(env) {
+  # always present so the slot is part of the blessed ui
+  env$endpointAlias <- character(0)
+  .predDf <- env$predDf
+  if (is.null(.predDf)) return(invisible())
+  # `ll(x) ~ ...` does not require `x` to be a model variable, and nothing keys
+  # on `var` for these rows
+  .w <- which(as.character(.predDf$distribution) != "LL")
+  if (length(.w) == 0L) return(invisible())
+  .dupVar <- unique(.predDf$var[.w][duplicated(.predDf$var[.w])])
+  if (length(.dupVar) == 0L) return(invisible())
+  .dup <- .w[.predDf$var[.w] %in% .dupVar]
+  .dupCond <- unique(.predDf$cond[.dup][duplicated(.predDf$cond[.dup])])
+  if (length(.dupCond) > 0L) {
+    stop("endpoint(s) '", paste(.userEndpointNames(.dupCond), collapse="', '"),
+         "' are defined more than once; give each endpoint its own name with ",
+         "'| <name>' (like 'cp ~ add(add.sd1) | phase1')",
+         call.=FALSE)
+  }
+  .taken <- .errAllModelNames(env)
+  .alias <- character(0)
+  for (.i in .dup) {
+    .nm <- .errEndpointAliasName(.predDf$var[.i], .predDf$cond[.i],
+                                 c(.taken, names(.alias)))
+    .alias[.nm] <- .predDf$var[.i]
+    .predDf$var[.i] <- .nm
+  }
+  env$predDf <- .predDf
+  env$endpointAlias <- .alias
+  invisible()
+}
+
+#' Get the endpoint alias mapping of a ui
+#'
+#' @param ui rxode2 ui (or parse environment)
+#' @return Named character vector, names are the generated alias and values are
+#'   the user's variable; `character(0)` when there are no aliases (including
+#'   for a ui created before this feature existed)
+#' @author Matthew L. Fidler
+#' @noRd
+.rxEndpointAlias <- function(ui) {
+  .a <- tryCatch(ui$endpointAlias, error=function(e) NULL)
+  if (!is.character(.a)) return(character(0))
+  .a
+}
+
+#' Model lines defining the endpoint aliases
+#'
+#' @param ui rxode2 ui (or parse environment)
+#' @return Named list of `alias ~ source` expressions, named by the alias
+#' @author Matthew L. Fidler
+#' @noRd
+.rxEndpointAliasLines <- function(ui) {
+  .a <- .rxEndpointAlias(ui)
+  if (length(.a) == 0L) return(list())
+  .ret <- lapply(seq_along(.a), function(i) {
+    bquote(.(str2lang(names(.a)[i])) ~ .(str2lang(.a[[i]])))
+  })
+  names(.ret) <- names(.a)
+  .ret
+}
+
+#' `linCmt()` definition needed by the endpoint aliases
+#'
+#' A `linCmt()` alias sources `rxLinCmt`, which is normally inlined at each
+#' endpoint; the parser allows only one `linCmt()` per model, so define it once
+#' and let the aliases read it.
+#'
+#' @param ui rxode2 ui (or parse environment)
+#' @return `rxLinCmt ~ linCmt()` or `NULL`
+#' @author Matthew L. Fidler
+#' @noRd
+.rxEndpointLinCmtLine <- function(ui) {
+  if (!any(.rxEndpointAlias(ui) == "rxLinCmt")) return(NULL)
+  quote(rxLinCmt ~ linCmt())
+}
+
+#' `predDf$var` with generated aliases resolved back to the user's variable
+#'
+#' @param ui rxode2 ui (or parse environment)
+#' @return Character vector the same length as `predDf$var`
+#' @author Matthew L. Fidler
+#' @noRd
+.rxEndpointSourceVar <- function(ui) {
+  .v <- ui$predDf$var
+  .a <- .rxEndpointAlias(ui)
+  if (length(.a) == 0L) return(.v)
+  .w <- match(.v, names(.a))
+  ifelse(is.na(.w), .v, .a[.w])
+}
+
 #' Check for error exceptions
 #'
 #' @param env Environment to check for error exceptions
@@ -1470,6 +1628,7 @@ rxErrTypeCombine <- function(oldErrType, newErrType) {
       if (!is.null(.env$errGlobal)) {
         stop(paste(.env$errGlobal, collapse="\n"), call.=FALSE)
       }
+      .env$endpointAlias <- character(0)
       if (!is.null(.env$predDf)) {
         .lstChr <- .env$lstChr
         .lines <- .env$predDf$line
@@ -1500,10 +1659,16 @@ rxErrTypeCombine <- function(oldErrType, newErrType) {
         if (.env$earlyErr) {
           .handleErrs(.env)
         }
+        # endpoints sharing a model variable each get their own alias; the
+        # source is always defined by now, so append the definitions last
+        .errAssignEndpointAliases(.env)
+        .aliasChr <- vapply(.rxEndpointAliasLines(.env), deparse1,
+                            character(1), USE.NAMES=FALSE)
         if (any(.env$predDf$linCmt)) {
-          .env$mv0 <- rxModelVars(paste(c(.lstChr, "rxLinCmt ~ linCmt()"), collapse="\n"))
+          .env$mv0 <- rxModelVars(paste(c(.lstChr, "rxLinCmt ~ linCmt()", .aliasChr),
+                                        collapse="\n"))
         } else {
-          .env$mv0 <- rxModelVars(paste(.lstChr, collapse="\n"))
+          .env$mv0 <- rxModelVars(paste(c(.lstChr, .aliasChr), collapse="\n"))
         }
       } else {
         if (.env$earlyErr) {

--- a/R/mu.R
+++ b/R/mu.R
@@ -1066,6 +1066,9 @@
   .predDf <- ui$predDf
   if (is.null(.predDf)) return(NULL)
   .mv <- ui$mv0
+  # a generated endpoint alias is a suppressed assignment (in `slhs`), so check
+  # the user's variable it came from
+  .srcVar <- .rxEndpointSourceVar(ui)
   lapply(seq_along(.predDf$cond), function(i) {
     .cond <- .predDf$cond[i]
     .w <- which(.iniDf$condition == .cond)
@@ -1082,7 +1085,7 @@
                   paste0("endpoint '", .userEndpointNames(.predDf$cond[i]), "' needs the following parameters estimated or modeled: ",
                          paste(.ret, collapse=", ")))
     }
-    if (.predDf$distribution[i] %in% c("norm", "t") && !(.predDf$var[i] %in% c(.mv$lhs, .mv$state, "rxLinCmt"))) {
+    if (.predDf$distribution[i] %in% c("norm", "t") && !(.srcVar[i] %in% c(.mv$lhs, .mv$state, "rxLinCmt"))) {
       ui$err <- c(ui$err,
                   paste0("endpoint '", .userEndpointNames(.predDf$cond[i]), "' is not defined in the model"))
     }

--- a/R/piping-model.R
+++ b/R/piping-model.R
@@ -407,6 +407,26 @@ model.rxModelVars <- model.rxode2
   .ret
 }
 
+#' Get the endpoint condition (the name after `|`) of a `~` line
+#'
+#' @param expr Model line expression
+#' @return The condition as a character, or `NULL` when the line is not a `~`
+#'   line with a `| <name>` condition
+#' @author Matthew L. Fidler
+#' @noRd
+.getEndpointCondFromLine <- function(expr) {
+  if (!is.call(expr) || length(expr) != 3L ||
+        !identical(expr[[1]], quote(`~`))) {
+    return(NULL)
+  }
+  .rhs <- expr[[3]]
+  if (is.call(.rhs) && identical(.rhs[[1]], quote(`|`)) &&
+        length(.rhs) == 3L && is.name(.rhs[[3]])) {
+    return(deparse1(.rhs[[3]]))
+  }
+  NULL
+}
+
 #' Find the line of the original expression
 #'
 #' @param expr Expression
@@ -418,6 +438,10 @@ model.rxModelVars <- model.rxode2
 #'
 #' @param returnAllLines A boolean to determine if all line numbers
 #'   should be returned, by default `FALSE`
+#'
+#' @param cond Endpoint condition (the name after `|`) when the piped
+#'   expression named one, otherwise `NULL`.  This selects a single
+#'   endpoint when several endpoints share the same lhs variable.
 #'
 #' @return The return can be:
 #'
@@ -437,9 +461,27 @@ model.rxModelVars <- model.rxode2
 #' @author Matthew L. Fidler
 #'
 #' @noRd
-.getModelLineFromExpression <- function(lhsExpr, rxui, errorLine=FALSE, returnAllLines=FALSE) {
+.getModelLineFromExpression <- function(lhsExpr, rxui, errorLine=FALSE, returnAllLines=FALSE,
+                                        cond=NULL) {
   .origLines <- rxui$lstExpr
   .errLines <- rxui$predDf$line
+  if (errorLine && !returnAllLines && !is.null(cond)) {
+    # `cp ~ prop(x) | phase1` names the endpoint directly; this is the only way
+    # to reach one of several endpoints that share a lhs variable.  Require the
+    # variable to match too, so piping an endpoint onto some *other* endpoint's
+    # condition keeps its current meaning (rename the condition).
+    .lhs <- lhsExpr
+    if (is.call(.lhs)) {
+      if (identical(.lhs[[1]], quote(`ll`)) && length(.lhs) == 2L) {
+        .lhs <- .lhs[[2]]
+      } else if (identical(.lhs[[1]], quote(`linCmt`))) {
+        .lhs <- quote(`rxLinCmt`)
+      }
+    }
+    .w <- which(rxui$predDf$cond == cond &
+                  .rxEndpointSourceVar(rxui) == deparse1(.lhs))
+    if (length(.w) == 1L) return(rxui$predDf$line[.w])
+  }
   .expr3 <- .getModelLineEquivalentLhsExpression(lhsExpr)
   .ret <- .getModelineFromExpressionsAndOriginalLines(lhsExpr, .expr3, errorLine, .errLines, .origLines, rxui, returnAllLines)
   if (is.null(.ret)) {
@@ -493,6 +535,39 @@ attr(rxUiGet.mvFromExpression, "desc") <- "Calculate model variables from stored
     }
   }
   FALSE
+}
+
+#' Get the model line of an endpoint dropped by its condition name
+#'
+#' When several endpoints share one model variable each has a generated alias,
+#' so `-cp` is ambiguous; `-<cond>` names the endpoint instead.  This only
+#' applies to those shared-variable endpoints, and only when the name is not
+#' also a model variable, so no existing drop changes meaning.
+#'
+#' @param line Drop expression from `model({})` piping
+#' @param rxui rxode2 UI
+#' @return The `predDf$line` of the endpoint, or `NULL`
+#' @author Matthew L. Fidler
+#' @noRd
+.getDropEndpointLineFromCondition <- function(line, rxui) {
+  .alias <- .rxEndpointAlias(rxui)
+  if (length(.alias) == 0L) return(NULL)
+  if (!(length(line) == 2L && identical(line[[1]], quote(`-`)) &&
+          is.name(line[[2]]))) {
+    return(NULL)
+  }
+  .predDf <- rxui$predDf
+  .name <- deparse1(line[[2]])
+  .w <- which(.predDf$cond == .name & .predDf$var %in% names(.alias))
+  if (length(.w) != 1L) return(NULL)
+  # the name may also be an ordinary model variable; dropping that line is what
+  # `-name` has always meant, so leave it alone
+  .lstExpr <- rxui$lstExpr
+  .other <- setdiff(seq_along(.lstExpr), .predDf$line)
+  for (.i in .other) {
+    if (identical(.getLhs(.lstExpr[[.i]]), line[[2]])) return(NULL)
+  }
+  .predDf$line[.w]
 }
 
 .getAdditionalDropLines <- function(line, rxui, isErr, isDrop) {
@@ -585,13 +660,19 @@ attr(rxUiGet.mvFromExpression, "desc") <- "Calculate model variables from stored
     } else {
       .isErr  <- .isErrorExpression(line)
       .isDrop <- .isDropExpression(line)
+      .cond <- .getEndpointCondFromLine(line)
       if (.isDrop && .isErr) {
-        .ret <- .getModelLineFromExpression(.getModelLineEquivalentLhsExpression(line), rxui, .isErr, FALSE)
+        .ret <- .getModelLineFromExpression(.getModelLineEquivalentLhsExpression(line), rxui, .isErr, FALSE,
+                                            cond=.cond)
       } else if (.isDrop) {
-        .ret <- .getModelLineFromExpression(.getModelLineEquivalentLhsExpression(line), rxui, .isErr, .isDrop)
-        .ret <- c(.ret, .getAdditionalDropLines(line, rxui, .isErr, .isDrop))
+        .ret <- .getDropEndpointLineFromCondition(line, rxui)
+        if (is.null(.ret)) {
+          .ret <- .getModelLineFromExpression(.getModelLineEquivalentLhsExpression(line), rxui, .isErr, .isDrop)
+          .ret <- c(.ret, .getAdditionalDropLines(line, rxui, .isErr, .isDrop))
+        }
       } else {
-        .ret <- .getModelLineFromExpression(.getLhs(line), rxui, .isErr, .isDrop)
+        .ret <- .getModelLineFromExpression(.getLhs(line), rxui, .isErr, .isDrop,
+                                            cond=.cond)
       }
       if (length(.ret)  == 1) {
         if (.isErr && is.na(.ret)) {
@@ -600,9 +681,18 @@ attr(rxUiGet.mvFromExpression, "desc") <- "Calculate model variables from stored
         }
       }
       if (is.null(.ret)) {
-        assign(".err",
-               c(.err, paste0("the lhs expression '", deparse1(line[[2]]), "' is duplicated in the model and cannot be modified by piping")),
-               envir=.env)
+        .msg <- paste0("the lhs expression '", deparse1(line[[2]]),
+                       "' is duplicated in the model and cannot be modified by piping")
+        if (.isErr) {
+          .cnd <- rxui$predDf$cond[.rxEndpointSourceVar(rxui) == deparse1(line[[2]])]
+          if (length(.cnd) > 1L) {
+            .msg <- paste0("'", deparse1(line[[2]]), "' is used by more than one endpoint (",
+                           paste(.cnd, collapse=", "),
+                           "); name the one to modify, like '", deparse1(line[[2]]),
+                           " ~ ... | ", .cnd[1], "'")
+          }
+        }
+        assign(".err", c(.err, .msg), envir=.env)
       } else if (is.na(.ret[1])) {
           assign(".err",
                  c(.err, paste0("the lhs expression '", deparse1(line[[2]]), "' is not in the model and cannot be modified by piping")),
@@ -692,7 +782,8 @@ rxUiGet.errParams <- function(x, ...) {
   .x <- x[[1]]
   .exact <- x[[2]]
   unlist(lapply(.x$lstExpr[.x$predDf$line], function(x) {
-    .getVariablesFromExpression(x[[3]])
+    # `err | cond` -- the condition names the endpoint, it is not a parameter
+    .getVariablesFromExpression(x[[3]], ignorePipe=TRUE)
   }))
 }
 attr(rxUiGet.errParams, "desc") <- "Get the error-associated variables"

--- a/R/rxUiBlessed.R
+++ b/R/rxUiBlessed.R
@@ -1,6 +1,6 @@
 ## created by .createRxUiBlessedList() in ui-assign-parts.R edit there
 .rxUiBlessed <- c("covLhsDf", "covariates", "curHi", "curLow", 
-    "errParams0", "estNotAllowed", "eta", "etaLhsDf", "extraCmt", 
+    "endpointAlias", "errParams0", "estNotAllowed", "eta", "etaLhsDf", "extraCmt", 
     "extraDvid", "hasErrors", "iniDf", "level", "levelLhsDf", 
     "lstExpr", "meta", "mixProbs", "model", "modelName", "mu2RefCovariateReplaceDataFrame", 
     "muRefCovariateDataFrame", "muRefCovariateEmpty", "muRefCurEval", 

--- a/R/rxUiGet.R
+++ b/R/rxUiGet.R
@@ -196,7 +196,7 @@ rxUiGet.props <- function(x, ...) {
   names(.var) <- .cnds
   .lhs <- .mv$lhs
   .state <- .mv$state
-  .end <- .x$predDf$var
+  .end <- unique(.rxEndpointSourceVar(.x))
   .end <- .end[.end %in% c(.lhs, .state)]
   .lhs <- .lhs[!(.lhs %in% .end)]
   .varLhs <- .x$varLhs
@@ -315,6 +315,8 @@ rxUiGet.multipleEndpoint <- function(x, ...) {
     return(invisible())
   }
   if (length(.info$cond) == 1) return(NULL)
+  # show the user's variable, not a generated endpoint alias
+  .info$var <- .rxEndpointSourceVar(.x)
   if (getOption("rxode2.combine.dvid", TRUE)) {
     .info <- .info[order(.info$dvid), ]
   }

--- a/R/ui-rename.R
+++ b/R/ui-rename.R
@@ -256,7 +256,7 @@ rxRename <- function(.data, ..., envir=parent.frame()) {
   if (is.list(rxui) || inherits(rxui, "raw")) {
     rxui <- rxUiDecompress(rxui)
   }
-  .vars <- unique(c(rxui$mv0$state, rxui$mv0$params, rxui$mv0$lhs, rxui$predDf$var, rxui$predDf$cond, rxui$iniDf$name))
+  .vars <- unique(c(rxui$mv0$state, rxui$mv0$params, rxui$mv0$lhs, .rxEndpointSourceVar(rxui), rxui$predDf$cond, rxui$iniDf$name))
   .modelLines <- .quoteCallInfoLines(match.call(expand.dots = TRUE)[-(1:2)], envir=envir)
   .lst <- lapply(seq_along(.modelLines), function(i) {
     .assertRenameErrorModelLine(.modelLines[[i]], .vars)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -403,6 +403,8 @@ navbar:
           href: articles/rxode2-confint.html
         - text: "ETA/EPS resampling"
           href: articles/rxode2-eta-eps-resampling.html
+        - text: "Separating phase 1 and phase 3 residual error"
+          href: articles/rxode2-phase-residual-error.html
   - text: "Examples"
     icon: fas fa-hospital
     menu:

--- a/tests/testthat/test-ar.R
+++ b/tests/testthat/test-ar.R
@@ -288,3 +288,35 @@ rxTest({
   })
 
 })
+
+rxTest({
+  test_that("ar() on two endpoints sharing a variable keeps separate state", {
+    .f <- function() {
+      ini({
+        tcl <- 1
+        tv <- 3
+        add.sd1 <- 0.7
+        add.sd2 <- 0.5
+        ar1.cor <- 0.5
+        ar2.cor <- 0.3
+      })
+      model({
+        cl <- exp(tcl)
+        v <- exp(tv)
+        d/dt(central) <- -cl / v * central
+        cp <- central / v
+        cp ~ add(add.sd1) + ar(ar1.cor) | phase1
+        cp ~ add(add.sd2) + ar(ar2.cor) | phase2
+      })
+    }
+    .ui <- .f()
+    expect_equal(.ui$predDf$var, c("rx.cp.phase1", "rx.cp.phase2"))
+    .all <- paste(vapply(rxCombineErrorLines(.ui), deparse1, character(1)),
+                  collapse="\n")
+    expect_true(grepl("rx.arRes.rx.cp.phase1", .all, fixed=TRUE))
+    expect_true(grepl("rx.arRes.rx.cp.phase2", .all, fixed=TRUE))
+    # each endpoint uses its own correlation, found through the `| cond`
+    expect_true(grepl("ar1.cor", .all, fixed=TRUE))
+    expect_true(grepl("ar2.cor", .all, fixed=TRUE))
+  })
+})

--- a/tests/testthat/test-ss-extra-dose-duration.R
+++ b/tests/testthat/test-ss-extra-dose-duration.R
@@ -103,7 +103,9 @@ rxTest({
       # from the lagged infusion onward the reported dose is the amount, not the
       # rate and not 0
       expect_true(all(.r$cd[.r$time >= 3] == 100))
-      expect_true(all(.r$dn >= 1))
+      # before the lagged dose lands there is no dose yet, so dosenum() is 0 --
+      # the same pre-dose row a plain lagged infusion reports
+      expect_true(all(.r$dn[.r$time >= 3] >= 1))
       # the dose lands at the lag time, so time-after-dose counts from there
       expect_equal(.r$ta[.r$time >= 3], .r$time[.r$time >= 3] - 3)
     }

--- a/tests/testthat/test-ui-multiple-endpoint.R
+++ b/tests/testthat/test-ui-multiple-endpoint.R
@@ -411,3 +411,398 @@ rxTest({
 
   })
 })
+
+rxTest({
+
+  .sameVarModel <- function() {
+    ini({
+      tka <- 0.45
+      tcl <- 1
+      tv <- 3.45
+      add.sd1 <- 0.7
+      add.sd2 <- 0.5
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl)
+      v <- exp(tv)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl / v * center
+      cp <- center / v
+      cp ~ add(add.sd1) | phase1
+      cp ~ add(add.sd2) | phase2
+    })
+  }
+
+  test_that("same variable on multiple endpoints gets a generated alias", {
+
+    ui <- .sameVarModel()
+
+    expect_equal(ui$predDf$cond, c("phase1", "phase2"))
+    expect_equal(ui$predDf$var, c("rx.cp.phase1", "rx.cp.phase2"))
+    expect_equal(ui$endpointAlias, c("rx.cp.phase1"="cp", "rx.cp.phase2"="cp"))
+    expect_equal(ui$predDf$dvid, 1:2)
+    expect_equal(ui$predDf$cmt, 3:4)
+
+    # the user's model({}) block is untouched
+    expect_equal(ui$lstExpr[[ui$predDf$line[1]]],
+                 quote(cp ~ add(add.sd1) | phase1))
+    expect_equal(ui$lstExpr[[ui$predDf$line[2]]],
+                 quote(cp ~ add(add.sd2) | phase2))
+    expect_equal(modelExtract(ui, endpoint=TRUE),
+                 c("cp ~ add(add.sd1) | phase1", "cp ~ add(add.sd2) | phase2"))
+    # and it round-trips through the function
+    expect_equal(ui$fun()$lstExpr, ui$lstExpr)
+
+    # the endpoint table shows the user's variable, not the alias
+    expect_true(all(startsWith(ui$multipleEndpoint$variable, "cp ~ ")))
+    expect_equal(unique(ui$props$output$endpoint), "cp")
+
+    # each endpoint gets its own residual parameter
+    expect_equal(dimnames(ui$simulationSigma)[[1]],
+                 c("rxerr.rx.cp.phase1", "rxerr.rx.cp.phase2"))
+    expect_equal(dim(ui$simulationSigma), c(2L, 2L))
+
+    # the alias is defined in the assembled model
+    .sim <- rxNorm(ui$simulationModel)
+    expect_true(grepl("rx.cp.phase1~cp", .sim, fixed=TRUE))
+    expect_true(grepl("rx.cp.phase2~cp", .sim, fixed=TRUE))
+    expect_true(grepl("rxerr.rx.cp.phase1", .sim, fixed=TRUE))
+    expect_true(grepl("rxerr.rx.cp.phase2", .sim, fixed=TRUE))
+
+    # the ini simulation model defines each residual exactly once
+    .ini <- vapply(rxode2:::getBaseIniSimModel(ui)[[2]][-1], deparse1, character(1),
+                   USE.NAMES=FALSE)
+    expect_equal(sum(.ini == "rxerr.rx.cp.phase1 <- 1"), 1L)
+    expect_equal(sum(.ini == "rxerr.rx.cp.phase2 <- 1"), 1L)
+
+    # the symengine/estimation model builds too
+    expect_error(eval(rxode2:::getBaseSymengineModel(ui)), NA)
+  })
+
+  test_that("same variable on multiple endpoints solves with separate residuals", {
+
+    ui <- .sameVarModel()
+    ev <- et(amt=100)
+    ev <- et(ev, seq(1, 24, 4), cmt="phase1")
+    ev <- et(ev, seq(1, 24, 4), cmt="phase2")
+
+    withr::with_seed(42, {
+      d <- as.data.frame(suppressWarnings(rxSolve(ui, ev, nSub=3, addDosing=FALSE)))
+    })
+    .a <- d[d$CMT == 3, c("sim.id", "time", "ipredSim", "sim")]
+    .b <- d[d$CMT == 4, c("sim.id", "time", "ipredSim", "sim")]
+    .m <- merge(.a, .b, by=c("sim.id", "time"))
+    expect_true(nrow(.m) > 0L)
+    # same prediction, independent residual draws
+    expect_equal(.m$ipredSim.x, .m$ipredSim.y)
+    expect_false(isTRUE(all.equal(.m$sim.x - .m$ipredSim.x,
+                                  .m$sim.y - .m$ipredSim.y)))
+  })
+
+  test_that("only the shared variable is aliased", {
+
+    ui <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd1 <- 0.7
+        add.sd2 <- 0.5
+        add.sd3 <- 0.3
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        eff <- cp * 2
+        cp ~ add(add.sd1) | phase1
+        cp ~ add(add.sd2) | phase2
+        eff ~ add(add.sd3) | pd
+      })
+    }
+    ui <- ui()
+    expect_equal(ui$predDf$var, c("rx.cp.phase1", "rx.cp.phase2", "eff"))
+    expect_equal(ui$endpointAlias, c("rx.cp.phase1"="cp", "rx.cp.phase2"="cp"))
+  })
+
+  test_that("a generated alias does not collide with a user variable", {
+
+    ui <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd1 <- 0.7
+        add.sd2 <- 0.5
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        rx.cp.phase1 <- cp * 2
+        cp ~ add(add.sd1) | phase1
+        cp ~ add(add.sd2) | phase2
+      })
+    }
+    ui <- ui()
+    expect_equal(ui$predDf$var, c("rx.cp.phase1.1", "rx.cp.phase2"))
+  })
+
+  test_that("a generated alias keeps its derived names free", {
+
+    # `rxerr.<var>` is the endpoint's simulated residual draw and `rx.ar*.<var>`
+    # its AR(1) state, so an alias whose derived names are taken by a user
+    # variable would silently make the residual deterministic
+    ui <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd1 <- 0.7
+        add.sd2 <- 0.5
+        sdx <- 9
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        rxerr.rx.cp.phase1 <- sdx
+        cp ~ add(add.sd1) | phase1
+        cp ~ add(add.sd2) | phase2
+      })
+    }
+    ui <- ui()
+    expect_equal(ui$predDf$var, c("rx.cp.phase1.1", "rx.cp.phase2"))
+    expect_equal(dimnames(ui$simulationSigma)[[1]],
+                 c("rxerr.rx.cp.phase1.1", "rxerr.rx.cp.phase2"))
+
+    ev <- et(amt=100)
+    ev <- et(ev, c(1, 2), cmt="phase1")
+    ev <- et(ev, c(1, 2), cmt="phase2")
+    withr::with_seed(1, {
+      d <- as.data.frame(suppressWarnings(rxSolve(ui, ev, nSub=3, addDosing=FALSE)))
+    })
+    # the residual still varies between subjects for both endpoints
+    .r <- d$sim - d$ipredSim
+    expect_true(length(unique(.r[d$CMT == 3])) > 1L)
+    expect_true(length(unique(.r[d$CMT == 4])) > 1L)
+
+    # the same guard covers the AR(1) state names
+    ui2 <- function() {
+      ini({
+        tcl <- 1
+        tv <- 3
+        add.sd1 <- 0.7
+        add.sd2 <- 0.5
+        cor1 <- 0.5
+      })
+      model({
+        cl <- exp(tcl)
+        v <- exp(tv)
+        d/dt(central) <- -cl / v * central
+        cp <- central / v
+        rx.arRes.rx.cp.phase1 <- 1
+        eff <- rx.arRes.rx.cp.phase1
+        cp ~ add(add.sd1) + ar(cor1) | phase1
+        cp ~ add(add.sd2) | phase2
+      })
+    }
+    expect_equal(ui2()$predDf$var, c("rx.cp.phase1.1", "rx.cp.phase2"))
+  })
+
+  test_that("dropping by condition does not shadow a real model variable", {
+
+    f <- function() {
+      ini({
+        add.sd1 <- 0.7
+        add.sd2 <- 0.5
+      })
+      model({
+        phase2 <- 1
+        cp <- phase2
+        cp ~ add(add.sd1) | phase1
+        cp ~ add(add.sd2) | phase2
+      })
+    }
+    # `phase2` is both an endpoint condition and an ordinary lhs; `-phase2` has
+    # always meant the lhs, so it must keep meaning that
+    .d <- suppressMessages(f() |> model(-phase2))
+    expect_equal(.d$predDf$cond, c("phase1", "phase2"))
+    expect_false(any(vapply(.d$lstExpr, function(e) identical(e, quote(phase2 <- 1)),
+                            logical(1))))
+  })
+
+  test_that("two endpoints on one variable must be named", {
+
+    f <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd1 <- 0.7
+        add.sd2 <- 0.5
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd1)
+        cp ~ add(add.sd2)
+      })
+    }
+    expect_error(f(), "defined more than once")
+  })
+
+  test_that("linCmt() endpoints can share the model", {
+
+    f <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd1 <- 0.7
+        add.sd2 <- 0.5
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        linCmt() ~ add(add.sd1) | phase1
+        linCmt() ~ add(add.sd2) | phase2
+      })
+    }
+    ui <- f()
+    expect_equal(ui$predDf$var, c("rx.rxLinCmt.phase1", "rx.rxLinCmt.phase2"))
+    expect_true(ui$props$linCmt)
+    expect_error(ui$simulationModel, NA)
+  })
+
+  test_that("ll() endpoints are never aliased", {
+
+    f <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd1 <- 0.7
+        add.sd2 <- 0.5
+        sd3 <- 0.3
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        eff <- cp * 2
+        cp ~ add(add.sd1) | phase1
+        cp ~ add(add.sd2) | phase2
+        ll(eff) ~ log(sd3) + log(eff)
+      })
+    }
+    ui <- f()
+    expect_equal(ui$predDf$var, c("rx.cp.phase1", "rx.cp.phase2", "eff"))
+    expect_equal(ui$endpointAlias, c("rx.cp.phase1"="cp", "rx.cp.phase2"="cp"))
+  })
+
+  test_that("piping selects a shared-variable endpoint by its condition", {
+
+    ui <- .sameVarModel()
+
+    .p <- ui |> model(cp ~ prop(add.sd2) | phase2)
+    expect_equal(as.character(.p$predDf$errType), c("add", "prop"))
+    expect_equal(.p$predDf$cond, c("phase1", "phase2"))
+    expect_equal(.p$lstExpr[[.p$predDf$line[1]]],
+                 quote(cp ~ add(add.sd1) | phase1))
+
+    # without a condition it is ambiguous
+    expect_error(ui |> model(cp ~ prop(add.sd2)),
+                 "used by more than one endpoint")
+
+    # dropping by condition collapses back to a single un-aliased endpoint
+    .d <- suppressMessages(ui |> model(-phase2))
+    expect_equal(.d$predDf$cond, "phase1")
+    expect_equal(.d$predDf$var, "cp")
+    expect_equal(.d$endpointAlias, character(0))
+    expect_false("add.sd2" %in% .d$iniDf$name)
+
+    # piping the same line again is stable
+    expect_equal((.p |> model(cp ~ prop(add.sd2) | phase2))$lstExpr, .p$lstExpr)
+  })
+
+  test_that("an endpoint condition is not an error parameter", {
+
+    f <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd)
+      })
+    }
+    ui <- f()
+    expect_equal(ui$errParams, "add.sd")
+
+    # naming the endpoint of a single-endpoint model must not try to make the
+    # condition an estimated parameter
+    .a <- ui |> model(cp ~ add(add.sd) | assay1)
+    expect_equal(.a$predDf$cond, "assay1")
+    expect_false("assay1" %in% .a$iniDf$name)
+    expect_equal(.a$errParams, "add.sd")
+  })
+
+  test_that("a shared-variable endpoint can be added by piping", {
+
+    f <- function() {
+      ini({
+        tka <- 0.45
+        tcl <- 1
+        tv <- 3.45
+        add.sd1 <- 0.7
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(tcl)
+        v <- exp(tv)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl / v * center
+        cp <- center / v
+        cp ~ add(add.sd1) | phase1
+      })
+    }
+    .a <- suppressMessages(f() |> model(cp ~ add(add.sd2) | phase2, append=TRUE))
+    expect_equal(.a$predDf$cond, c("phase1", "phase2"))
+    expect_equal(.a$predDf$var, c("rx.cp.phase1", "rx.cp.phase2"))
+  })
+
+  test_that("renaming a shared endpoint variable regenerates the alias", {
+
+    .r <- .sameVarModel() |> rxRename(conc=cp)
+    expect_equal(.r$predDf$var, c("rx.conc.phase1", "rx.conc.phase2"))
+    expect_equal(.r$endpointAlias, c("rx.conc.phase1"="conc", "rx.conc.phase2"="conc"))
+  })
+
+})

--- a/tests/testthat/test-ui-multiple-endpoint.R
+++ b/tests/testthat/test-ui-multiple-endpoint.R
@@ -597,6 +597,29 @@ rxTest({
     expect_true(length(unique(.r[d$CMT == 3])) > 1L)
     expect_true(length(unique(.r[d$CMT == 4])) > 1L)
 
+    # conditions that differ only in a character the estimation `ar()` names
+    # normalize away must still get distinct aliases
+    ui3 <- function() {
+      ini({
+        tcl <- 1
+        tv <- 3
+        add.sd1 <- 0.7
+        add.sd2 <- 0.5
+        cor1 <- 0.5
+        cor2 <- 0.3
+      })
+      model({
+        cl <- exp(tcl)
+        v <- exp(tv)
+        d/dt(central) <- -cl / v * central
+        cp <- central / v
+        cp ~ add(add.sd1) + ar(cor1) | phase.1
+        cp ~ add(add.sd2) + ar(cor2) | phase_1
+      })
+    }
+    ui3 <- ui3()
+    expect_equal(length(unique(gsub("[^A-Za-z0-9]", "_", ui3$predDf$var))), 2L)
+
     # the same guard covers the AR(1) state names
     ui2 <- function() {
       ini({

--- a/vignettes/articles/Modifying-Models.Rmd
+++ b/vignettes/articles/Modifying-Models.Rmd
@@ -301,6 +301,71 @@ mod6 <- mod5 |>
 print(mod6)
 ```
 
+### Multiple endpoints that share one prediction
+
+The `cp2 <- cp` line above exists only to give the second assay a
+variable of its own.  That is not required: the same prediction can
+carry more than one residual error model as long as each endpoint is
+named with `| <name>` after the error expression.
+
+```{r sharedEndpoint}
+mod4b <- mod |>
+  model(cp ~ add(add.sd) | assay1) |>
+  model(cp ~ lnorm(lnorm.sd) | assay2, append=TRUE)
+
+print(mod4b)
+```
+
+The first pipe names the endpoint that was already there; the second
+appends a new one on the same `cp`.
+
+The name after `|` is the endpoint's compartment/`dvid` name, so a
+record with `cmt="assay1"` is compared against `add.sd` and a record
+with `cmt="assay2"` against `lnorm.sd`.  `$multipleEndpoint` shows the
+translation:
+
+```{r sharedEndpointTable}
+mod4b$multipleEndpoint
+```
+
+Behind the scenes `rxode2` gives each of these endpoints its own
+generated variable (`rx.cp.assay1`, `rx.cp.assay2`) so that they get
+separate residual parameters and separate simulated residuals; the
+mapping is in `$endpointAlias`:
+
+```{r sharedEndpointAlias}
+mod4b$endpointAlias
+```
+
+You do not need to write those lines yourself and they never appear in
+your `model({})` block -- but they are why `$predDf$var` differs from
+the variable you typed.
+
+Because both endpoints have the same left-hand side, piping has to be
+told which one you mean; name the condition:
+
+```{r sharedEndpointPipe}
+mod4c <- mod4b |>
+  model(cp ~ prop(prop.sd) | assay2)
+
+print(mod4c)
+```
+
+Piping `cp ~ prop(prop.sd)` without the `| assay2` is an error that
+lists the conditions to choose from.  The same name drops a single
+endpoint:
+
+```{r sharedEndpointDrop}
+mod4d <- mod4c |>
+  model(-assay2)
+
+print(mod4d)
+```
+
+Each endpoint still needs its own name.  Writing `cp ~ add(add.sd1)`
+and `cp ~ add(add.sd2)` with no `|` gives two endpoints that data can
+never tell apart, so that is rejected when the model is built.
+
 ### Remove lines in the model
 
 The lines in a model can be removed in one of 2 ways either use

--- a/vignettes/articles/rxode2-phase-residual-error.Rmd
+++ b/vignettes/articles/rxode2-phase-residual-error.Rmd
@@ -1,0 +1,271 @@
+---
+title: "Separating phase 1 and phase 3 residual error"
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+```{r setup}
+library(rxode2)
+library(ggplot2)
+```
+
+## Why one residual error model is often not enough
+
+A pooled population PK analysis usually combines studies that were not
+run under the same conditions.  Phase 1 data come from rich sampling
+in healthy volunteers at a single site, with a validated assay and
+controlled sample handling.  Phase 3 data come from sparse sampling in
+patients across many sites, with nominal rather than recorded times,
+more variable sample handling, and sometimes a different assay
+version.
+
+The structural model is the same for both -- the drug does not change
+between phases -- but the *noise around the prediction* is not.  Fitting
+one residual error model to the pooled data splits the difference: it
+overstates the noise on the phase 1 observations and understates it on
+the phase 3 ones.  Anything that reads the residual error then
+inherits that compromise, including the width of a simulated
+prediction interval and the weighting each observation gets during
+estimation.
+
+The fix is to keep one prediction and give it two residual error
+models, one per phase.
+
+## Two endpoints on one prediction
+
+An `rxode2` error line may be named with `| <name>` after the error
+expression.  The name is the endpoint, and the same model variable may
+be used by more than one of them:
+
+```{r model}
+pk <- function() {
+  ini({
+    tka <- 0.45; label("Log Ka")
+    tcl <- 1;    label("Log Cl")
+    tv  <- 3.45; label("Log V")
+    eta.ka ~ 0.6
+    eta.cl ~ 0.3
+    eta.v  ~ 0.1
+    phase1.sd <- 0.2; label("Phase 1 additive error (mg/L)")
+    phase3.sd <- 0.7; label("Phase 3 additive error (mg/L)")
+  })
+  model({
+    ka <- exp(tka + eta.ka)
+    cl <- exp(tcl + eta.cl)
+    v  <- exp(tv + eta.v)
+    d/dt(depot)  <- -ka * depot
+    d/dt(center) <-  ka * depot - cl / v * center
+    cp <- center / v
+    cp ~ add(phase1.sd) | phase1
+    cp ~ add(phase3.sd) | phase3
+  })
+}
+
+pk <- pk()
+print(pk)
+```
+
+There is one `cp`, one set of ODEs and one set of structural
+parameters.  What differs is which standard deviation is applied, and
+that is chosen per observation record.
+
+The `$multipleEndpoint` table shows how a record selects its endpoint:
+
+```{r multipleEndpoint}
+pk$multipleEndpoint
+```
+
+So an observation with `cmt="phase1"` (equivalently `dvid=1`) gets
+`phase1.sd`, and one with `cmt="phase3"` (`dvid=2`) gets `phase3.sd`.
+
+### What rxode2 does with the shared variable
+
+Almost everything downstream of the model -- the simulated residual
+draw, the residual parameter lookup, `ar()` state -- is keyed on the
+endpoint's prediction variable.  Two endpoints named `cp` would
+collide there, so `rxode2` gives each of them a generated variable of
+its own and records the mapping:
+
+```{r alias}
+pk$endpointAlias
+pk$predDf[, c("cond", "var", "dvid", "cmt")]
+```
+
+You never write those lines and they never appear in your `model({})`
+block, in `modelExtract()`, or in the solved output.  They are only
+worth knowing about because `$predDf$var` is where they show up.
+
+Before this was supported the aliases had to be written by hand:
+
+```r
+cp.phase1 <- cp
+cp.phase3 <- cp
+cp.phase1 ~ add(phase1.sd) | phase1
+cp.phase3 ~ add(phase3.sd) | phase3
+```
+
+That model still works and still means the same thing -- it is just no
+longer necessary.
+
+## Simulating each phase
+
+Label the observation records with the phase they belong to.  A rich
+phase 1 profile and a sparse phase 3 trough/peak design:
+
+```{r events}
+ph1 <- et(amt=100) |>
+  et(seq(0.25, 24, by=0.5), cmt="phase1")
+
+ph3 <- et(amt=100) |>
+  et(c(1, 4, 12, 24), cmt="phase3")
+```
+
+Solving each design gives `ipredSim` (the individual prediction) and
+`sim` (the prediction plus residual error):
+
+```{r solve}
+set.seed(42)
+s1 <- rxSolve(pk, ph1, nSub=100, addDosing=FALSE)
+s3 <- rxSolve(pk, ph3, nSub=100, addDosing=FALSE)
+```
+
+The residual spread differs by exactly the amount the model says it
+should:
+
+```{r residSd}
+c(phase1 = sd(s1$sim - s1$ipredSim),
+  phase3 = sd(s3$sim - s3$ipredSim))
+```
+
+```{r plotPhase, fig.width=7, fig.height=4}
+d <- rbind(
+  data.frame(phase="phase1", time=s1$time, resid=s1$sim - s1$ipredSim),
+  data.frame(phase="phase3", time=s3$time, resid=s3$sim - s3$ipredSim))
+
+ggplot(d, aes(x=resid, fill=phase)) +
+  geom_density(alpha=0.5) +
+  xlab("sim - ipredSim (mg/L)") +
+  theme_bw()
+```
+
+### Both phases in one simulation
+
+The two endpoints are just two compartments, so a single event table
+can carry both.  This is what a pooled dataset looks like: the same
+subject contributes rich early samples and sparse late ones, and each
+record is scored against its own error model.
+
+```{r bothPhases}
+both <- et(amt=100) |>
+  et(seq(0.25, 12, by=0.5), cmt="phase1") |>
+  et(c(24, 36, 48), cmt="phase3")
+
+set.seed(42)
+sBoth <- as.data.frame(rxSolve(pk, both, nSub=50, addDosing=FALSE))
+
+# CMT 3 is the phase1 endpoint and CMT 4 the phase3 endpoint, as
+# $multipleEndpoint showed above
+sBoth$phase <- ifelse(sBoth$CMT == 3, "phase1", "phase3")
+tapply(sBoth$sim - sBoth$ipredSim, sBoth$phase, sd)
+```
+
+The two endpoints draw their residuals independently, so a record in
+one phase never inherits the other phase's noise.
+
+## Predicting a trial with one phase's noise
+
+The most common reason to separate the two is to *predict* with only
+one of them.  When you simulate a future phase 3 trial, the noise you
+want on the simulated observations is the phase 3 noise -- using the
+pooled value would give an interval that is too narrow, and using the
+phase 1 value one that is far too narrow.
+
+Because the endpoint is chosen per record, this is just a matter of
+which compartment the observation records name:
+
+```{r futureTrial, fig.width=7, fig.height=4}
+future <- et(amt=100) |>
+  et(seq(0, 48, by=1), cmt="phase3")
+
+set.seed(1)
+sFuture <- rxSolve(pk, future, nSub=500, addDosing=FALSE)
+
+ci <- confint(sFuture, "sim", level=0.90)
+
+plot(ci, ylab="Simulated concentration (mg/L)")
+```
+
+Swapping `cmt="phase3"` for `cmt="phase1"` in that event table gives
+the same central tendency with the tighter phase 1 interval, which is
+the right answer for predicting a replicate phase 1 study and the
+wrong one for a phase 3 trial.
+
+If you want the prediction with no residual error at all, use
+`ipredSim`, which is the same for both endpoints.
+
+## Different error structures per phase
+
+The phases do not have to share an error *structure*, only a
+prediction.  An assay that is precise near the LLOQ but proportional
+higher up, versus one that is additive throughout, is written directly:
+
+```{r mixedStructure}
+pk2 <- pk |>
+  model(cp ~ prop(phase3.prop) | phase3)
+
+print(pk2)
+```
+
+Since both endpoints have the same left-hand side, the `| phase3` is
+what tells piping which one to replace; without it the model piping
+reports the available conditions instead of guessing.  The same name
+removes an endpoint:
+
+```{r dropPhase}
+pk3 <- pk2 |>
+  model(-phase3)
+
+print(pk3)
+```
+
+Transformations are per endpoint too, so `cp ~ lnorm(phase3.sd) |
+phase3` gives phase 3 a log-normal residual while phase 1 stays
+additive.
+
+## Estimating both from pooled data
+
+Nothing here is simulation-only.  Give `nlmixr2` a pooled dataset with
+a `dvid` (or `cmt`) column naming the phase and it estimates both
+standard deviations at once:
+
+```r
+library(nlmixr2)
+
+# `dat` is the pooled analysis dataset with a `dvid` column whose
+# values are "phase1" and "phase3" on the observation records
+fit <- nlmixr2(pk, dat, "focei")
+fit$parFixedDf["phase1.sd", ]
+fit$parFixedDf["phase3.sd", ]
+```
+
+Each observation is weighted by the residual error of the study it
+came from, so the rich phase 1 profiles no longer inflate the phase 3
+error and the sparse phase 3 records no longer inflate the phase 1
+error.
+
+## Notes
+
+- The name after `|` is a compartment name.  In the data it can be
+  supplied as a character `cmt` column, a character `dvid` column, or
+  the numeric `dvid` shown by `$multipleEndpoint`.
+- Endpoints sharing a prediction must each be named.  Two unnamed
+  endpoints on one variable are rejected when the model is built,
+  because no data record could tell them apart.
+- The split is not limited to two, and not limited to study phase --
+  assay version, matrix (plasma versus dried blood spot), and site are
+  all handled the same way.

--- a/vignettes/articles/rxode2-phase-residual-error.Rmd
+++ b/vignettes/articles/rxode2-phase-residual-error.Rmd
@@ -20,9 +20,8 @@ A pooled population PK analysis usually combines studies that were not
 run under the same conditions.  Phase 1 data come from rich sampling
 in healthy volunteers at a single site, with a validated assay and
 controlled sample handling.  Phase 3 data come from sparse sampling in
-patients across many sites, with nominal rather than recorded times,
-more variable sample handling, and sometimes a different assay
-version.
+patients across many sites, more variable sample handling, and
+sometimes a different assay version.
 
 The structural model is the same for both -- the drug does not change
 between phases -- but the *noise around the prediction* is not.  Fitting


### PR DESCRIPTION
## The problem

An rxode2 UI model may name the same variable on more than one residual-error
endpoint, distinguished by the `| <cond>` condition:

```r
cp ~ add(add.sd1) | phase1
cp ~ add(add.sd2) | phase2
```

`$predDf` then has two rows with distinct `cond` but a **duplicated `var`**, and
everything keyed on `var` collided:

| symptom | cause |
|---|---|
| `rxSolve()` fails outright with `The simulated residual errors do not match the model specification (1=2)` | `$simulationSigma` carries two `rxerr.cp` dimnames against a single model parameter, so `op->nsvar != errNcol` in `src/rxode2_df.cpp` |
| both endpoints share one residual draw | `rxerr.<var>` in `R/err-sim.R` |
| two `ar()` endpoints silently share one AR(1) state | `rx.arRes.<var>` etc. |
| neither endpoint can be reached by piping | `the lhs expression 'cp' is duplicated in the model and cannot be modified by piping` |

The workaround was to write the alias variables by hand:

```r
cp.phase1 <- cp
cp.phase2 <- cp
cp.phase1 ~ add(add.sd1) | phase1
cp.phase2 ~ add(add.sd2) | phase2
```

FOCEi and SAEM themselves already worked for the plain case; the damage was in
simulation, piping, `ar()`, and any downstream package that assumes `predDf$var`
is unique.

## The approach

Endpoints that share a variable now get a **generated alias**
(`rx.<var>.<cond>`) recorded in a new blessed slot `$endpointAlias`, which
becomes their `$predDf$var`.

`$lstExpr` is deliberately **not** rewritten, so `print()`, `$fun`,
`modelExtract()` and `$multipleEndpoint` still show the model exactly as
written:

```
cp <- center/v
cp ~ add(add.sd1) | phase1
cp ~ add(add.sd2) | phase2
```

The alias *definition* (`rx.cp.phase1 ~ cp`, a suppressed `~` assignment so it
lands in `mv$slhs` and adds no output column) is injected only where a runnable
model is assembled: the `.lstChr` used to build `$mv0`, and
`rxCombineErrorLines()`. Every nlmixr2est engine (focei, saem, nlme, nlm, nls)
funnels through `rxCombineErrorLines`, and `rx_pred_f_` has a single producer
(`.rxGetPredictionF`) reachable only from what that function consumes -- that is
what bounds the injection to two sites.

A `linCmt()` endpoint is special-cased: the parser allows only one `linCmt()`
call per model, so a single `rxLinCmt ~ linCmt()` is emitted once outside the
`if (CMT == k)` branches and the aliases read it.

Generated names also keep the names *derived* from them free (`rxerr.<alias>`,
`rx.ar*.<alias>`, `rx_arE_<alias>`), so a user variable cannot quietly take over
an endpoint's residual draw.

### Piping

`model(cp ~ prop(x) | phase2)` targets one endpoint and `model(-phase2)` drops
one, falling back to the pre-existing lhs match when the name is also an
ordinary model variable so no existing drop changes meaning. Piping a shared
endpoint without a condition now lists the conditions to choose from.

Two endpoints sharing a *condition* (`cp ~ add(a)` written twice) error at parse
time asking for `| <name>` -- no data record could tell them apart.

## Also fixed (all pre-existing)

- An endpoint's condition was read as a residual parameter, so
  `model(cp ~ add(add.sd) | assay1)` failed with *"the following parameter(s)
  were in the ini block but not in the model block: assay1"*. This is what made
  a conditioned endpoint unpipeable at all.
- `.rxFindArArg()` matched the endpoint against the left-hand side, which never
  carries the condition, so a modeled `ar()` on a `| cond` endpoint was not
  found.
- The "cannot find additive standard deviation" message tested
  `$predDf$condition`, a column that does not exist, so its multiple-endpoint
  hint printed even for single-endpoint models.
- `test-ss-extra-dose-duration.R:106` asserted `all(.r$dn >= 1)` including the
  pre-dose row, where `dosenum()` is legitimately 0 (#1342). Test-only; the
  dose-history code is unchanged.

## Compatibility

No `$predDf` column is added, removed or renamed -- only the **value** of `var`
changes, and only in a configuration that previously failed outright, so no
saved fit or released reverse dependency can be carrying such a value.
Single-endpoint and distinct-variable multi-endpoint models are untouched
(`$endpointAlias` is `character(0)`), and `.rxEndpointAlias()` returns
`character(0)` for a ui serialized before this change.

## Testing

- Full suite: `FAIL 0 | PASS 40282` before merging main; after the merge the
  only failures were 3 pre-existing ones in `test-ss-extra-dose-duration.R`,
  confirmed identical on a clean `origin/main` worktree and fixed here.
- New tests in `test-ui-multiple-endpoint.R` cover: alias generation and
  `$endpointAlias`; `$lstExpr`/`modelExtract`/`$fun` round-trip; the
  `simulationSigma` dimnames regression; a real `rxSolve()` producing
  *independent* residuals per endpoint; assembled-model compilation; a third
  endpoint on a different variable staying un-aliased; name collision with a
  user variable and with a derived name; conditions differing only in a
  character the `ar()` names normalize away; `linCmt()` endpoints; `ll()`
  endpoints staying un-aliased; the duplicate-condition error; and the piping
  select/add/drop/rename paths.
- `test-ar.R` gains a two-endpoint `ar()` case asserting distinct AR state.
- End-to-end `focei` and `saem` fits on `theo_sd` split by `dvid` recover
  separate `add.sd1`/`add.sd2`.
- Two GitHub Copilot review passes; both rounds' findings verified and fixed
  (one round-two claim was reproduced as a false positive and rejected).

## Docs

- `Modifying-Models.Rmd` gains a "Multiple endpoints that share one prediction"
  section, next to the existing two-assay example that this replaces.
- New article `rxode2-phase-residual-error.Rmd` on separating phase 1 and
  phase 3 residual noise in predictions, registered in `_pkgdown.yml`. A sister
  article on *fitting* these models is in nlmixr2/nlmixr2#416.

Both articles were purled and run end-to-end.
