### PR TITLE
fix(solve): emit the record that turns a pushed evid_() infusion back off

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -711,16 +711,20 @@
   written into the event table for fixed rate, fixed duration, modeled rate,
   modeled duration, `evid=4`, `addl`, `ss=1`, `ss=2` and a split bolus.  A
   steady-state dose pushed into a compartment that also carries a modeled
-  `alag()` is still not expanded the way the event table expands it, and remains
-  a known gap.
+  `alag()` is still not expanded the way the event table expands it, and a
+  steady-state constant infusion pushed with a duration rather than a rate is
+  still not rejected the way the event table rejects it; both remain known gaps.
 
 - The last-record guard for a modeled `rate()`/`dur()` infusion start was off by
-  one.  `handleTurnOnModeledRate()`/`handleTurnOnModeledDuration()` rejected only
+  one: `handleTurnOnModeledRate()`/`handleTurnOnModeledDuration()` rejected only
   `idx >= n_all_times` and then read (and, through `updateRate()`/`updateDur()`,
-  wrote) record `idx + 1`, so a start sitting on the LAST record read the next
-  subject's first record instead of reporting that it has no stop.  The
-  event-array growth in `_rxPushDose()` also now allocates the guard slot its
-  own comment promises.
+  wrote) record `idx + 1`.  The only way to reach it was the lone modeled start
+  the push path used to emit, so with that fixed the guard is defensive rather
+  than a user-visible fix.  Separately, `_rxPushDose()`'s event-array growth
+  under-reserved when a bolus is split across compartments -- it counted the
+  translated events rather than the records they expand into, which the `idose`
+  growth beside it already did -- and now allocates the guard slot its own
+  comment promises for `ix` and `timeThread` too.
 
 - `updateRate()` no longer leaves `ind->idx` pointing at the dose record when a
   modeled `rate()` evaluates to zero or less.  Both of its error returns skipped

--- a/NEWS.md
+++ b/NEWS.md
@@ -709,7 +709,10 @@
   data error 997/886 instead of scheduling the infusion.  The translator emits
   up to three records now, and a pushed infusion matches the same regimen
   written into the event table for fixed rate, fixed duration, modeled rate,
-  modeled duration, `evid=4`, `addl` and steady state.
+  modeled duration, `evid=4`, `addl`, `ss=1`, `ss=2` and a split bolus.  A
+  steady-state dose pushed into a compartment that also carries a modeled
+  `alag()` is still not expanded the way the event table expands it, and remains
+  a known gap.
 
 - The last-record guard for a modeled `rate()`/`dur()` infusion start was off by
   one.  `handleTurnOnModeledRate()`/`handleTurnOnModeledDuration()` rejected only

--- a/NEWS.md
+++ b/NEWS.md
@@ -701,6 +701,24 @@
 
 ## Bug fixes
 
+- An infusion pushed from inside the model with `evid_()` now turns back off.
+  `evid=4` (reset + dose) used both slots of the translated event for the reset
+  and the infusion start, so the stop record was dropped and the infusion ran
+  for the rest of the solve; a modeled `rate=-1`/`rate=-2` dose was pushed
+  without its companion "off" record at all, so the solve failed outright with
+  data error 997/886 instead of scheduling the infusion.  The translator emits
+  up to three records now, and a pushed infusion matches the same regimen
+  written into the event table for fixed rate, fixed duration, modeled rate,
+  modeled duration, `evid=4`, `addl` and steady state.
+
+- The last-record guard for a modeled `rate()`/`dur()` infusion start was off by
+  one.  `handleTurnOnModeledRate()`/`handleTurnOnModeledDuration()` rejected only
+  `idx >= n_all_times` and then read (and, through `updateRate()`/`updateDur()`,
+  wrote) record `idx + 1`, so a start sitting on the LAST record read the next
+  subject's first record instead of reporting that it has no stop.  The
+  event-array growth in `_rxPushDose()` also now allocates the guard slot its
+  own comment promises.
+
 - `updateRate()` no longer leaves `ind->idx` pointing at the dose record when a
   modeled `rate()` evaluates to zero or less.  Both of its error returns skipped
   the trailing restore of the saved index, so the corrupted value stayed live

--- a/inst/include/rxode2EventTranslate.h
+++ b/inst/include/rxode2EventTranslate.h
@@ -1,20 +1,23 @@
 #ifndef RXODE2_EVENT_TRANSLATE_H
 #define RXODE2_EVENT_TRANSLATE_H
 
-/* Result of translating one NONMEM/rxode2 event: 1 or 2 internal events.
+/* Result of translating one NONMEM/rxode2 event: 1 to 3 internal events.
  *
  * This header is shared by:
  *   src/etTran.cpp   - batch event-table translation
  *   inst/include/rxode2parseHandleEvid.h - runtime evid_() push
  */
 
+#define RX_TRANSLATED_EVENT_MAX 3
+
 typedef struct {
-  int    n;            /* number of output events: 1 (bolus/obs/reset) or 2 (infusion: start+stop) */
-  int    evid[2];      /* internal rxode2 evid code(s) */
-  double time[2];      /* event time(s): [0]=start, [1]=stop */
-  double amt[2];       /* amounts: [0]=+amt (or +rate), [1]=-amt (or -rate) */
-  double ii[2];        /* ii values */
-  int    isDose[2];    /* 1 if this event contributes an idose entry */
+  int    n;            /* number of output events: 1 (bolus/obs/reset), 2 (infusion:
+                        * start+stop) or 3 (evid=4 reset + infusion start+stop) */
+  int    evid[RX_TRANSLATED_EVENT_MAX];   /* internal rxode2 evid code(s) */
+  double time[RX_TRANSLATED_EVENT_MAX];   /* event time(s) */
+  double amt[RX_TRANSLATED_EVENT_MAX];    /* amounts (+amt/+rate, then -rate) */
+  double ii[RX_TRANSLATED_EVENT_MAX];     /* ii values */
+  int    isDose[RX_TRANSLATED_EVENT_MAX]; /* 1 if this event contributes an idose entry */
 } rx_translated_event;
 
 // EVID = 0; Observations
@@ -116,16 +119,62 @@ static inline int _rxShouldSplitTranslatedBolus(int evid, int cmt, double amt, i
  * For evid == 0 or 2: observation row pushed, isDose=0.
  * For evid 1-7: translated from NONMEM semantics.
  */
+/* Write the dose record into out->[k], plus its off record into out->[k+1] when
+ * the dose needs one; returns the number of slots used (1 or 2).
+ *
+ * A fixed rate (rateI 1) or fixed duration (rateI 2) infusion stores the RATE as
+ * its amount and is turned off by a -rate record at time + dur.  A modeled rate
+ * (rateI 9) or modeled duration (rateI 8) stores the AMT instead and is turned
+ * off by a companion record at the SAME time carrying the matching off rateI (7
+ * and 6) and a regular flg -- updateRate()/updateDur() fill in that record's
+ * rate and stop time once the model has been evaluated.  Either way the off
+ * record has to sit immediately after the on record, which is what
+ * handleTurnOnModeledRate()/handleTurnOnModeledDuration() and the
+ * getDoseP1()/getAllTimesP1() macros require.
+ *
+ * flg 40 (a constant steady-state infusion) never turns off, modeled or not --
+ * getTime__() skips the infusion-time calculation for that flg entirely, and
+ * etTran.cpp emits no off record for it either.
+ */
+static inline int
+_rxTranslateDoseInto(rx_translated_event *out, int k, double time,
+                     int cmt100, int cmt99, int rateI, int flg,
+                     double amt, double useRate, double dur, double ii_val) {
+  out->evid[k]   = cmt100*100000 + rateI*10000 + cmt99*100 + flg;
+  out->time[k]   = time;
+  out->amt[k]    = (rateI == EVIDF_INF_RATE || rateI == EVIDF_INF_DUR) ? useRate : amt;
+  out->ii[k]     = ii_val;
+  out->isDose[k] = 1;
+  if ((rateI == EVIDF_INF_RATE || rateI == EVIDF_INF_DUR) && flg != EVID0_SSINF) {
+    out->evid[k+1]   = cmt100*100000 + rateI*10000 + cmt99*100 + flg;
+    out->time[k+1]   = time + dur;
+    out->amt[k+1]    = -useRate;
+    out->ii[k+1]     = 0.0;
+    out->isDose[k+1] = 1;
+    return 2;
+  }
+  if ((rateI == EVIDF_MODEL_RATE_ON || rateI == EVIDF_MODEL_DUR_ON) &&
+      flg != EVID0_SSINF) {
+    int offI = (rateI == EVIDF_MODEL_RATE_ON) ? EVIDF_MODEL_RATE_OFF : EVIDF_MODEL_DUR_OFF;
+    out->evid[k+1]   = cmt100*100000 + offI*10000 + cmt99*100 + EVID0_REGULAR;
+    out->time[k+1]   = time;
+    out->amt[k+1]    = amt;
+    out->ii[k+1]     = 0.0;
+    out->isDose[k+1] = 1;
+    return 2;
+  }
+  return 1;
+}
+
 static inline rx_translated_event
 _rxTranslateOneEvent(double time, int evid, int cmt, double amt,
                      double ii_val, int ss, double rate, int isDur) {
   rx_translated_event out;
   out.n = 0;
-  out.evid[0] = 0; out.evid[1] = 0;
-  out.time[0] = 0; out.time[1] = 0;
-  out.amt[0]  = 0; out.amt[1]  = 0;
-  out.ii[0]   = 0; out.ii[1]   = 0;
-  out.isDose[0] = 0; out.isDose[1] = 0;
+  for (int _i = 0; _i < RX_TRANSLATED_EVENT_MAX; ++_i) {
+    out.evid[_i] = 0; out.time[_i] = 0; out.amt[_i] = 0;
+    out.ii[_i] = 0; out.isDose[_i] = 0;
+  }
 
   /* Classic rxode2 internal evid (>= 100): pass through verbatim */
   if (evid >= 100) {
@@ -181,21 +230,8 @@ _rxTranslateOneEvent(double time, int evid, int cmt, double amt,
 
   case 1:
     /* Dose: bolus or infusion */
-    out.evid[0]   = cmt100*100000 + rateI*10000 + cmt99*100 + flg;
-    out.time[0]   = time;
-    out.amt[0]    = (rateI == 1 || rateI == 2) ? useRate : amt;
-    out.ii[0]     = ii_val;
-    out.isDose[0] = 1;
-    out.n         = 1;
-    if ((rateI == 1 || rateI == 2) && flg != 40) {
-      /* Infusion stop event */
-      out.evid[1]   = cmt100*100000 + rateI*10000 + cmt99*100 + flg;
-      out.time[1]   = time + dur;
-      out.amt[1]    = -useRate;
-      out.ii[1]     = 0.0;
-      out.isDose[1] = 1;
-      out.n         = 2;
-    }
+    out.n = _rxTranslateDoseInto(&out, 0, time, cmt100, cmt99, rateI, flg,
+                                 amt, useRate, dur, ii_val);
     break;
 
   case 7:
@@ -219,18 +255,14 @@ _rxTranslateOneEvent(double time, int evid, int cmt, double amt,
     break;
 
   case 4:
-    /* Reset + dose: two events (reset first, then dose) */
-    out.n         = 2;
+    /* Reset + dose: the reset first, then the dose and any off record it needs */
     out.evid[0]   = 3;
     out.time[0]   = time;
     out.amt[0]    = 0.0;
     out.ii[0]     = 0.0;
     out.isDose[0] = 0;
-    out.evid[1]   = cmt100*100000 + rateI*10000 + cmt99*100 + flg;
-    out.time[1]   = time;
-    out.amt[1]    = (rateI == 1 || rateI == 2) ? useRate : amt;
-    out.ii[1]     = ii_val;
-    out.isDose[1] = 1;
+    out.n         = 1 + _rxTranslateDoseInto(&out, 1, time, cmt100, cmt99, rateI,
+                                             flg, amt, useRate, dur, ii_val);
     break;
 
   case 5:

--- a/inst/include/rxode2EventTranslate.h
+++ b/inst/include/rxode2EventTranslate.h
@@ -177,10 +177,13 @@ _rxTranslateDoseInto(rx_translated_event *out, int k, double time,
  *     the unlagged time for it.  A pushed dose gets the plain flg 10/20 pair,
  *     so its trajectory differs from the same regimen in the event table.
  *
- *   - A steady-state constant infusion (flg 40) with a modeled duration
- *     (rate=-2).  etTran.cpp refuses that combination outright; here it becomes
- *     a lone flg 40 record that the solver reads through getRate(), so a model
- *     with dur() but no rate() steady-states at zero instead of erroring.
+ *   - A steady-state constant infusion (flg 40) carrying a duration, either
+ *     modeled (rate=-2) or fixed (isDur, which makes useRate = amt/dur = 0).
+ *     etTran.cpp refuses both outright; here each becomes a lone flg 40 record
+ *     carrying no usable rate, so the compartment steady-states at zero with no
+ *     error.  The fixed-duration spelling is the surprising one, since the
+ *     sibling infuse(0, rate, ...) is the legitimate way to write a constant
+ *     infusion and works.
  */
 static inline rx_translated_event
 _rxTranslateOneEvent(double time, int evid, int cmt, double amt,

--- a/inst/include/rxode2EventTranslate.h
+++ b/inst/include/rxode2EventTranslate.h
@@ -166,6 +166,22 @@ _rxTranslateDoseInto(rx_translated_event *out, int k, double time,
   return 1;
 }
 
+/* Two ways this translator does NOT yet agree with etTran.cpp, both only
+ * reachable through the runtime evid_() push:
+ *
+ *   - A steady-state dose into a compartment carrying a modeled alag().
+ *     etTran.cpp's ssAtDoseTime handling rewrites flg 10 -> 9 (and 20 -> 19) for
+ *     such a compartment and expands the dose into a four record sequence (the
+ *     flg 9 steady state start, an INFRM flg 8 record, then the lagged flg 1
+ *     start and its stop).  flg 9 is not just bookkeeping -- getLag() returns
+ *     the unlagged time for it.  A pushed dose gets the plain flg 10/20 pair,
+ *     so its trajectory differs from the same regimen in the event table.
+ *
+ *   - A steady-state constant infusion (flg 40) with a modeled duration
+ *     (rate=-2).  etTran.cpp refuses that combination outright; here it becomes
+ *     a lone flg 40 record that the solver reads through getRate(), so a model
+ *     with dur() but no rate() steady-states at zero instead of erroring.
+ */
 static inline rx_translated_event
 _rxTranslateOneEvent(double time, int evid, int cmt, double amt,
                      double ii_val, int ss, double rate, int isDur) {

--- a/inst/include/rxode2parseGetTime.h
+++ b/inst/include/rxode2parseGetTime.h
@@ -191,7 +191,11 @@ static inline void handleTurnOffModeledDuration(int idx, rx_solve *rx, rx_solvin
 
 static inline void handleTurnOnModeledDuration(int idx, rx_solve *rx, rx_solving_options *op, rx_solving_options_ind *ind) {
   // This calculates the rate and the duration and then assigns it to the next record
-  if (idx >= ind->n_all_times){
+  // idx + 1 has to exist: the checks and updateDur() below read getEvidP1() and
+  // write setDoseP1()/setAllTimesP1(), so the LAST record has no room for the
+  // stop this start needs.  (A negative idx is an extra dose and indexes the
+  // extraDose* pools instead; it never trips this.)
+  if (idx + 1 >= ind->n_all_times){
     // error: Last record, can't be used.
     if (!(ind->err & rxErrModelDataErr8)){
       ind->err += rxErrModelDataErr8;
@@ -226,7 +230,8 @@ static inline void handleTurnOffModeledRate(int idx, rx_solve *rx, rx_solving_op
 
 static inline void handleTurnOnModeledRate(int idx, rx_solve *rx, rx_solving_options *op, rx_solving_options_ind *ind) {
   // This calculates the rate and the duration and then assigns it to the next record
-  if (idx >= ind->n_all_times){
+  // idx + 1 has to exist; see handleTurnOnModeledDuration() above
+  if (idx + 1 >= ind->n_all_times){
     // error: Last record, can't be used.
     if (!(ind->err & rxErrModelDataErr9)){
       ind->err += rxErrModelDataErr9;

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -1613,6 +1613,10 @@ extern "C" int _rxPushDose(rx_solving_options_ind *_ind, double _curTime,
       memset(d + _ind->n_all_times, 0, (newCap + 1 - _ind->n_all_times) * sizeof(double));
       memset(i2 + _ind->n_all_times, 0, (newCap + 1 - _ind->n_all_times) * sizeof(double));
       memset(ev2 + _ind->n_all_times, 0, (newCap + 1 - _ind->n_all_times) * sizeof(int));
+      // ix and timeThread carry the same guard slot, so zero it here too --
+      // realloc leaves it holding whatever was in the old block
+      memset(ix + _ind->n_all_times, 0, (newCap + 1 - _ind->n_all_times) * sizeof(int));
+      memset(tt + _ind->n_all_times, 0, (newCap + 1 - _ind->n_all_times) * sizeof(double));
     }
 
     // Grow idose if needed

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -1546,11 +1546,14 @@ extern "C" int _rxPushDose(rx_solving_options_ind *_ind, double _curTime,
       }
     }
 
-    int nDose = 0;
+    // A split bolus expands its one translated event into splitBolusN-1 records,
+    // so the RECORD count is not ev.n; reserve by the same split-aware count the
+    // idose growth below already uses, or the append loop overruns the arrays.
+    int nDose = 0, nRec = 0;
     for (int _k = 0; _k < ev.n; _k++) {
-      if (ev.isDose[_k]) {
-        nDose += (_k == splitDoseEvent) ? rx->splitBolusN - 1 : 1;
-      }
+      int nHere = (_k == splitDoseEvent) ? rx->splitBolusN - 1 : 1;
+      nRec += nHere;
+      if (ev.isDose[_k]) nDose += nHere;
     }
 
     // Check per-individual push limit (maxExtra > 0 enables the guard).
@@ -1573,27 +1576,30 @@ extern "C" int _rxPushDose(rx_solving_options_ind *_ind, double _curTime,
     // times; the current solver loop uses a cached nx = n_all_times and never
     // accesses getSolve(j) for j >= nx.  The solve array is grown to the correct
     // size by rxAllocInd() at the start of the next rxSolve() call.
-    if (_ind->n_all_times + ev.n > _ind->indOwnAllocN) {
-      int newCap = _ind->n_all_times + ev.n + EVID_EXTRA_SIZE;
-      // dose, all_times, ii, evid: allocate newCap+1 so that the [idx+1]
-      // "plus-one" macros (setDoseP1, getDoseP1, setAllTimesP1, getAllTimesP1,
-      // getEvidP1) are always within bounds when idx == n_all_times-1.
+    if (_ind->n_all_times + nRec > _ind->indOwnAllocN) {
+      int newCap = _ind->n_all_times + nRec + EVID_EXTRA_SIZE;
+      // Every event array holds newCap+1 elements, the same invariant
+      // rxAllocInd() sets up: dose, all_times, ii and evid need the guard so the
+      // [idx+1] "plus-one" macros (setDoseP1, getDoseP1, setAllTimesP1,
+      // getAllTimesP1, getEvidP1) stay in bounds when idx == n_all_times-1, and
+      // ix and timeThread carry it so an accidental [n_all_times] read does not
+      // reach adjacent heap metadata.
       // Each successful realloc is published on _ind straight away.  realloc()
       // frees the old block when it moves one, so holding the new pointer in a
       // local until every call has succeeded would leave _ind pointing at freed
       // memory on a later failure -- and the driver loop keeps reading these
       // arrays after the abort flag is set.
-      double *a   = (double*)realloc(_ind->all_times,  newCap * sizeof(double));
+      double *a   = (double*)realloc(_ind->all_times,  (newCap+1) * sizeof(double));
       if (a   != NULL) _ind->all_times  = a;
-      double *d   = (double*)realloc(_ind->dose,       newCap * sizeof(double));
+      double *d   = (double*)realloc(_ind->dose,       (newCap+1) * sizeof(double));
       if (d   != NULL) _ind->dose       = d;
-      double *i2  = (double*)realloc(_ind->ii,         newCap * sizeof(double));
+      double *i2  = (double*)realloc(_ind->ii,         (newCap+1) * sizeof(double));
       if (i2  != NULL) _ind->ii         = i2;
-      int    *ev2 = (int*)   realloc(_ind->evid,       newCap * sizeof(int));
+      int    *ev2 = (int*)   realloc(_ind->evid,       (newCap+1) * sizeof(int));
       if (ev2 != NULL) _ind->evid       = ev2;
-      int    *ix  = (int*)   realloc(_ind->ix,         newCap * sizeof(int));
+      int    *ix  = (int*)   realloc(_ind->ix,         (newCap+1) * sizeof(int));
       if (ix  != NULL) _ind->ix         = ix;
-      double *tt  = (double*)realloc(_ind->timeThread, newCap * sizeof(double));
+      double *tt  = (double*)realloc(_ind->timeThread, (newCap+1) * sizeof(double));
       if (tt  != NULL) _ind->timeThread = tt;
       if (!a || !d || !i2 || !ev2 || !ix || !tt) {
         int bad = 1;
@@ -1603,10 +1609,10 @@ extern "C" int _rxPushDose(rx_solving_options_ind *_ind, double _curTime,
       }
       _ind->indOwnAllocN = newCap;
       // Zero guard elements (solve slots are grown on next rxAllocInd call)
-      memset(a + _ind->n_all_times, 0, (newCap - _ind->n_all_times) * sizeof(double));
-      memset(d + _ind->n_all_times, 0, (newCap - _ind->n_all_times) * sizeof(double));
-      memset(i2 + _ind->n_all_times, 0, (newCap - _ind->n_all_times) * sizeof(double));
-      memset(ev2 + _ind->n_all_times, 0, (newCap - _ind->n_all_times) * sizeof(int));
+      memset(a + _ind->n_all_times, 0, (newCap + 1 - _ind->n_all_times) * sizeof(double));
+      memset(d + _ind->n_all_times, 0, (newCap + 1 - _ind->n_all_times) * sizeof(double));
+      memset(i2 + _ind->n_all_times, 0, (newCap + 1 - _ind->n_all_times) * sizeof(double));
+      memset(ev2 + _ind->n_all_times, 0, (newCap + 1 - _ind->n_all_times) * sizeof(int));
     }
 
     // Grow idose if needed

--- a/tests/testthat/test-evid-push-infusion.R
+++ b/tests/testthat/test-evid-push-infusion.R
@@ -226,6 +226,40 @@ rxTest({
     expect_equal(rxSolve(mod, .pars, et(obs))$cp, want$cp, tolerance = 1e-5)
   })
 
+  test_that("a split bolus pushed as evid=4 reserves enough room (#1322 follow-up)", {
+    # splitBolus expands one translated event into splitBolusN-1 records, so an
+    # evid=4 push writes 1 + (splitBolusN-1) records where the capacity check
+    # only reserved ev.n = 2.  Push repeatedly so the EVID_EXTRA_SIZE slack that
+    # hid the overrun is used up.
+    mSplit <- rxode2({
+      splitBolus(depot, depot, central)
+      d/dt(depot) <- -ka * depot
+      d/dt(central) <- ka * depot - cl / v * central
+      cp <- central / v
+      if (t < 1) {
+        evid_(t + 6, 4, 50, 1, 0, 6, 9, 0)
+      }
+    })
+    mBase <- rxode2({
+      d/dt(depot) <- -ka * depot
+      d/dt(central) <- ka * depot - cl / v * central
+      cp <- central / v
+    })
+    e <- et(amt = 100, time = 0) |> et(seq(0, 72, by = 1))
+    eBase <- e |> et(amt = 100, time = 0, cmt = 2)
+    for (.t in seq(6, 60, by = 6)) {
+      eBase <- eBase |>
+        et(amt = 50, time = .t, cmt = 1, evid = 4) |>
+        et(amt = 50, time = .t, cmt = 2)
+    }
+    p <- c(ka = 0.5, cl = 1, v = 10)
+    rSplit <- rxSolve(mSplit, p, e)
+    rBase <- rxSolve(mBase, p, eBase)
+    expect_true(all(is.finite(rSplit$cp)))
+    expect_equal(rSplit$depot, rBase$depot, tolerance = 1e-5)
+    expect_equal(rSplit$central, rBase$central, tolerance = 1e-5)
+  })
+
   test_that("pushed fixed-rate and bolus doses are unchanged", {
     modRate <- rxode2({
       d/dt(central) <- -cl / v * central

--- a/tests/testthat/test-evid-push-infusion.R
+++ b/tests/testthat/test-evid-push-infusion.R
@@ -1,0 +1,249 @@
+rxTest({
+
+  # Infusions pushed from inside the model with evid_().  _rxTranslateOneEvent()
+  # has to emit the record that turns the infusion back off: a fixed rate/
+  # duration dose needs a -rate record at time + dur, and a modeled rate/duration
+  # dose needs its companion "off" record at the same time for updateRate()/
+  # updateDur() to fill in.  Each pushed regimen is compared against the same
+  # regimen written into the event table.
+
+  .obs <- c(0, 1e-8, seq(0.5, 24, by = 0.5))
+  .ref <- rxode2({
+    d/dt(central) <- -cl / v * central
+    cp <- central / v
+  })
+  .pars <- c(cl = 1, v = 10)
+
+  .expectSameAsEventTable <- function(mod, ev, pars = .pars, tolerance = 1e-5) {
+    got <- rxSolve(mod, pars, et(.obs))
+    want <- rxSolve(.ref, .pars, ev |> et(.obs))
+    expect_equal(got$time, want$time)
+    expect_equal(got$cp, want$cp, tolerance = tolerance)
+  }
+
+  test_that("a pushed evid=4 infusion turns off (#1322 follow-up)", {
+    # evid=4 is reset + dose, and the translated event only had room for those
+    # two records, so the infusion stop was dropped and the infusion ran for the
+    # rest of the solve.
+    mod <- rxode2({
+      d/dt(central) <- -cl / v * central
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(2, 4, 100, 1, 10, 0, 0, 0)
+      }
+    })
+    .expectSameAsEventTable(mod, et(amt = 100, time = 2, rate = 10, evid = 4))
+  })
+
+  test_that("a pushed evid=4 bolus is unchanged", {
+    mod <- rxode2({
+      d/dt(central) <- -cl / v * central
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(2, 4, 100, 1, 0, 0, 0, 0)
+      }
+    })
+    .expectSameAsEventTable(mod, et(amt = 100, time = 2, evid = 4))
+  })
+
+  test_that("a pushed modeled rate (rate=-1) dose solves (#1322 follow-up)", {
+    # the modeled on record was pushed without its off record, so
+    # handleTurnOnModeledRate() reported data error 997 and the solve failed
+    mod <- rxode2({
+      d/dt(central) <- -cl / v * central
+      rate(central) <- 10
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(2, 1, 100, 1, -1, 0, 0, 0)
+      }
+    })
+    .expectSameAsEventTable(mod, et(amt = 100, time = 2, rate = 10))
+  })
+
+  test_that("a pushed modeled duration (rate=-2) dose solves (#1322 follow-up)", {
+    mod <- rxode2({
+      d/dt(central) <- -cl / v * central
+      dur(central) <- 10
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(2, 1, 100, 1, -2, 0, 0, 0)
+      }
+    })
+    .expectSameAsEventTable(mod, et(amt = 100, time = 2, dur = 10))
+  })
+
+  test_that("a pushed evid=4 modeled rate dose resets and solves", {
+    mod <- rxode2({
+      d/dt(central) <- -cl / v * central
+      rate(central) <- 10
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(2, 4, 100, 1, -1, 0, 0, 0)
+      }
+    })
+    .expectSameAsEventTable(mod, et(amt = 100, time = 2, rate = 10, evid = 4))
+  })
+
+  test_that("pushed modeled rate/duration doses repeat with addl", {
+    obs <- c(0, 1e-8, seq(0.5, 48, by = 0.5))
+    modRate <- rxode2({
+      d/dt(central) <- -cl / v * central
+      rate(central) <- 10
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(2, 1, 100, 1, -1, 12, 2, 0)
+      }
+    })
+    modDur <- rxode2({
+      d/dt(central) <- -cl / v * central
+      dur(central) <- 10
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(2, 1, 100, 1, -2, 12, 2, 0)
+      }
+    })
+    want <- rxSolve(.ref, .pars,
+                    et(amt = 100, time = 2, rate = 10, ii = 12, addl = 2) |> et(obs))
+    expect_equal(rxSolve(modRate, .pars, et(obs))$cp, want$cp, tolerance = 1e-5)
+    expect_equal(rxSolve(modDur, .pars, et(obs))$cp, want$cp, tolerance = 1e-5)
+  })
+
+  test_that("a pushed modeled rate dose reaches steady state", {
+    mod <- rxode2({
+      d/dt(central) <- -cl / v * central
+      rate(central) <- 10
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(2, 1, 100, 1, -1, 12, 0, 1)
+      }
+    })
+    .expectSameAsEventTable(mod, et(amt = 100, time = 2, rate = 10, ii = 12, ss = 1))
+  })
+
+  test_that("a pushed fixed-duration (infuseDur) dose matches the event table", {
+    # infuseDur() sets isDur, so rate carries the DURATION and rateI is 2
+    mod <- rxode2({
+      d/dt(central) <- -cl / v * central
+      cp <- central / v
+      if (t < 1e-8) {
+        infuseDur(100, 10, 1, 0, 0, 0)
+      }
+    })
+    got <- rxSolve(mod, .pars, et(.obs))
+    want <- rxSolve(.ref, .pars, et(amt = 100, time = 0, dur = 10) |> et(.obs))
+    expect_equal(got$cp, want$cp, tolerance = 1e-5)
+  })
+
+  test_that("a pushed modeled rate constant infusion (ss=1, ii=0, amt=0) solves", {
+    # flg 40 never turns off -- getTime__() skips the infusion-time calculation
+    # for it and etTran.cpp emits no off record either, so the pushed path must
+    # not add one.  The extra record would be numerically inert, so this checks
+    # the trajectory; that the record itself is gone is checked by comparing
+    # what the two translators emit, which the fix keeps in step.
+    mod <- rxode2({
+      d/dt(central) <- -cl / v * central
+      rate(central) <- 10
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(0, 1, 0, 1, -1, 0, 0, 1)
+      }
+    })
+    got <- rxSolve(mod, .pars, et(.obs))
+    want <- rxSolve(.ref, .pars, et(amt = 0, time = 0, rate = 10, ss = 1, ii = 0) |> et(.obs))
+    # the push happens during the first evaluation, so the steady state is in
+    # place from the next output row onward rather than at time 0 itself
+    expect_equal(got$cp[-1], want$cp[-1], tolerance = 1e-5)
+  })
+
+  test_that("a pushed modeled infusion works above compartment 100 and with a modeled lag", {
+    # cmt100 has to survive into the off record, and the off record's time is
+    # written by updateRate() as laggedStart + dur
+    mod <- rxode2({
+      d/dt(central) <- -cl / v * central
+      rate(central) <- 10
+      alag(central) <- 3
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(2, 1, 100, 1, -1, 0, 0, 0)
+      }
+    })
+    ref <- rxode2({
+      d/dt(central) <- -cl / v * central
+      alag(central) <- 3
+      cp <- central / v
+    })
+    got <- rxSolve(mod, .pars, et(.obs))
+    want <- rxSolve(ref, .pars, et(amt = 100, time = 2, rate = 10) |> et(.obs))
+    expect_equal(got$cp, want$cp, tolerance = 1e-5)
+
+    # a compartment above 100: the pushed dose and the event-table dose must
+    # reach the same state
+    .states <- paste0("a", seq_len(120))
+    .mod <- paste0("d/dt(", .states, ") <- -0.1*", .states, collapse = "\n")
+    modHi <- rxode2(paste0(.mod, "\nrate(a110) <- 10\n",
+                           "if (t < 1e-8) { evid_(2, 1, 100, 110, -1, 0, 0, 0) }"))
+    refHi <- rxode2(.mod)
+    gotHi <- rxSolve(modHi, et(seq(0, 24, by = 1)))
+    wantHi <- rxSolve(refHi, et(amt = 100, time = 2, rate = 10, cmt = "a110") |>
+                        et(seq(0, 24, by = 1)))
+    expect_equal(gotHi$a110, wantHi$a110, tolerance = 1e-5)
+  })
+
+  test_that("a pushed evid=4 modeled duration dose resets and solves", {
+    mod <- rxode2({
+      d/dt(central) <- -cl / v * central
+      dur(central) <- 10
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(2, 4, 100, 1, -2, 0, 0, 0)
+      }
+    })
+    .expectSameAsEventTable(mod, et(amt = 100, time = 2, dur = 10, evid = 4))
+  })
+
+  test_that("a pushed steady state (ss=2) infusion matches the event table", {
+    mod <- rxode2({
+      d/dt(central) <- -cl / v * central
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(2, 1, 100, 1, 10, 12, 0, 2)
+      }
+    })
+    .expectSameAsEventTable(mod, et(amt = 100, time = 2, rate = 10, ii = 12, ss = 2))
+  })
+
+  test_that("pushed fixed-rate doses repeat with addl", {
+    obs <- c(0, 1e-8, seq(0.5, 48, by = 0.5))
+    mod <- rxode2({
+      d/dt(central) <- -cl / v * central
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(2, 1, 100, 1, 10, 12, 2, 0)
+      }
+    })
+    want <- rxSolve(.ref, .pars,
+                    et(amt = 100, time = 2, rate = 10, ii = 12, addl = 2) |> et(obs))
+    expect_equal(rxSolve(mod, .pars, et(obs))$cp, want$cp, tolerance = 1e-5)
+  })
+
+  test_that("pushed fixed-rate and bolus doses are unchanged", {
+    modRate <- rxode2({
+      d/dt(central) <- -cl / v * central
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(2, 1, 100, 1, 10, 0, 0, 0)
+      }
+    })
+    .expectSameAsEventTable(modRate, et(amt = 100, time = 2, rate = 10))
+
+    modBolus <- rxode2({
+      d/dt(central) <- -cl / v * central
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(2, 1, 100, 1, 0, 0, 0, 0)
+      }
+    })
+    .expectSameAsEventTable(modBolus, et(amt = 100, time = 2))
+  })
+
+})

--- a/tests/testthat/test-evid-push-infusion.R
+++ b/tests/testthat/test-evid-push-infusion.R
@@ -229,12 +229,18 @@ rxTest({
   test_that("a split bolus pushed as evid=4 reserves enough room (#1322 follow-up)", {
     # splitBolus expands one translated event into splitBolusN-1 records, so an
     # evid=4 push writes 1 + (splitBolusN-1) records where the capacity check
-    # only reserved ev.n = 2.  Push repeatedly so the EVID_EXTRA_SIZE slack that
-    # hid the overrun is used up.
+    # only reserved ev.n = 2.  Three targets steps n_all_times by 3 and never
+    # lands on the one offset that overruns, so this uses FOUR (nRec = 4 against
+    # a reservation of 2), which does reach past the end of the block.  Push
+    # repeatedly so the EVID_EXTRA_SIZE slack that hid the overrun is used up.
+    # The overrun is a couple of elements that malloc bucketing usually absorbs,
+    # so this exercises the boundary rather than failing deterministically
+    # without the fix -- it is here to give a heap checker something to catch.
     mSplit <- rxode2({
-      splitBolus(depot, depot, central)
+      splitBolus(depot, depot, central, peri)
       d/dt(depot) <- -ka * depot
-      d/dt(central) <- ka * depot - cl / v * central
+      d/dt(central) <- ka * depot - cl / v * central - q * central + q * peri
+      d/dt(peri) <- q * central - q * peri
       cp <- central / v
       if (t < 1) {
         evid_(t + 6, 4, 50, 1, 0, 6, 9, 0)
@@ -242,22 +248,25 @@ rxTest({
     })
     mBase <- rxode2({
       d/dt(depot) <- -ka * depot
-      d/dt(central) <- ka * depot - cl / v * central
+      d/dt(central) <- ka * depot - cl / v * central - q * central + q * peri
+      d/dt(peri) <- q * central - q * peri
       cp <- central / v
     })
     e <- et(amt = 100, time = 0) |> et(seq(0, 72, by = 1))
-    eBase <- e |> et(amt = 100, time = 0, cmt = 2)
+    eBase <- e |> et(amt = 100, time = 0, cmt = 2) |> et(amt = 100, time = 0, cmt = 3)
     for (.t in seq(6, 60, by = 6)) {
       eBase <- eBase |>
         et(amt = 50, time = .t, cmt = 1, evid = 4) |>
-        et(amt = 50, time = .t, cmt = 2)
+        et(amt = 50, time = .t, cmt = 2) |>
+        et(amt = 50, time = .t, cmt = 3)
     }
-    p <- c(ka = 0.5, cl = 1, v = 10)
+    p <- c(ka = 0.5, cl = 1, v = 10, q = 0.3)
     rSplit <- rxSolve(mSplit, p, e)
     rBase <- rxSolve(mBase, p, eBase)
     expect_true(all(is.finite(rSplit$cp)))
     expect_equal(rSplit$depot, rBase$depot, tolerance = 1e-5)
     expect_equal(rSplit$central, rBase$central, tolerance = 1e-5)
+    expect_equal(rSplit$peri, rBase$peri, tolerance = 1e-5)
   })
 
   test_that("a split bolus pushed as evid=1 reserves enough room (#1322 follow-up)", {

--- a/tests/testthat/test-evid-push-infusion.R
+++ b/tests/testthat/test-evid-push-infusion.R
@@ -260,6 +260,63 @@ rxTest({
     expect_equal(rSplit$central, rBase$central, tolerance = 1e-5)
   })
 
+  test_that("a split bolus pushed as evid=1 reserves enough room (#1322 follow-up)", {
+    # the same under-reservation as the evid=4 case above, on the commoner
+    # spelling: one translated event, splitBolusN-1 records
+    mSplit <- rxode2({
+      splitBolus(depot, depot, central)
+      d/dt(depot) <- -ka * depot
+      d/dt(central) <- ka * depot - cl / v * central
+      cp <- central / v
+      if (t < 1) {
+        evid_(t + 6, 1, 50, 1, 0, 6, 9, 0)
+      }
+    })
+    mBase <- rxode2({
+      d/dt(depot) <- -ka * depot
+      d/dt(central) <- ka * depot - cl / v * central
+      cp <- central / v
+    })
+    e <- et(amt = 100, time = 0) |> et(seq(0, 72, by = 1))
+    eBase <- e |> et(amt = 100, time = 0, cmt = 2)
+    for (.t in seq(6, 60, by = 6)) {
+      eBase <- eBase |>
+        et(amt = 50, time = .t, cmt = 1) |>
+        et(amt = 50, time = .t, cmt = 2)
+    }
+    p <- c(ka = 0.5, cl = 1, v = 10)
+    rSplit <- rxSolve(mSplit, p, e)
+    rBase <- rxSolve(mBase, p, eBase)
+    expect_true(all(is.finite(rSplit$cp)))
+    expect_equal(rSplit$depot, rBase$depot, tolerance = 1e-5)
+    expect_equal(rSplit$central, rBase$central, tolerance = 1e-5)
+  })
+
+  test_that("a pushed infusion into a splitBolus compartment is not split", {
+    # _rxShouldSplitTranslatedBolus() requires whI == 0, so only a bolus splits;
+    # an infusion into the same compartment stays whole
+    mSplit <- rxode2({
+      splitBolus(depot, depot, central)
+      d/dt(depot) <- -ka * depot
+      d/dt(central) <- ka * depot - cl / v * central
+      cp <- central / v
+      if (t < 1e-8) {
+        infuse(100, 10, 1, 0, 0, 0)
+      }
+    })
+    mBase <- rxode2({
+      d/dt(depot) <- -ka * depot
+      d/dt(central) <- ka * depot - cl / v * central
+      cp <- central / v
+    })
+    p <- c(ka = 0.5, cl = 1, v = 10)
+    obs <- c(0, 1e-8, seq(0.5, 30, by = 0.5))
+    rSplit <- rxSolve(mSplit, p, et(obs))
+    rBase <- rxSolve(mBase, p, et(amt = 100, time = 0, rate = 10, cmt = 1) |> et(obs))
+    expect_equal(rSplit$depot, rBase$depot, tolerance = 1e-5)
+    expect_equal(rSplit$central, rBase$central, tolerance = 1e-5)
+  })
+
   test_that("pushed fixed-rate and bolus doses are unchanged", {
     modRate <- rxode2({
       d/dt(central) <- -cl / v * central


### PR DESCRIPTION
Follow-up to #1332 (issue #1322). Everything here was found by iterating a
GitHub Copilot review over that area -- seven rounds, each one re-run against
the new diff.

## What was broken

`_rxTranslateOneEvent()` -- the translator behind the in-model `evid_()` dose
push, whose only caller is `_rxPushDose()` -- could not emit an infusion's stop
record in two cases:

- **`evid=4` (reset + dose).** `rx_translated_event` had exactly two slots, so
  the reset and the infusion start used them both and the stop was dropped. A
  pushed `evid_(2, 4, 100, 1, 10, 0, 0, 0)` infusion never turned off: `cp`
  reached 8.89 at t=24 where the same regimen in the event table gives 1.90.

- **A modeled rate (`rate=-1`) or modeled duration (`rate=-2`) dose** was
  emitted as a lone ON record. `handleTurnOnModeledRate()` /
  `handleTurnOnModeledDuration()` require the matching OFF at the next raw
  index, so the solve failed outright with data error 997/886 instead of
  scheduling the infusion.

The struct holds three records now and both cases go through one helper. A
modeled dose gets its companion OFF at the same time carrying the matching off
`rateI` (7 for rate, 6 for duration) and a regular flg -- what `etTran.cpp`
emits for the same input. `flg 40` (a constant steady-state infusion) gets no
off record, modeled or not, again matching `etTran.cpp`.

A pushed infusion now tracks the event-table regimen for fixed rate, fixed
duration, modeled rate, modeled duration, `evid=4`, `addl`, `ss=1`, `ss=2`, a
compartment above 100, a modeled `alag()`, and a split bolus.

## Two more from the same review

- **`_rxPushDose()`'s event-array growth under-reserved.** It counted the
  translated events (`ev.n`) while the append loop writes
  `ev.n - 1 + (splitBolusN - 1)` records when a bolus is split across
  compartments -- the `idose` growth beside it already used the split-aware
  count. With four split targets every push overran the block. The check now
  uses the same count, and `ix`/`timeThread` get the `+1` guard slot
  `rxAllocInd()` gives them (zeroed, as `rxAllocInd()` `calloc`s them).

- **The last-record guard for a modeled infusion start was off by one:** it
  rejected only `idx >= n_all_times` and then read `getEvidP1()` and, through
  `updateRate()`/`updateDur()`, wrote `dose[idx+1]`/`all_times[idx+1]`. The only
  way to reach it was the lone modeled start the push path used to emit, so with
  that fixed the guard is defensive rather than a user-visible fix, and NEWS says
  so.

## Known gaps, documented rather than changed

Both are pre-existing -- the push path has never handled them -- and both are
recorded in a comment on `_rxTranslateOneEvent()`:

- A steady-state dose into a compartment carrying a modeled `alag()`.
  `etTran.cpp`'s `ssAtDoseTime` handling rewrites flg 10 -> 9 (20 -> 19) and
  expands the dose into four records; flg 9 changes behavior rather than just
  bookkeeping, since `getLag()` returns the unlagged time for it. A pushed dose
  gets the plain flg 10/20 pair and its trajectory differs by 9.05, where the
  same regimen without a modeled lag agrees to 9e-07.

- A steady-state constant infusion (flg 40) carrying a duration, modeled
  (`rate=-2`) or fixed (`infuseDur`, where `useRate = amt/dur = 0`).
  `etTran.cpp` refuses both; here each becomes a lone flg 40 record with no
  usable rate, so the compartment steady-states at zero with no error. The
  fixed-duration spelling is the surprising one, since `infuse(0, rate, ...)`
  beside it is the legitimate constant infusion and works.

Fixing the second would mean erroring from `_rxPushDose()` the way the data path
errors, which adds a guard on an `rxSolve` path -- left for a separate decision.

## Testing

`tests/testthat/test-evid-push-infusion.R` compares each pushed regimen against
the same regimen written into the event table. The split-bolus tests exercise the
reservation boundary for a heap checker rather than failing deterministically
without the fix -- the overrun is a couple of elements that malloc bucketing
usually absorbs -- and the comment says so.

Full suite: FAIL 5 | PASS 40465. Those five failures are pre-existing on
`origin/main`: verified by reverting this branch's entire diff, rebuilding clean
at 98e9ac5cf and getting the identical five (`test-piping-ini.R:1282,1285` and
`test-ss-extra-dose-duration.R:106` x3).
