### PR TITLE
Do not promote reserved rxode2 variables when piping a model

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,11 @@
   model block".  Reserved names are now retained as-is, and the list comes
   from the parser itself rather than a second copy in R.
 
+- `rxRename()` now refuses to rename a parameter to a reserved rxode2
+  variable.  `rxRename(t = tcl)` produced the same unparseable model, and
+  `rxRename(pi = tcl)` produced a model that parsed but silently ignored the
+  renamed parameter, since `pi` reads as the constant.
+
 ### Event translation
 
 - A steady-state dose into a compartment with a modeled `alag()` pushed

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,16 @@
   the append-only convention the struct already documents, so the stride was
   the whole of the disagreement.
 
+### Model piping
+
+- Model piping no longer promotes a reserved rxode2 variable to a population
+  parameter.  Appending or prepending a line that used `t`, `time`, `tlast`,
+  `newind`, `rxFlag`, one of the `M_` constants or `pi`/`NA`/`NaN`/`Inf`
+  added it to the `ini({})` block, and the resulting model then failed to
+  parse with "the following parameter(s) were in the ini block but not in the
+  model block".  Reserved names are now retained as-is, and the list comes
+  from the parser itself rather than a second copy in R.
+
 ### Event translation
 
 - A steady-state dose into a compartment with a modeled `alag()` pushed

--- a/NEWS.md
+++ b/NEWS.md
@@ -80,7 +80,8 @@
   from the parser itself rather than a second copy in R.
 
 - `rxRename()` now refuses to rename a parameter to a reserved rxode2
-  variable.  `rxRename(t = tcl)` produced the same unparseable model, and
+  variable.  `rxRename(t = tcl)`, `rxRename(lhs = tcl)` and
+  `rxRename(cmt = tcl)` produced the same unparseable model, and
   `rxRename(pi = tcl)` or `rxRename(E = tcl)` produced a model that parsed but
   silently ignored the renamed parameter, since the name reads back as the
   constant.

--- a/NEWS.md
+++ b/NEWS.md
@@ -80,9 +80,12 @@
   from the parser itself rather than a second copy in R.
 
 - `rxRename()` now refuses to rename a parameter to a reserved rxode2
-  variable.  `rxRename(t = tcl)` produced the same unparseable model, and
-  `rxRename(pi = tcl)` produced a model that parsed but silently ignored the
-  renamed parameter, since `pi` reads as the constant.
+  variable or to one of symengine's constants.  `rxRename(t = tcl)` produced
+  the same unparseable model, and `rxRename(pi = tcl)` or
+  `rxRename(E = tcl)` produced a model that parsed but silently ignored the
+  renamed parameter, since the name reads back as the constant -- for the
+  symengine ones (`E`, `e`, `I`, `Catalan`, `GoldenRatio`, `EulerGamma`)
+  only inside the estimation models, where it is hardest to notice.
 
 ### Event translation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -80,12 +80,10 @@
   from the parser itself rather than a second copy in R.
 
 - `rxRename()` now refuses to rename a parameter to a reserved rxode2
-  variable or to one of symengine's constants.  `rxRename(t = tcl)` produced
-  the same unparseable model, and `rxRename(pi = tcl)` or
-  `rxRename(E = tcl)` produced a model that parsed but silently ignored the
-  renamed parameter, since the name reads back as the constant -- for the
-  symengine ones (`E`, `e`, `I`, `Catalan`, `GoldenRatio`, `EulerGamma`)
-  only inside the estimation models, where it is hardest to notice.
+  variable.  `rxRename(t = tcl)` produced the same unparseable model, and
+  `rxRename(pi = tcl)` or `rxRename(E = tcl)` produced a model that parsed but
+  silently ignored the renamed parameter, since the name reads back as the
+  constant.
 
 ### Event translation
 

--- a/R/intern.R
+++ b/R/intern.R
@@ -32,6 +32,22 @@
   .Call(`_rxode2_rxIsReservedName`, as.character(x))
 }
 
+#' Is this a name model piping must never turn into an estimated parameter?
+#'
+#' The parser's reserved names, plus `E`: not reserved by the parser, but
+#' symengine's Euler constant (`.rxSEreserved`), so an `ini({})` entry of that
+#' name reads back as 2.718 in the estimation models and does nothing.  The
+#' rest of `.rxSEreserved` (`e`, `I`, ...) shadows a parameter the same way,
+#' but those names are accepted parameter names today, so they are left alone.
+#'
+#' @param x character vector of names to test
+#' @return logical vector the same length as `x`
+#' @author Matthew L. Fidler
+#' @noRd
+.rxIsReservedPipeName <- function(x) {
+  .rxIsReservedName(x) | x == "E"
+}
+
 .trans <- function(parse_file, prefix, model_md5, parseStr, isEscIn, inME, goodFuns, fullPrintIn) {
   .Call(`_rxode2_trans`,
         parse_file, prefix, model_md5, parseStr, isEscIn, inME, goodFuns, fullPrintIn)

--- a/R/intern.R
+++ b/R/intern.R
@@ -19,6 +19,19 @@
   .Call(`_rxode2_isLinCmt`)
 }
 
+#' Are these names reserved rxode2 variables?
+#'
+#' Wraps the parser's own `isReservedName()` so there is one list of reserved
+#' names; a reserved name is never a model parameter or covariate.
+#'
+#' @param x character vector of names to test
+#' @return logical vector the same length as `x`
+#' @author Matthew L. Fidler
+#' @noRd
+.rxIsReservedName <- function(x) {
+  .Call(`_rxode2_rxIsReservedName`, as.character(x))
+}
+
 .trans <- function(parse_file, prefix, model_md5, parseStr, isEscIn, inME, goodFuns, fullPrintIn) {
   .Call(`_rxode2_trans`,
         parse_file, prefix, model_md5, parseStr, isEscIn, inME, goodFuns, fullPrintIn)

--- a/R/intern.R
+++ b/R/intern.R
@@ -38,7 +38,9 @@
 #' symengine's Euler constant (`.rxSEreserved`), so an `ini({})` entry of that
 #' name reads back as 2.718 in the estimation models and does nothing.  The
 #' rest of `.rxSEreserved` (`e`, `I`, ...) shadows a parameter the same way,
-#' but those names are accepted parameter names today, so they are left alone.
+#' but those names are accepted parameter names today, and a hand-written
+#' `ini({})` is shadowed just the same, so blocking them only here would not
+#' fix it; see issue #1359.
 #'
 #' @param x character vector of names to test
 #' @return logical vector the same length as `x`

--- a/R/piping-model.R
+++ b/R/piping-model.R
@@ -1000,7 +1000,10 @@ rxSetCovariateNamesForPiping <- function(covariates=NULL) {
 #' @noRd
 .addVariableToIniDf <- function(var, rxui, toEta=NA, value=1, promote=FALSE) {
   # reserved rxode2 names (t, time, tlast, newind, the M_ constants, ...) are
-  # never estimated parameters or covariates, so they are retained as-is
+  # never estimated parameters or covariates, so they are retained as-is.  "E"
+  # is not reserved by the parser but is symengine's Euler constant
+  # (`.rxSEreserved`), so an estimated parameter of that name would collide in
+  # the estimation models.
   if (.rxIsReservedName(var) || var == "E") {
     return(invisible())
   }

--- a/R/piping-model.R
+++ b/R/piping-model.R
@@ -999,12 +999,11 @@ rxSetCovariateNamesForPiping <- function(covariates=NULL) {
 #' @author Matthew L. Fidler
 #' @noRd
 .addVariableToIniDf <- function(var, rxui, toEta=NA, value=1, promote=FALSE) {
-  # reserved rxode2 names (t, time, tlast, newind, the M_ constants, ...) are
-  # never estimated parameters or covariates, so they are retained as-is.  "E"
-  # is not reserved by the parser but is symengine's Euler constant
-  # (`.rxSEreserved`), so an estimated parameter of that name would collide in
-  # the estimation models.
-  if (.rxIsReservedName(var) || var == "E") {
+  # A reserved rxode2 name (`t`, `time`, `tlast`, `newind`, the `M_`
+  # constants, ...) can be neither an estimated parameter nor a covariate, so
+  # it is retained as-is.  `E` is not reserved by the parser -- it can still be
+  # a covariate -- but is kept out of the ini block, see .rxIsReservedPipeName.
+  if (.rxIsReservedPipeName(var)) {
     return(invisible())
   }
   if (!is.null(.varSelect$cov)) {

--- a/R/piping-model.R
+++ b/R/piping-model.R
@@ -999,12 +999,9 @@ rxSetCovariateNamesForPiping <- function(covariates=NULL) {
 #' @author Matthew L. Fidler
 #' @noRd
 .addVariableToIniDf <- function(var, rxui, toEta=NA, value=1, promote=FALSE) {
-  if (var %in% c("pi", "M_E", "M_E", "E", "M_PI", "M_PI_2",
-                 "M_PI_4", "M_1_PI", "M_2_PI", "M_2PI", "M_SQRT_PI",
-                 "M_2_SQRTPI", "M_1_SQRT_2PI", "M_SQRT2", "M_SQRT_3",
-                 "M_SQRT_32", "M_SQRT_2dPI", "M_LN_SQRT_PI",
-                 "M_LN_SQRT_2PI", "M_LN_SQRT_PId2", "M_LOG10_2",
-                 "M_LOG2E", "M_LOG10E", "M_LN2", "M_LN10")) {
+  # reserved rxode2 names (t, time, tlast, newind, the M_ constants, ...) are
+  # never estimated parameters or covariates, so they are retained as-is
+  if (.rxIsReservedName(var) || var == "E") {
     return(invisible())
   }
   if (!is.null(.varSelect$cov)) {

--- a/R/ui-rename.R
+++ b/R/ui-rename.R
@@ -30,10 +30,10 @@
   } else {
     .var.name2 <- as.character(line[[3]])
   }
-  # A reserved name -- the parser's (`t`, `time`, `M_PI`, ...) or one of
-  # symengine's constants (`E`, `e`, `I`, ...) -- reads back as that constant,
-  # so the renamed parameter would sit in the ini block doing nothing.
-  if (.rxIsReservedName(.var.name) || .var.name %in% names(.rxSEreserved)) {
+  # A reserved name (`t`, `time`, `M_PI`, `E`, ...) reads back as that
+  # constant, so the renamed parameter would sit in the ini block doing
+  # nothing.
+  if (.rxIsReservedPipeName(.var.name)) {
     stop("'", .var.name, "' is a reserved rxode2 variable; cannot rename '",
          .var.name2, "' to '", .var.name, "'",
          call.=FALSE)

--- a/R/ui-rename.R
+++ b/R/ui-rename.R
@@ -30,6 +30,11 @@
   } else {
     .var.name2 <- as.character(line[[3]])
   }
+  if (.rxIsReservedName(.var.name)) {
+    stop("'", .var.name, "' is a reserved rxode2 variable; cannot rename '",
+         .var.name2, "' to '", .var.name, "'",
+         call.=FALSE)
+  }
   if (.var.name %in% vars) {
     stop("the new variable '", .var.name,
          "' is already present in the model; cannot replace '",

--- a/R/ui-rename.R
+++ b/R/ui-rename.R
@@ -30,7 +30,10 @@
   } else {
     .var.name2 <- as.character(line[[3]])
   }
-  if (.rxIsReservedName(.var.name)) {
+  # A reserved name -- the parser's (`t`, `time`, `M_PI`, ...) or one of
+  # symengine's constants (`E`, `e`, `I`, ...) -- reads back as that constant,
+  # so the renamed parameter would sit in the ini block doing nothing.
+  if (.rxIsReservedName(.var.name) || .var.name %in% names(.rxSEreserved)) {
     stop("'", .var.name, "' is a reserved rxode2 variable; cannot rename '",
          .var.name2, "' to '", .var.name, "'",
          call.=FALSE)

--- a/src/init.c
+++ b/src/init.c
@@ -370,6 +370,7 @@ void nullGlobals(void);
 SEXP _rxode2_codeLoaded(void);
 SEXP _rxode2_parseModel(SEXP type);
 SEXP _rxode2_isLinCmt(void);
+SEXP _rxode2_rxIsReservedName(SEXP inSEXP);
 SEXP _rxode2_trans(SEXP parse_file, SEXP prefix, SEXP model_md5, SEXP parseStr,
                    SEXP isEscIn, SEXP inME, SEXP goodFuns, SEXP fullPrintIn);
 SEXP _rxode2_rxSetSeed(SEXP);
@@ -968,6 +969,7 @@ void R_init_rxode2(DllInfo *info){
     {"_rxode2_rxToSEChar", (DL_FUNC) &_rxode2_rxToSEChar, 1},
     {"_rxode2_rxCse", (DL_FUNC) &_rxode2_rxCse, 1},
     {"_rxode2_isLinCmt", (DL_FUNC) &_rxode2_isLinCmt, 0},
+    {"_rxode2_rxIsReservedName", (DL_FUNC) &_rxode2_rxIsReservedName, 1},
     {"rxode2_get_mv", (DL_FUNC) &rxode2_get_mv, 0},
     {"_rxode2_rxGetSeed", (DL_FUNC) &_rxode2_rxGetSeed, 0},
     {"_rxode2_setGlobalSeed", (DL_FUNC) &_rxode2_setGlobalSeed, 1},

--- a/src/parseVars.h
+++ b/src/parseVars.h
@@ -96,15 +96,20 @@ static inline int isReservedVariable(const char *s) {
 }
 
 
-// Names that can never be a user variable: the reserved variables above plus
-// the constants skipped by skipReservedVariables().  Exposed to R through
+// Names that can never be a user variable: the reserved variables above, the
+// constants skipped by skipReservedVariables(), and the names new_or_ith()
+// drops or rewrites before it reaches either.  Exposed to R through
 // `.rxIsReservedName()` so model piping does not promote them.
 static inline int isReservedName(const char *s) {
   return isReservedVariable(s) ||
     !strcmp("pi", s) ||
     !strcmp("NA", s) ||
     !strcmp("NaN", s) ||
-    !strcmp("Inf", s);
+    !strcmp("Inf", s) ||
+    !strcmp("lhs", s) ||
+    !strcmp("rxlin___", s) ||
+    // any spelling of CMT but the exact one is rewritten to CMT
+    (strcmp("CMT", s) && !rxstrcmpi("CMT", s));
 }
 
 static inline int isKa(const char *s) {

--- a/src/parseVars.h
+++ b/src/parseVars.h
@@ -95,6 +95,17 @@ static inline int isReservedVariable(const char *s) {
 }
 
 
+// Names that can never be a user variable: the reserved variables above plus
+// the constants skipped by skipReservedVariables().  Exposed to R through
+// `.rxIsReservedName()` so model piping does not promote them.
+static inline int isReservedName(const char *s) {
+  return isReservedVariable(s) ||
+    !strcmp("pi", s) ||
+    !strcmp("NA", s) ||
+    !strcmp("NaN", s) ||
+    !strcmp("Inf", s);
+}
+
 static inline int isKa(const char *s) {
   if (tb.hasKa) return 1;
   if (!strcmp("ka", s) || !strcmp("Ka", s) || !strcmp("KA", s) || !strcmp("kA", s)) {

--- a/src/tran.c
+++ b/src/tran.c
@@ -845,6 +845,26 @@ SEXP _rxode2_isLinCmt(void) {
   return ret;
 }
 
+// Vectorized R interface to isReservedName(); see .rxIsReservedName()
+SEXP _rxode2_rxIsReservedName(SEXP inSEXP) {
+  rxProtectGuard;
+  if (TYPEOF(inSEXP) != STRSXP) {
+    (Rf_error)(_("'x' must be a character vector"));
+  }
+  int n = Rf_length(inSEXP);
+  SEXP ret = rxP(Rf_allocVector(LGLSXP, n));
+  for (int i = 0; i < n; ++i) {
+    SEXP cur = STRING_ELT(inSEXP, i);
+    if (cur == NA_STRING) {
+      LOGICAL(ret)[i] = NA_LOGICAL;
+    } else {
+      LOGICAL(ret)[i] = isReservedName(CHAR(cur)) ? 1 : 0;
+    }
+  }
+  rxUP(1);
+  return ret;
+}
+
 #include "parseSyntaxErrors.h"
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/testthat/test-piping-reserved-vars.R
+++ b/tests/testthat/test-piping-reserved-vars.R
@@ -84,11 +84,28 @@ rxTest({
 
   test_that("rxRename refuses to rename a parameter to a reserved variable", {
     expect_error(rxRename(.base(), t = tcl), "reserved rxode2 variable")
-    # a silent one: `pi` would parse as the constant, leaving the renamed
-    # parameter in the ini block doing nothing
+    # silent ones: `pi` parses as the constant, and each symengine constant
+    # reads back as its value in the estimation models, so in both cases the
+    # renamed parameter would sit in the ini block doing nothing
     expect_error(rxRename(.base(), pi = tcl), "reserved rxode2 variable")
+    for (nm in names(.rxSEreserved)) {
+      .call <- as.call(c(list(quote(rxRename), quote(.ui)),
+                         stats::setNames(list(quote(tcl)), nm)))
+      .ui <- .base()
+      expect_error(eval(.call), "reserved rxode2 variable", info = nm)
+    }
     # renaming to an ordinary name still works
     expect_true("tcl2" %in% rxRename(.base(), tcl2 = tcl)$iniDf$name)
+  })
+
+  test_that("E is kept out of the ini block but is still an ordinary covariate", {
+    # E is not reserved by the parser, so a model may legitimately read it from
+    # the data; it is only kept from becoming an ESTIMATED parameter, since
+    # symengine reads it back as Euler's number in the estimation models
+    ui <- .base()
+    ui <- do.call(model, list(ui, quote(cp2 <- cp * E), append = quote(cp)))
+    expect_false("E" %in% ui$iniDf$name)
+    expect_true("E" %in% ui$allCovs)
   })
 
   test_that("non-reserved variables are still promoted when appending", {

--- a/tests/testthat/test-piping-reserved-vars.R
+++ b/tests/testthat/test-piping-reserved-vars.R
@@ -64,6 +64,33 @@ rxTest({
     expect_equal(s$cp2, s$cp * exp(-s$time / 10))
   })
 
+  test_that("reserved variables are not added as covariates with auto=FALSE", {
+    for (v in c("t", "time", "pi", "M_PI", "NA", "Inf")) {
+      ui <- .base()
+      ui <- do.call(model, list(ui, str2lang(paste0("cp2 <- cp * ", v)),
+                                append = quote(cp), auto = FALSE))
+      expect_equal(ui$iniDf$name, c("tka", "tcl", "add.sd"), info = v)
+      expect_false(v %in% ui$allCovs, info = v)
+      expect_false(v %in% ui$mv$params, info = v)
+    }
+  })
+
+  test_that("a reserved variable in an error line is rejected, not promoted", {
+    # `t` cannot be an additive error standard deviation; the endpoint check
+    # has to see that rather than an auto-promoted `t` in the ini block
+    expect_error(do.call(model, list(.base(), quote(cp ~ add(t)))),
+                 "estimated or modeled")
+  })
+
+  test_that("rxRename refuses to rename a parameter to a reserved variable", {
+    expect_error(rxRename(.base(), t = tcl), "reserved rxode2 variable")
+    # a silent one: `pi` would parse as the constant, leaving the renamed
+    # parameter in the ini block doing nothing
+    expect_error(rxRename(.base(), pi = tcl), "reserved rxode2 variable")
+    # renaming to an ordinary name still works
+    expect_true("tcl2" %in% rxRename(.base(), tcl2 = tcl)$iniDf$name)
+  })
+
   test_that("non-reserved variables are still promoted when appending", {
     ui <- .base()
     ui <- do.call(model, list(ui, quote(cp2 <- cp * exp(tf)), append = quote(cp)))

--- a/tests/testthat/test-piping-reserved-vars.R
+++ b/tests/testthat/test-piping-reserved-vars.R
@@ -1,0 +1,76 @@
+rxTest({
+
+  test_that(".rxIsReservedName tracks the parser's reserved names", {
+    expect_true(all(.rxIsReservedName(c("t", "time", "tlast", "newind", "NEWIND",
+                                        "rxFlag", "amt", "mixnum", "mixest",
+                                        "mixunif", "M_PI", "M_E", "M_LN10",
+                                        "pi", "NA", "NaN", "Inf"))))
+    # the reserved variables the parser matches case-insensitively
+    expect_true(all(.rxIsReservedName(c("Time", "TIME", "AMT"))))
+    # ordinary model variables are not reserved
+    expect_false(any(.rxIsReservedName(c("tka", "ka", "cl", "v", "eta.ka",
+                                         "add.sd", "wt", "T"))))
+    expect_equal(.rxIsReservedName(character(0)), logical(0))
+    expect_equal(.rxIsReservedName(NA_character_), NA)
+  })
+
+  # a model with no reserved names in it, used as the piping base below
+  .base <- function() {
+    ini({
+      tka <- log(1.5)
+      tcl <- log(1)
+      add.sd <- 0.7
+    })
+    model({
+      ka <- exp(tka)
+      cl <- exp(tcl)
+      d/dt(depot) <- -ka * depot
+      d/dt(center) <- ka * depot - cl * center
+      cp <- center
+      cp ~ add(add.sd)
+    })
+  }
+
+  test_that("reserved variables are not promoted when appending", {
+    for (v in c("t", "time", "tlast", "newind", "rxFlag", "M_PI", "pi",
+                "NA", "NaN", "Inf")) {
+      ui <- .base()
+      expect_error(
+        ui <- do.call(model, list(ui, str2lang(paste0("cp2 <- cp * ", v)),
+                                  append = quote(cp))),
+        NA, info = v)
+      expect_equal(ui$iniDf$name, c("tka", "tcl", "add.sd"), info = v)
+      expect_false(v %in% ui$allCovs, info = v)
+    }
+  })
+
+  test_that("reserved variables are not promoted when prepending", {
+    ui <- .base()
+    ui <- do.call(model, list(ui, str2lang("f <- t * 2"), append = FALSE))
+    expect_equal(ui$iniDf$name, c("tka", "tcl", "add.sd"))
+    expect_false("t" %in% ui$allCovs)
+  })
+
+  test_that("a piped model using t still solves", {
+    ui <- .base()
+    ui <- do.call(model, list(ui, quote(cp2 <- cp * exp(-t / 10)),
+                              append = quote(cp)))
+    s <- rxSolve(ui, et(amt = 100, ii = 24, addl = 2) |> et(seq(0, 72, by = 12)),
+                 params = c(tka = log(1.5), tcl = log(1), add.sd = 0),
+                 returnType = "data.frame")
+    expect_true(all(is.finite(s$cp2)))
+    expect_equal(s$cp2, s$cp * exp(-s$time / 10))
+  })
+
+  test_that("non-reserved variables are still promoted when appending", {
+    ui <- .base()
+    ui <- do.call(model, list(ui, quote(cp2 <- cp * exp(tf)), append = quote(cp)))
+    expect_true("tf" %in% ui$iniDf$name)
+    # a covariate-looking name still becomes a covariate rather than a parameter
+    ui <- .base()
+    ui <- do.call(model, list(ui, quote(cp2 <- cp * wt), append = quote(cp)))
+    expect_false("wt" %in% ui$iniDf$name)
+    expect_true("wt" %in% ui$allCovs)
+  })
+
+})

--- a/tests/testthat/test-piping-reserved-vars.R
+++ b/tests/testthat/test-piping-reserved-vars.R
@@ -12,9 +12,21 @@ rxTest({
     # ordinary model variables are not reserved
     expect_false(any(.rxIsReservedName(c("tka", "ka", "cl", "v", "eta.ka",
                                          "add.sd", "wt", "T"))))
+    # names new_or_ith() drops or rewrites before the reserved check
+    expect_true(all(.rxIsReservedName(c("lhs", "rxlin___", "cmt", "Cmt"))))
+    # ... but the exact spelling CMT is an ordinary variable
+    expect_false(.rxIsReservedName("CMT"))
     expect_equal(.rxIsReservedName(character(0)), logical(0))
     expect_equal(.rxIsReservedName(NA_character_), NA)
   })
+
+  # every name .addVariableToIniDf must refuse, in one place.  The piping
+  # branches reach it through different gates (the theta/eta regexes only let
+  # some names through at all), so the guard itself is exercised directly here.
+  .reserved <- c("t", "time", "Time", "tlast", "newind", "NEWIND", "rxFlag",
+                 "amt", "AMT", "mixnum", "mixest", "mixunif", "rx_mixsel_1_2_",
+                 "M_PI", "M_E", "M_LN10", "M_SQRT_2dPI", "pi", "NA", "NaN",
+                 "Inf", "lhs", "rxlin___", "cmt", "E")
 
   # a model with no reserved names in it, used as the piping base below
   .base <- function() {
@@ -32,6 +44,39 @@ rxTest({
       cp ~ add(add.sd)
     })
   }
+
+  test_that(".addVariableToIniDf refuses every reserved name", {
+    for (v in .reserved) {
+      ui <- rxUiDecompress(.base())
+      .before <- ui$iniDf
+      # promote=NA is the error-parameter path, which adds unconditionally;
+      # promote=TRUE is the population-parameter path
+      .addVariableToIniDf(v, ui, promote = NA)
+      .addVariableToIniDf(v, ui, promote = TRUE)
+      expect_equal(ui$iniDf, .before, info = v)
+    }
+    # a name that is not reserved does get added, so the loop above is not
+    # passing because .addVariableToIniDf never adds anything
+    .withCov <- function() {
+      ini({
+        tka <- log(1.5)
+        tcl <- log(1)
+        add.sd <- 0.7
+      })
+      model({
+        ka <- exp(tka)
+        cl <- exp(tcl + tf)
+        d/dt(depot) <- -ka * depot
+        d/dt(center) <- ka * depot - cl * center
+        cp <- center
+        cp ~ add(add.sd)
+      })
+    }
+    ui <- rxUiDecompress(.withCov())
+    expect_true("tf" %in% ui$allCovs)
+    .addVariableToIniDf("tf", ui, promote = TRUE)
+    expect_true("tf" %in% ui$iniDf$name)
+  })
 
   test_that("reserved variables are not promoted when appending", {
     for (v in c("t", "time", "tlast", "newind", "rxFlag", "M_PI", "pi",
@@ -84,6 +129,10 @@ rxTest({
 
   test_that("rxRename refuses to rename a parameter to a reserved variable", {
     expect_error(rxRename(.base(), t = tcl), "reserved rxode2 variable")
+    # `lhs` and any spelling of CMT but the exact one are dropped or rewritten
+    # by the parser, so the renamed parameter never reaches the model block
+    expect_error(rxRename(.base(), lhs = tcl), "reserved rxode2 variable")
+    expect_error(rxRename(.base(), cmt = tcl), "reserved rxode2 variable")
     # silent ones: `pi` parses as the constant and `E` reads back as Euler's
     # number in the estimation models, so in both cases the renamed parameter
     # would sit in the ini block doing nothing

--- a/tests/testthat/test-piping-reserved-vars.R
+++ b/tests/testthat/test-piping-reserved-vars.R
@@ -155,6 +155,14 @@ rxTest({
                  "estimated or modeled")
   })
 
+  test_that("ini() piping rejects a reserved variable rather than adding it", {
+    for (nm in c("t", "time", "pi", "lhs", "E")) {
+      .call <- as.call(list(quote(ini), quote(.ui), call("<-", as.name(nm), 1)))
+      .ui <- .base()
+      expect_error(eval(.call), "cannot find parameter", info = nm)
+    }
+  })
+
   test_that("non-reserved variables are still promoted when appending", {
     ui <- .base()
     ui <- do.call(model, list(ui, quote(cp2 <- cp * exp(tf)), append = quote(cp)))

--- a/tests/testthat/test-piping-reserved-vars.R
+++ b/tests/testthat/test-piping-reserved-vars.R
@@ -84,16 +84,11 @@ rxTest({
 
   test_that("rxRename refuses to rename a parameter to a reserved variable", {
     expect_error(rxRename(.base(), t = tcl), "reserved rxode2 variable")
-    # silent ones: `pi` parses as the constant, and each symengine constant
-    # reads back as its value in the estimation models, so in both cases the
-    # renamed parameter would sit in the ini block doing nothing
+    # silent ones: `pi` parses as the constant and `E` reads back as Euler's
+    # number in the estimation models, so in both cases the renamed parameter
+    # would sit in the ini block doing nothing
     expect_error(rxRename(.base(), pi = tcl), "reserved rxode2 variable")
-    for (nm in names(.rxSEreserved)) {
-      .call <- as.call(c(list(quote(rxRename), quote(.ui)),
-                         stats::setNames(list(quote(tcl)), nm)))
-      .ui <- .base()
-      expect_error(eval(.call), "reserved rxode2 variable", info = nm)
-    }
+    expect_error(rxRename(.base(), E = tcl), "reserved rxode2 variable")
     # renaming to an ordinary name still works
     expect_true("tcl2" %in% rxRename(.base(), tcl2 = tcl)$iniDf$name)
   })
@@ -106,6 +101,9 @@ rxTest({
     ui <- do.call(model, list(ui, quote(cp2 <- cp * E), append = quote(cp)))
     expect_false("E" %in% ui$iniDf$name)
     expect_true("E" %in% ui$allCovs)
+    # and it is not silently accepted as a residual parameter either
+    expect_error(do.call(model, list(.base(), quote(cp ~ add(E)))),
+                 "estimated or modeled")
   })
 
   test_that("non-reserved variables are still promoted when appending", {

--- a/tests/testthat/test-piping-reserved-vars.R
+++ b/tests/testthat/test-piping-reserved-vars.R
@@ -7,6 +7,8 @@ rxTest({
                                         "pi", "NA", "NaN", "Inf"))))
     # the reserved variables the parser matches case-insensitively
     expect_true(all(.rxIsReservedName(c("Time", "TIME", "AMT"))))
+    # names the parser reserves through a pattern rather than a literal
+    expect_true(all(.rxIsReservedName(c("rx_mixsel_1_2_", "rx_mixsel_2_2_"))))
     # ordinary model variables are not reserved
     expect_false(any(.rxIsReservedName(c("tka", "ka", "cl", "v", "eta.ka",
                                          "add.sd", "wt", "T"))))


### PR DESCRIPTION
## The bug

Piping a model line that used a reserved rxode2 variable promoted that
variable to a population parameter, and the resulting model then failed to
parse:

```r
ui |> model(cp2 <- cp * exp(-t / 10), append = quote(cp))
#> i promote `t` to population parameter with initial estimate 1
#> Error: syntax/parsing errors:
#> the following parameter(s) were in the ini block but not in the model block: t
```

`t`, `time` and `tlast` failed this way; `newind`, `rxFlag`, the `M_`
constants and `pi`/`NA`/`NaN`/`Inf` were saved only by the theta/eta name
regexes never matching them.

## The cause

Only the append/prepend branch of `.modelHandleModelLines()` is affected: it
extracts candidate variables from the expression itself rather than from the
parser's model variables, so it has no way to know a name is reserved.  The
guard that was supposed to catch this, in `.addVariableToIniDf()`, listed only
the `M_` constants and `pi` -- a hand-written second copy of a list the parser
already owns.

## The fix

`isReservedName()` in `src/parseVars.h` is the parser's own reserved-name
predicate: `isReservedVariable()` (which the merge from main just extended
with the mixture selectors, picked up here for free) plus the constants
`skipReservedVariables()` skips, plus the names `new_or_ith()` drops or
rewrites before either -- `lhs`, `rxlin___`, and every spelling of `CMT` but
the exact one.  It is exposed to R as `.rxIsReservedName()` through a new
`.Call` entry point, and `.rxIsReservedPipeName()` adds `E` to it (not
reserved by the parser, but symengine's Euler constant, so it can never be an
estimated parameter).  `.addVariableToIniDf()` now asks that predicate instead
of carrying its own list.

Also fixed, found in review: `rxRename()` reached the same broken model from
the other direction.  `rxRename(t = tcl)`, `rxRename(lhs = tcl)` and
`rxRename(cmt = tcl)` produced the same unparseable model, and
`rxRename(pi = tcl)` / `rxRename(E = tcl)` produced a model that parsed but
silently ignored the renamed parameter, since the name reads back as the
constant.  The rename assertion now rejects all of them.

## Not fixed here

symengine's other constants (`e`, `I`, `Catalan`, `GoldenRatio`,
`EulerGamma`) shadow a parameter of the same name too -- `rxS()` reads an eta
named `e` back as 2.718.  Blocking them in the piping guard was tried and
reverted: a hand-written `ini({})` block is shadowed identically, so a
piping-only guard closes one of two routes to the same wrong answer while
breaking `tests/testthat/test-piping-ini.R:298`.  Filed as #1359.

The parser's *forbidden* names (`evid`, `ii`, `print`, `printf`, `id`, `if`,
`ifelse`) are deliberately left out: they already raise a specific, correct
parser error ("'evid' cannot be a variable in an rxode2 model") rather than
the silent failure this PR is about.

## Testing

`tests/testthat/test-piping-reserved-vars.R` covers the predicate itself, the
`.addVariableToIniDf()` guard directly (the append branch only reaches it for
names matching the theta/eta regexes, so most reserved names never exercised
it through piping), append/prepend/`auto=FALSE`/error-line/`ini()`/`rxRename`
paths, a solve confirming a piped model using `t` gives `cp * exp(-t/10)`, and
the negative controls -- an ordinary name is still promoted, a covariate-shaped
name is still a covariate, and `E` stays an ordinary covariate while being
kept out of the ini block.

Full suite: 0 failures, 59188 passes.  Reviewed with Antigravity
(gemini-3.1-pro-high) over seven rounds until it converged.
