### PR TITLE
fix(mix): an expanded mix() is still a mixture model

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,10 +31,13 @@
 - A `mix()` model whose call has been expanded by symengine -- the form
   every estimation method's prediction model is built from -- is now still
   recognized as a mixture model.  The expansion emits one reserved
-  `rx_mixsel_<k>_` selector per component, which keeps the component count
-  the dropped `mix()` call carried, so `mixnum` reports it and a
+  `rx_mixsel_<k>_<n>_` selector per component, spelling out the component
+  count the dropped `mix()` call carried, so `mixnum` reports it and a
   per-individual `mixest` supplied in the data or in `iCov` reaches the
-  solve.  Previously such a model parsed with no mixture at all: the
+  solve.  The total is spelled out rather than inferred from the largest
+  selector present, because a component whose expression folds to zero --
+  any sensitivity with respect to an eta only one component uses -- drops
+  its selector out of the expression entirely.  Previously such a model parsed with no mixture at all: the
   `mixest` column was discarded, `ind->mixest` stayed 0, and every
   `mix()`-derived variable solved as 0 -- which silently corrupted the
   predictions in the fit table (nlmixr2/nlmixr2est#1041).

--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,12 @@
 - `rx_mixsel_<k>_<n>_` is now a reserved variable name, like `mixest`,
   `mixnum` and `mixunif`.  A model cannot use it for anything else.
 
+- An `iCov` column that a homogeneous solve group is split on no longer
+  drops the subject when its value is `NA`.  The split key came from
+  `interaction()`, which is `NA` for a row with any `NA`, and the `split()`
+  it feeds discarded that row -- so the subject vanished from the solve
+  output instead of being rejected.
+
 ### Event translation
 
 - A steady-state dose into a compartment with a modeled `alag()` pushed

--- a/NEWS.md
+++ b/NEWS.md
@@ -53,7 +53,15 @@
   whole group took the first subject's component.
 
 - `rx_mixsel_<k>_<n>_` is now a reserved variable name, like `mixest`,
-  `mixnum` and `mixunif`.  A model cannot use it for anything else.
+  `mixnum` and `mixunif`.  A model cannot use it for anything else, and
+  selectors that disagree with each other, or with a literal `mix()` in the
+  same model, about the number of components are a syntax error.
+
+- Note that the expansion drops the mixture PROBABILITIES along with the
+  `mix()` call, so an expanded model can be told which component a subject
+  belongs to (`mixest`) but cannot sample one from a supplied `mixunif`.
+  Simulation from `mixunif` needs the `mix()` call itself, which every
+  hand-written model keeps.
 
 - An `iCov` column that a homogeneous solve group is split on no longer
   drops the subject when its value is `NA`.  The split key came from

--- a/NEWS.md
+++ b/NEWS.md
@@ -47,10 +47,13 @@
   never ran `_mix()`, so the supplied assignment never reached it.
 
 - A `mixest` or `mixunif` column in `iCov` now splits a homogeneous event
-  group.  Subjects that share an event table are solved as one group, and
-  the group was only split on iCov columns that are model parameters;
-  `mixest` is a reserved variable, so the whole group took the first
-  subject's component.
+  group when the model is a mixture model.  Subjects that share an event
+  table are solved as one group, and the group was only split on iCov
+  columns that are model parameters; `mixest` is a reserved variable, so the
+  whole group took the first subject's component.
+
+- `rx_mixsel_<k>_<n>_` is now a reserved variable name, like `mixest`,
+  `mixnum` and `mixunif`.  A model cannot use it for anything else.
 
 ### Event translation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,29 @@
   the append-only convention the struct already documents, so the stride was
   the whole of the disagreement.
 
+### Mixture models
+
+- A `mix()` model whose call has been expanded by symengine -- the form
+  every estimation method's prediction model is built from -- is now still
+  recognized as a mixture model.  The expansion emits one reserved
+  `rx_mixsel_<k>_` selector per component, which keeps the component count
+  the dropped `mix()` call carried, so `mixnum` reports it and a
+  per-individual `mixest` supplied in the data or in `iCov` reaches the
+  solve.  Previously such a model parsed with no mixture at all: the
+  `mixest` column was discarded, `ind->mixest` stayed 0, and every
+  `mix()`-derived variable solved as 0 -- which silently corrupted the
+  predictions in the fit table (nlmixr2/nlmixr2est#1041).
+
+- `ind->mixest` is now set when the value is read from the data, not only
+  inside `_mix()`.  A model that reads `mixest` without calling `mix()`
+  never ran `_mix()`, so the supplied assignment never reached it.
+
+- A `mixest` or `mixunif` column in `iCov` now splits a homogeneous event
+  group.  Subjects that share an event table are solved as one group, and
+  the group was only split on iCov columns that are model parameters;
+  `mixest` is a reserved variable, so the whole group took the first
+  subject's component.
+
 ### Event translation
 
 - A steady-state dose into a compartment with a modeled `alag()` pushed

--- a/R/etNew.R
+++ b/R/etNew.R
@@ -843,7 +843,11 @@
     }
     .subIc <- iCov[.idx, , drop = FALSE]
     .splitCols <- setdiff(names(.subIc), .idName)
-    .splitNeeded <- unique(c(tolower(.modelParams), tolower(.keep)))
+    # mixest/mixunif are reserved variables, so they are never model params;
+    # they still make the subjects in a group solve differently, so they have
+    # to split the group like any other varying iCov column.
+    .splitNeeded <- unique(c(tolower(.modelParams), tolower(.keep),
+                             "mixest", "mixunif"))
     .splitCols <- .splitCols[tolower(.splitCols) %in% .splitNeeded]
     .splitKey <- if (length(.splitCols) == 0L) {
       factor(rep.int("1", nrow(.subIc)))

--- a/R/etNew.R
+++ b/R/etNew.R
@@ -804,7 +804,18 @@
   if (!is.data.frame(df) || ncol(df) == 0L) {
     return(rep.int("1", if (is.data.frame(df)) nrow(df) else 0L))
   }
-  do.call(interaction, c(unname(df), list(drop = TRUE, lex.order = TRUE)))
+  # interaction() returns NA for a row with an NA in any column, and the
+  # split(drop = TRUE) it feeds then DISCARDS that row -- silently dropping the
+  # subject from the solve.  Give NA a level of its own instead, so the subject
+  # survives to the per-subject validation that should reject it.  The
+  # character conversion matches what interaction() does to build its levels,
+  # so grouping is otherwise unchanged.
+  .df <- lapply(unname(df), function(.col) {
+    .chr <- as.character(.col)
+    .chr[is.na(.col)] <- "\001NA\001"
+    .chr
+  })
+  do.call(interaction, c(.df, list(drop = TRUE, lex.order = TRUE)))
 }
 
 # The iCov columns a homogeneous solve group has to be split on: the model's

--- a/R/etNew.R
+++ b/R/etNew.R
@@ -807,6 +807,18 @@
   do.call(interaction, c(unname(df), list(drop = TRUE, lex.order = TRUE)))
 }
 
+# The iCov columns a homogeneous solve group has to be split on: the model's
+# own parameters, plus -- for a mixture model only -- the reserved mixture
+# names, which are never model parameters but do make the subjects in a group
+# solve differently.
+.rxGroupSolveParams <- function(mv) {
+  .p <- mv$params
+  if (isTRUE(unname(mv$flags["mix"]) > 0L)) {
+    .p <- c(.p, "mixest", "mixunif")
+  }
+  .p
+}
+
 .etGroupedSolveDataFrameICov <- function(events, iCov, keep = NULL, modelParams = character(0)) {
   .groups <- attr(events, "rxHomGroups", exact = TRUE)
   if (!is.data.frame(events) || is.null(.groups) || !inherits(iCov, "data.frame")) {
@@ -843,11 +855,7 @@
     }
     .subIc <- iCov[.idx, , drop = FALSE]
     .splitCols <- setdiff(names(.subIc), .idName)
-    # mixest/mixunif are reserved variables, so they are never model params;
-    # they still make the subjects in a group solve differently, so they have
-    # to split the group like any other varying iCov column.
-    .splitNeeded <- unique(c(tolower(.modelParams), tolower(.keep),
-                             "mixest", "mixunif"))
+    .splitNeeded <- unique(c(tolower(.modelParams), tolower(.keep)))
     .splitCols <- .splitCols[tolower(.splitCols) %in% .splitNeeded]
     .splitKey <- if (length(.splitCols) == 0L) {
       factor(rep.int("1", nrow(.subIc)))

--- a/R/rxsolve.R
+++ b/R/rxsolve.R
@@ -3563,7 +3563,7 @@ rxSolve.default <- function(object, params = NULL, events = NULL, inits = NULL, 
     .mv <- rxModelVars(object)
     .groupedSolve <- .etGroupedSolveDataICov(.origEvents, .ctl$iCov,
                                              keep = .ctl$keep,
-                                             modelParams = .mv$params)
+                                             modelParams = .rxGroupSolveParams(.mv))
     if (!is.null(.groupedSolve)) {
       events <- .groupedSolve$events
       .ctl$iCov <- .groupedSolve$iCov
@@ -3574,7 +3574,7 @@ rxSolve.default <- function(object, params = NULL, events = NULL, inits = NULL, 
     .mv <- rxModelVars(object)
     .groupedSolve <- .etGroupedSolveDataFrameICov(events, .ctl$iCov,
                                                   keep = .ctl$keep,
-                                                  modelParams = .mv$params)
+                                                  modelParams = .rxGroupSolveParams(.mv))
     if (!is.null(.groupedSolve)) {
       events <- .groupedSolve$events
       .ctl$iCov <- .groupedSolve$iCov

--- a/R/symengine.R
+++ b/R/symengine.R
@@ -1790,26 +1790,14 @@ rxToSE <- function(x, envir = NULL, progress = FALSE,
 }
 
 
-# The reserved name of the k-th component selector of an expanded mix().  A
-# bare `mixest == k` loses the component count once the mix() call is gone;
+# The reserved name of the k-th of n component selectors of an expanded mix().
+# A bare `mixest == k` loses the component count once the mix() call is gone;
 # this name keeps it, so the parser still reports the model as a mixture and
-# rxode2 will take a per-individual mixest from the data or iCov.
-.rxMixSelName <- function(k) paste0("rx_mixsel_", as.integer(k), "_")
-
-# rxEq(mixest, k) -- what .rxToSEMix() feeds symengine for component k -- comes
-# back out as the selector name rather than as `(mixest == k)`
-.rxFromSEMixSel <- function(x) {
-  .a <- x[[2]]
-  .b <- x[[3]]
-  if (identical(.b, quote(mixest))) {
-    .tmp <- .a
-    .a <- .b
-    .b <- .tmp
-  }
-  if (!identical(.a, quote(mixest))) return(NULL)
-  if (!is.numeric(.b) || length(.b) != 1L) return(NULL)
-  if (is.na(.b) || .b < 1 || .b != round(.b)) return(NULL)
-  .rxMixSelName(.b)
+# rxode2 will take a per-individual mixest from the data or iCov.  It goes into
+# symengine as an ordinary symbol -- it is constant in every eta, so it rides
+# through differentiation and comes back out unchanged.
+.rxMixSelName <- function(k, n) {
+  paste0("rx_mixsel_", as.integer(k), "_", as.integer(n), "_")
 }
 
 # Convert the mix() expression to a if clause with mixest for symengine
@@ -1818,7 +1806,13 @@ rxToSE <- function(x, envir = NULL, progress = FALSE,
     if (i %% 2 == 0)  {
       # Noting that argument 1 is the function name,
       # The even arguments are the mixture values
-      paste0("rxEq(mixest, ", i/2, ")*(", .rxToSE(x[[i]], envir = envir, progress = progress), ")")
+      .nm <- .rxMixSelName(i/2, length(x) %/% 2)
+      # the selector is generated here rather than read out of the model text,
+      # so it has to be introduced to the symengine environment by hand
+      if (isEnv && is.environment(envir) && !exists(.nm, envir = envir)) {
+        assign(.nm, symengine::Symbol(.nm), envir = envir)
+      }
+      paste0(.nm, "*(", .rxToSE(x[[i]], envir = envir, progress = progress), ")")
     } else {
       ""
     }
@@ -2976,10 +2970,6 @@ rxFromSE <- function(x, unknownDerivatives = c("forward", "central", "error"),
     } else {
       if (length(x[[1]]) == 1) {
         .x1 <- as.character(x[[1]])
-        if (.x1 == "rxEq" && length(x) == 3L) {
-          .ms <- .rxFromSEMixSel(x)
-          if (!is.null(.ms)) return(.ms)
-        }
         .xc <- .SEsingle[[.x1]]
         if (!is.null(.xc)) {
           if (length(x) == 2) {

--- a/R/symengine.R
+++ b/R/symengine.R
@@ -1809,7 +1809,8 @@ rxToSE <- function(x, envir = NULL, progress = FALSE,
       .nm <- .rxMixSelName(i/2, length(x) %/% 2)
       # the selector is generated here rather than read out of the model text,
       # so it has to be introduced to the symengine environment by hand
-      if (isEnv && is.environment(envir) && !exists(.nm, envir = envir)) {
+      if (isEnv && is.environment(envir) &&
+            !exists(.nm, envir = envir, inherits = FALSE)) {
         assign(.nm, symengine::Symbol(.nm), envir = envir)
       }
       paste0(.nm, "*(", .rxToSE(x[[i]], envir = envir, progress = progress), ")")

--- a/R/symengine.R
+++ b/R/symengine.R
@@ -1790,6 +1790,28 @@ rxToSE <- function(x, envir = NULL, progress = FALSE,
 }
 
 
+# The reserved name of the k-th component selector of an expanded mix().  A
+# bare `mixest == k` loses the component count once the mix() call is gone;
+# this name keeps it, so the parser still reports the model as a mixture and
+# rxode2 will take a per-individual mixest from the data or iCov.
+.rxMixSelName <- function(k) paste0("rx_mixsel_", as.integer(k), "_")
+
+# rxEq(mixest, k) -- what .rxToSEMix() feeds symengine for component k -- comes
+# back out as the selector name rather than as `(mixest == k)`
+.rxFromSEMixSel <- function(x) {
+  .a <- x[[2]]
+  .b <- x[[3]]
+  if (identical(.b, quote(mixest))) {
+    .tmp <- .a
+    .a <- .b
+    .b <- .tmp
+  }
+  if (!identical(.a, quote(mixest))) return(NULL)
+  if (!is.numeric(.b) || length(.b) != 1L) return(NULL)
+  if (is.na(.b) || .b < 1 || .b != round(.b)) return(NULL)
+  .rxMixSelName(.b)
+}
+
 # Convert the mix() expression to a if clause with mixest for symengine
 .rxToSEMix <- function(x, envir = NULL, progress = FALSE, isEnv=TRUE) {
   .expr <- vapply(seq_along(x), function(i) {
@@ -2954,6 +2976,10 @@ rxFromSE <- function(x, unknownDerivatives = c("forward", "central", "error"),
     } else {
       if (length(x[[1]]) == 1) {
         .x1 <- as.character(x[[1]])
+        if (.x1 == "rxEq" && length(x) == 3L) {
+          .ms <- .rxFromSEMixSel(x)
+          if (!is.null(.ms)) return(.ms)
+        }
         .xc <- .SEsingle[[.x1]]
         if (!is.null(.xc)) {
           if (length(x) == 2) {

--- a/src/genModelVars.h
+++ b/src/genModelVars.h
@@ -35,7 +35,10 @@ static inline SEXP calcSLinCmt(void) {
   INTEGER(sLinCmt)[10]= tb.thread;
   INTEGER(sLinCmt)[11]= tb.nLlik;
   INTEGER(sLinCmt)[12] = tb.ndiff;
-  INTEGER(sLinCmt)[13] = tb.hasMix;
+  // An expanded mix() has no mix() call left; its rx_mixsel_<k>_ selectors
+  // carry the component count so the model still reads as a mixture (mixest
+  // supplied per individual, mixnum reporting the count).
+  INTEGER(sLinCmt)[13] = tb.hasMix ? tb.hasMix : tb.mixSel;
   INTEGER(sLinCmt)[14] = tb.evid_;
   INTEGER(sLinCmt)[15] = tb.hasDelay;
   INTEGER(sLinCmt)[16] = tb.linCmtBraw;

--- a/src/parseFuns.h
+++ b/src/parseFuns.h
@@ -333,6 +333,12 @@ static inline int handleFunctionSum(transFunctions *tf) {
         /* Free(v2); */
         trans_syntax_error_report_fn(_gbuf.s);
       }
+      if (tb.mixSel != 0 && tb.mixSel != (ii + 1)/2) {
+        sPrint(&_gbuf,
+               _("'mix' cannot change the number of arguments (%d) in a model (ie mixnum from %d to %d)"),
+               ii, tb.mixSel, (ii + 1)/2);
+        trans_syntax_error_report_fn(_gbuf.s);
+      }
       if (tb.hasMix == 0) {
         tb.hasMix = (ii + 1)/2; // number of mixtures
       } else if (tb.hasMix != (ii + 1)/2) {

--- a/src/parseVars.h
+++ b/src/parseVars.h
@@ -61,7 +61,7 @@ static inline int isReservedVariable(const char *s) {
     !rxstrcmpi("mixnum", s) ||
     !rxstrcmpi("mixest", s) ||
     !rxstrcmpi("mixunif", s) ||
-    mixSelNum(s) != 0 ||
+    mixSelNum(s, NULL) != 0 ||
     !strcmp("rx__PTR__", s) ||
     !strcmp("tlast", s) ||
     // Ignore M_ constants

--- a/src/parseVars.h
+++ b/src/parseVars.h
@@ -61,6 +61,7 @@ static inline int isReservedVariable(const char *s) {
     !rxstrcmpi("mixnum", s) ||
     !rxstrcmpi("mixest", s) ||
     !rxstrcmpi("mixunif", s) ||
+    mixSelNum(s) != 0 ||
     !strcmp("rx__PTR__", s) ||
     !strcmp("tlast", s) ||
     // Ignore M_ constants

--- a/src/print_node.c
+++ b/src/print_node.c
@@ -19,7 +19,8 @@ void wprint_node(int depth, char *name, char *value, void *client_data) {
     nodeInf(value) ||
     nodeMixnum(value) ||
     nodeMixest(value) ||
-    nodeMixunif(value);
+    nodeMixunif(value) ||
+    nodeMixSel(value);
   if (!tmp && nodeHas(identifier)) {
     tmp = nodeFunGamma(value) ||
       nodeFunLfactorial(value) ||

--- a/src/print_node.h
+++ b/src/print_node.h
@@ -46,7 +46,11 @@ static inline int nodeMixSel(char *value) {
   int n = 0;
   int k = mixSelNum(value, &n);
   if (k == 0) return 0;
-  if (tb.mixSel != 0 && tb.mixSel != n) {
+  // both the selector form and a literal mix() must agree on the count; the
+  // combined value genModelVars() reports takes mix() first, so a silent
+  // disagreement would report the wrong number of components
+  if ((tb.mixSel != 0 && tb.mixSel != n) ||
+      (tb.hasMix != 0 && tb.hasMix != n)) {
     updateSyntaxCol();
     trans_syntax_error_report_fn((char*)_("a mixture model cannot change its number of components"));
     return 1;

--- a/src/print_node.h
+++ b/src/print_node.h
@@ -39,6 +39,19 @@ static inline int nodeMixest(char *value) {
   return 0;
 }
 
+// rx_mixsel_<k>_ is the per-component selector an expanded mix() leaves
+// behind; it reads as (mixest == k) and, unlike a bare mixest == k, keeps the
+// component count visible to the parser (tb.mixSel).
+static inline int nodeMixSel(char *value) {
+  int k = mixSelNum(value);
+  if (k == 0) return 0;
+  if (k > tb.mixSel) tb.mixSel = k;
+  sAppend(&sb,   "(_solveData->subjects[_cSub].mixest == %d)", k);
+  sAppend(&sbDt, "(_solveData->subjects[_cSub].mixest == %d)", k);
+  sAppend(&sbt,  "rx_mixsel_%d_", k);
+  return 1;
+}
+
 static inline int nodeMixunif(char *value) {
   if (!rxstrcmpi("mixunif",value)){
     aAppendN("_solveData->subjects[_cSub].mixunif", 35);

--- a/src/print_node.h
+++ b/src/print_node.h
@@ -39,16 +39,22 @@ static inline int nodeMixest(char *value) {
   return 0;
 }
 
-// rx_mixsel_<k>_ is the per-component selector an expanded mix() leaves
+// rx_mixsel_<k>_<n>_ is the per-component selector an expanded mix() leaves
 // behind; it reads as (mixest == k) and, unlike a bare mixest == k, keeps the
 // component count visible to the parser (tb.mixSel).
 static inline int nodeMixSel(char *value) {
-  int k = mixSelNum(value);
+  int n = 0;
+  int k = mixSelNum(value, &n);
   if (k == 0) return 0;
-  if (k > tb.mixSel) tb.mixSel = k;
+  if (tb.mixSel != 0 && tb.mixSel != n) {
+    updateSyntaxCol();
+    trans_syntax_error_report_fn((char*)_("a mixture model cannot change its number of components"));
+    return 1;
+  }
+  tb.mixSel = n;
   sAppend(&sb,   "(_solveData->subjects[_cSub].mixest == %d)", k);
   sAppend(&sbDt, "(_solveData->subjects[_cSub].mixest == %d)", k);
-  sAppend(&sbt,  "rx_mixsel_%d_", k);
+  sAppend(&sbt,  "rx_mixsel_%d_%d_", k, n);
   return 1;
 }
 

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -4230,6 +4230,21 @@ static inline NumericVector getMixUnif(const RObject &ev1)  {
   return mixUnif;
 }
 
+// A mixest supplied per individual (from the data or from iCov) arrives in
+// mixunif carrying the >= 1.0 sentinel.  _mix() decodes that sentinel, but a
+// model whose mix() call was expanded to rx_mixsel_<k>_ selectors never calls
+// _mix() -- it reads ind->mixest directly -- so decode it here as well.
+static inline void rxSetIndMix(rx_solving_options_ind* ind, unsigned int nsub,
+                               const NumericVector& mixUnif) {
+  ind->mixest = 0;
+  if (nsub >= (unsigned int)mixUnif.size()) {
+    ind->mixunif = rxunifmix(ind);
+  } else {
+    ind->mixunif = mixUnif[nsub];
+    if (ind->mixunif >= 1.0) ind->mixest = trunc(ind->mixunif);
+  }
+}
+
 // This loops through the data to put each individual into the
 // approiate data structure.
 // At the same time calculate hmax per individual as well
@@ -4516,14 +4531,10 @@ static inline void rxSolve_datSetupHmax(const RObject &obj, const List &rxContro
           ind->ndoses           = ndoses;
           ind->nevid2           = groupNevid2;
           ind->HMAX             = curHmax;
-          if (rx->mixnum) {
-            ind->mixest = 0;
-            if (nsub >= mixUnif.size()) {
-              ind->mixunif = rxunifmix(ind);
-            } else {
-              ind->mixunif = mixUnif[nsub];
-            }
-          }
+          // A homogeneous group is ONE translated subject, so the per-id
+          // mixest vector is indexed by the group, not by the expanded
+          // subject counter.
+          if (rx->mixnum) rxSetIndMix(ind, (unsigned int)groupIndex, mixUnif);
           nsub++;
         }
         if (groupNevid2 > 0) rx->hasEvid2 = 1;
@@ -4622,14 +4633,7 @@ static inline void rxSolve_datSetupHmax(const RObject &obj, const List &rxContro
             // Finalize last solve.
             ind->n_all_times    = ndoses+nobs;
             ind->n_all_times_orig = ind->n_all_times;
-            if (rx->mixnum) {
-              ind->mixest = 0;
-              if (nsub >= mixUnif.size()) {
-                ind->mixunif = rxunifmix(ind);
-              } else {
-                ind->mixunif = mixUnif[nsub];
-              }
-            }
+            if (rx->mixnum) rxSetIndMix(ind, nsub, mixUnif);
             if (ind->n_all_times > rx->maxAllTimes) rx->maxAllTimes= ind->n_all_times;
             ind->cov_ptr = &(_globals.gcov[curcovi]);
             for (ii = 0; ii < ncov; ii++){
@@ -4729,14 +4733,7 @@ static inline void rxSolve_datSetupHmax(const RObject &obj, const List &rxContro
       // Finalize the prior individual
       ind->n_all_times    = ndoses+nobs;
       ind->n_all_times_orig = ind->n_all_times;
-      if (rx->mixnum) {
-        ind->mixest = 0;
-        if (nsub >= mixUnif.size()) {
-          ind->mixunif = rxunifmix(ind);
-        } else {
-          ind->mixunif = mixUnif[nsub];
-        }
-      }
+      if (rx->mixnum) rxSetIndMix(ind, nsub, mixUnif);
       if (ind->n_all_times > rx->maxAllTimes) rx->maxAllTimes= ind->n_all_times;
       ind->cov_ptr = &(_globals.gcov[curcovi]);
       for (ii = 0; ii < ncov; ii++){

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -4241,7 +4241,7 @@ static inline void rxSetIndMix(rx_solving_options_ind* ind, unsigned int nsub,
     ind->mixunif = rxunifmix(ind);
   } else {
     ind->mixunif = mixUnif[nsub];
-    if (ind->mixunif >= 1.0) ind->mixest = trunc(ind->mixunif);
+    if (ind->mixunif >= 1.0) ind->mixest = (int) trunc(ind->mixunif);
   }
 }
 

--- a/src/seFromSEcalls.h
+++ b/src/seFromSEcalls.h
@@ -298,14 +298,6 @@ static const char *seOps2Call(seCtx *ctx, const char *name,
     if (ctx->failed) return "";
     b = seEmit(ctx, args[1]);
     if (ctx->failed) return "";
-    /* rxEq(mixest, k) is a mixture component selector, which .rxFromSE()
-       renders as the reserved rx_mixsel_<k>_ name so the component count
-       survives to the parser.  Hand it to R rather than keeping a second copy
-       of that rule here. */
-    if (strcmp(name, "rxEq") == 0 &&
-        (strcmp(a, "mixest") == 0 || strcmp(b, "mixest") == 0)) {
-      return seFail(ctx);
-    }
     return seNamedConstant(seCat(ctx, seOps2[i].open, a, seOps2[i].mid, b,
                                  seOps2[i].close, NULL));
   }

--- a/src/seFromSEcalls.h
+++ b/src/seFromSEcalls.h
@@ -298,6 +298,14 @@ static const char *seOps2Call(seCtx *ctx, const char *name,
     if (ctx->failed) return "";
     b = seEmit(ctx, args[1]);
     if (ctx->failed) return "";
+    /* rxEq(mixest, k) is a mixture component selector, which .rxFromSE()
+       renders as the reserved rx_mixsel_<k>_ name so the component count
+       survives to the parser.  Hand it to R rather than keeping a second copy
+       of that rule here. */
+    if (strcmp(name, "rxEq") == 0 &&
+        (strcmp(a, "mixest") == 0 || strcmp(b, "mixest") == 0)) {
+      return seFail(ctx);
+    }
     return seNamedConstant(seCat(ctx, seOps2[i].open, a, seOps2[i].mid, b,
                                  seOps2[i].close, NULL));
   }

--- a/src/tran.c
+++ b/src/tran.c
@@ -492,6 +492,7 @@ void reset(void) {
   tb.simflg     = 0;
   tb.nLlik      = 0;
   tb.hasMix     = 0;
+  tb.mixSel     = 0;
   tb.evid_      = 0;
   tb.isMexp     = 0;
   tb.hasDdt     = 0;

--- a/src/tran.h
+++ b/src/tran.h
@@ -122,6 +122,7 @@ lhs symbols?
   int lvlStr;
   int dummyLhs;
   int hasMix; // Has mixture function
+  int mixSel; // Largest rx_mixsel_<k>_ component seen (an expanded mix())
   int evid_; // pushing evid_() flag
   int *splitBolus; // source then target de indexes (+1)
   int splitBolusN;
@@ -482,6 +483,23 @@ extern sbuf sbt;
 #define aAppendN(str, len) sAppendN(&sb, str, len); sAppendN(&sbDt, str, len);
 #define aProp(prop) curLineProp(&sbPm, prop); curLineProp(&sbPmDt, prop); curLineProp(&sbNrmL, prop);
 #define aType(type) curLineType(&sbPm, type); curLineType(&sbPmDt, type); curLineType(&sbNrmL, type);
+
+// A mix() call that has been through symengine comes back with the call
+// expanded to one selector per component.  The selectors are named
+// rx_mixsel_<k>_ so the component count the expansion dropped survives to the
+// parser; returns k (>= 1), or 0 when the name is an ordinary variable.
+static inline int mixSelNum(const char *s) {
+  if (strncmp(s, "rx_mixsel_", 10)) return 0;
+  const char *p = s + 10;
+  int k = 0;
+  if (*p < '1' || *p > '9') return 0; // no leading zero, no empty index
+  for (; *p >= '0' && *p <= '9'; p++) {
+    k = k*10 + (*p - '0');
+    if (k > 100000) return 0;
+  }
+  if (strcmp(p, "_")) return 0; // must end with the trailing underscore
+  return k;
+}
 
 static inline int toInt(char *v2){
   errno = 0;

--- a/src/tran.h
+++ b/src/tran.h
@@ -122,7 +122,7 @@ lhs symbols?
   int lvlStr;
   int dummyLhs;
   int hasMix; // Has mixture function
-  int mixSel; // Largest rx_mixsel_<k>_ component seen (an expanded mix())
+  int mixSel; // Component count declared by rx_mixsel_<k>_<n>_ selectors
   int evid_; // pushing evid_() flag
   int *splitBolus; // source then target de indexes (+1)
   int splitBolusN;
@@ -484,20 +484,40 @@ extern sbuf sbt;
 #define aProp(prop) curLineProp(&sbPm, prop); curLineProp(&sbPmDt, prop); curLineProp(&sbNrmL, prop);
 #define aType(type) curLineType(&sbPm, type); curLineType(&sbPmDt, type); curLineType(&sbNrmL, type);
 
-// A mix() call that has been through symengine comes back with the call
-// expanded to one selector per component.  The selectors are named
-// rx_mixsel_<k>_ so the component count the expansion dropped survives to the
-// parser; returns k (>= 1), or 0 when the name is an ordinary variable.
-static inline int mixSelNum(const char *s) {
-  if (strncmp(s, "rx_mixsel_", 10)) return 0;
-  const char *p = s + 10;
+// One unsigned index, no leading zero, terminated by '_'.  Advances *sp past
+// the terminator; returns 0 (and leaves *sp alone) when the text is anything
+// else.
+static inline int mixSelIdx(const char **sp) {
+  const char *p = *sp;
   int k = 0;
   if (*p < '1' || *p > '9') return 0; // no leading zero, no empty index
   for (; *p >= '0' && *p <= '9'; p++) {
     k = k*10 + (*p - '0');
-    if (k > 100000) return 0;
+    if (k > 100000) return 0;         // implausible; not a selector
   }
-  if (strcmp(p, "_")) return 0; // must end with the trailing underscore
+  if (*p != '_') return 0;
+  *sp = p + 1;
+  return k;
+}
+
+// A mix() call that has been through symengine comes back with the call
+// expanded to one selector per component, named rx_mixsel_<k>_<n>_ -- "the
+// k-th of n components".  The TOTAL is spelled out rather than inferred from
+// the largest k present, because a component whose expression folds to zero
+// (any sensitivity of a mixture w.r.t. an eta that only one component uses)
+// drops its selector out of the expression entirely.
+//
+// Returns k (>= 1), or 0 when the name is an ordinary variable; when it is a
+// selector and nTot is non-NULL, *nTot is set to n.
+static inline int mixSelNum(const char *s, int *nTot) {
+  if (strncmp(s, "rx_mixsel_", 10)) return 0;
+  const char *p = s + 10;
+  int k = mixSelIdx(&p);
+  if (k == 0) return 0;
+  int n = mixSelIdx(&p);
+  if (n == 0 || *p != '\0') return 0; // rx_mixsel_<k>_<n>_ and nothing more
+  if (k > n) return 0;
+  if (nTot != NULL) *nTot = n;
   return k;
 }
 

--- a/tests/testthat/test-mix.R
+++ b/tests/testthat/test-mix.R
@@ -325,8 +325,13 @@ rxTest({
     # component that folds away must not shrink the mixture
     .mv3 <- rxModelVars("a = b*rx_mixsel_1_3_\n")
     expect_equal(unname(.mv3$flags["mix"]), 3L)
-    # and selectors that disagree about the total are a syntax error
+    # and selectors that disagree about the total are a syntax error, whether
+    # they disagree with each other or with a literal mix() in the same model
     expect_error(rxModelVars("a = rx_mixsel_1_2_ + rx_mixsel_2_3_\n"))
+    expect_error(rxModelVars("a = rx_mixsel_1_3_\nb = mix(c, p1, d)\n"))
+    expect_error(rxModelVars("b = mix(c, p1, d)\na = rx_mixsel_1_3_\n"))
+    # agreeing is fine
+    expect_error(rxModelVars("b = mix(c, p1, d)\na = rx_mixsel_1_2_\n"), NA)
   })
 
   test_that("an expanded mix() takes mixest per individual", {

--- a/tests/testthat/test-mix.R
+++ b/tests/testthat/test-mix.R
@@ -304,6 +304,67 @@ rxTest({
 
   })
 
+  test_that("an expanded mix() still reads as a mixture model", {
+    # symengine drops the mix() call; the rx_mixsel_<k>_ selectors it leaves
+    # behind carry the component count so the model still reports as a mixture
+    .m <- rxode2("Kel = kel1*rx_mixsel_1_ + kel2*rx_mixsel_2_\nd/dt(centr) = -Kel*centr\nme = mixest\nmn = mixnum\n")
+    .mv <- rxModelVars(.m)
+    expect_equal(unname(.mv$flags["mix"]), 2L)
+    # the selectors are reserved, not parameters
+    expect_false(any(c("rx_mixsel_1_", "rx_mixsel_2_") %in% .mv$params))
+    # and they survive the normalized-model round trip
+    expect_equal(unname(rxModelVars(rxNorm(.m))$flags["mix"]), 2L)
+
+    # a name that only looks like a selector stays an ordinary variable
+    .mv2 <- rxModelVars("a = rx_mixsel_ + rx_mixsel_0_ + rx_mixsel_1x_\n")
+    expect_equal(unname(.mv2$flags["mix"]), 0L)
+    expect_true(all(c("rx_mixsel_", "rx_mixsel_0_", "rx_mixsel_1x_") %in% .mv2$params))
+  })
+
+  test_that("an expanded mix() takes mixest per individual", {
+    .m <- rxode2("Kel = kel1*rx_mixsel_1_ + kel2*rx_mixsel_2_\nd/dt(centr) = -Kel*centr\ncp = centr/V\nme = mixest\nmn = mixnum\n")
+    .p <- c(kel1 = 0.5, kel2 = 1.5, V = 2)
+    .ev <- et(amt = 1, cmt = "centr") |> et(c(1, 4)) |> et(id = 1:6)
+    .want <- c(1L, 2L, 1L, 2L, 2L, 1L)
+
+    # supplied through iCov, on a homogeneous event table (every subject has
+    # the same times, so the subjects are solved as one group -- the group has
+    # to be split on mixest and indexed by group)
+    .s <- rxSolve(.m, .ev, params = .p,
+                  iCov = data.frame(id = 1:6, mixest = .want),
+                  returnType = "data.frame")
+    .s <- .s[!duplicated(.s$id), ]
+    .s <- .s[order(.s$id), ]
+    expect_equal(.s$me, as.double(.want))
+    expect_equal(.s$mn, rep(2.0, 6))
+    expect_equal(.s$Kel, ifelse(.want == 1L, 0.5, 1.5))
+
+    # and supplied as an ordinary data column
+    .d <- as.data.frame(.ev)
+    .d$mixest <- .want[.d$id]
+    .s2 <- rxSolve(.m, .d, params = .p, returnType = "data.frame")
+    .s2 <- .s2[!duplicated(.s2$id), ]
+    .s2 <- .s2[order(.s2$id), ]
+    expect_equal(.s2$Kel, ifelse(.want == 1L, 0.5, 1.5))
+  })
+
+  test_that("mix() round trips through symengine as rx_mixsel_<k>_", {
+    # rxFromSE() is NSE, so the symengine text has to reach it as a value
+    .se <- rxToSE("mix(cl1, p1, cl2)")
+    expect_equal(.se, "(rxEq(mixest, 1)*(cl1)+rxEq(mixest, 2)*(cl2))")
+    .r <- rxFromSE(.se)
+    expect_match(.r, "rx_mixsel_1_", fixed = TRUE)
+    expect_match(.r, "rx_mixsel_2_", fixed = TRUE)
+    expect_false(grepl("mixest", .r, fixed = TRUE))
+    # symengine reads the selector back as a plain symbol -- it is constant in
+    # every eta, so a derivative carries it through untouched
+    .s <- rxS("cl = cl1*rx_mixsel_1_ + cl2*rx_mixsel_2_\nrx_pred_ = cl/exp(tv + eta.v)\n")
+    .dSe <- symengine::D(get("rx_pred_", envir = .s), "eta.v")
+    .d <- rxFromSE(.dSe)
+    expect_match(.d, "rx_mixsel_1_", fixed = TRUE)
+    expect_match(.d, "rx_mixsel_2_", fixed = TRUE)
+  })
+
   test_that("test mixture models load with rxS()", {
 
  expect_error(rxS("tka=THETA[1];\ntcl1=THETA[2];\ntcl2=THETA[3];\ntv=THETA[4];\np1=THETA[5];\nadd.sd=THETA[6];\neta.ka=ETA[1];\neta.cl=ETA[2];\neta.v=ETA[3];\nka=exp(tka+eta.ka);\ncl=mix(exp(tcl1+eta.cl),p1,exp(tcl2+eta.cl));\nv=exp(tv+eta.v);\nme=mixest;\nmn=mixnum;\nmu=mixunif;\nrx_yj_~2;\nrx_lambda_~1;\nrx_low_~0;\nrx_hi_~1;\nrx_pred_f_~linCmtA(rx__PTR__,t,2,1,1,-1,1,cl,v,0.0,0.0,0.0,0.0,ka);\nrx_pred_~rx_pred_f_;\nrx_r_~(add.sd)^2;\n"),

--- a/tests/testthat/test-mix.R
+++ b/tests/testthat/test-mix.R
@@ -144,10 +144,10 @@ rxTest({
 
   test_that("test dsl to change mix()", {
     expect_equal(rxToSE("mix(a1, p1, b)"),
-                 "(rxEq(mixest, 1)*(a1)+rxEq(mixest, 2)*(b))")
+                 "(rx_mixsel_1_2_*(a1)+rx_mixsel_2_2_*(b))")
 
     expect_equal(rxToSE("mix(a1, p1, b, p2, c)"),
-                 "(rxEq(mixest, 1)*(a1)+rxEq(mixest, 2)*(b)+rxEq(mixest, 3)*(c))")
+                 "(rx_mixsel_1_3_*(a1)+rx_mixsel_2_3_*(b)+rx_mixsel_3_3_*(c))")
   })
 
   test_that("mix() simulation", {
@@ -305,24 +305,32 @@ rxTest({
   })
 
   test_that("an expanded mix() still reads as a mixture model", {
-    # symengine drops the mix() call; the rx_mixsel_<k>_ selectors it leaves
+    # symengine drops the mix() call; the rx_mixsel_<k>_<n>_ selectors it leaves
     # behind carry the component count so the model still reports as a mixture
-    .m <- rxode2("Kel = kel1*rx_mixsel_1_ + kel2*rx_mixsel_2_\nd/dt(centr) = -Kel*centr\nme = mixest\nmn = mixnum\n")
+    .m <- rxode2("Kel = kel1*rx_mixsel_1_2_ + kel2*rx_mixsel_2_2_\nd/dt(centr) = -Kel*centr\nme = mixest\nmn = mixnum\n")
     .mv <- rxModelVars(.m)
     expect_equal(unname(.mv$flags["mix"]), 2L)
     # the selectors are reserved, not parameters
-    expect_false(any(c("rx_mixsel_1_", "rx_mixsel_2_") %in% .mv$params))
+    expect_false(any(c("rx_mixsel_1_2_", "rx_mixsel_2_2_") %in% .mv$params))
     # and they survive the normalized-model round trip
     expect_equal(unname(rxModelVars(rxNorm(.m))$flags["mix"]), 2L)
 
     # a name that only looks like a selector stays an ordinary variable
-    .mv2 <- rxModelVars("a = rx_mixsel_ + rx_mixsel_0_ + rx_mixsel_1x_\n")
+    .mv2 <- rxModelVars("a = rx_mixsel_ + rx_mixsel_0_2_ + rx_mixsel_1_ + rx_mixsel_1_2 + rx_mixsel_3_2_\n")
     expect_equal(unname(.mv2$flags["mix"]), 0L)
-    expect_true(all(c("rx_mixsel_", "rx_mixsel_0_", "rx_mixsel_1x_") %in% .mv2$params))
+    expect_true(all(c("rx_mixsel_", "rx_mixsel_0_2_", "rx_mixsel_1_",
+                      "rx_mixsel_1_2", "rx_mixsel_3_2_") %in% .mv2$params))
+
+    # the count is spelled out, not inferred from the largest k present: a
+    # component that folds away must not shrink the mixture
+    .mv3 <- rxModelVars("a = b*rx_mixsel_1_3_\n")
+    expect_equal(unname(.mv3$flags["mix"]), 3L)
+    # and selectors that disagree about the total are a syntax error
+    expect_error(rxModelVars("a = rx_mixsel_1_2_ + rx_mixsel_2_3_\n"))
   })
 
   test_that("an expanded mix() takes mixest per individual", {
-    .m <- rxode2("Kel = kel1*rx_mixsel_1_ + kel2*rx_mixsel_2_\nd/dt(centr) = -Kel*centr\ncp = centr/V\nme = mixest\nmn = mixnum\n")
+    .m <- rxode2("Kel = kel1*rx_mixsel_1_2_ + kel2*rx_mixsel_2_2_\nd/dt(centr) = -Kel*centr\ncp = centr/V\nme = mixest\nmn = mixnum\n")
     .p <- c(kel1 = 0.5, kel2 = 1.5, V = 2)
     .ev <- et(amt = 1, cmt = "centr") |> et(c(1, 4)) |> et(id = 1:6)
     .want <- c(1L, 2L, 1L, 2L, 2L, 1L)
@@ -348,21 +356,21 @@ rxTest({
     expect_equal(.s2$Kel, ifelse(.want == 1L, 0.5, 1.5))
   })
 
-  test_that("mix() round trips through symengine as rx_mixsel_<k>_", {
+  test_that("mix() round trips through symengine as rx_mixsel_<k>_<n>_", {
     # rxFromSE() is NSE, so the symengine text has to reach it as a value
     .se <- rxToSE("mix(cl1, p1, cl2)")
-    expect_equal(.se, "(rxEq(mixest, 1)*(cl1)+rxEq(mixest, 2)*(cl2))")
+    expect_equal(.se, "(rx_mixsel_1_2_*(cl1)+rx_mixsel_2_2_*(cl2))")
     .r <- rxFromSE(.se)
-    expect_match(.r, "rx_mixsel_1_", fixed = TRUE)
-    expect_match(.r, "rx_mixsel_2_", fixed = TRUE)
+    expect_match(.r, "rx_mixsel_1_2_", fixed = TRUE)
+    expect_match(.r, "rx_mixsel_2_2_", fixed = TRUE)
     expect_false(grepl("mixest", .r, fixed = TRUE))
     # symengine reads the selector back as a plain symbol -- it is constant in
     # every eta, so a derivative carries it through untouched
-    .s <- rxS("cl = cl1*rx_mixsel_1_ + cl2*rx_mixsel_2_\nrx_pred_ = cl/exp(tv + eta.v)\n")
+    .s <- rxS("cl = cl1*rx_mixsel_1_2_ + cl2*rx_mixsel_2_2_\nrx_pred_ = cl/exp(tv + eta.v)\n")
     .dSe <- symengine::D(get("rx_pred_", envir = .s), "eta.v")
     .d <- rxFromSE(.dSe)
-    expect_match(.d, "rx_mixsel_1_", fixed = TRUE)
-    expect_match(.d, "rx_mixsel_2_", fixed = TRUE)
+    expect_match(.d, "rx_mixsel_1_2_", fixed = TRUE)
+    expect_match(.d, "rx_mixsel_2_2_", fixed = TRUE)
   })
 
   test_that("test mixture models load with rxS()", {

--- a/tests/testthat/test-mix.R
+++ b/tests/testthat/test-mix.R
@@ -347,6 +347,18 @@ rxTest({
     expect_equal(.s$mn, rep(2.0, 6))
     expect_equal(.s$Kel, ifelse(.want == 1L, 0.5, 1.5))
 
+    # a missing component is rejected, not silently dropped from the solve
+    expect_error(rxSolve(.m, .ev, params = .p,
+                         iCov = data.frame(id = 1:6, mixest = c(NA_integer_, .want[-1]))),
+                 "mixest")
+    # as are values outside 1..nMix, and non-integers
+    expect_error(rxSolve(.m, .ev, params = .p,
+                         iCov = data.frame(id = 1:6, mixest = c(0L, .want[-1]))),
+                 "mixest")
+    expect_error(rxSolve(.m, .ev, params = .p,
+                         iCov = data.frame(id = 1:6, mixest = c(3L, .want[-1]))),
+                 "mixest")
+
     # and supplied as an ordinary data column
     .d <- as.data.frame(.ev)
     .d$mixest <- .want[.d$id]


### PR DESCRIPTION
## The bug

A `mix()` model that has been through symengine -- which is **every** estimation
method's prediction model -- was no longer recognized as a mixture model at all.

symengine expands the `mix()` call into a sum of per-component selectors, so the
call itself is gone by the time the parser sees the model.  `tb.hasMix` is only
set by a literal `mix()` call, so `RxMvFlag_mix` came back 0, and from there:

- `etTrans()` discarded a `mixest` column supplied in the data or in `iCov`;
- nothing populated `ind->mixest`, because that only happened inside `_mix()`,
  which an expanded model never calls;
- every `mixest == k` selector was therefore false, and each `mix()`-derived
  variable solved as **0**.

In a fit table that is silent: the predictions are wrong, not missing.  Reported
downstream as nlmixr2/nlmixr2est#1041, where a SAEM mixture fit came back with
`mixest`, `mixnum` and the whole `mix()` result zero for every subject, and
`IPRED`/`PRED` computed from an elimination rate of 0.

## The fix

The expansion now emits one reserved `rx_mixsel_<k>_<n>_` selector per
component -- "the k-th of n" -- and the parser turns that back into the
`mixest == k` comparison while recording the component count.

The total is **spelled out** rather than inferred from the largest selector
present, because a component whose expression folds to zero (any sensitivity
with respect to an eta only one component uses) drops its selector out of the
expression entirely.  Selectors that disagree with each other, or with a literal
`mix()` in the same model, about the count are a syntax error.

The selector goes into symengine as an ordinary symbol.  It is constant in every
eta, so it rides through differentiation untouched and comes back out unchanged
-- which means neither `rxFromSE()` nor its C fast path needs a rule for it, and
they cannot disagree.

Three further gaps in the same path are closed:

- `ind->mixest` is decoded from the supplied value at individual setup rather
  than only inside `_mix()`.
- A `mixest`/`mixunif` column in `iCov` now splits a homogeneous solve group.
  Subjects sharing an event table solve as one group, and the group was only
  split on iCov columns that are model parameters; `mixest` is a reserved
  variable, so the whole group took the first subject's component.  Only a
  mixture model splits on it, so a non-mixture model's grouping is unchanged.
- The grouped path indexes the per-id `mixest` vector by group rather than by
  the expanded subject counter, which previously walked off the end of it.

## An unrelated bug found on the way

`.etGroupedSolveSplitKey()` fed `interaction()` the raw columns.  `interaction()`
is `NA` for a row with an `NA` in any column and the `split(drop = TRUE)` it
feeds **discards** that row -- so a subject with a missing value in a column its
group is split on vanished from the solve output entirely, rather than being
rejected.  `NA` now gets a level of its own and the subject reaches the
per-subject validation that should reject it: a missing `mixest` is now the
error it always should have been.

## Behaviour changes

- `rx_mixsel_<k>_<n>_` is a new reserved variable name, alongside `mixest`,
  `mixnum` and `mixunif`.
- `rxToSE()` on a `mix()` call now emits the selector instead of
  `rxEq(mixest, k)`.
- The expansion drops the mixture *probabilities* along with the `mix()` call,
  so an expanded model can be told which component a subject belongs to
  (`mixest`) but cannot sample one from a supplied `mixunif`.  Simulation from
  `mixunif` needs the `mix()` call, which every hand-written model keeps.

## Testing

`test-mix.R` gains coverage for: the expanded form reporting as a mixture and
its selectors not becoming parameters; the normalized-model round trip; names
that only look like selectors staying ordinary variables; a folded component not
shrinking the mixture; disagreeing counts erroring; `mixest` per individual
through both `iCov` (on a homogeneous event table, which is what exercises the
group split and the group indexing) and a plain data column; and `NA`/`0`/`> nMix`
being rejected rather than silently dropped or zeroed.

`test-mix.R`, `test-iCov.R`, `test-et.R` and the symengine translation tests
(including the byte-for-byte `rxFromSE` fixture) pass locally; the full suite is
left to CI.
