### PR TITLE
Simulate residual error for every subject from et(id=) (closes #1341)

### DIFF
--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -3892,6 +3892,75 @@ static inline void rxSolve_ev1Update(const RObject &obj,
 
 // This function simulates individual parameter values and residual
 // parameter values and then converts them to a data.frame.  This
+// A homogeneous event table stores ONE representative subject per group and
+// the real ids in `rxHomGroups`, so its raw row counts are one group's worth.
+// Expand every count by the group sizes, the way `rxSolve_datSetupHmax()`
+// does: the residual (`sigma`) draw is sized from these, and an unexpanded
+// count simulates the residual for the first subject only.
+static inline unsigned int rxSolve_countHomGroups(SEXP hgs,
+                                                  const IntegerVector &id,
+                                                  const IntegerVector &evid,
+                                                  rx_solve *rx) {
+  List hgl = as<List>(hgs);
+  int nHg = hgl.size();
+  unsigned int nSub0 = 0;
+  for (int hg = 0; hg < nHg; ++hg) {
+    nSub0 += Rf_length(hgl[hg]);
+  }
+  rx->nall = 0;
+  rx->nobs = 0;
+  rx->nobs2 = 0;
+  int evid9 = 0;
+  for (int j = 0; j < evid.size(); ++j) {
+    int gi = id[j] - 1;
+    int mult = (gi >= 0 && gi < nHg) ? Rf_length(hgl[gi]) : 1;
+    rx->nall += mult;
+    if (isObs(evid[j])) rx->nobs += mult;
+    if (evid[j] == 0) rx->nobs2 += mult;
+    if (evid[j] == 9) evid9 += mult;
+  }
+  rx->nevid9 = evid9;
+  return nSub0;
+}
+
+// Fill in rx->nall/nobs/nobs2/nevid9 from the translated events and return the
+// number of subjects they hold.  `curObs` -- the number of rows drawn for
+// `sigma` -- is derived from these counts.
+static inline unsigned int rxSolve_countEvents(const RObject &ev1, rx_solve *rx) {
+  rx->nall = 0;
+  rx->nobs = 0;
+  rx->nobs2 = 0;
+  rx->nevid9 = 0;
+  if (!(rxIs(ev1, "event.data.frame") || rxIs(ev1, "event.matrix"))) {
+    return 0;
+  }
+  DataFrame dataf = as<DataFrame>(ev1);
+  IntegerVector evid = as<IntegerVector>(dataf[rxcEvid]);
+  rx->nall = evid.size();
+  int evid9 = 0;
+  for (unsigned int j = rx->nall; j--;) {
+    if (isObs(evid[j])) rx->nobs++;
+    if (evid[j] == 0) rx->nobs2++;
+    if (evid[j] == 9) evid9++;
+  }
+  rx->nevid9 = evid9;
+  if (rxcId <= -1) return 1;
+  IntegerVector id = as<IntegerVector>(dataf[rxcId]);
+  unsigned int nSub0 = 0;
+  int lastid = id[id.size()-1]+42;
+  for (unsigned int j = rx->nall; j--;) {
+    if (lastid != id[j]) {
+      lastid = id[j];
+      nSub0++;
+    }
+  }
+  SEXP hgs = Rf_getAttrib(ev1, Rf_install("rxHomGroups"));
+  if (!Rf_isNull(hgs)) {
+    return rxSolve_countHomGroups(hgs, id, evid, rx);
+  }
+  return nSub0;
+}
+
 // allows rxSolve_ to solve as if the user specified these parameters
 // directly
 static inline void rxSolve_simulate(const RObject &obj,
@@ -3985,72 +4054,8 @@ static inline void rxSolve_simulate(const RObject &obj,
         cbindPar1 = true;
       }
     }
-    unsigned int nSub0 = 0;
     int curObs = 0;
-    rx->nall = 0;
-    rx->nobs = 0;
-    rx->nobs2 = 0;
-    if (rxIs(ev1,"event.data.frame")||
-        rxIs(ev1,"event.matrix")){
-      if (rxcId > -1){
-        DataFrame dataf = as<DataFrame>(ev1);
-        IntegerVector id = as<IntegerVector>(dataf[rxcId]);
-        IntegerVector evid  = as<IntegerVector>(dataf[rxcEvid]);
-        int lastid= id[id.size()-1]+42;
-        rx->nall = evid.size();
-        int evid9=0;
-        for (unsigned int j = rx->nall; j--;){
-          if (lastid != id[j]){
-            lastid=id[j];
-            nSub0++;
-          }
-          if (isObs(evid[j])) rx->nobs++;
-          if (evid[j] == 0) rx->nobs2++;
-          if (evid[j] == 9) evid9++;
-        }
-        rx->nevid9 = evid9;
-        // Get true number of subjects if this is a homogenous event table.
-        RObject hgs = Rf_getAttrib(ev1, Rf_install("rxHomGroups"));
-        if (!Rf_isNull(hgs)) {
-          List hgl = as<List>(hgs);
-          int nHg = hgl.size();
-          nSub0 = 0;
-          for (int _hg = 0; _hg < nHg; ++_hg) {
-            nSub0 += Rf_length(hgl[_hg]);
-          }
-          // A homogeneous table stores ONE representative subject per group and
-          // the real ids in `rxHomGroups`, so the raw row counts above are one
-          // group's worth.  Expand them the way the setup pass below does; the
-          // residual (`sigma`) draw is sized from these, and an unexpanded count
-          // simulates the residual for the first subject only.
-          rx->nall = 0;
-          rx->nobs = 0;
-          rx->nobs2 = 0;
-          evid9 = 0;
-          for (int _j = 0; _j < evid.size(); ++_j) {
-            int _gi = id[_j] - 1;
-            int _mult = (_gi >= 0 && _gi < nHg) ? Rf_length(hgl[_gi]) : 1;
-            rx->nall += _mult;
-            if (isObs(evid[_j])) rx->nobs += _mult;
-            if (evid[_j] == 0) rx->nobs2 += _mult;
-            if (evid[_j] == 9) evid9 += _mult;
-          }
-          rx->nevid9 = evid9;
-        }
-      } else {
-        nSub0 =1;
-        DataFrame dataf = as<DataFrame>(ev1);
-        IntegerVector evid  = as<IntegerVector>(dataf[rxcEvid]);
-        rx->nall = evid.size();
-        int evid9=0;
-        for (unsigned int j =rx->nall; j--;){
-          if (isObs(evid[j])) rx->nobs++;
-          if (evid[j] == 0) rx->nobs2++;
-          if (evid[j] == 9) evid9++;
-        }
-        rx->nevid9= evid9;
-      }
-    }
+    unsigned int nSub0 = rxSolve_countEvents(ev1, rx);
     if (simVar && nSub0 == nSub*nStud){
     } else if (nSub > 1 && nSub0 > 1 && nSub != nSub0){
       rxSolveFree();

--- a/src/rxData.cpp
+++ b/src/rxData.cpp
@@ -3890,8 +3890,6 @@ static inline void rxSolve_ev1Update(const RObject &obj,
   _rxModels[".lastEv1"] = ev1;
 }
 
-// This function simulates individual parameter values and residual
-// parameter values and then converts them to a data.frame.  This
 // A homogeneous event table stores ONE representative subject per group and
 // the real ids in `rxHomGroups`, so its raw row counts are one group's worth.
 // Expand every count by the group sizes, the way `rxSolve_datSetupHmax()`
@@ -3961,6 +3959,8 @@ static inline unsigned int rxSolve_countEvents(const RObject &ev1, rx_solve *rx)
   return nSub0;
 }
 
+// This function simulates individual parameter values and residual
+// parameter values and then converts them to a data.frame.  This
 // allows rxSolve_ to solve as if the user specified these parameters
 // directly
 static inline void rxSolve_simulate(const RObject &obj,

--- a/tests/testthat/test-sigma-hom-et-1341.R
+++ b/tests/testthat/test-sigma-hom-et-1341.R
@@ -25,7 +25,7 @@ rxTest({
   }
 
   test_that("sigma is simulated for every subject that comes from et(id=) (#1341)", {
-    .b <- .solve1341(et(amt = 320) %>% et(.t1341) %>% et(id = 1:6),
+    .b <- .solve1341(et(amt = 320) |> et(.t1341) |> et(id = 1:6),
                      addDosing = FALSE)
     expect_equal(nrow(.b$df), 6L * length(.t1341))
     # one draw per observation row, not one subject's worth recycled
@@ -33,7 +33,7 @@ rxTest({
     expect_equal(.b$sigmaRows, nrow(.b$df))
 
     # ... and it matches the nSub= path exactly
-    .a <- .solve1341(et(amt = 320) %>% et(.t1341), nSub = 6, addDosing = FALSE)
+    .a <- .solve1341(et(amt = 320) |> et(.t1341), nSub = 6, addDosing = FALSE)
     expect_equal(.b$df$y - .b$df$cp, .a$df$y - .a$df$cp)
   })
 
@@ -44,10 +44,10 @@ rxTest({
   # one of them draws, which catches an under- and an over-sized draw alike.
   test_that("every addDosing branch draws n times the single-subject count (#1341)", {
     .shapes <- list(
-      plain = et(amt = 320) %>% et(.t1341),
-      evid2 = et(amt = 320) %>% et(.t1341) %>% et(time = 2, evid = 2),
-      addl  = et(time = 0, amt = 320, addl = 2, ii = 12) %>% et(.t1341),
-      ss    = et(time = 0, amt = 320, ii = 12, ss = 1) %>% et(.t1341),
+      plain = et(amt = 320) |> et(.t1341),
+      evid2 = et(amt = 320) |> et(.t1341) |> et(time = 2, evid = 2),
+      addl  = et(time = 0, amt = 320, addl = 2, ii = 12) |> et(.t1341),
+      ss    = et(time = 0, amt = 320, ii = 12, ss = 1) |> et(.t1341),
       # no record at time 0, so etTrans adds an evid=9 ini record per subject;
       # those take no residual draw
       evid9 = et(c(1, 2, 4, 8))
@@ -55,8 +55,8 @@ rxTest({
     for (.nm in names(.shapes)) {
       for (.ad in list(NULL, FALSE, TRUE, NA)) {
         .lbl <- paste0(.nm, "/addDosing=", if (is.null(.ad)) "NULL" else .ad)
-        .one <- .solve1341(.shapes[[.nm]] %>% et(id = 1L), addDosing = .ad)
-        .many <- .solve1341(.shapes[[.nm]] %>% et(id = 1:4), addDosing = .ad)
+        .one <- .solve1341(.shapes[[.nm]] |> et(id = 1L), addDosing = .ad)
+        .many <- .solve1341(.shapes[[.nm]] |> et(id = 1:4), addDosing = .ad)
         expect_equal(.many$sigmaRows, 4L * .one$sigmaRows, label = .lbl)
         expect_equal(nrow(.many$df), 4L * nrow(.one$df), label = .lbl)
         expect_equal(length(unique(.many$df$y - .many$df$cp)), nrow(.many$df),
@@ -66,8 +66,8 @@ rxTest({
   })
 
   test_that("sigma expands per group when the groups differ (#1341)", {
-    .ev <- rbind(et(amt = 320) %>% et(.t1341) %>% et(id = 1:3),
-                 et(amt = 100) %>% et(.t1341) %>% et(id = 4:5))
+    .ev <- rbind(et(amt = 320) |> et(.t1341) |> et(id = 1:3),
+                 et(amt = 100) |> et(.t1341) |> et(id = 4:5))
     .b <- .solve1341(.ev, seed = 4, addDosing = FALSE)
     expect_equal(length(unique(.b$df$y - .b$df$cp)), nrow(.b$df))
     expect_equal(.b$sigmaRows, nrow(.b$df))

--- a/tests/testthat/test-sigma-hom-et-1341.R
+++ b/tests/testthat/test-sigma-hom-et-1341.R
@@ -73,6 +73,29 @@ rxTest({
     expect_equal(.b$sigmaRows, nrow(.b$df))
   })
 
+  test_that("omega is drawn per subject from et(id=) as well (#1341)", {
+    # omega was never part of the bug; pin that, so a later change to the
+    # expanded counts cannot quietly take the between-subject draws with it
+    .mo <- rxode2({
+      cli <- cl * exp(eta.cl)
+      d/dt(depot)  <- -ka * depot
+      d/dt(center) <-  ka * depot - cli / v * center
+      cp <- center / v
+      y  <- cp + err
+    })
+    .b <- withr::with_seed(8, {
+      suppressWarnings(rxSolve(.mo, et(amt = 320) |> et(.t1341) |> et(id = 1:6),
+                               .p1341, sigma = .s1341,
+                               omega = lotri(eta.cl ~ 0.3), addDosing = FALSE))
+    })
+    .df <- as.data.frame(.b)
+    # one cli per subject, six distinct subjects
+    expect_equal(length(unique(.df$cli)), 6L)
+    # ... and the residual is still one draw per row
+    expect_equal(length(unique(.df$y - .df$cp)), nrow(.df))
+    expect_equal(nrow(attr(class(.b), ".rxode2.env")$.sigma), nrow(.df))
+  })
+
   test_that("a non-homogeneous multi-subject data set still draws one sigma per row (#1341)", {
     .ev <- rbind(data.frame(id = 1, time = c(0, 1, 2, 3), amt = c(320, NA, NA, NA),
                             evid = c(1, 0, 0, 0)),

--- a/tests/testthat/test-sigma-hom-et-1341.R
+++ b/tests/testthat/test-sigma-hom-et-1341.R
@@ -73,6 +73,14 @@ rxTest({
     expect_equal(.b$sigmaRows, nrow(.b$df))
   })
 
+  test_that("the expansion holds across studies as well (#1341)", {
+    .b <- .solve1341(et(amt = 320) |> et(.t1341) |> et(id = 1:4),
+                     seed = 9, nStud = 3, addDosing = FALSE)
+    expect_equal(nrow(.b$df), 3L * 4L * length(.t1341))
+    expect_equal(.b$sigmaRows, nrow(.b$df))
+    expect_equal(length(unique(.b$df$y - .b$df$cp)), nrow(.b$df))
+  })
+
   test_that("omega is drawn per subject from et(id=) as well (#1341)", {
     # omega was never part of the bug; pin that, so a later change to the
     # expanded counts cannot quietly take the between-subject draws with it


### PR DESCRIPTION
Closes #1341.

## The bug

When the subjects come from the event table's `id` column (`et(id = 1:n)`)
rather than from `nSub=`, residual error was simulated for **one subject
only**: exactly `nobs-per-subject` values were drawn, subject 1 got them, and
every other observation reused a single value.  Silently wrong rather than an
error -- the simulated residual comes out nearly constant, so the residual SD
is far below the model's and any prediction interval built from it is far too
narrow.  `omega` was never affected.

```r
sd(a$y - a$cp)   # 0.5067032   nSub = 6            -- correct
sd(b$y - b$cp)   # 0.1956454   et(id = 1:6)        -- wrong
```

## Cause

`et(id = 1:n)` with identical subjects produces a *homogeneous* event table:
`etTrans()` keeps only ONE representative translated subject per group and
carries the real ids in the `rxHomGroups` attribute.

The early setup pass in `rxSolve_()` corrected `nSub0` from that attribute but
left `rx->nall` / `nobs` / `nobs2` / `nevid9` at one representative subject's
worth -- and `curObs`, the number of rows drawn for `sigma`, is computed from
those.  `src/rxode2_df.cpp` then reads the drawn matrix with a row index
clamped by `min2(kk + 1, errNrow - 1)`, so subject 1 consumed every draw and
everyone after it reused the last row.

## Fix

Expand those counts by the group sizes in that early pass, exactly the way the
later setup pass (the `finalizeGroup` lambda) already does.  Nothing else reads
those fields between the two passes -- only the `curObs` calculation this is
for -- and the later pass recomputes them from scratch regardless.

After the fix the `et(id = 1:6)` residuals are bit-identical to the `nSub = 6`
path, and the sweep from the issue gives one distinct draw per observation row
for every (observations-per-subject, subject-count) combination.  The
`cp ~ add(add.sd)` UI form matches too.

## Tests

`tests/testthat/test-sigma-hom-et-1341.R`.  The drawn matrix is asserted
directly, not just the simulated values: the solve's clamped index means too
few rows repeat silently and too many are silently ignored, so the values alone
see neither.  The pinned property is the one the fix guarantees -- n identical
subjects draw exactly n times what one of them draws -- checked across all four
`addDosing` branches (which read `nobs2`, `nobs` and `nall` respectively) and
for plain, `evid=2`, `addl`, steady-state and `evid=9`-ini event shapes, plus
groups with differing regimens and a non-homogeneous multi-subject data set.

Verified the tests are real regressions: with the C hunk reverted the file
fails immediately; with it restored all 68 assertions pass.

## Verification

- New file: 68 assertions pass.
- Curated batch of 37 test files touching `sigma=` / `nSub=` / `et(id=)` /
  `rxHomGroups`: clean apart from one `test-par-solve.R:4` failure that is
  pre-existing cross-file leakage of `_rxModels` state -- that solve passes no
  `omega`, `sigma` or `thetaMat`, so it never enters the branch this diff
  touches, and `par-solve` passes standalone (704 assertions).
- Three independent Antigravity (Gemini) review rounds.  Round 1 and 2 found no
  correctness, memory-safety or state-overwrite issues and asked only for wider
  test coverage and for the over-allocation case to be detectable; both are
  addressed in the test commits.  Round 3 returned no findings.