### PR TITLE
fix: pushed evid=4 doses no longer re-reset on every addl repeat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -462,3 +462,13 @@ Evidence:
 - Regression test:
   `test-etTrans.R` `"evid=4 expanded through addl only resets on the first
   dose (matches NONMEM, issue #1351)"`.
+
+**Genuine bug found in the runtime PUSH path (`evid_()`/`bolus()`/`infuse()`),
+now FIXED**: `_rxPushDose()` (`src/par_solve.cpp`) built its `addl` loop by
+passing the original `_evid` unmodified to `_rxTranslateOneEvent()` on every
+repeat, so a pushed `evid_(time, 4, amt, cmt, rate, ii, addl, ss)` reset on
+every repetition -- unlike the data-table path above. Fixed by rewriting the
+evid passed in for `_rep > 0` from 4 to 1 (search `_doseEvid` in
+`_rxPushDose()`), mirroring `etTran.cpp`'s `case 4:`. Regression test:
+`test-evid-push-infusion.R` `"a pushed evid=4 dose repeated with addl resets
+only once (rxode2#1351/#1352)"`.

--- a/src/par_solve.cpp
+++ b/src/par_solve.cpp
@@ -1531,7 +1531,13 @@ extern "C" int _rxPushDose(rx_solving_options_ind *_ind, double _curTime,
     // auto-schedule further repeats.  For the first dose (rep==0) with SS, we
     // pass the original _ii so flg is set correctly; for all others ii=0.
     double _doseIi = (_rep == 0 && _doseSs != 0) ? _ii : 0.0;
-    rx_translated_event ev = _rxTranslateOneEvent(_doseTime, _evid, _cmt,
+    // NONMEM (and etTran.cpp's data-table addl expansion, see the case 4:
+    // comment there) resets only on the FIRST occurrence of an evid=4
+    // (reset+dose) record; addl repeats are plain doses, not further resets.
+    // rxode2#1351/#1352: without this the pushed evid_()/addl path re-reset
+    // the compartment on every repeat.
+    int _doseEvid = (_rep > 0 && _evid == 4) ? 1 : _evid;
+    rx_translated_event ev = _rxTranslateOneEvent(_doseTime, _doseEvid, _cmt,
                                                   _amt, _doseIi, _doseSs,
                                                   _rate, _isDurFlag);
     if (ev.n < 0) {

--- a/tests/testthat/test-evid-push-infusion.R
+++ b/tests/testthat/test-evid-push-infusion.R
@@ -226,6 +226,22 @@ rxTest({
     expect_equal(rxSolve(mod, .pars, et(obs))$cp, want$cp, tolerance = 1e-5)
   })
 
+  test_that("a pushed evid=4 dose repeated with addl resets only once (rxode2#1351/#1352)", {
+    # _rxPushDose()'s addl loop used to pass the original evid (4, reset+dose)
+    # unmodified to every repeat, so every addl repetition re-reset the
+    # compartment -- unlike the data-table addl expansion in etTran.cpp, which
+    # resets only on the first evid=4 occurrence (matches NONMEM, see
+    # rxode2#1351). Both spellings must now agree.
+    mod <- rxode2({
+      d/dt(central) <- -cl / v * central
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(2, 4, 100, 1, 0, 12, 2, 0)
+      }
+    })
+    .expectSameAsEventTable(mod, et(amt = 100, time = 2, evid = 4, ii = 12, addl = 2))
+  })
+
   test_that("a split bolus pushed as evid=4 reserves enough room (#1322 follow-up)", {
     # splitBolus expands one translated event into splitBolusN-1 records, so an
     # evid=4 push writes 1 + (splitBolusN-1) records where the capacity check
@@ -253,10 +269,16 @@ rxTest({
       cp <- central / v
     })
     e <- et(amt = 100, time = 0) |> et(seq(0, 72, by = 1))
-    eBase <- e |> et(amt = 100, time = 0, cmt = 2) |> et(amt = 100, time = 0, cmt = 3)
-    for (.t in seq(6, 60, by = 6)) {
+    # evid=4 resets only on the FIRST addl repetition (t=6, matching NONMEM --
+    # see rxode2#1351); write the reference the same way, evid=4 once then
+    # plain doses, rather than evid=4 at every repeat.
+    eBase <- e |> et(amt = 100, time = 0, cmt = 2) |> et(amt = 100, time = 0, cmt = 3) |>
+      et(amt = 50, time = 6, cmt = 1, evid = 4) |>
+      et(amt = 50, time = 6, cmt = 2) |>
+      et(amt = 50, time = 6, cmt = 3)
+    for (.t in seq(12, 60, by = 6)) {
       eBase <- eBase |>
-        et(amt = 50, time = .t, cmt = 1, evid = 4) |>
+        et(amt = 50, time = .t, cmt = 1) |>
         et(amt = 50, time = .t, cmt = 2) |>
         et(amt = 50, time = .t, cmt = 3)
     }

--- a/tests/testthat/test-evid-push-infusion.R
+++ b/tests/testthat/test-evid-push-infusion.R
@@ -242,6 +242,23 @@ rxTest({
     .expectSameAsEventTable(mod, et(amt = 100, time = 2, evid = 4, ii = 12, addl = 2))
   })
 
+  test_that("a pushed evid=4 infusion repeated with addl resets only once", {
+    # the infusion form of the test above: the first occurrence translates to
+    # three records (reset, on, off) and every repeat to two (on, off)
+    obs <- c(0, 1e-8, seq(0.5, 48, by = 0.5))
+    mod <- rxode2({
+      d/dt(central) <- -cl / v * central
+      cp <- central / v
+      if (t < 1e-8) {
+        evid_(2, 4, 100, 1, 10, 12, 2, 0)
+      }
+    })
+    want <- rxSolve(.ref, .pars,
+                    et(amt = 100, time = 2, rate = 10, evid = 4, ii = 12, addl = 2) |>
+                      et(obs))
+    expect_equal(rxSolve(mod, .pars, et(obs))$cp, want$cp, tolerance = 1e-5)
+  })
+
   test_that("a split bolus pushed as evid=4 reserves enough room (#1322 follow-up)", {
     # splitBolus expands one translated event into splitBolusN-1 records, so an
     # evid=4 push writes 1 + (splitBolusN-1) records where the capacity check


### PR DESCRIPTION
## Why

While fixing #1350 (PR #1352), review found a genuine bug in the runtime
push path that #1351 turned out NOT to be: `_rxPushDose()`'s `addl` loop
(`src/par_solve.cpp`) passed the original `_evid` (e.g. 4, reset+dose)
unmodified to `_rxTranslateOneEvent()` on every repeat, so a pushed
`evid_(time, 4, amt, cmt, rate, ii, addl, ss)` reset the compartment on
*every* `addl` repetition instead of only the first.

This disagreed with both NONMEM and rxode2's own data-table `addl`
expansion in `etTran.cpp`, which (per #1351, confirmed correct and
matching NONMEM in #1353) resets only on the first `evid=4` occurrence
and treats the repeats as plain doses. The push path is the one place
that still got this wrong -- it was deliberately left out of #1352 to
avoid colliding with the active `evid4-addl` branch.

## What changed

- `src/par_solve.cpp`: for `_rep > 0` in `_rxPushDose()`'s addl loop,
  rewrite the evid passed to `_rxTranslateOneEvent()` from 4 to 1,
  mirroring `etTran.cpp`'s `case 4:` (reset once, then plain doses).
- `tests/testthat/test-evid-push-infusion.R`: fixed the split-bolus
  capacity test ("a split bolus pushed as evid=4 reserves enough room"),
  whose reference (`eBase`) had literally written `evid=4` at every
  addl-equivalent repeat -- that was encoding the old, buggy
  reset-every-time behavior as ground truth. Also added a dedicated
  regression test, "a pushed evid=4 dose repeated with addl resets only
  once (rxode2#1351/#1352)".
- `CLAUDE.md`: documented the fix alongside the #1351 "not a bug" entry.

## Test plan
- [x] Pushed vs. data-table `addl` forms of the same `evid=4` regimen now
      agree to ~3e-7 (previously off by several units of concentration)
- [x] `devtools::test(filter='evid-push-infusion')` passes, including the
      new regression test and the fixed split-bolus capacity test
- [x] Full regression pass: evid-push, evid-push-infusion,
      adaptive-dosing-arg-vars, nmtest, etTrans, et, evid3,
      tied-modeled-rate-dur, model-rate, occ, odeToLin, ind-lin -- 0 failures