### PR TITLE
build: track header dependencies so an object cannot go stale

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -166,3 +166,4 @@ tests/testthat/test-lincmt-parse.R
 ^LICENSE\.md$
 ^tools$
 ^tools/
+^src/.*[.]d$

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ tests/testthat/_problems/
 *.tar.gz
 *.tgz
 inst/tools/*.Rout
+/src/*.d

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # rxode2 5.1.7 (development version)
 
+## Internal
+
+- The build now tracks header dependencies.  R's rules rebuild an object only
+  when its own source is newer, so an incremental build silently kept objects
+  that had been compiled against an earlier version of a header they include.
+  That reaches across packages: a `LinkingTo` package's headers are just
+  another include path, so a struct whose layout changes there leaves objects
+  here compiled to the old layout and the resulting shared library mixes both
+  -- a corrupt binary rather than a compile error.  `src/Makevars*` now
+  compiles with `-MMD -MP` and reads back the generated `.d` files.
+
 ## Bug fixes
 
 - A steady-state constant infusion (`ss=1`, `ii=0`, `amt=0`) pushed from

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,15 @@
   -- a corrupt binary rather than a compile error.  `src/Makevars*` now
   compiles with `-MMD -MP` and reads back the generated `.d` files.
 
+- `inst/tools/workaround.R` now writes a generated source only when its
+  content actually changed.  It had rewritten the vendored SUNDIALS sources,
+  `RcppExports.cpp`, `sbuf.c`, `codegen2.h` and the rest on every install,
+  refreshing their mtimes and so recompiling 22 files each time.  Relatedly,
+  `inst/include/rxode2parseVer.h` was digested into the very md5 it carries,
+  so that fingerprint -- and the header -- changed on every build regardless
+  of the sources; it is now excluded from its own digest, which also lets the
+  model cache the md5 keys actually hit.
+
 ## Bug fixes
 
 - A steady-state constant infusion (`ss=1`, `ii=0`, `amt=0`) pushed from

--- a/cleanup
+++ b/cleanup
@@ -3,3 +3,4 @@ rm -f src/Makevars
 rm -f config.*
 rm -f src/Makevars.win
 rm -f inst/include/*.gch
+rm -f src/*.d

--- a/cleanup.win
+++ b/cleanup.win
@@ -3,3 +3,4 @@
 rm -f src/Makevars.win
 rm -f src/Makevars
 rm -f inst/include/*.gch
+rm -f src/*.d

--- a/inst/tools/workaround.R
+++ b/inst/tools/workaround.R
@@ -1,3 +1,21 @@
+## Every generated source below is rewritten on each install.  Writing one
+## byte-for-byte still gives it a new mtime, and make then rebuilds every
+## object that depends on it -- 22 of them here, and more once header
+## dependencies are tracked.  Compare first and write only on a real change.
+## All of these writes use a binary connection, so the comparison is exact.
+.writeLinesIfChanged <- function(text, path, sep = "\n") {
+  .new <- paste0(paste(text, collapse = sep), sep)
+  if (file.exists(path)) {
+    .old <- tryCatch(readChar(path, file.size(path), useBytes = TRUE),
+                     error = function(e) NULL)
+    if (identical(.old, .new)) return(invisible(FALSE))
+  }
+  .con <- file(path, "wb")
+  on.exit(close(.con))
+  writeLines(text, .con, sep = sep)
+  invisible(TRUE)
+}
+
 ## This is only for rxode2
 ## inst/include/rxode2_RcppExports.h is the header consumed by generated model
 ## code -- it should carry only <Rcpp.h>.  Strip RcppArmadillo and RcppEigen.
@@ -22,9 +40,7 @@
 .hdr_f <- "inst/include/rxode2_RcppExports.h"
 .hdr_l <- .strip_rcpp_guard(readLines(.hdr_f))
 .hdr_l <- .hdr_l[regexpr("^[#]include <RcppEigen.h>", .hdr_l) == -1]
-.hdr_out <- file(.hdr_f, "wb")
-writeLines(.hdr_l, .hdr_out)
-close(.hdr_out)
+.writeLinesIfChanged(.hdr_l, .hdr_f)
 
 ## Implementation: clean up stale guards, then ensure RcppArmadillo.h appears
 ## BEFORE rxode2.h (which includes R.h / Rinternals.h).  RcppCommon.h defines
@@ -38,18 +54,14 @@ if (!any(grepl("RcppArmadillo", .cpp_l, fixed = TRUE))) {
     .cpp_l <- append(.cpp_l, "#include <RcppArmadillo.h>", after = .rx_line[1] - 1L)
   }
 }
-.cpp_out <- file(.cpp_f, "wb")
-writeLines(.cpp_l, .cpp_out)
-close(.cpp_out)
+.writeLinesIfChanged(.cpp_l, .cpp_f)
 
 l <- readLines("R/RcppExports.R")
 w <- which(regexpr("# Register entry points", l, fixed=TRUE) != -1)
 if (length(w) >= 1) {
   w <- w[1]
   l <- l[seq(1, w-1)]
-  RcppExports.R <- file("R/RcppExports.R", "wb")
-  writeLines(l, RcppExports.R)
-  close(RcppExports.R)
+  .writeLinesIfChanged(l, "R/RcppExports.R")
 }
 
 compilerPath <- tools::Rcmd("config CC", stdout=TRUE)
@@ -187,9 +199,7 @@ if (file.exists(.ef)) {
   .el <- readLines(.ef)
   .el <- gsub("abort();", "return;", .el, fixed = TRUE)
   .el <- gsub('fprintf(stderr, "%s", log_msg);', '', .el, fixed = TRUE)
-  .ef_out <- file(.ef, "wb")
-  writeLines(.el, .ef_out, sep = "\n")
-  close(.ef_out)
+  .writeLinesIfChanged(.el, .ef)
 }
 
 ## Fix 1b: sundials_sundials_logger.c
@@ -207,9 +217,7 @@ if (file.exists(.lf)) {
   .ll <- gsub("logger->error_fp   = stderr;", "logger->error_fp   = NULL;", .ll, fixed = TRUE)
   .ll <- gsub("logger->warning_fp = stdout;", "logger->warning_fp = NULL;", .ll, fixed = TRUE)
   .ll <- strsplit(.ll, "\n", fixed = TRUE)[[1]]
-  .lf_out <- file(.lf, "wb")
-  writeLines(.ll, .lf_out, sep = "\n")
-  close(.lf_out)
+  .writeLinesIfChanged(.ll, .lf)
 }
 
 ## Fix 1c: sundials_nvector_serial.c
@@ -219,9 +227,7 @@ if (file.exists(.nf)) {
   .nl <- readLines(.nf)
   .nl <- gsub("N_VPrintFile_Serial(x, stdout);",
                "/* N_VPrintFile_Serial stdout removed for CRAN */", .nl, fixed = TRUE)
-  .nf_out <- file(.nf, "wb")
-  writeLines(.nl, .nf_out, sep = "\n")
-  close(.nf_out)
+  .writeLinesIfChanged(.nl, .nf)
 }
 
 ## Fix 1d: sundials_sundials_nvector.c
@@ -231,9 +237,7 @@ if (file.exists(.nvf)) {
   .nv <- readLines(.nvf)
   .nv <- gsub('printf("NULL Vector\\n");', '', .nv, fixed = TRUE)
   .nv <- gsub('printf("NULL Print Op\\n");', '', .nv, fixed = TRUE)
-  .nvf_out <- file(.nvf, "wb")
-  writeLines(.nv, .nvf_out, sep = "\n")
-  close(.nvf_out)
+  .writeLinesIfChanged(.nv, .nvf)
 }
 
 ## Fix 3: Remove deprecated SUNDIALS 7.x workspace-query function usage.
@@ -255,9 +259,7 @@ if (file.exists(.nvf)) {
 if (file.exists(.nf3)) {
   .nl3 <- .strip_deprecated_pragma(readLines(.nf3))
   .nl3 <- gsub("= N_VSpace_Serial;", "= NULL;", .nl3, fixed = TRUE)
-  .nf3_out <- file(.nf3, "wb")
-  writeLines(.nl3, .nf3_out, sep = "\n")
-  close(.nf3_out)
+  .writeLinesIfChanged(.nl3, .nf3)
 }
 
 ## sunlinsol_band: null out deprecated SUNLinSolSpace_Band function pointer
@@ -265,9 +267,7 @@ if (file.exists(.nf3)) {
 if (file.exists(.lbf)) {
   .lb <- .strip_deprecated_pragma(readLines(.lbf))
   .lb <- gsub("= SUNLinSolSpace_Band;", "= NULL;", .lb, fixed = TRUE)
-  .lbf_out <- file(.lbf, "wb")
-  writeLines(.lb, .lbf_out, sep = "\n")
-  close(.lbf_out)
+  .writeLinesIfChanged(.lb, .lbf)
 }
 
 ## sunlinsol_dense: null out deprecated SUNLinSolSpace_Dense function pointer
@@ -275,9 +275,7 @@ if (file.exists(.lbf)) {
 if (file.exists(.ldf)) {
   .ld <- .strip_deprecated_pragma(readLines(.ldf))
   .ld <- gsub("= SUNLinSolSpace_Dense;", "= NULL;", .ld, fixed = TRUE)
-  .ldf_out <- file(.ldf, "wb")
-  writeLines(.ld, .ldf_out, sep = "\n")
-  close(.ldf_out)
+  .writeLinesIfChanged(.ld, .ldf)
 }
 
 ## sunmatrix_band: null out deprecated SUNMatSpace_Band function pointer
@@ -285,9 +283,7 @@ if (file.exists(.ldf)) {
 if (file.exists(.mbf)) {
   .mb <- .strip_deprecated_pragma(readLines(.mbf))
   .mb <- gsub("= SUNMatSpace_Band;", "= NULL;", .mb, fixed = TRUE)
-  .mbf_out <- file(.mbf, "wb")
-  writeLines(.mb, .mbf_out, sep = "\n")
-  close(.mbf_out)
+  .writeLinesIfChanged(.mb, .mbf)
 }
 
 ## sunmatrix_dense: null out deprecated SUNMatSpace_Dense function pointer
@@ -295,9 +291,7 @@ if (file.exists(.mbf)) {
 if (file.exists(.mdf)) {
   .md <- .strip_deprecated_pragma(readLines(.mdf))
   .md <- gsub("= SUNMatSpace_Dense;", "= NULL;", .md, fixed = TRUE)
-  .mdf_out <- file(.mdf, "wb")
-  writeLines(.md, .mdf_out, sep = "\n")
-  close(.mdf_out)
+  .writeLinesIfChanged(.md, .mdf)
 }
 
 ## sunmatrix_sparse: null out deprecated SUNMatSpace_Sparse function pointer
@@ -305,9 +299,7 @@ if (file.exists(.mdf)) {
 if (file.exists(.msf)) {
   .ms <- .strip_deprecated_pragma(readLines(.msf))
   .ms <- gsub("= SUNMatSpace_Sparse;", "= NULL;", .ms, fixed = TRUE)
-  .msf_out <- file(.msf, "wb")
-  writeLines(.ms, .msf_out, sep = "\n")
-  close(.msf_out)
+  .writeLinesIfChanged(.ms, .msf)
 }
 
 ## sundials_cvode: replace deprecated N_VSpace call with zero assignments
@@ -315,9 +307,7 @@ if (file.exists(.msf)) {
 if (file.exists(.cvf3)) {
   .cv3 <- .strip_deprecated_pragma(readLines(.cvf3))
   .cv3 <- gsub("N_VSpace(y0, &lrw1, &liw1);", "lrw1 = 0; liw1 = 0;", .cv3, fixed = TRUE)
-  .cvf3_out <- file(.cvf3, "wb")
-  writeLines(.cv3, .cvf3_out, sep = "\n")
-  close(.cvf3_out)
+  .writeLinesIfChanged(.cv3, .cvf3)
 }
 
 ## sundials_cvode_ls: replace deprecated N_VSpace/SUNMatSpace/SUNLinSolSpace calls
@@ -330,9 +320,7 @@ if (file.exists(.clf)) {
               "lrw = 0; liw = 0; retval = 0;", .cl, fixed = TRUE)
   .cl <- gsub("retval = SUNLinSolSpace(cvls_mem->LS, &lrw, &liw);",
               "lrw = 0; liw = 0; retval = 0;", .cl, fixed = TRUE)
-  .clf_out <- file(.clf, "wb")
-  writeLines(.cl, .clf_out, sep = "\n")
-  close(.clf_out)
+  .writeLinesIfChanged(.cl, .clf)
 }
 
 ## ---------------------------------------------------------------------------
@@ -399,9 +387,7 @@ for (.sp in file.path("src", .sp_files)) {
     .sl <- gsub("N_VSpace(SPTFQMR_CONTENT(S)->vtemp1, &lrw1, &liw1);",
                 "lrw1 = 0; liw1 = 0;", .sl, fixed = TRUE)
     .sl <- .fix_monitoring_endif(.sl)
-    .sp_out <- file(.sp, "wb")
-    writeLines(.sl, .sp_out, sep = "\n")
-    close(.sp_out)
+    .writeLinesIfChanged(.sl, .sp)
   }
 }
 
@@ -425,9 +411,7 @@ if (!nzchar(.bh_ie)) {
   "if( res != 0 ) throw std::runtime_error(\"implicit Euler LU factorization singular\");",
   .ie_lines
 )
-.ie_out <- file("src/implicit_euler_rxode2.hpp", "wb")
-writeLines(.ie_lines, .ie_out, sep = "\n")
-close(.ie_out)
+.writeLinesIfChanged(.ie_lines, "src/implicit_euler_rxode2.hpp")
 
 
 .badStan <- ""
@@ -474,13 +458,9 @@ close(.makevars)
 ## before the digest::digest() call below, which needs the 'digest' package
 ## (Suggests, not Imports) and may be absent on --no-suggests CI runners.
 
-unlink("src/sbuf.c")
 l <- readLines("inst/include/sbuf.c")
-sbuf.c <- file("src/sbuf.c", "wb")
-writeLines(l, sbuf.c)
-close(sbuf.c)
+.writeLinesIfChanged(l, "src/sbuf.c")
 
-unlink("src/codegen2.h")
 l <- readLines("inst/include/rxode2_model_shared.c")
 
 l <- l[l != ""]
@@ -553,10 +533,7 @@ df$argMax <- df$argMin
 dfStr <- deparse(df)
 dfStr[1] <- paste(".parseEnv$.rxode2parseDf <- ", dfStr[1])
 
-dfIni.R <- file("R/dfIni.R", "wb")
-writeLines(dfStr,
-           dfIni.R)
-close(dfIni.R)
+.writeLinesIfChanged(dfStr, "R/dfIni.R")
 
 ## deparse1 came from R 4.0, use deparse2
 deparse2 <- function(expr, collapse = " ", width.cutoff = 500L, ...) {
@@ -587,10 +564,7 @@ final <- c("#include <time.h>",
            "}"
            )
 
-codegen2.h <- file("src/codegen2.h", "wb")
-writeLines(final,
-           codegen2.h)
-close(codegen2.h)
+.writeLinesIfChanged(final, "src/codegen2.h")
 
 ## --- Optional: model-cache MD5 (needs 'digest', which is in Suggests) ---
 ## Skipped gracefully when digest is not installed (e.g. --no-suggests CI).
@@ -599,25 +573,26 @@ if (requireNamespace("digest", quietly = TRUE)) {
   cpp <- list.files("src", pattern = "\\.(c|h|cpp|f)$")
   cpp <- cpp[!dir.exists(file.path("src", cpp))]
   include <- list.files("inst/include", recursive = TRUE)
+  ## rxode2parseVer.h holds the md5 written just below, so digesting it
+  ## would fold the previous build's fingerprint into this one and the md5
+  ## would differ on every build even when no source did -- which both
+  ## defeats the model cache it exists to key and rewrites the header (and
+  ## so rebuilds everything including it) every time.
+  include <- include[include != "rxode2parseVer.h"]
 
   md5 <- digest::digest(c(lapply(c(paste0("src/", cpp),
                                    paste0("inst/include/", include)
                                    ), digest::digest, file = TRUE),
                           ""))
-  unlink("R/rxode2_md5.R")
-  md5file <- file("R/rxode2_md5.R", "wb")
-  writeLines(sprintf("rxode2.md5 <- \"%s\"\n", md5), md5file)
-  close(md5file)
+  .writeLinesIfChanged(sprintf("rxode2.md5 <- \"%s\"\n", md5), "R/rxode2_md5.R")
 
   l <- readLines("DESCRIPTION")
   w <- which(regexpr("Version[:] *(.*)$", l) != -1)
   v <- gsub("Version[:] *(.*)$", "\\1", l[w])
 
-  unlink("inst/include/rxode2parseVer.h")
-  ode.h <- file("inst/include/rxode2parseVer.h", "wb")
-  writeLines(c(sprintf("#define __VER_md5__ \"%s\"", md5),
-               "#define __VER_repo__ \"https://github.com/nlmixr2/rxode2\"",
-               sprintf("#define __VER_ver__ \"%s\"", v)),
-             ode.h)
-  close(ode.h)
+  .writeLinesIfChanged(
+    c(sprintf("#define __VER_md5__ \"%s\"", md5),
+      "#define __VER_repo__ \"https://github.com/nlmixr2/rxode2\"",
+      sprintf("#define __VER_ver__ \"%s\"", v)),
+    "inst/include/rxode2parseVer.h")
 }

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -14,5 +14,26 @@ PKG_LIBS    = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS) @SL@
 PKG_CPPFLAGS = @SUNDIALS_INC@
 
 # Release options -- -O3 gives meaningful speedup on the ODE hot paths
-PKG_CFLAGS  =  -D_isrxode2_ @O2@
-PKG_CXXFLAGS = @O2@ $(SHLIB_OPENMP_CXXFLAGS) -D_isrxode2_ -DBOOST_DISABLE_ASSERTS -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION -D_HAS_AUTO_PTR_ETC=0 -D_REENTRANT -include rxode2_sundials_stan_compat.h -@ISYSTEM@"$(BH)" -@ISYSTEM@"$(EG)" $(SH) -@ISYSTEM@"$(RCPP)" -DARMA_DONT_USE_OPENMP -DEIGEN_DONT_PARALLELIZE
+PKG_CFLAGS  =  -D_isrxode2_ @O2@ -MMD -MP
+PKG_CXXFLAGS = @O2@ $(SHLIB_OPENMP_CXXFLAGS) -D_isrxode2_ -DBOOST_DISABLE_ASSERTS -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION -D_HAS_AUTO_PTR_ETC=0 -D_REENTRANT -include rxode2_sundials_stan_compat.h -@ISYSTEM@"$(BH)" -@ISYSTEM@"$(EG)" $(SH) -@ISYSTEM@"$(RCPP)" -DARMA_DONT_USE_OPENMP -DEIGEN_DONT_PARALLELIZE -MMD -MP
+
+################################################################################
+## Header dependency tracking.
+##
+## R's build rules make an object depend on its own source only, so an object
+## goes stale -- silently -- when a header it includes changes and the source
+## does not.  That reaches across packages too: a LinkingTo package's headers
+## are just another include path, so a struct that changes there leaves the
+## objects here compiled to the previous layout.
+##
+## -MMD (in PKG_CFLAGS/PKG_CXXFLAGS above) records each object's headers in a
+## .d file beside it; -MP emits a phony target per header so one that is later
+## renamed or deleted does not break the build.  The .d files the previous
+## build wrote are read back below.
+##
+## Makevars is read before shlib.mk defines "all", so without .DEFAULT_GOAL the
+## first target of the first .d file becomes make's default goal and the shared
+## library is never linked.
+################################################################################
+.DEFAULT_GOAL := all
+-include $(wildcard *.d)


### PR DESCRIPTION
## What

Compile with `-MMD -MP` and read the generated `.d` files back in
`src/Makevars*`, so an object is rebuilt when a header it includes changes --
not only when its own source changes.

## Why

R's build rules make an object depend on its own source alone. `make`
therefore reuses `foo.o` whenever only a header that `foo.cpp` includes has
changed, and nothing warns.

That crosses package boundaries. A `LinkingTo` package's headers are just
another include path, so when a struct there gains or reorders a field, the
objects compiled against the previous layout are kept and linked alongside
freshly compiled ones. The library's halves then disagree about member
offsets -- a corrupt binary rather than a compile error, surfacing as a
segfault far from the cause.

This is not hypothetical. On a development install of rxode2 5.1.7:

- `src/approx.o` was compiled 2026-07-24.
- `inst/include/rxode2parseStruct.h`, which defines `rx_solving_options_ind`
  and `rx_solving_options`, changed 28 times after that, twice reshaping the
  structs outright ("append the origin fields at the end of their structs",
  "struct tail").
- `approx.cpp` itself had not changed since 2026-06-15, so `make` never
  recompiled it. 129 of 270 objects in that tree were older than the newest
  header; in nlmixr2est, 15 of 34 were three months old.

`_update_par_ptr()` and `getValue()` in `approx.cpp` then read
`ind->cov_ptr`, `ind->ix` and `op->ncov` at obsolete offsets. They run only
when a solve carries a per-row covariate, so most work was unaffected and the
failure looked like an estimator bug:

```r
library(rxode2)
m <- rxode2("param(WT); y = 2 * WT;")
d <- data.frame(ID = rep(1:2, each = 3), TIME = rep(0:2, 2),
                WT = c(70, 71, 72,  80, 80, 80))
rxSolve(m, d)   # segfault; one subject, or a WT constant within subject, is fine
```

Every nlmixr2est SAEM fit whose model read a covariate segfaulted --
`.configsaem()` hands the kernel a pre-translated event matrix, so the
covariate stays a per-row column -- while focei on the same model was fine,
because `etTrans()` reduces an id-invariant covariate into the per-id `cov1`
table and `ncov` is 0. nlmixr2est's own `tests/testthat/test-inpar-saem.R`
segfaulted as well. A clean rebuild fixed all of it: no source was wrong.

Documentation cannot prevent this, and a green test suite does not catch it,
because the suite runs against the same mixed binary.

## How

`-MMD` makes each object record its headers in a `.d` file beside it; `-MP`
emits a phony target per header so one that is later renamed or deleted does
not break the next build. The `.d` files the previous build wrote are read
back at the end of `src/Makevars*`.

`.DEFAULT_GOAL := all` is load-bearing, not cosmetic. `Makevars` is read
before `shlib.mk` defines `all`, so without it the first target of the first
included `.d` file becomes make's default goal: the objects rebuild and the
shared library is never relinked -- failing silently in exactly the way this
change exists to prevent. This was observed, not theorised.

`.d` files are added to `.gitignore`, to `.Rbuildignore`, and to the
`cleanup` scripts (which run for `R CMD build` and `R CMD INSTALL --clean`,
not on an ordinary install, so incremental builds keep their dependency
information).

## Verified

Per package: clean build, then a no-op rebuild, then touching one header.

| package | objects / depfiles | no-op rebuild | header touched | recompiled | relinked |
| --- | --- | --- | --- | --- | --- |
| rxode2 | 270 / 263 | 22 before the second commit below | `rxode2parseStruct.h` | 50 | yes |
| nlmixr2est | 34 / 34 | 0 | `armahead.h` | 16 | yes |
| babelmixr2 | 5 / 5 | 0 | `timeIndexer.h` | 1 | yes |
| nonmem2rx | 19 / 19 | 0 | `abbrec.g.d_parser.h` | 1 | yes |
| rxode2ll | 17 / 17 | 0 | `llik.h` | 16 | yes |
| nlmixr2extra | 3 / 3 | 0 | (no in-package header is included) | -- | -- |

rxode2's 263 depfiles for 270 objects are correct: the 7 Fortran sources are
not given `-MMD` (they have no `#include` graph to track).

## Second commit: stop regenerating unchanged sources

rxode2 only. `inst/tools/workaround.R` rewrote every file it generates on
each install -- the vendored SUNDIALS sources, `RcppExports.cpp`, `sbuf.c`,
`codegen2.h`, `dfIni.R`. Rewriting a file byte-for-byte still gives it a new
mtime, which is why a no-op rebuild recompiled 22 objects before this branch,
and why tracking header dependencies would otherwise have spread that churn
to everything including the regenerated headers.

`inst/include/rxode2parseVer.h` was worse than churn: it holds an md5 digested
from every file in `src/` and `inst/include` -- itself included -- so each
build folded the previous build's fingerprint into the new one:

```
run 1: __VER_md5__ "cd3502928e7fa0b78a8e49f954aff1e9"
run 2: __VER_md5__ "a931d9be31b9c3605b631fcfd3b5bc29"   # nothing else changed
```

That header is included by `genModelVars.h`, `rxData.cpp` and `rxode2_df.cpp`,
so the churn reached well past the file itself -- and the md5 could never key
the model cache it exists for, since a fingerprint that changes every build
never matches. It is now excluded from its own digest.

`.writeLinesIfChanged()` compares before writing; every one of these writes
already used a binary connection, so the comparison is exact. The four
`unlink()` calls that deleted a generated file just before rewriting it are
gone -- they would have defeated the comparison.

Verified: three consecutive `workaround.R` runs change no mtimes at all.

A throwaway two-source package confirms the mechanism end to end: with a
header changed from `111` to `222` and no source touched, the old build
recompiles nothing and keeps returning `111`; with this change it recompiles
only the one dependent source, relinks, and returns `222`.

## Portability

`-MMD -MP` are GCC/Clang spellings, understood by every compiler CRAN
currently checks with (GCC, Clang, Intel oneAPI's clang-based `icx`). If you
would rather not take even that risk, the flags can be gated behind a
compiler probe in `configure`/`workaround.R`; say the word and I will add it.