### PR TITLE
Reject a pushed steady-state constant infusion paired with a duration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,14 @@
 
 ## Bug fixes
 
+- A steady-state constant infusion (`ss=1`, `ii=0`, `amt=0`) pushed from
+  inside a model with a duration -- modeled (`rate=-2`, e.g. via `evid_()`)
+  or fixed (`infuseDur()`) -- now errors instead of silently steady-stating
+  the compartment to zero.  That combination never had a usable rate (a
+  constant infusion never turns off, so there is nothing for the duration to
+  measure), and the event-table path already refused it; the runtime push
+  path did not check for it (#1350).
+
 - Piping an omega block into a model with ten or more etas no longer
   permutes the etas that were not piped over.  They were renumbered with
   `factor(paste(neta1))`, which sorts the numbers as TEXT -- "10" before

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,12 +3,13 @@
 ## Bug fixes
 
 - A steady-state constant infusion (`ss=1`, `ii=0`, `amt=0`) pushed from
-  inside a model with a duration -- modeled (`rate=-2`, e.g. via `evid_()`)
-  or fixed (`infuseDur()`) -- now errors instead of silently steady-stating
-  the compartment to zero.  That combination never had a usable rate (a
-  constant infusion never turns off, so there is nothing for the duration to
-  measure), and the event-table path already refused it; the runtime push
-  path did not check for it (#1350).
+  inside a model with a duration -- modeled (`rate=-2`, e.g. via `evid_()`),
+  fixed (`infuseDur()`), or a hand-encoded classic internal `evid` (>= 100)
+  -- now errors instead of silently steady-stating the compartment to zero.
+  That combination never had a usable rate (a constant infusion never turns
+  off, so there is nothing for the duration to measure), and the event-table
+  path already refused it; the runtime push path did not check for it
+  (#1350).
 
 - Piping an omega block into a model with ten or more etas no longer
   permutes the etas that were not piped over.  They were renumbered with

--- a/inst/include/rxode2EventTranslate.h
+++ b/inst/include/rxode2EventTranslate.h
@@ -203,14 +203,23 @@ _rxTranslateOneEvent(double time, int evid, int cmt, double amt,
     out.ii[_i] = 0; out.isDose[_i] = 0;
   }
 
-  /* Classic rxode2 internal evid (>= 100): pass through verbatim */
+  /* Classic rxode2 internal evid (>= 100): pass through verbatim.  A caller
+   * can hand-encode this format directly (evid_()'s "evid" documents it as a
+   * supported form), so the flg-40-plus-duration guard has to apply here too
+   * -- otherwise a hand-encoded evid reproduces the exact silent-zero bug
+   * this file otherwise rejects (rxode2#1350). */
   if (evid >= 100) {
+    int _wh, _wCmt, _wh100, _whI, _flg;
+    getWh(evid, &_wh, &_wCmt, &_wh100, &_whI, &_flg);
+    if (_flg == EVID0_SSINF && (_whI == EVIDF_INF_DUR || _whI == EVIDF_MODEL_DUR_ON)) {
+      out.n = -1;
+      return out;
+    }
     out.n         = 1;
     out.evid[0]   = evid;
     out.time[0]   = time;
     out.amt[0]    = amt;
     out.ii[0]     = ii_val;
-    int _flg      = evid % 100;
     out.isDose[0] = (_flg == 1 || _flg == 10 || _flg == 20 || _flg == 40) ? 1 : 0;
     return out;
   }

--- a/inst/include/rxode2EventTranslate.h
+++ b/inst/include/rxode2EventTranslate.h
@@ -139,13 +139,25 @@ static inline int _rxShouldSplitTranslatedBolus(int evid, int cmt, double amt, i
 static inline int
 _rxTranslateDoseInto(rx_translated_event *out, int k, double time,
                      int cmt100, int cmt99, int rateI, int flg,
-                     double amt, double useRate, double dur, double ii_val) {
+                     double amt, double useRate, double dur, double ii_val,
+                     int isDur) {
   /* A steady-state constant infusion (flg 40) never turns off, so pairing it
    * with a duration -- modeled (rateI 8) or fixed (rateI 2) -- is meaningless;
    * reject it the way etTran.cpp already does for the event table
    * (rxode2#1350).  -1 signals the caller to abort instead of silently
-   * emitting a rate-less record that steady-states the compartment to zero. */
-  if (flg == EVID0_SSINF && (rateI == EVIDF_INF_DUR || rateI == EVIDF_MODEL_DUR_ON)) {
+   * emitting a rate-less record that steady-states the compartment to zero.
+   *
+   * rateI 9 (modeled RATE) is legitimate at flg 40 -- it is the supported
+   * spelling for a modeled constant infusion -- UNLESS it was reached via
+   * infuseDur()'s duration slot (isDur set, meaning the caller wrote -1 into
+   * a *duration*, NONMEM's "this was meant to be a modeled rate but landed
+   * in the DUR column" mistake).  etTran.cpp rejects that same column
+   * mistake for the event table; infuseDur() is the only push-path caller
+   * that can produce rateI 9 with isDur set, since evid_()/infuse() always
+   * pass isDur 0. */
+  if (flg == EVID0_SSINF &&
+      (rateI == EVIDF_INF_DUR || rateI == EVIDF_MODEL_DUR_ON ||
+       (rateI == EVIDF_MODEL_RATE_ON && isDur))) {
     return -1;
   }
   out->evid[k]   = cmt100*100000 + rateI*10000 + cmt99*100 + flg;
@@ -267,7 +279,7 @@ _rxTranslateOneEvent(double time, int evid, int cmt, double amt,
   case 1:
     /* Dose: bolus or infusion */
     out.n = _rxTranslateDoseInto(&out, 0, time, cmt100, cmt99, rateI, flg,
-                                 amt, useRate, dur, ii_val);
+                                 amt, useRate, dur, ii_val, isDur);
     break;
 
   case 7:
@@ -299,7 +311,7 @@ _rxTranslateOneEvent(double time, int evid, int cmt, double amt,
     out.isDose[0] = 0;
     {
       int doseN = _rxTranslateDoseInto(&out, 1, time, cmt100, cmt99, rateI,
-                                       flg, amt, useRate, dur, ii_val);
+                                       flg, amt, useRate, dur, ii_val, isDur);
       out.n = (doseN < 0) ? -1 : 1 + doseN;
     }
     break;

--- a/inst/include/rxode2EventTranslate.h
+++ b/inst/include/rxode2EventTranslate.h
@@ -140,6 +140,14 @@ static inline int
 _rxTranslateDoseInto(rx_translated_event *out, int k, double time,
                      int cmt100, int cmt99, int rateI, int flg,
                      double amt, double useRate, double dur, double ii_val) {
+  /* A steady-state constant infusion (flg 40) never turns off, so pairing it
+   * with a duration -- modeled (rateI 8) or fixed (rateI 2) -- is meaningless;
+   * reject it the way etTran.cpp already does for the event table
+   * (rxode2#1350).  -1 signals the caller to abort instead of silently
+   * emitting a rate-less record that steady-states the compartment to zero. */
+  if (flg == EVID0_SSINF && (rateI == EVIDF_INF_DUR || rateI == EVIDF_MODEL_DUR_ON)) {
+    return -1;
+  }
   out->evid[k]   = cmt100*100000 + rateI*10000 + cmt99*100 + flg;
   out->time[k]   = time;
   out->amt[k]    = (rateI == EVIDF_INF_RATE || rateI == EVIDF_INF_DUR) ? useRate : amt;
@@ -166,8 +174,8 @@ _rxTranslateDoseInto(rx_translated_event *out, int k, double time,
   return 1;
 }
 
-/* Two ways this translator does NOT yet agree with etTran.cpp, both only
- * reachable through the runtime evid_() push:
+/* One way this translator does NOT yet agree with etTran.cpp, only reachable
+ * through the runtime evid_() push:
  *
  *   - A steady-state dose into a compartment carrying a modeled alag().
  *     etTran.cpp's ssAtDoseTime handling rewrites flg 10 -> 9 (and 20 -> 19) for
@@ -177,13 +185,13 @@ _rxTranslateDoseInto(rx_translated_event *out, int k, double time,
  *     the unlagged time for it.  A pushed dose gets the plain flg 10/20 pair,
  *     so its trajectory differs from the same regimen in the event table.
  *
- *   - A steady-state constant infusion (flg 40) carrying a duration, either
- *     modeled (rate=-2) or fixed (isDur, which makes useRate = amt/dur = 0).
- *     etTran.cpp refuses both outright; here each becomes a lone flg 40 record
- *     carrying no usable rate, so the compartment steady-states at zero with no
- *     error.  The fixed-duration spelling is the surprising one, since the
- *     sibling infuse(0, rate, ...) is the legitimate way to write a constant
- *     infusion and works.
+ * A steady-state constant infusion (flg 40) carrying a duration, either
+ * modeled (rate=-2) or fixed (isDur, which makes useRate = amt/dur), is
+ * rejected below with out.n = -1 the same way etTran.cpp refuses it for the
+ * event table (rxode2#1350) -- flg 40 never turns off (getTime__() skips the
+ * infusion-time calculation for it and etTran.cpp emits no off record), so a
+ * duration is meaningless and previously produced a lone flg 40 record with
+ * no usable rate, silently steady-stating the compartment to zero.
  */
 static inline rx_translated_event
 _rxTranslateOneEvent(double time, int evid, int cmt, double amt,
@@ -280,8 +288,11 @@ _rxTranslateOneEvent(double time, int evid, int cmt, double amt,
     out.amt[0]    = 0.0;
     out.ii[0]     = 0.0;
     out.isDose[0] = 0;
-    out.n         = 1 + _rxTranslateDoseInto(&out, 1, time, cmt100, cmt99, rateI,
-                                             flg, amt, useRate, dur, ii_val);
+    {
+      int doseN = _rxTranslateDoseInto(&out, 1, time, cmt100, cmt99, rateI,
+                                       flg, amt, useRate, dur, ii_val);
+      out.n = (doseN < 0) ? -1 : 1 + doseN;
+    }
     break;
 
   case 5:

--- a/inst/include/rxode2parseStruct.h
+++ b/inst/include/rxode2parseStruct.h
@@ -615,6 +615,12 @@ typedef struct rx_solve_s {
   // Set to 1 (atomically) when any individual exceeds maxExtra; checked after
   // the solve completes to emit an error.
   int extraPushAbort;
+  // Set to 1 (atomically) when evid_()/infuse()/infuseDur() push a steady-state
+  // constant infusion (flg 40) paired with a duration (modeled rate=-2 or fixed
+  // dur); checked after the solve completes to emit an error, mirroring the
+  // rejection etTran.cpp already applies to the same combination in the event
+  // table (rxode2#1350).
+  int ssInfDurAbort;
   int *splitBolus;
   int splitBolusN;
   rx_fn_pointers fns;

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -1534,6 +1534,18 @@ extern "C" int _rxPushDose(rx_solving_options_ind *_ind, double _curTime,
     rx_translated_event ev = _rxTranslateOneEvent(_doseTime, _evid, _cmt,
                                                   _amt, _doseIi, _doseSs,
                                                   _rate, _isDurFlag);
+    if (ev.n < 0) {
+      // Steady-state constant infusion (flg 40) paired with a duration --
+      // meaningless since flg 40 never turns off (rxode2#1350).  Abort the
+      // same deferred way maxExtra does: the message fires once the parallel
+      // solve loop has finished (rxode2_df.cpp), not from inside it.
+      int bad = 1;
+#pragma omp atomic write
+      rx->ssInfDurAbort = bad;
+#pragma omp atomic write
+      op->badSolve = bad;
+      return -1;
+    }
     if (ev.n == 0) continue;
 
     int splitDoseEvent = -1;

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -6005,6 +6005,7 @@ static inline void iniRx(rx_solve* rx) {
   rx->whileexit= 0;
   rx->maxExtra = 100;
   rx->extraPushAbort = 0;
+  rx->ssInfDurAbort = 0;
   rx->splitBolus = NULL;
   rx->splitBolusN = 0;
 
@@ -6394,6 +6395,7 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
     rx->maxwhile = asInt(rxControl[Rxc_maxwhile], "maxwhile");
     rx->maxExtra = asInt(rxControl[Rxc_maxExtra], "maxExtra");
     rx->extraPushAbort = 0;
+    rx->ssInfDurAbort = 0;
     rxLoadSplitBolus(rxSolveDat->mv, rx);
     rx->sumType = asInt(rxControl[Rxc_sumType], "sumType");
     rx->prodType = asInt(rxControl[Rxc_prodType], "prodType");
@@ -6439,6 +6441,7 @@ SEXP rxSolve_(const RObject &obj, const List &rxControl,
     rx->maxwhile = asInt(rxControl[Rxc_maxwhile], "maxwhile");
     rx->maxExtra = asInt(rxControl[Rxc_maxExtra], "maxExtra");
     rx->extraPushAbort = 0;
+    rx->ssInfDurAbort = 0;
     rxLoadSplitBolus(rxSolveDat->mv, rx);
     rx_solving_options* op = rx->op;
     op->naTimeInputWarn = 0;

--- a/src/rxSerialize.cpp
+++ b/src/rxSerialize.cpp
@@ -209,7 +209,7 @@ SEXP rxSaveState_() {
   W_RX_I32(linCmtHcmt); W_RX_I32(linCmtHmeanI); W_RX_I32(linCmtHmeanO);
   W_RX_DBL(linCmtSuspect); W_RX_I32(linCmtForwardMax);
   W_RX_I32(mixnum); W_RX_I32(input_mixnum);
-  W_RX_I32(maxExtra); W_RX_I32(extraPushAbort);
+  W_RX_I32(maxExtra); W_RX_I32(extraPushAbort); W_RX_I32(ssInfDurAbort);
   W_RX_I32(splitBolusN);
   W_RX_BOOL(sample);
 
@@ -792,7 +792,7 @@ SEXP rxRestoreState_(SEXP rawSexp) {
   R_RX_I32(linCmtHcmt); R_RX_I32(linCmtHmeanI); R_RX_I32(linCmtHmeanO);
   R_RX_DBL(linCmtSuspect); R_RX_I32(linCmtForwardMax);
   R_RX_I32(mixnum); R_RX_I32(input_mixnum);
-  R_RX_I32(maxExtra); R_RX_I32(extraPushAbort);
+  R_RX_I32(maxExtra); R_RX_I32(extraPushAbort); R_RX_I32(ssInfDurAbort);
   R_RX_I32(splitBolusN);
   R_RX_BOOL(sample);
 

--- a/src/rxode2_df.cpp
+++ b/src/rxode2_df.cpp
@@ -387,6 +387,11 @@ SEXP rxode2_df(int doDose0, int doTBS, std::vector<int>& lvlI, bool isIdentity) 
           _("evid_() pushed more than maxExtra=%d events per individual; increase maxExtra in rxControl()/rxSolve()"),
           rx->maxExtra);
       }
+      if (rx->ssInfDurAbort) {
+        rxSolveFreeC();
+        (Rf_errorcall)(R_NilValue, "%s",
+          _("specifying duration with a steady state constant infusion makes no sense"));
+      }
       for (int solveid = 0; solveid < (int)(rx->nsub * rx->nsim); solveid++){
         rx_solving_options_ind *indE = &(rx->subjects[solveid]);
         if (indE->err != 0) {
@@ -405,6 +410,11 @@ SEXP rxode2_df(int doDose0, int doTBS, std::vector<int>& lvlI, bool isIdentity) 
         (Rf_errorcall)(R_NilValue,
           _("evid_() pushed more than maxExtra=%d events per individual; increase maxExtra in rxControl()/rxSolve()"),
           rx->maxExtra);
+      }
+      if (rx->ssInfDurAbort) {
+        rxSolveFreeC();
+        (Rf_errorcall)(R_NilValue, "%s",
+          _("specifying duration with a steady state constant infusion makes no sense"));
       }
       if (indLinNoConv) {
         warning(_("some ID(s) did not converge the inductive linearization; These values are replaced with 'NA'; loosen 'atol'/'rtol' or raise 'maxsteps'"));

--- a/tests/testthat/test-evid-push-infusion.R
+++ b/tests/testthat/test-evid-push-infusion.R
@@ -384,6 +384,47 @@ rxTest({
                  "makes no sense")
   })
 
+  test_that("a hand-encoded classic internal evid cannot bypass the flg-40 duration guard (#1350)", {
+    # evid_()'s "evid" documents evid >= 100 as a supported hand-encoded
+    # classic rxode2 form (cmt100*100000 + rateI*10000 + cmt99*100 + flg),
+    # passed through _rxTranslateOneEvent() verbatim rather than through
+    # _rxTranslateDoseInto() -- so the guard above has to be duplicated for
+    # this path or a hand-encoded evid reproduces the same silent zero.
+    # cmt99=1: rateI=2 (fixed dur) -> 2*10000 + 1*100 + 40 = 20140
+    modFixedDur <- rxode2({
+      d/dt(central) <- -cl / v * central
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(0, 20140, 0, 1, 0, 0, 0, 0)
+      }
+    })
+    expect_error(rxSolve(modFixedDur, .pars, et(.obs)), "makes no sense")
+
+    # rateI=8 (modeled dur) -> 8*10000 + 1*100 + 40 = 80140
+    modModeledDur <- rxode2({
+      d/dt(central) <- -cl / v * central
+      dur(central) <- 10
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(0, 80140, 0, 1, 0, 0, 0, 0)
+      }
+    })
+    expect_error(rxSolve(modModeledDur, .pars, et(.obs)), "makes no sense")
+
+    # control: rateI=1 (fixed rate) at the same flg=40 must keep working --
+    # 1*10000 + 1*100 + 40 = 10140; amt carries the rate for rateI 1/2
+    modFixedRate <- rxode2({
+      d/dt(central) <- -cl / v * central
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(0, 10140, 10, 1, 0, 0, 0, 0)
+      }
+    })
+    got <- rxSolve(modFixedRate, .pars, et(.obs))
+    want <- rxSolve(.ref, .pars, et(amt = 0, time = 0, rate = 10, ss = 1, ii = 0) |> et(.obs))
+    expect_equal(got$cp[-1], want$cp[-1], tolerance = 1e-5)
+  })
+
   test_that("a pushed steady state constant infusion by fixed rate is unchanged (#1350)", {
     # the legitimate spelling -- a constant infusion by fixed RATE -- must keep
     # working; only pairing flg 40 with a duration is rejected.  (The modeled

--- a/tests/testthat/test-evid-push-infusion.R
+++ b/tests/testthat/test-evid-push-infusion.R
@@ -346,4 +346,61 @@ rxTest({
     .expectSameAsEventTable(modBolus, et(amt = 100, time = 2))
   })
 
+  test_that("a pushed steady state constant infusion with a duration errs (#1350)", {
+    # flg 40 (ss=1, ii=0, amt=0) never turns off, so pairing it with a duration
+    # -- modeled (rate=-2) or fixed -- gives no usable rate and used to
+    # silently steady-state the compartment to zero instead of erring the way
+    # the same combination already does in the event table.
+    modModeledDur <- rxode2({
+      d/dt(central) <- -cl / v * central
+      dur(central) <- 10
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(0, 1, 0, 1, -2, 0, 0, 1)
+      }
+    })
+    expect_error(rxSolve(modModeledDur, .pars, et(.obs)),
+                 "makes no sense")
+
+    modFixedDur <- rxode2({
+      d/dt(central) <- -cl / v * central
+      cp <- central / v
+      if (t < 1e-8) {
+        infuseDur(0, 10, 1, 0, 0, 1)
+      }
+    })
+    expect_error(rxSolve(modFixedDur, .pars, et(.obs)),
+                 "makes no sense")
+
+    modModeledDurReset <- rxode2({
+      d/dt(central) <- -cl / v * central
+      dur(central) <- 10
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(0, 4, 0, 1, -2, 0, 0, 1)
+      }
+    })
+    expect_error(rxSolve(modModeledDurReset, .pars, et(.obs)),
+                 "makes no sense")
+  })
+
+  test_that("a pushed steady state constant infusion by fixed rate is unchanged (#1350)", {
+    # the legitimate spelling -- a constant infusion by fixed RATE -- must keep
+    # working; only pairing flg 40 with a duration is rejected.  (The modeled
+    # rate sibling is already covered by "a pushed modeled rate constant
+    # infusion (ss=1, ii=0, amt=0) solves" above.)
+    modFixedRate <- rxode2({
+      d/dt(central) <- -cl / v * central
+      cp <- central / v
+      if (t < 1e-8) {
+        infuse(0, 10, 1, 0, 0, 1)
+      }
+    })
+    got <- rxSolve(modFixedRate, .pars, et(.obs))
+    want <- rxSolve(.ref, .pars, et(amt = 0, time = 0, rate = 10, ss = 1, ii = 0) |> et(.obs))
+    # the push happens during the first evaluation, so the steady state is in
+    # place from the next output row onward rather than at time 0 itself
+    expect_equal(got$cp[-1], want$cp[-1], tolerance = 1e-5)
+  })
+
 })

--- a/tests/testthat/test-evid-push-infusion.R
+++ b/tests/testthat/test-evid-push-infusion.R
@@ -425,6 +425,39 @@ rxTest({
     expect_equal(got$cp[-1], want$cp[-1], tolerance = 1e-5)
   })
 
+  test_that("infuseDur()'s duration slot rejects the modeled-rate column mistake at flg 40 (#1350)", {
+    # infuseDur() reuses _rxPushDose's "rate" slot to carry its "dur" argument
+    # (isDur set), so a NONMEM-style column mistake -- writing -1 (modeled
+    # RATE's sentinel) into a DURATION -- collapses onto the same rateI=9 as
+    # evid_()'s legitimate rate=-1 spelling.  etTran.cpp still rejects that
+    # mistake for the event table when flg=40 (the rate/dur distinction is
+    # column-based there), so the push path has to track which argument slot
+    # produced rateI=9 to reject it too, via the isDur bit.
+    modColumnMistake <- rxode2({
+      d/dt(central) <- -cl / v * central
+      rate(central) <- 10
+      cp <- central / v
+      if (t < 1e-8) {
+        infuseDur(0, -1, 1, 0, 0, 1)
+      }
+    })
+    expect_error(rxSolve(modColumnMistake, .pars, et(.obs)), "makes no sense")
+
+    # control: the identical rateI=9 reached via evid_()'s "rate" argument
+    # (isDur unset) is the legitimate spelling and must keep working
+    modLegit <- rxode2({
+      d/dt(central) <- -cl / v * central
+      rate(central) <- 10
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(0, 1, 0, 1, -1, 0, 0, 1)
+      }
+    })
+    got <- rxSolve(modLegit, .pars, et(.obs))
+    want <- rxSolve(.ref, .pars, et(amt = 0, time = 0, rate = 10, ss = 1, ii = 0) |> et(.obs))
+    expect_equal(got$cp[-1], want$cp[-1], tolerance = 1e-5)
+  })
+
   test_that("a pushed steady state constant infusion by fixed rate is unchanged (#1350)", {
     # the legitimate spelling -- a constant infusion by fixed RATE -- must keep
     # working; only pairing flg 40 with a duration is rejected.  (The modeled


### PR DESCRIPTION
## Summary

Fixes #1350. `_rxTranslateOneEvent()`/`_rxTranslateDoseInto()` (the runtime
`evid_()`/`infuse()`/`infuseDur()` push path used by `src/par_solve.cpp`'s
`_rxPushDose()`) let a steady-state constant infusion (`ss=1`, `ii=0`,
`amt=0`, internal flg 40) be paired with a duration -- modeled (`rate=-2`) or
fixed (`infuseDur()`) -- and silently emitted a rate-less event record,
steady-stating the compartment to zero with no error. flg 40 never turns
off, so a duration is meaningless for it; `src/etTran.cpp` already refuses
the same combination for the event table.

Three commits close this, in the order a second-opinion review
(antigravity/gemini-3.1-pro-high, 3 rounds) surfaced them:

- The core guard: `_rxTranslateDoseInto()` now returns a `-1` sentinel for
  flg 40 + a duration, and `_rxPushDose()` aborts the same deferred way the
  existing `maxExtra` guard does -- a new `rx->ssInfDurAbort` flag (paired
  with `op->badSolve`, set via `#pragma omp atomic write` from inside the
  OpenMP-parallel solve loop) is checked once the loop finishes and raised as
  an R error in `src/rxode2_df.cpp`.
- `evid_()`'s documented hand-encoded classic-internal-evid form (`evid >=
  100`) bypassed the guard entirely by returning before reaching
  `_rxTranslateDoseInto()`; it now decodes via the existing `getWh()` helper
  and applies the same check.
- `infuseDur()` reuses the push call's `rate` slot to carry its `dur`
  argument, so `infuseDur(amt, -1, ...)` collapsed onto the same `rateI=9`
  (modeled rate) as `evid_()`'s legitimate `rate=-1` spelling. `etTran.cpp`
  rejects that same NONMEM column mistake (duration column holding the
  modeled-rate sentinel) for the event table when flg=40, so
  `_rxTranslateDoseInto()` now takes an `isDur` parameter and rejects it too,
  while still allowing the legitimate `evid_()` spelling (`isDur` unset).

A related-but-separate bug the review also surfaced -- the push path
re-resetting the system on every `addl` repeat of an `evid=4` (reset+dose)
push, instead of only the first, unlike the event-table path -- is **not**
fixed here; it is unrelated to durations and is tracked by the already-active
`#1351`/`evid4-addl` workstream.

## Test plan

- [x] `devtools::test(filter='evid-push-infusion')` -- 45 passing, including
      new regression tests for all three fixes and their legitimate
      counterparts (fixed/modeled-rate constant infusion by `infuse()`,
      `evid_()`, and hand-encoded classic evid all still solve unchanged)
- [x] `devtools::test(filter='^et$|adaptive-dosing|capture-adaptive|ind-lin|event-sensitivities|rxMemoryEstimate|altrep-output|adjoint-discrete|nmtest')` -- 4984 passing
- [x] Manual reproduction of all three `#1350` reproducer cases (modeled
      duration, fixed duration via `infuseDur()`, hand-encoded evid, and the
      `infuseDur(-1)` column mistake) now error; the legitimate constant
      infusion by fixed or modeled rate still solves correctly