### PR TITLE
docs: pin evid=4 + addl reset-once semantics as NONMEM-correct

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,3 +437,28 @@ logit(cor)), with the ini transformed and the report back-transformed -- a
 parameter-transform feature spanning the ini/theta/report handling. AR(1)
 SIMULATION, the lag/diff/lag0 fixes, opt-out asserts, and the symbolic-gradient
 AR estimation model are complete.
+
+### `evid=4` (reset+dose) expanded through `addl` resets only once -- NOT A BUG
+
+`et(amt=100, time=2, evid=4, ii=12, addl=2)` resets the compartment on the
+FIRST dose only; the two `addl`-repeated doses are plain doses, not further
+resets. Writing the same regimen as three explicit `evid=4` records instead
+resets every time and gives different output (see GitHub issue #1351 for the
+reproducer and numbers). **The `addl` form is correct and matches NONMEM** --
+do not "fix" it to reset on every repetition.
+
+Evidence:
+- NONMEM does the same for the analogous `ss` + `addl` case ("NONMEM does not
+  keep the steady state flag with additional doses, it simply keeps dosing
+  without the steady state flag") --
+  https://blog.nlmixr2.org/blog/2024-04-04-steady-state/
+- `tests/testthat/nmtest-evid4.rds` (`test-nmtest.R` test `"evid4"`) is data
+  derived from real NONMEM output: its `addl`-equivalent rows after the
+  initial `evid=4` are plain `evid=1`, never another `evid=4`.
+- Architecturally this falls out of `src/etTran.cpp` `case 4:` (search
+  `// NONMEM-matching, intentional`): an `evid=4` record pushes exactly one
+  `EVID=3` reset, then rewrites `cevid` to a plain-dose code before the `addl`
+  expansion loop ever runs, so the loop has no reset left to repeat.
+- Regression test:
+  `test-etTrans.R` `"evid=4 expanded through addl only resets on the first
+  dose (matches NONMEM, issue #1351)"`.

--- a/src/etTran.cpp
+++ b/src/etTran.cpp
@@ -2166,6 +2166,20 @@ List etTrans(List inData, const RObject &obj, bool addCmt=false,
       cevid = -1;
       break;
     case 4:
+      // NONMEM-matching, intentional: an EVID=4 record pushes exactly ONE
+      // EVID=3 reset (below), then falls through to the normal dose-record
+      // logic with 'cevid' rewritten to a plain-dose code (no reset bit).
+      // When this record also has 'addl' > 0, the later addl-expansion loop
+      // (search "cii > 0 && caddl > 0" below) starts from this already-reset
+      // 'cevid', so the repeated doses it emits are plain doses -- they do
+      // NOT reset the compartment again. This matches NONMEM: expanding an
+      // EVID=4 + ADDL record resets only on the first occurrence, and is
+      // pinned by the real-NONMEM-derived fixture
+      // tests/testthat/nmtest-evid4.rds (test-nmtest.R "evid4"), whose later
+      // ADDL-equivalent rows are plain EVID=1, not EVID=4. See GitHub issue
+      // #1351 and https://blog.nlmixr2.org/blog/2024-04-04-steady-state/ for
+      // the analogous ADDL+SS behavior. Do not "fix" this to reset on every
+      // addl repetition -- that was considered and is wrong.
       if (mdvCol != -1 && (inMdv[i] == 0 || IntegerVector::is_na(inMdv[i]))){
         stop(_("'mdv' cannot be 0 when 'evid'=4 id: %s row: %d"), CHAR(idLvl[cid-1]), i+1);
       }

--- a/tests/testthat/test-etTrans.R
+++ b/tests/testthat/test-etTrans.R
@@ -855,6 +855,44 @@ d/dt(blood)     = a*intestine - b*blood
         )
     })
 
+    test_that("evid=4 expanded through addl only resets on the first dose (matches NONMEM, issue #1351)", {
+      # NONMEM resets the compartment on the FIRST evid=4 occurrence only;
+      # the addl-repeated doses are plain doses, not additional resets.
+      # This is pinned by the real-NONMEM-derived fixture used in
+      # test-nmtest.R ("evid4"): its ADDL-equivalent rows are plain EVID=1
+      # after the initial EVID=4/SS record, never another EVID=4. See
+      # https://blog.nlmixr2.org/blog/2024-04-04-steady-state/ for the
+      # analogous ADDL+SS behavior. Do not "fix" this to reset on every
+      # addl repetition.
+      modAddl <- rxode2({
+        d/dt(central) <- -cl / v * central
+        cp <- central / v
+      })
+      pars <- c(cl = 1, v = 10)
+
+      addlEt <- et(amt = 100, time = 2, evid = 4, ii = 12, addl = 2) |> et(seq(0, 40, by = 1))
+      explicitEt <- et(amt = 100, time = 2, evid = 4) |>
+        et(amt = 100, time = 14, evid = 4) |>
+        et(amt = 100, time = 26, evid = 4) |>
+        et(seq(0, 40, by = 1))
+
+      addl <- rxSolve(modAddl, pars, addlEt)
+      explicit <- rxSolve(modAddl, pars, explicitEt)
+
+      # the addl expansion resets once, then just doses -- it must NOT match
+      # the explicit form, which resets at every evid=4 occurrence
+      expect_false(isTRUE(all.equal(addl$cp, explicit$cp)))
+
+      # only-first-resets reference, expanded by hand
+      onlyFirstResetEt <- et(amt = 100, time = 2, evid = 4) |>
+        et(amt = 100, time = 14, evid = 1) |>
+        et(amt = 100, time = 26, evid = 1) |>
+        et(seq(0, 40, by = 1))
+      onlyFirstReset <- rxSolve(modAddl, pars, onlyFirstResetEt)
+
+      expect_equal(addl$cp, onlyFirstReset$cp)
+    })
+
 
     mod <- rxode2parse("    CO = (187 * WT^0.81) * 60/1000
     QHT = 4 * CO/100

--- a/vignettes/rxode2-event-types.Rmdh
+++ b/vignettes/rxode2-event-types.Rmdh
@@ -450,6 +450,42 @@ ev <- et(timeUnits="hr") |>
 rxSolve(m1, ev) |> plot(depot, C2, eff)
 ```
 
+## `addl` only resets the first `evid=4`
+
+This is a common surprise, so it is worth calling out on its own: when an
+`evid=4` (reset+dose) record is repeated with `addl`, only the *first*
+occurrence resets the compartments.  The `addl`-repeated doses are ordinary
+doses, not further resets.
+
+```{r}
+addlEv <- et(amt=10000, time=2, evid=4, ii=12, addl=2) |>
+    et(seq(0, 40, length.out=200))
+
+explicitEv <- et(amt=10000, time=2,  evid=4) |>
+    et(amt=10000, time=14, evid=4) |>
+    et(amt=10000, time=26, evid=4) |>
+    et(seq(0, 40, length.out=200))
+
+addl <- rxSolve(m1, addlEv)
+explicit <- rxSolve(m1, explicitEv)
+
+library(patchwork)
+plot(addl, C2) + ggtitle("addl=2 (resets once)") +
+    plot(explicit, C2) + ggtitle("three explicit evid=4 (resets every time)")
+```
+
+The two regimens are *not* the same, and this is deliberate: it matches
+NONMEM, which also resets an `evid=4` record's `addl` repeats as plain doses
+rather than repeated resets.  Write the regimen out as separate `evid=4`
+records (as in `explicitEv` above) if a reset is wanted at every repetition.
+
+The same asymmetry applies to `ss` combined with `addl`: NONMEM does not carry
+the steady-state flag into the `addl`-repeated doses either, it just keeps
+dosing normally after the first, steady-state dose -- see
+[this blog post](https://blog.nlmixr2.org/blog/2024-04-04-steady-state/) for a
+worked discussion. `rxode2` follows the same convention (see the Steady State
+section above).
+
 # Turning off compartments
 
 Setting `cmt="-depot"` with `evid=2` turns off a compartment: its


### PR DESCRIPTION
## Summary
- Confirms and documents that expanding an `evid=4` (reset+dose) record through `addl` resets only on the first occurrence -- the `addl`-repeated doses are plain doses, not further resets -- and that this matches NONMEM (not the bug flagged in #1351).
- Adds a code comment at `case 4:` in `src/etTran.cpp` explaining why the addl-expansion loop structurally can't re-add a reset.
- Adds a regression test in `test-etTrans.R` pinning the behavior against both the explicit-repeat form and an only-first-resets reference.
- Adds a `CLAUDE.md` "Known Issues" entry and a new vignette subsection ("`addl` only resets the first `evid=4`") in `vignettes/rxode2-event-types.Rmdh`, cross-referencing the analogous `ss`+`addl` behavior from https://blog.nlmixr2.org/blog/2024-04-04-steady-state/.

Closes #1351 (already closed as not-planned with the same explanation).

## Test plan
- [x] `devtools::test(filter='etTrans')` passes, including the new regression test
- [x] `devtools::test(filter='nmtest')` passes (real-NONMEM-derived evid=4 fixture)
- [x] `devtools::test(filter='evid-push-infusion')` passes