### PR TITLE
fix: stop symengine's constants from shadowing a model variable of the same name (#1359)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -88,7 +88,7 @@
 
 ### Estimation / symengine translation
 
-- A model variable named after one of symengine's constants (`e`, `E`, `I`,
+- A model variable named after one of symengine's constants (`e`, `I`,
   `Catalan`, `GoldenRatio` or `EulerGamma`) is no longer shadowed by that
   constant in the symbolic layer.  `rxS()` bound the constants into the model
   environment, so reading the name back gave the constant rather than the
@@ -98,7 +98,10 @@
   the model-side name straight to symengine, which for the event-sensitivity
   code silently dropped the term instead of erroring.  A `matExp()`/`indLin()`
   model likewise emitted `k_p_q=exp(1)` for a rate constant that was the
-  parameter `e` (#1359).
+  parameter `e`, and `lag(e, 1)` lagged Euler's number (#1359).  `E` is the
+  one exception: it is the symengine spelling of the model language's `M_E`,
+  so the environment's `E` still means Euler's number and a model variable of
+  that name is reached through its internal name instead.
 
 ### Event translation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -99,10 +99,11 @@
   code silently dropped the term instead of erroring.  A `matExp()`/`indLin()`
   model likewise emitted `k_p_q=exp(1)` for a rate constant that was the
   parameter `e`, `lag(e, 1)` lagged Euler's number, and a delay whose duration
-  depended on `e` lost its breaking-point correction terms (#1359).  `E` is the
-  one exception: it is the symengine spelling of the model language's `M_E`,
-  so the environment's `E` still means Euler's number and a model variable of
-  that name is reached through its internal name instead.
+  depended on `e` lost its breaking-point correction terms and then computed
+  its jump amplitude from `M_E` (#1359).  `E` is the one exception: it is the
+  symengine spelling of the model language's `M_E`, so the environment's `E`
+  still means Euler's number and a model variable of that name is reached
+  through its internal name instead.
 
 ### Event translation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -98,7 +98,8 @@
   the model-side name straight to symengine, which for the event-sensitivity
   code silently dropped the term instead of erroring.  A `matExp()`/`indLin()`
   model likewise emitted `k_p_q=exp(1)` for a rate constant that was the
-  parameter `e`, and `lag(e, 1)` lagged Euler's number (#1359).  `E` is the
+  parameter `e`, `lag(e, 1)` lagged Euler's number, and a delay whose duration
+  depended on `e` lost its breaking-point correction terms (#1359).  `E` is the
   one exception: it is the symengine spelling of the model language's `M_E`,
   so the environment's `E` still means Euler's number and a model variable of
   that name is reached through its internal name instead.

--- a/NEWS.md
+++ b/NEWS.md
@@ -86,6 +86,18 @@
   silently ignored the renamed parameter, since the name reads back as the
   constant.
 
+### Estimation / symengine translation
+
+- A model variable named after one of symengine's constants (`e`, `E`, `I`,
+  `Catalan`, `GoldenRatio` or `EulerGamma`) is no longer shadowed by that
+  constant in the symbolic layer.  `rxS()` bound the constants into the model
+  environment, so reading the name back gave the constant rather than the
+  model variable and differentiating by it failed with "Input is not a
+  SYMBOL"; the remaining `symengine::D()` call sites in the Jacobian, adjoint,
+  delay-differential, event-sensitivity and mu-referencing code also passed
+  the model-side name straight to symengine, which for the event-sensitivity
+  code silently dropped the term instead of erroring (#1359).
+
 ### Event translation
 
 - A steady-state dose into a compartment with a modeled `alag()` pushed

--- a/NEWS.md
+++ b/NEWS.md
@@ -96,7 +96,9 @@
   SYMBOL"; the remaining `symengine::D()` call sites in the Jacobian, adjoint,
   delay-differential, event-sensitivity and mu-referencing code also passed
   the model-side name straight to symengine, which for the event-sensitivity
-  code silently dropped the term instead of erroring (#1359).
+  code silently dropped the term instead of erroring.  A `matExp()`/`indLin()`
+  model likewise emitted `k_p_q=exp(1)` for a rate constant that was the
+  parameter `e` (#1359).
 
 ### Event translation
 

--- a/R/adjoint.R
+++ b/R/adjoint.R
@@ -166,14 +166,14 @@ rxSolveAdjoint <- function(object, params, events, calcSens, adjStates = NULL,
       if (is.null(.rSE)) next
       .valStr <- rxode2::rxFromSE(.rSE)
       .dStr <- vapply(calcSens, function(p) {
-        .d <- symengine::D(.rSE, p); rxode2::rxFromSE(.d) }, character(1))
+        .d <- symengine::D(.rSE, .rxSEsym(p)); rxode2::rxFromSE(.d) }, character(1))
       .kind <- "rate"
     } else {
       .dSE <- get0(paste0("rx_dur_", .c, "_"), envir = .model, inherits = FALSE)
       if (is.null(.dSE)) next
       .valStr <- rxode2::rxFromSE(.dSE)
       .dStr <- vapply(calcSens, function(p) {
-        .d <- symengine::D(.dSE, p); rxode2::rxFromSE(.d) }, character(1))
+        .d <- symengine::D(.dSE, .rxSEsym(p)); rxode2::rxFromSE(.d) }, character(1))
       .kind <- "dur"
     }
     .infusSym[[length(.infusSym) + 1L]] <- list(cmt = .c, t1 = .t1, amt = .amt,
@@ -185,12 +185,12 @@ rxSolveAdjoint <- function(object, params, events, calcSens, adjStates = NULL,
   for (.c in unique(.doses$cmt[.doses$cmt %in% .st])) {
     .fSE <- get0(paste0("rx_f_", .c, "_"), envir = .model, inherits = FALSE)
     if (!is.null(.fSE)) .dFexpr[[.c]] <- vapply(calcSens, function(p) {
-      .d <- symengine::D(.fSE, p); rxode2::rxFromSE(.d) }, character(1))
+      .d <- symengine::D(.fSE, .rxSEsym(p)); rxode2::rxFromSE(.d) }, character(1))
     .lSE <- get0(paste0("rx_lag_", .c, "_"), envir = .model, inherits = FALSE)
     if (!is.null(.lSE)) {
       .lagStr[[.c]] <- rxode2::rxFromSE(.lSE)
       .dLagStr[[.c]] <- vapply(calcSens, function(p) {
-        .d <- symengine::D(.lSE, p); rxode2::rxFromSE(.d) }, character(1))
+        .d <- symengine::D(.lSE, .rxSEsym(p)); rxode2::rxFromSE(.d) }, character(1))
     }
   }
   .evR <- .ev[!is.na(.ev$evid) & .ev$evid %in% c(5L, 6L), , drop = FALSE]
@@ -428,9 +428,9 @@ rxSolveAdjoint <- function(object, params, events, calcSens, adjStates = NULL,
   ## directly; with() would ignore enclos and mis-resolve `pred`).
   .ph <- eval(parse(text = pred), envir = .model)
   .predC <- rxode2::rxFromSE(.ph)
-  .dhdy <- lapply(.st, function(i) { .d <- symengine::D(.ph, i); rxode2::rxFromSE(.d) })
+  .dhdy <- lapply(.st, function(i) { .d <- symengine::D(.ph, .rxSEsym(i)); rxode2::rxFromSE(.d) })
   names(.dhdy) <- .st
-  .dhdp <- lapply(calcSens, function(p) { .d <- symengine::D(.ph, p); rxode2::rxFromSE(.d) })
+  .dhdp <- lapply(calcSens, function(p) { .d <- symengine::D(.ph, .rxSEsym(p)); rxode2::rxFromSE(.d) })
   names(.dhdp) <- calcSens
 
   ## event detection (needed before the backward model is built)
@@ -450,14 +450,14 @@ rxSolveAdjoint <- function(object, params, events, calcSens, adjStates = NULL,
       if (is.null(.rSE)) next
       .valStr <- rxode2::rxFromSE(.rSE)
       .dStr <- vapply(calcSens, function(p) {
-        .d <- symengine::D(.rSE, p); rxode2::rxFromSE(.d) }, character(1))
+        .d <- symengine::D(.rSE, .rxSEsym(p)); rxode2::rxFromSE(.d) }, character(1))
       .kind <- "rate"
     } else {
       .dSE <- get0(paste0("rx_dur_", .c, "_"), envir = .model, inherits = FALSE)
       if (is.null(.dSE)) next
       .valStr <- rxode2::rxFromSE(.dSE)
       .dStr <- vapply(calcSens, function(p) {
-        .d <- symengine::D(.dSE, p); rxode2::rxFromSE(.d) }, character(1))
+        .d <- symengine::D(.dSE, .rxSEsym(p)); rxode2::rxFromSE(.d) }, character(1))
       .kind <- "dur"
     }
     .infusSym[[length(.infusSym) + 1L]] <- list(cmt = .c, t1 = .t1, amt = .amt,
@@ -495,12 +495,12 @@ rxSolveAdjoint <- function(object, params, events, calcSens, adjStates = NULL,
   for (.c in unique(.doses$cmt[.doses$cmt %in% .st])) {
     .fSE <- get0(paste0("rx_f_", .c, "_"), envir = .model, inherits = FALSE)
     if (!is.null(.fSE)) .dFexpr[[.c]] <- vapply(calcSens, function(p) {
-      .d <- symengine::D(.fSE, p); rxode2::rxFromSE(.d) }, character(1))
+      .d <- symengine::D(.fSE, .rxSEsym(p)); rxode2::rxFromSE(.d) }, character(1))
     .lSE <- get0(paste0("rx_lag_", .c, "_"), envir = .model, inherits = FALSE)
     if (!is.null(.lSE)) {
       .lagStr[[.c]] <- rxode2::rxFromSE(.lSE)
       .dLagStr[[.c]] <- vapply(calcSens, function(p) {
-        .d <- symengine::D(.lSE, p); rxode2::rxFromSE(.d) }, character(1))
+        .d <- symengine::D(.lSE, .rxSEsym(p)); rxode2::rxFromSE(.d) }, character(1))
     }
   }
   ## replace(evid5)/multiply(evid6) costate jumps (replace -> 0; multiply -> *alpha)

--- a/R/adjoint.R
+++ b/R/adjoint.R
@@ -166,14 +166,14 @@ rxSolveAdjoint <- function(object, params, events, calcSens, adjStates = NULL,
       if (is.null(.rSE)) next
       .valStr <- rxode2::rxFromSE(.rSE)
       .dStr <- vapply(calcSens, function(p) {
-        .d <- symengine::D(.rSE, .rxSEsym(p)); rxode2::rxFromSE(.d) }, character(1))
+        .d <- symengine::D(.rSE, .rxSEres(p)); rxode2::rxFromSE(.d) }, character(1))
       .kind <- "rate"
     } else {
       .dSE <- get0(paste0("rx_dur_", .c, "_"), envir = .model, inherits = FALSE)
       if (is.null(.dSE)) next
       .valStr <- rxode2::rxFromSE(.dSE)
       .dStr <- vapply(calcSens, function(p) {
-        .d <- symengine::D(.dSE, .rxSEsym(p)); rxode2::rxFromSE(.d) }, character(1))
+        .d <- symengine::D(.dSE, .rxSEres(p)); rxode2::rxFromSE(.d) }, character(1))
       .kind <- "dur"
     }
     .infusSym[[length(.infusSym) + 1L]] <- list(cmt = .c, t1 = .t1, amt = .amt,
@@ -185,12 +185,12 @@ rxSolveAdjoint <- function(object, params, events, calcSens, adjStates = NULL,
   for (.c in unique(.doses$cmt[.doses$cmt %in% .st])) {
     .fSE <- get0(paste0("rx_f_", .c, "_"), envir = .model, inherits = FALSE)
     if (!is.null(.fSE)) .dFexpr[[.c]] <- vapply(calcSens, function(p) {
-      .d <- symengine::D(.fSE, .rxSEsym(p)); rxode2::rxFromSE(.d) }, character(1))
+      .d <- symengine::D(.fSE, .rxSEres(p)); rxode2::rxFromSE(.d) }, character(1))
     .lSE <- get0(paste0("rx_lag_", .c, "_"), envir = .model, inherits = FALSE)
     if (!is.null(.lSE)) {
       .lagStr[[.c]] <- rxode2::rxFromSE(.lSE)
       .dLagStr[[.c]] <- vapply(calcSens, function(p) {
-        .d <- symengine::D(.lSE, .rxSEsym(p)); rxode2::rxFromSE(.d) }, character(1))
+        .d <- symengine::D(.lSE, .rxSEres(p)); rxode2::rxFromSE(.d) }, character(1))
     }
   }
   .evR <- .ev[!is.na(.ev$evid) & .ev$evid %in% c(5L, 6L), , drop = FALSE]
@@ -428,9 +428,9 @@ rxSolveAdjoint <- function(object, params, events, calcSens, adjStates = NULL,
   ## directly; with() would ignore enclos and mis-resolve `pred`).
   .ph <- eval(parse(text = pred), envir = .model)
   .predC <- rxode2::rxFromSE(.ph)
-  .dhdy <- lapply(.st, function(i) { .d <- symengine::D(.ph, .rxSEsym(i)); rxode2::rxFromSE(.d) })
+  .dhdy <- lapply(.st, function(i) { .d <- symengine::D(.ph, .rxSEres(i)); rxode2::rxFromSE(.d) })
   names(.dhdy) <- .st
-  .dhdp <- lapply(calcSens, function(p) { .d <- symengine::D(.ph, .rxSEsym(p)); rxode2::rxFromSE(.d) })
+  .dhdp <- lapply(calcSens, function(p) { .d <- symengine::D(.ph, .rxSEres(p)); rxode2::rxFromSE(.d) })
   names(.dhdp) <- calcSens
 
   ## event detection (needed before the backward model is built)
@@ -450,14 +450,14 @@ rxSolveAdjoint <- function(object, params, events, calcSens, adjStates = NULL,
       if (is.null(.rSE)) next
       .valStr <- rxode2::rxFromSE(.rSE)
       .dStr <- vapply(calcSens, function(p) {
-        .d <- symengine::D(.rSE, .rxSEsym(p)); rxode2::rxFromSE(.d) }, character(1))
+        .d <- symengine::D(.rSE, .rxSEres(p)); rxode2::rxFromSE(.d) }, character(1))
       .kind <- "rate"
     } else {
       .dSE <- get0(paste0("rx_dur_", .c, "_"), envir = .model, inherits = FALSE)
       if (is.null(.dSE)) next
       .valStr <- rxode2::rxFromSE(.dSE)
       .dStr <- vapply(calcSens, function(p) {
-        .d <- symengine::D(.dSE, .rxSEsym(p)); rxode2::rxFromSE(.d) }, character(1))
+        .d <- symengine::D(.dSE, .rxSEres(p)); rxode2::rxFromSE(.d) }, character(1))
       .kind <- "dur"
     }
     .infusSym[[length(.infusSym) + 1L]] <- list(cmt = .c, t1 = .t1, amt = .amt,
@@ -495,12 +495,12 @@ rxSolveAdjoint <- function(object, params, events, calcSens, adjStates = NULL,
   for (.c in unique(.doses$cmt[.doses$cmt %in% .st])) {
     .fSE <- get0(paste0("rx_f_", .c, "_"), envir = .model, inherits = FALSE)
     if (!is.null(.fSE)) .dFexpr[[.c]] <- vapply(calcSens, function(p) {
-      .d <- symengine::D(.fSE, .rxSEsym(p)); rxode2::rxFromSE(.d) }, character(1))
+      .d <- symengine::D(.fSE, .rxSEres(p)); rxode2::rxFromSE(.d) }, character(1))
     .lSE <- get0(paste0("rx_lag_", .c, "_"), envir = .model, inherits = FALSE)
     if (!is.null(.lSE)) {
       .lagStr[[.c]] <- rxode2::rxFromSE(.lSE)
       .dLagStr[[.c]] <- vapply(calcSens, function(p) {
-        .d <- symengine::D(.lSE, .rxSEsym(p)); rxode2::rxFromSE(.d) }, character(1))
+        .d <- symengine::D(.lSE, .rxSEres(p)); rxode2::rxFromSE(.d) }, character(1))
     }
   }
   ## replace(evid5)/multiply(evid6) costate jumps (replace -> 0; multiply -> *alpha)

--- a/R/adjointDiscrete.R
+++ b/R/adjointDiscrete.R
@@ -43,7 +43,7 @@
     if (!is.null(.fSE)) {
       .fStr[[.c]] <- rxode2::rxFromSE(.fSE)
       .dFdpStr[[.c]] <- vapply(calcSens, function(p) {
-        .d <- symengine::D(.fSE, p); rxode2::rxFromSE(.d) }, character(1))
+        .d <- symengine::D(.fSE, .rxSEsym(p)); rxode2::rxFromSE(.d) }, character(1))
     }
   }
   ## pre-parse every expression once and evaluate the parsed forms against a
@@ -300,7 +300,7 @@
       .tauRes <- tryCatch(eval(parse(text = .tau), envir = .model), error = function(e) NULL)
       if (!is.null(.tauRes) && inherits(.tauRes, "Basic")) {
         for (.pp in calcSens) {
-          .dD <- tryCatch(symengine::D(.tauRes, symengine::S(.pp)), error = function(e) NULL)
+          .dD <- tryCatch(symengine::D(.tauRes, .rxSEsym(.pp)), error = function(e) NULL)
           if (!is.null(.dD)) .dtauByP[.pp] <- rxode2::rxFromSE(.dD)
         }
       }
@@ -350,7 +350,7 @@
   for (k in seq_len(.ns)) {
     .fSE <- get0(paste0("rx_f_", .st[k], "_"), envir = .model, inherits = FALSE)
     for (p in seq_len(.np)) {
-      .expr <- if (is.null(.fSE)) "0" else { .d <- symengine::D(.fSE, calcSens[p]); rxode2::rxFromSE(.d) }
+      .expr <- if (is.null(.fSE)) "0" else { .d <- symengine::D(.fSE, .rxSEsym(calcSens[p])); rxode2::rxFromSE(.d) }
       .dfLines <- c(.dfLines, sprintf("rx__adjdF_%d_%d__=%s", k - 1L, p - 1L, .expr))
     }
   }
@@ -363,7 +363,7 @@
     for (k in seq_len(.ns)) {
       .lSE <- get0(paste0("rx_lag_", .st[k], "_"), envir = .model, inherits = FALSE)
       for (p in seq_len(.np)) {
-        .expr <- if (is.null(.lSE)) "0" else { .d <- symengine::D(.lSE, calcSens[p]); rxode2::rxFromSE(.d) }
+        .expr <- if (is.null(.lSE)) "0" else { .d <- symengine::D(.lSE, .rxSEsym(calcSens[p])); rxode2::rxFromSE(.d) }
         .dlagLines <- c(.dlagLines, sprintf("rx__adjDlag_%d_%d__=%s", k - 1L, p - 1L, .expr))
       }
     }
@@ -382,9 +382,9 @@
       .dSE <- get0(paste0("rx_dur_", .st[k], "_"), envir = .model, inherits = FALSE)
       for (p in seq_len(.np)) {
         .expr <- if (!is.null(.rSE)) {              # rate(): d(rate)/dtheta
-          .d <- symengine::D(.rSE, calcSens[p]); rxode2::rxFromSE(.d)
+          .d <- symengine::D(.rSE, .rxSEsym(calcSens[p])); rxode2::rxFromSE(.d)
         } else if (!is.null(.dSE)) {                # dur(): d(1/dur)/dtheta = -dur'/dur^2
-          .d <- -symengine::D(.dSE, calcSens[p]) / (.dSE * .dSE); rxode2::rxFromSE(.d)
+          .d <- -symengine::D(.dSE, .rxSEsym(calcSens[p])) / (.dSE * .dSE); rxode2::rxFromSE(.d)
         } else "0"
         .drateLines <- c(.drateLines, sprintf("rx__adjDrate_%d_%d__=%s", k - 1L, p - 1L, .expr))
       }
@@ -398,11 +398,11 @@
     for (i in seq_len(.ns)) for (j in seq_len(.ns)) {
       .dfx <- get0(paste0("rx__df_", .st[i], "_dy_", .st[j], "__"), envir = .model, inherits = FALSE)
       for (p in seq_len(.np)) {
-        .expr <- if (is.null(.dfx)) "0" else { .d <- symengine::D(.dfx, calcSens[p]); rxode2::rxFromSE(.d) }
+        .expr <- if (is.null(.dfx)) "0" else { .d <- symengine::D(.dfx, .rxSEsym(calcSens[p])); rxode2::rxFromSE(.d) }
         .jpLines <- c(.jpLines, sprintf("rx__adjJp_%d_%d_%d__=%s", i - 1L, j - 1L, p - 1L, .expr))
       }
       for (m in seq_len(.ns)) {
-        .expr <- if (is.null(.dfx)) "0" else { .d <- symengine::D(.dfx, .st[m]); rxode2::rxFromSE(.d) }
+        .expr <- if (is.null(.dfx)) "0" else { .d <- symengine::D(.dfx, .rxSEsym(.st[m])); rxode2::rxFromSE(.d) }
         .jyLines <- c(.jyLines, sprintf("rx__adjJy_%d_%d_%d__=%s", i - 1L, j - 1L, m - 1L, .expr))
       }
     }

--- a/R/adjointDiscrete.R
+++ b/R/adjointDiscrete.R
@@ -286,7 +286,7 @@
       # d f_i / d(delay(y_j, tau)): substitute a plain symbol for delay(), then
       # differentiate w.r.t. it.
       .gName <- "rx__gdlyATMP__"
-      .modTxt <- deparse1(.substDelay(.fullExpr, .dc, as.name(.gName)))
+      .modTxt <- deparse1(.rxSEresLang(.substDelay(.fullExpr, .dc, as.name(.gName))))
       .dj <- symengine::D(symengine::S(.modTxt), symengine::S(.gName))
       .djTxt <- gsub(.gName, paste0("delay(", .stateJ, ",", .tau, ")"),
                      rxode2::rxFromSE(.dj), fixed = TRUE)
@@ -297,7 +297,8 @@
       # Param-dependent delay tau(p): d tau / d p per calcSens param (resolved in
       # the symengine env), feeding the breaking-point correction to F_p below.
       .dtauByP <- stats::setNames(rep("0", .np), calcSens)
-      .tauRes <- tryCatch(eval(parse(text = .tau), envir = .model), error = function(e) NULL)
+      .tauRes <- tryCatch(eval(.rxSEresLang(parse(text = .tau)[[1L]]), envir = .model),
+                          error = function(e) NULL)
       if (!is.null(.tauRes) && inherits(.tauRes, "Basic")) {
         for (.pp in calcSens) {
           .dD <- tryCatch(symengine::D(.tauRes, .rxSEres(.pp)), error = function(e) NULL)

--- a/R/adjointDiscrete.R
+++ b/R/adjointDiscrete.R
@@ -43,7 +43,7 @@
     if (!is.null(.fSE)) {
       .fStr[[.c]] <- rxode2::rxFromSE(.fSE)
       .dFdpStr[[.c]] <- vapply(calcSens, function(p) {
-        .d <- symengine::D(.fSE, .rxSEsym(p)); rxode2::rxFromSE(.d) }, character(1))
+        .d <- symengine::D(.fSE, .rxSEres(p)); rxode2::rxFromSE(.d) }, character(1))
     }
   }
   ## pre-parse every expression once and evaluate the parsed forms against a
@@ -300,7 +300,7 @@
       .tauRes <- tryCatch(eval(parse(text = .tau), envir = .model), error = function(e) NULL)
       if (!is.null(.tauRes) && inherits(.tauRes, "Basic")) {
         for (.pp in calcSens) {
-          .dD <- tryCatch(symengine::D(.tauRes, .rxSEsym(.pp)), error = function(e) NULL)
+          .dD <- tryCatch(symengine::D(.tauRes, .rxSEres(.pp)), error = function(e) NULL)
           if (!is.null(.dD)) .dtauByP[.pp] <- rxode2::rxFromSE(.dD)
         }
       }
@@ -350,7 +350,7 @@
   for (k in seq_len(.ns)) {
     .fSE <- get0(paste0("rx_f_", .st[k], "_"), envir = .model, inherits = FALSE)
     for (p in seq_len(.np)) {
-      .expr <- if (is.null(.fSE)) "0" else { .d <- symengine::D(.fSE, .rxSEsym(calcSens[p])); rxode2::rxFromSE(.d) }
+      .expr <- if (is.null(.fSE)) "0" else { .d <- symengine::D(.fSE, .rxSEres(calcSens[p])); rxode2::rxFromSE(.d) }
       .dfLines <- c(.dfLines, sprintf("rx__adjdF_%d_%d__=%s", k - 1L, p - 1L, .expr))
     }
   }
@@ -363,7 +363,7 @@
     for (k in seq_len(.ns)) {
       .lSE <- get0(paste0("rx_lag_", .st[k], "_"), envir = .model, inherits = FALSE)
       for (p in seq_len(.np)) {
-        .expr <- if (is.null(.lSE)) "0" else { .d <- symengine::D(.lSE, .rxSEsym(calcSens[p])); rxode2::rxFromSE(.d) }
+        .expr <- if (is.null(.lSE)) "0" else { .d <- symengine::D(.lSE, .rxSEres(calcSens[p])); rxode2::rxFromSE(.d) }
         .dlagLines <- c(.dlagLines, sprintf("rx__adjDlag_%d_%d__=%s", k - 1L, p - 1L, .expr))
       }
     }
@@ -382,9 +382,9 @@
       .dSE <- get0(paste0("rx_dur_", .st[k], "_"), envir = .model, inherits = FALSE)
       for (p in seq_len(.np)) {
         .expr <- if (!is.null(.rSE)) {              # rate(): d(rate)/dtheta
-          .d <- symengine::D(.rSE, .rxSEsym(calcSens[p])); rxode2::rxFromSE(.d)
+          .d <- symengine::D(.rSE, .rxSEres(calcSens[p])); rxode2::rxFromSE(.d)
         } else if (!is.null(.dSE)) {                # dur(): d(1/dur)/dtheta = -dur'/dur^2
-          .d <- -symengine::D(.dSE, .rxSEsym(calcSens[p])) / (.dSE * .dSE); rxode2::rxFromSE(.d)
+          .d <- -symengine::D(.dSE, .rxSEres(calcSens[p])) / (.dSE * .dSE); rxode2::rxFromSE(.d)
         } else "0"
         .drateLines <- c(.drateLines, sprintf("rx__adjDrate_%d_%d__=%s", k - 1L, p - 1L, .expr))
       }
@@ -398,11 +398,11 @@
     for (i in seq_len(.ns)) for (j in seq_len(.ns)) {
       .dfx <- get0(paste0("rx__df_", .st[i], "_dy_", .st[j], "__"), envir = .model, inherits = FALSE)
       for (p in seq_len(.np)) {
-        .expr <- if (is.null(.dfx)) "0" else { .d <- symengine::D(.dfx, .rxSEsym(calcSens[p])); rxode2::rxFromSE(.d) }
+        .expr <- if (is.null(.dfx)) "0" else { .d <- symengine::D(.dfx, .rxSEres(calcSens[p])); rxode2::rxFromSE(.d) }
         .jpLines <- c(.jpLines, sprintf("rx__adjJp_%d_%d_%d__=%s", i - 1L, j - 1L, p - 1L, .expr))
       }
       for (m in seq_len(.ns)) {
-        .expr <- if (is.null(.dfx)) "0" else { .d <- symengine::D(.dfx, .rxSEsym(.st[m])); rxode2::rxFromSE(.d) }
+        .expr <- if (is.null(.dfx)) "0" else { .d <- symengine::D(.dfx, .rxSEres(.st[m])); rxode2::rxFromSE(.d) }
         .jyLines <- c(.jyLines, sprintf("rx__adjJy_%d_%d_%d__=%s", i - 1L, j - 1L, m - 1L, .expr))
       }
     }

--- a/R/dde.R
+++ b/R/dde.R
@@ -446,7 +446,7 @@
       if (!is.null(.tauRes) && inherits(.tauRes, "Basic")) {
         for (.pp in params) {
           ## assign before rxFromSE, which captures its argument (NSE)
-          .psym <- symengine::S(.pp)
+          .psym <- .rxSEsym(.pp)
           .dD <- tryCatch(symengine::D(.tauRes, .psym), error = function(e) NULL)
           if (!is.null(.dD)) .dtauByP[.pp] <- rxFromSE(.dD)
         }
@@ -474,7 +474,7 @@
     ## sens-compartment pre-history: d(history)/d(param)
     if (is.null(.rhsB)) next
     for (.p in params) {
-      .dp <- tryCatch(symengine::D(.rhsB, symengine::S(.p)), error = function(e) NULL)
+      .dp <- tryCatch(symengine::D(.rhsB, .rxSEsym(.p)), error = function(e) NULL)
       if (is.null(.dp)) next
       .dpTxt <- rxFromSE(.dp)
       if (identical(.dpTxt, "0")) next
@@ -606,7 +606,7 @@
       for (.p in calcSens) {
         .dt <- "0"
         if (!is.null(.tauRes) && inherits(.tauRes, "Basic")) {
-          .dD <- tryCatch(symengine::D(.tauRes, symengine::S(.p)), error = function(e) NULL)
+          .dD <- tryCatch(symengine::D(.tauRes, .rxSEsym(.p)), error = function(e) NULL)
           if (!is.null(.dD)) .dt <- rxode2::rxFromSE(.dD)
         }
         if (identical(.dt, "0")) next
@@ -736,7 +736,7 @@
     if (is.null(.f)) return(list())
     .out <- list()
     for (.k in .st) {
-      .d <- tryCatch(symengine::D(.f, symengine::S(.k)), error = function(e) NULL)
+      .d <- tryCatch(symengine::D(.f, .rxSEsym(.k)), error = function(e) NULL)
       if (is.null(.d)) next
       .t <- rxode2::rxFromSE(.d)
       if (!identical(.t, "0")) .out[[.k]] <- .t
@@ -934,8 +934,8 @@
       .mm <- regmatches(.cmt, regexec(
         paste0("^rx__sens_", .si, "_BY_(.+)_BY_(.+)__$"), .cmt))[[1L]]
       if (length(.mm) != 3L) next
-      .d2 <- tryCatch(symengine::D(symengine::D(.rhsB, symengine::S(.mm[2L])),
-                                   symengine::S(.mm[3L])),
+      .d2 <- tryCatch(symengine::D(symengine::D(.rhsB, .rxSEsym(.mm[2L])),
+                                   .rxSEsym(.mm[3L])),
                       error = function(e) NULL)
       if (is.null(.d2)) next
       .d2Txt <- rxFromSE(.d2)
@@ -988,7 +988,7 @@
       .jdE <- symengine::D(.fsub, .g)                       # JD = df/dg
       .hgy <- list()
       for (.mState in .states) {                            # H_gy = d^2 f/dg dy
-        .ym <- symengine::S(.mState)
+        .ym <- .rxSEsym(.mState)
         .v <- .nz(symengine::D(.jdE, .ym))
         if (!is.null(.v)) .hgy[[.mState]] <- .v
       }
@@ -998,7 +998,7 @@
       })
       .hgp <- list()
       for (.pp in params) {                                 # H_gp = d^2 f/dg dp
-        .v <- .nz(symengine::D(.jdE, symengine::S(.pp)))
+        .v <- .nz(symengine::D(.jdE, .rxSEsym(.pp)))
         if (!is.null(.v)) .hgp[[.pp]] <- .v
       }
       ## param-dependent delay: d tau/dp and d^2 tau/dp dq weight the
@@ -1010,7 +1010,7 @@
       if (!is.null(.tauRes) && inherits(.tauRes, "Basic")) {
         .dE <- list()
         for (.pp in params) {
-          .psym <- symengine::S(.pp)
+          .psym <- .rxSEsym(.pp)
           .dpp <- tryCatch(symengine::D(.tauRes, .psym), error = function(e) NULL)
           if (!is.null(.dpp)) {
             .dtau[.pp] <- rxFromSE(.dpp)
@@ -1020,7 +1020,7 @@
         for (.p1 in params) {
           if (is.null(.dE[[.p1]]) || identical(.dtau[[.p1]], "0")) next
           for (.p2 in params) {
-            .d2 <- tryCatch(symengine::D(.dE[[.p1]], symengine::S(.p2)),
+            .d2 <- tryCatch(symengine::D(.dE[[.p1]], .rxSEsym(.p2)),
                             error = function(e) NULL)
             if (!is.null(.d2)) {
               .txt <- rxFromSE(.d2)
@@ -1183,7 +1183,7 @@
       .g <- symengine::S(.t$gName)
       .jdE <- symengine::D(.fsub, .g)
       for (.zName in c(.states, vapply(.terms, function(z) z$gName, character(1L)))) {
-        .zsym <- symengine::S(.zName)
+        .zsym <- .rxSEsym(.zName)
         .d <- symengine::D(.jdE, .zsym)
         if (!identical(rxFromSE(.d), "0")) {
           stop("nonlinear delay 'delay(", .t$stateJ, ", ", .t$tau,
@@ -1260,7 +1260,7 @@
       ## reject nonlinear delays; assign symengine results before rxFromSE
       ## (which captures its argument)
       for (.mState in .states) {
-        .msym <- symengine::S(.mState)
+        .msym <- .rxSEsym(.mState)
         .dm <- symengine::D(.jdE, .msym)
         if (!identical(rxFromSE(.dm), "0")) {
           stop("nonlinear delay 'delay(", .t$stateJ, ", ", .t$tau,
@@ -1279,14 +1279,14 @@
       .hgp <- list()
       .dE <- list()
       for (.pp in params) {
-        .d <- symengine::D(.jdE, symengine::S(.pp))
+        .d <- symengine::D(.jdE, .rxSEsym(.pp))
         .txt <- rxFromSE(.d)
         if (!identical(.txt, "0")) { .hgp[[.pp]] <- .restore(.txt); .dE[[.pp]] <- .d }
       }
       .hgpp <- list()
       for (.p1 in names(.dE)) {
         for (.p2 in params) {
-          .d2 <- symengine::D(.dE[[.p1]], symengine::S(.p2))
+          .d2 <- symengine::D(.dE[[.p1]], .rxSEsym(.p2))
           .txt <- rxFromSE(.d2)
           if (!identical(.txt, "0")) .hgpp[[paste0(.p1, "|", .p2)]] <- .restore(.txt)
         }

--- a/R/dde.R
+++ b/R/dde.R
@@ -441,7 +441,7 @@
       .dtauByP <- stats::setNames(rep("0", length(params)), params)
       ## eval the duration text in the env to resolve intermediates (S() on a
       ## function expression is intercepted here)
-      .tauRes <- tryCatch(eval(parse(text = .tau), envir = model),
+      .tauRes <- tryCatch(eval(.rxSEresLang(parse(text = .tau)[[1L]]), envir = model),
                           error = function(e) NULL)
       if (!is.null(.tauRes) && inherits(.tauRes, "Basic")) {
         for (.pp in params) {
@@ -600,9 +600,12 @@
       .stateJ <- deparse1(.dc[[2L]]); .tau <- deparse1(.dc[[3L]])
       if (is.na(match(.stateJ, .st))) next
       .g <- "rx__gdlyJTMP__"
-      .dj <- symengine::D(symengine::S(deparse1(.substDelay(.full, .dc, as.name(.g)))), symengine::S(.g))
+      .dj <- symengine::D(
+        symengine::S(deparse1(.rxSEresLang(.substDelay(.full, .dc, as.name(.g))))),
+        symengine::S(.g))
       .djTxt <- gsub(.g, paste0("delay(", .stateJ, ",", .tau, ")"), rxode2::rxFromSE(.dj), fixed = TRUE)
-      .tauRes <- tryCatch(eval(parse(text = .tau), envir = .m), error = function(e) NULL)
+      .tauRes <- tryCatch(eval(.rxSEresLang(parse(text = .tau)[[1L]]), envir = .m),
+                          error = function(e) NULL)
       for (.p in calcSens) {
         .dt <- "0"
         if (!is.null(.tauRes) && inherits(.tauRes, "Basic")) {
@@ -1005,7 +1008,7 @@
       ## rxDelayD/rxDelayD2 corrections below ("0" for a constant delay)
       .dtau <- stats::setNames(rep("0", length(params)), params)
       .d2tau <- list()
-      .tauRes <- tryCatch(eval(parse(text = .t$tau), envir = model),
+      .tauRes <- tryCatch(eval(.rxSEresLang(parse(text = .t$tau)[[1L]]), envir = model),
                           error = function(e) NULL)
       if (!is.null(.tauRes) && inherits(.tauRes, "Basic")) {
         .dE <- list()

--- a/R/dde.R
+++ b/R/dde.R
@@ -446,7 +446,7 @@
       if (!is.null(.tauRes) && inherits(.tauRes, "Basic")) {
         for (.pp in params) {
           ## assign before rxFromSE, which captures its argument (NSE)
-          .psym <- .rxSEsym(.pp)
+          .psym <- .rxSEres(.pp)
           .dD <- tryCatch(symengine::D(.tauRes, .psym), error = function(e) NULL)
           if (!is.null(.dD)) .dtauByP[.pp] <- rxFromSE(.dD)
         }
@@ -474,7 +474,7 @@
     ## sens-compartment pre-history: d(history)/d(param)
     if (is.null(.rhsB)) next
     for (.p in params) {
-      .dp <- tryCatch(symengine::D(.rhsB, .rxSEsym(.p)), error = function(e) NULL)
+      .dp <- tryCatch(symengine::D(.rhsB, .rxSEres(.p)), error = function(e) NULL)
       if (is.null(.dp)) next
       .dpTxt <- rxFromSE(.dp)
       if (identical(.dpTxt, "0")) next
@@ -606,7 +606,7 @@
       for (.p in calcSens) {
         .dt <- "0"
         if (!is.null(.tauRes) && inherits(.tauRes, "Basic")) {
-          .dD <- tryCatch(symengine::D(.tauRes, .rxSEsym(.p)), error = function(e) NULL)
+          .dD <- tryCatch(symengine::D(.tauRes, .rxSEres(.p)), error = function(e) NULL)
           if (!is.null(.dD)) .dt <- rxode2::rxFromSE(.dD)
         }
         if (identical(.dt, "0")) next
@@ -736,7 +736,7 @@
     if (is.null(.f)) return(list())
     .out <- list()
     for (.k in .st) {
-      .d <- tryCatch(symengine::D(.f, .rxSEsym(.k)), error = function(e) NULL)
+      .d <- tryCatch(symengine::D(.f, .rxSEres(.k)), error = function(e) NULL)
       if (is.null(.d)) next
       .t <- rxode2::rxFromSE(.d)
       if (!identical(.t, "0")) .out[[.k]] <- .t
@@ -934,8 +934,8 @@
       .mm <- regmatches(.cmt, regexec(
         paste0("^rx__sens_", .si, "_BY_(.+)_BY_(.+)__$"), .cmt))[[1L]]
       if (length(.mm) != 3L) next
-      .d2 <- tryCatch(symengine::D(symengine::D(.rhsB, .rxSEsym(.mm[2L])),
-                                   .rxSEsym(.mm[3L])),
+      .d2 <- tryCatch(symengine::D(symengine::D(.rhsB, .rxSEres(.mm[2L])),
+                                   .rxSEres(.mm[3L])),
                       error = function(e) NULL)
       if (is.null(.d2)) next
       .d2Txt <- rxFromSE(.d2)
@@ -988,7 +988,7 @@
       .jdE <- symengine::D(.fsub, .g)                       # JD = df/dg
       .hgy <- list()
       for (.mState in .states) {                            # H_gy = d^2 f/dg dy
-        .ym <- .rxSEsym(.mState)
+        .ym <- .rxSEres(.mState)
         .v <- .nz(symengine::D(.jdE, .ym))
         if (!is.null(.v)) .hgy[[.mState]] <- .v
       }
@@ -998,7 +998,7 @@
       })
       .hgp <- list()
       for (.pp in params) {                                 # H_gp = d^2 f/dg dp
-        .v <- .nz(symengine::D(.jdE, .rxSEsym(.pp)))
+        .v <- .nz(symengine::D(.jdE, .rxSEres(.pp)))
         if (!is.null(.v)) .hgp[[.pp]] <- .v
       }
       ## param-dependent delay: d tau/dp and d^2 tau/dp dq weight the
@@ -1010,7 +1010,7 @@
       if (!is.null(.tauRes) && inherits(.tauRes, "Basic")) {
         .dE <- list()
         for (.pp in params) {
-          .psym <- .rxSEsym(.pp)
+          .psym <- .rxSEres(.pp)
           .dpp <- tryCatch(symengine::D(.tauRes, .psym), error = function(e) NULL)
           if (!is.null(.dpp)) {
             .dtau[.pp] <- rxFromSE(.dpp)
@@ -1020,7 +1020,7 @@
         for (.p1 in params) {
           if (is.null(.dE[[.p1]]) || identical(.dtau[[.p1]], "0")) next
           for (.p2 in params) {
-            .d2 <- tryCatch(symengine::D(.dE[[.p1]], .rxSEsym(.p2)),
+            .d2 <- tryCatch(symengine::D(.dE[[.p1]], .rxSEres(.p2)),
                             error = function(e) NULL)
             if (!is.null(.d2)) {
               .txt <- rxFromSE(.d2)
@@ -1183,7 +1183,7 @@
       .g <- symengine::S(.t$gName)
       .jdE <- symengine::D(.fsub, .g)
       for (.zName in c(.states, vapply(.terms, function(z) z$gName, character(1L)))) {
-        .zsym <- .rxSEsym(.zName)
+        .zsym <- .rxSEres(.zName)
         .d <- symengine::D(.jdE, .zsym)
         if (!identical(rxFromSE(.d), "0")) {
           stop("nonlinear delay 'delay(", .t$stateJ, ", ", .t$tau,
@@ -1260,7 +1260,7 @@
       ## reject nonlinear delays; assign symengine results before rxFromSE
       ## (which captures its argument)
       for (.mState in .states) {
-        .msym <- .rxSEsym(.mState)
+        .msym <- .rxSEres(.mState)
         .dm <- symengine::D(.jdE, .msym)
         if (!identical(rxFromSE(.dm), "0")) {
           stop("nonlinear delay 'delay(", .t$stateJ, ", ", .t$tau,
@@ -1279,14 +1279,14 @@
       .hgp <- list()
       .dE <- list()
       for (.pp in params) {
-        .d <- symengine::D(.jdE, .rxSEsym(.pp))
+        .d <- symengine::D(.jdE, .rxSEres(.pp))
         .txt <- rxFromSE(.d)
         if (!identical(.txt, "0")) { .hgp[[.pp]] <- .restore(.txt); .dE[[.pp]] <- .d }
       }
       .hgpp <- list()
       for (.p1 in names(.dE)) {
         for (.p2 in params) {
-          .d2 <- symengine::D(.dE[[.p1]], .rxSEsym(.p2))
+          .d2 <- symengine::D(.dE[[.p1]], .rxSEres(.p2))
           .txt <- rxFromSE(.d2)
           if (!identical(.txt, "0")) .hgpp[[paste0(.p1, "|", .p2)]] <- .restore(.txt)
         }

--- a/R/eventSens.R
+++ b/R/eventSens.R
@@ -640,11 +640,11 @@
   ## assign symengine results before rxFromSE (NSE capture; see R/dde.R)
   .tot <- NULL
   if (.rxSEres(param) %in% .vars) {
-    .tot <- symengine::D(sym, .rxSEsym(param))
+    .tot <- symengine::D(sym, .rxSEres(param))
   }
   for (.l in states) {
     if (!(.rxSEres(.l) %in% .vars)) next
-    .dl <- symengine::D(sym, .rxSEsym(.l))
+    .dl <- symengine::D(sym, .rxSEres(.l))
     .dlTxt <- rxFromSE(.dl)
     if (.dlTxt != "0" && .dlTxt != "0.0") {
       .S <- symengine::S(paste0("rx__sens_", .l, "_BY_", param, "__"))
@@ -668,11 +668,11 @@
   .vars <- .rxEventSensFreeSyms(sym)
   .tot <- NULL
   if (.rxSEres(param) %in% .vars) {
-    .tot <- symengine::D(sym, .rxSEsym(param))
+    .tot <- symengine::D(sym, .rxSEres(param))
   }
   for (.l in states) {
     if (!(.rxSEres(.l) %in% .vars)) next
-    .dl <- symengine::D(sym, .rxSEsym(.l))
+    .dl <- symengine::D(sym, .rxSEres(.l))
     .dlTxt <- rxFromSE(.dl)
     if (.dlTxt != "0" && .dlTxt != "0.0") {
       .S <- symengine::S(paste0("rx__sens_", .l, "_BY_", param, "__"))
@@ -717,12 +717,12 @@
   .tot <- NULL
   ## direct partial wrt q
   if (.rxSEres(q) %in% .vars) {
-    .tot <- symengine::D(.dgp, .rxSEsym(q))
+    .tot <- symengine::D(.dgp, .rxSEres(q))
   }
   ## state-coupling: d/dx_l * S^q_l
   for (.l in states) {
     if (!(.rxSEres(.l) %in% .vars)) next
-    .dxl <- symengine::D(.dgp, .rxSEsym(.l))
+    .dxl <- symengine::D(.dgp, .rxSEres(.l))
     if (rxFromSE(.dxl) %in% c("0", "0.0")) next
     .Sq <- symengine::S(paste0("rx__sens_", .l, "_BY_", q, "__"))
     .term <- .dxl * .Sq
@@ -761,12 +761,12 @@
   .tot <- NULL
   ## direct partial wrt r
   if (.rxSEres(r) %in% .vars) {
-    .tot <- symengine::D(.dgpq, .rxSEsym(r))
+    .tot <- symengine::D(.dgpq, .rxSEres(r))
   }
   ## state-coupling: d/dx_l * S^r_l
   for (.l in states) {
     if (!(.rxSEres(.l) %in% .vars)) next
-    .dxl <- symengine::D(.dgpq, .rxSEsym(.l))
+    .dxl <- symengine::D(.dgpq, .rxSEres(.l))
     if (rxFromSE(.dxl) %in% c("0", "0.0")) next
     .Sr <- symengine::S(paste0("rx__sens_", .l, "_BY_", r, "__"))
     .term <- .dxl * .Sr
@@ -963,7 +963,7 @@
         .fSymName <- paste0("rx__d_dt_", .kName, "__")
         if (!exists(.fSymName, envir = .model)) next
         .fSym <- get(.fSymName, envir = .model)
-        .Jkc <- tryCatch(symengine::D(.fSym, .rxSEsym(.cName)),
+        .Jkc <- tryCatch(symengine::D(.fSym, .rxSEres(.cName)),
                          error = function(e) NULL)
         if (is.null(.Jkc)) next
         .JkcTxt <- rxFromSE(.Jkc)

--- a/R/eventSens.R
+++ b/R/eventSens.R
@@ -639,12 +639,12 @@
   .vars <- .rxEventSensFreeSyms(sym)
   ## assign symengine results before rxFromSE (NSE capture; see R/dde.R)
   .tot <- NULL
-  if (param %in% .vars) {
-    .tot <- symengine::D(sym, symengine::S(param))
+  if (.rxSEres(param) %in% .vars) {
+    .tot <- symengine::D(sym, .rxSEsym(param))
   }
   for (.l in states) {
-    if (!(.l %in% .vars)) next
-    .dl <- symengine::D(sym, symengine::S(.l))
+    if (!(.rxSEres(.l) %in% .vars)) next
+    .dl <- symengine::D(sym, .rxSEsym(.l))
     .dlTxt <- rxFromSE(.dl)
     if (.dlTxt != "0" && .dlTxt != "0.0") {
       .S <- symengine::S(paste0("rx__sens_", .l, "_BY_", param, "__"))
@@ -667,12 +667,12 @@
 .rxEventSensDSym <- function(sym, param, states) {
   .vars <- .rxEventSensFreeSyms(sym)
   .tot <- NULL
-  if (param %in% .vars) {
-    .tot <- symengine::D(sym, symengine::S(param))
+  if (.rxSEres(param) %in% .vars) {
+    .tot <- symengine::D(sym, .rxSEsym(param))
   }
   for (.l in states) {
-    if (!(.l %in% .vars)) next
-    .dl <- symengine::D(sym, symengine::S(.l))
+    if (!(.rxSEres(.l) %in% .vars)) next
+    .dl <- symengine::D(sym, .rxSEsym(.l))
     .dlTxt <- rxFromSE(.dl)
     if (.dlTxt != "0" && .dlTxt != "0.0") {
       .S <- symengine::S(paste0("rx__sens_", .l, "_BY_", param, "__"))
@@ -716,13 +716,13 @@
   .vars <- .rxEventSensFreeSyms(.dgp)
   .tot <- NULL
   ## direct partial wrt q
-  if (q %in% .vars) {
-    .tot <- symengine::D(.dgp, symengine::S(q))
+  if (.rxSEres(q) %in% .vars) {
+    .tot <- symengine::D(.dgp, .rxSEsym(q))
   }
   ## state-coupling: d/dx_l * S^q_l
   for (.l in states) {
-    if (!(.l %in% .vars)) next
-    .dxl <- symengine::D(.dgp, symengine::S(.l))
+    if (!(.rxSEres(.l) %in% .vars)) next
+    .dxl <- symengine::D(.dgp, .rxSEsym(.l))
     if (rxFromSE(.dxl) %in% c("0", "0.0")) next
     .Sq <- symengine::S(paste0("rx__sens_", .l, "_BY_", q, "__"))
     .term <- .dxl * .Sq
@@ -760,13 +760,13 @@
   .vars <- .rxEventSensFreeSyms(.dgpq)
   .tot <- NULL
   ## direct partial wrt r
-  if (r %in% .vars) {
-    .tot <- symengine::D(.dgpq, symengine::S(r))
+  if (.rxSEres(r) %in% .vars) {
+    .tot <- symengine::D(.dgpq, .rxSEsym(r))
   }
   ## state-coupling: d/dx_l * S^r_l
   for (.l in states) {
-    if (!(.l %in% .vars)) next
-    .dxl <- symengine::D(.dgpq, symengine::S(.l))
+    if (!(.rxSEres(.l) %in% .vars)) next
+    .dxl <- symengine::D(.dgpq, .rxSEsym(.l))
     if (rxFromSE(.dxl) %in% c("0", "0.0")) next
     .Sr <- symengine::S(paste0("rx__sens_", .l, "_BY_", r, "__"))
     .term <- .dxl * .Sr
@@ -963,7 +963,7 @@
         .fSymName <- paste0("rx__d_dt_", .kName, "__")
         if (!exists(.fSymName, envir = .model)) next
         .fSym <- get(.fSymName, envir = .model)
-        .Jkc <- tryCatch(symengine::D(.fSym, symengine::S(.cName)),
+        .Jkc <- tryCatch(symengine::D(.fSym, .rxSEsym(.cName)),
                          error = function(e) NULL)
         if (is.null(.Jkc)) next
         .JkcTxt <- rxFromSE(.Jkc)

--- a/R/intern.R
+++ b/R/intern.R
@@ -29,6 +29,7 @@
 #' @author Matthew L. Fidler
 #' @noRd
 .rxIsReservedName <- function(x) {
+  # nolint next: object_usage_linter. registered in src/init.c
   .Call(`_rxode2_rxIsReservedName`, as.character(x))
 }
 

--- a/R/intern.R
+++ b/R/intern.R
@@ -34,13 +34,10 @@
 
 #' Is this a name model piping must never turn into an estimated parameter?
 #'
-#' The parser's reserved names, plus `E`: not reserved by the parser, but
-#' symengine's Euler constant (`.rxSEreserved`), so an `ini({})` entry of that
-#' name reads back as 2.718 in the estimation models and does nothing.  The
-#' rest of `.rxSEreserved` (`e`, `I`, ...) shadows a parameter the same way,
-#' but those names are accepted parameter names today, and a hand-written
-#' `ini({})` is shadowed just the same, so blocking them only here would not
-#' fix it; see issue #1359.
+#' The parser's reserved names, plus `E` -- not reserved by the parser, but kept
+#' out of the ini block since before `.rxSEreserved` stopped shadowing a model
+#' variable of that name (#1359).  The rest of `.rxSEreserved` (`e`, `I`, ...)
+#' are ordinary parameter names.
 #'
 #' @param x character vector of names to test
 #' @return logical vector the same length as `x`

--- a/R/mu.R
+++ b/R/mu.R
@@ -329,7 +329,7 @@
         return(NULL)
       }
       if (length(.thetas) == 1L) {
-        .d <- try(symengine::D(get("rxdummyLhs", rxS(paste0("rxdummyLhs=", deparse1(y)))), .rxSEsym(.thetas)), silent=TRUE)
+        .d <- try(symengine::D(get("rxdummyLhs", rxS(paste0("rxdummyLhs=", deparse1(y)))), .rxSEres(.thetas)), silent=TRUE)
         .extra <- try(str2lang(rxFromSE(.d)), silent=TRUE)
         .thetaD <- try(.muRefExtractTheta(.extra, env), silent=TRUE)
         if (inherits(.thetaD, "try-error")) .thetaD <- NULL

--- a/R/mu.R
+++ b/R/mu.R
@@ -329,7 +329,7 @@
         return(NULL)
       }
       if (length(.thetas) == 1L) {
-        .d <- try(symengine::D(get("rxdummyLhs", rxS(paste0("rxdummyLhs=", deparse1(y)))), .thetas), silent=TRUE)
+        .d <- try(symengine::D(get("rxdummyLhs", rxS(paste0("rxdummyLhs=", deparse1(y)))), .rxSEsym(.thetas)), silent=TRUE)
         .extra <- try(str2lang(rxFromSE(.d)), silent=TRUE)
         .thetaD <- try(.muRefExtractTheta(.extra, env), silent=TRUE)
         if (inherits(.thetaD, "try-error")) .thetaD <- NULL

--- a/R/rxIndLin.R
+++ b/R/rxIndLin.R
@@ -95,10 +95,14 @@ rxIndLinState <- function(preferred = NULL) {
   ## If we have *1/x this becomes simply /x
   .multCollapse <- function(x) {
     .txt <- paste(x, collapse = "*")
-    # symengine cannot parse a dotted identifier (`eta.Cl`), which is an
-    # ordinary rxode2 name, and this call is only tidying the result
-    # cosmetically.  Fall back to the plain product rather than failing the
-    # whole conversion: `-1*x` instead of `-x` is uglier but identical.
+    # These are model-side names.  S() reads one that matches a symengine
+    # constant (`e`, `I`, `Catalan`, ...) as the constant and would silently
+    # fold the variable away (#1359); it also cannot parse a dotted identifier
+    # (`eta.Cl`), which is an ordinary rxode2 name.  This call is only tidying
+    # the result cosmetically, so fall back to the plain product rather than
+    # losing a variable or failing the whole conversion: `-1*x` instead of `-x`
+    # is uglier but identical.
+    if (any(x %in% names(.rxSEreserved))) return(.txt)
     tryCatch(as.character(symengine::S(.txt)),
              error = function(e) .txt)
   }

--- a/R/rxJacobian.R
+++ b/R/rxJacobian.R
@@ -166,7 +166,7 @@ rxExpandGrid <- function(x, y, type = 0L) {
   .sn <- function(i, p) paste0("rx__sens_", state[i], "_BY_", params[p], "__")
   # differentiate by the symengine-side name: a state called `e`/`I`/`Catalan`
   # is bound under rx_SymPy_Res_* (#1359)
-  .stateSym <- lapply(state, .rxSEsym)
+  .stateSe <- .rxSEres(state)
   .lines <- character(0)
   .emit <- function(lhsSt, rhsSt, e) {
     if (is.null(e)) return(invisible())
@@ -185,7 +185,7 @@ rxExpandGrid <- function(x, y, type = 0L) {
     .dF_X_k <- list()
     for (k in seq_len(.ns)) {
       .fxik <- .fx(i, k); if (is.null(.fxik)) next
-      .d <- symengine::D(.fxik, .stateSym[[j]])
+      .d <- symengine::D(.fxik, .stateSe[j])
       if (paste(.d) != "0") {
         .dF_X_k[[k]] <- .d
       }
@@ -201,7 +201,7 @@ rxExpandGrid <- function(x, y, type = 0L) {
       }
       .fpip <- .fp(i, p)
       if (!is.null(.fpip)) {
-        .d <- symengine::D(.fpip, .stateSym[[j]])
+        .d <- symengine::D(.fpip, .stateSe[j])
         if (paste(.d) != "0") .acc <- if (is.null(.acc)) .d else .acc + .d
       }
       .emit(.sn(i, p), state[j], .acc)

--- a/R/rxJacobian.R
+++ b/R/rxJacobian.R
@@ -164,6 +164,9 @@ rxExpandGrid <- function(x, y, type = 0L) {
   .fp <- function(i, p) get0(paste0("rx__df_", state[i], "_dy_", params[p], "__"),
                              envir = model, inherits = FALSE)
   .sn <- function(i, p) paste0("rx__sens_", state[i], "_BY_", params[p], "__")
+  # differentiate by the symengine-side name: a state called `e`/`I`/`Catalan`
+  # is bound under rx_SymPy_Res_* (#1359)
+  .stateSym <- lapply(state, .rxSEsym)
   .lines <- character(0)
   .emit <- function(lhsSt, rhsSt, e) {
     if (is.null(e)) return(invisible())
@@ -182,7 +185,7 @@ rxExpandGrid <- function(x, y, type = 0L) {
     .dF_X_k <- list()
     for (k in seq_len(.ns)) {
       .fxik <- .fx(i, k); if (is.null(.fxik)) next
-      .d <- symengine::D(.fxik, state[j])
+      .d <- symengine::D(.fxik, .stateSym[[j]])
       if (paste(.d) != "0") {
         .dF_X_k[[k]] <- .d
       }
@@ -198,7 +201,7 @@ rxExpandGrid <- function(x, y, type = 0L) {
       }
       .fpip <- .fp(i, p)
       if (!is.null(.fpip)) {
-        .d <- symengine::D(.fpip, state[j])
+        .d <- symengine::D(.fpip, .stateSym[[j]])
         if (paste(.d) != "0") .acc <- if (is.null(.acc)) .d else .acc + .d
       }
       .emit(.sn(i, p), state[j], .acc)

--- a/R/symengine.R
+++ b/R/symengine.R
@@ -1532,7 +1532,11 @@ rxToSE <- function(x, envir = NULL, progress = FALSE,
   # (`with(envir, ...)`) would otherwise inline an lhs variable's definition and
   # break the call, so wrap the variable in symengine::S("var") to keep it a raw
   # symbol; it round-trips back to the bare name in rxFromSE().
-  .vref <- function(v) if (isEnv) paste0("symengine::S(\"", v, "\")") else v
+  .vref <- function(v) {
+    # .rxSEres(): a variable named like a symengine constant is bound under its
+    # rx_SymPy_Res_* name, and S() would read the plain name as the constant
+    if (isEnv) paste0("symengine::S(\"", .rxSEres(v), "\")") else v
+  }
   if (.len == 1L) {
     stop(.fun, "() takes 1-2 arguments")
   } else if (.len == 2L) {
@@ -4937,7 +4941,7 @@ rxFun2c <- function(fun, name, onlyF=FALSE) {
     .lastValue <- .s$rxLastValue
     return(c(list(.ret),
       lapply(.env$args, function(v) {
-      .v <- symengine::D(.lastValue, symengine::S(v))
+      .v <- symengine::D(.lastValue, .rxSEres(v))
       .v <- paste0("function(", paste(.env$args, collapse=", "), ") {\n", rxOptExpr(paste0("rxLastValue=", rxFromSE(.v)), msg=paste0("d(", .funName, ")/d(", v, ")")),
                    "\nrxLastValue}")
       .v <- eval(str2lang(.v))

--- a/R/symengine.R
+++ b/R/symengine.R
@@ -3422,6 +3422,61 @@ local({
   .f
 }
 
+#' The symengine name a model variable is bound under
+#'
+#' A model variable called `e`, `E`, `I`, `Catalan`, `GoldenRatio` or
+#' `EulerGamma` is bound under `rx_SymPy_Res_<name>` because symengine reads the
+#' plain name as the matching constant (`.rxSEreserved`); everything else keeps
+#' its name.  Mirrors `symengineRes()` (`src/expm.cpp`).
+#'
+#' @param name character vector of model variable names
+#' @return character vector of symengine names
+#' @author Matthew L. Fidler
+#' @noRd
+.rxSEres <- function(name) {
+  .w <- name %in% names(.rxSEreserved)
+  if (any(.w)) name[.w] <- paste0("rx_SymPy_Res_", name[.w])
+  name
+}
+
+#' The symengine `Symbol` to differentiate by for a model variable
+#'
+#' `symengine::S()` re-parses, so it reads a model variable called `e`, `I`,
+#' `Catalan`, ... as the matching constant and `D()` then fails with "Input is
+#' not a SYMBOL" (#1359); it also rejects a dotted rxode2 name (`eta.cl`).
+#' `Symbol()` on the `rx_SymPy_Res_*` name avoids both.
+#'
+#' @param name model variable name (length one)
+#' @return symengine `Symbol`
+#' @author Matthew L. Fidler
+#' @noRd
+.rxSEsym <- function(name) {
+  symengine::Symbol(.rxSEres(name))
+}
+
+#' Stop symengine's constants from shadowing model variables of the same name
+#'
+#' [rxS()] binds symengine's constants (`e`, `E`, `I`, `Catalan`,
+#' `GoldenRatio`, `EulerGamma`; `.rxSEreserved`) into the model environment,
+#' while [rxToSE()] renames a model variable of one of those names to
+#' `rx_SymPy_Res_<name>`.  Reading the plain name back therefore gave the
+#' constant and `D(expr, name)` errored (#1359).  Point the plain name at
+#' whatever the mangled name holds.
+#'
+#' @param env symengine environment built by [rxS()]
+#' @return `env`, invisibly (modified by reference)
+#' @author Matthew L. Fidler
+#' @noRd
+.rxSEunshadowConstants <- function(env) {
+  for (.v in names(.rxSEreserved)) {
+    .val <- get0(paste0("rx_SymPy_Res_", .v), envir = env, inherits = FALSE)
+    if (!is.null(.val)) {
+      assign(.v, .val, envir = env)
+    }
+  }
+  invisible(env)
+}
+
 #' Load a model into a symengine environment
 #'
 #' @param x rxode2 object
@@ -3507,6 +3562,9 @@ rxS <- function(x, doConst = TRUE, promoteLinSens = FALSE, envir=parent.frame())
     if (any(.cnst == x)) {
       .tmp <- paste0("rx_SymPy_Res_", x)
       assign(.tmp, symengine::Symbol(.tmp), envir = .env)
+      # the model declares a variable of this name, so the constant binding
+      # above must not shadow it (#1359)
+      assign(x, symengine::Symbol(.tmp), envir = .env)
     } else {
       .tmp <- rxToSE(x, envir=.env)
       assign(.tmp, symengine::Symbol(.tmp), envir = .env)
@@ -3521,6 +3579,7 @@ rxS <- function(x, doConst = TRUE, promoteLinSens = FALSE, envir=parent.frame())
   .env$..laggedVars <- .rxCollectLaggedVars(.expr)
   # loads the model into .env by side effect; the returned text is not used
   .rxToSE(.expr, envir=.env)
+  .rxSEunshadowConstants(.env)
   class(.env) <- "rxS"
   return(.env)
 }

--- a/R/symengine.R
+++ b/R/symengine.R
@@ -3450,6 +3450,19 @@ local({
   name
 }
 
+#' The one reserved name that cannot be unshadowed
+#'
+#' `E` is the symengine spelling of the model language's `M_E` (`.rxSEcnt`), so
+#' the environment's `E` has to keep meaning Euler's number: a model may use
+#' `M_E` and a variable called `E` in the same expression.  A model variable
+#' named `E` is still correct throughout -- it lives at `rx_SymPy_Res_E` and
+#' `rxFromSE()` maps it back -- but code differentiating by it must ask for
+#' `.rxSEres("E")` rather than reading the plain name.  No other `M_` constant
+#' translates to a reserved name, so no other name has this conflict.
+#'
+#' @noRd
+.rxSEnoUnshadow <- "E"
+
 #' Assign a symengine variable, unshadowing a constant of the same name
 #'
 #' [rxS()] binds symengine's constants (`e`, `E`, `I`, `Catalan`,
@@ -3460,6 +3473,7 @@ local({
 #' goes through here so the plain name always points at the same value -- doing
 #' it once after the model loads instead would leave the plain name stale as
 #' soon as the environment was extended with another [rxToSE()] call.
+#' `.rxSEnoUnshadow` is left alone.
 #'
 #' @param var symengine-side variable name
 #' @param value value to store
@@ -3471,7 +3485,7 @@ local({
   assign(var, value, envir = envir)
   if (substr(var, 1L, 13L) == "rx_SymPy_Res_") {
     .plain <- substring(var, 14L)
-    if (any(.plain == names(.rxSEreserved))) {
+    if (any(.plain == names(.rxSEreserved)) && !any(.plain == .rxSEnoUnshadow)) {
       assign(.plain, value, envir = envir)
     }
   }

--- a/R/symengine.R
+++ b/R/symengine.R
@@ -1115,7 +1115,7 @@ rxToSE <- function(x, envir = NULL, progress = FALSE,
       if (isEnv && is.name(x)) {
         if (substr(x, 1, 1) != ".") {
           if (!exists(.ret, envir = envir)) {
-            assign(.ret, symengine::Symbol(.ret), envir = envir)
+            .rxSEassign(.ret, symengine::Symbol(.ret), envir)
           }
         }
       }
@@ -1310,7 +1310,7 @@ rxToSE <- function(x, envir = NULL, progress = FALSE,
     .isNum <- TRUE
     if (isEnv) {
       if (envir$..doConst) {
-        assign(.var, x[[3]], envir = envir)
+        .rxSEassign(.var, x[[3]], envir)
       }
     }
     .expr <- x[[3]]
@@ -1332,7 +1332,7 @@ rxToSE <- function(x, envir = NULL, progress = FALSE,
       if (!inherits(.val, "try-error")) {
         .rx <- paste0(rxFromSE(.var), "=", rxFromSE(.val))
         assign("..lhs", c(envir$..lhs, .rx), envir = envir)
-        assign(.var, symengine::S(.var), envir = envir)
+        .rxSEassign(.var, symengine::S(.var), envir)
         return(invisible(NULL))
       }
     }
@@ -1375,7 +1375,7 @@ rxToSE <- function(x, envir = NULL, progress = FALSE,
       assign("..jac0..", .lst, envir = envir)
     } else if (!identical(x[[1]], quote(`~`))) {
       if (is.call(x[[3]]) && identical(as.character(x[[3]][[1]]), "linCmt")) {
-        assign(.var, symengine::S(.var), envir = envir)
+        .rxSEassign(.var, symengine::S(.var), envir)
         .name <- rxFromSE(.var)
         .rx <- paste0(.name, "=", paste(deparse(x[[3]]), collapse = ""))
         if (regexpr("^(nlmixr|rx)_", .var) == -1) {
@@ -1396,7 +1396,7 @@ rxToSE <- function(x, envir = NULL, progress = FALSE,
       .isNum <- (inherits(.expr, "numeric") || inherits(.expr, "integer"))
       if ((.isNum && envir$..doConst) ||
             (!.isNum)) {
-        assign(.var, .expr, envir = envir)
+        .rxSEassign(.var, .expr, envir)
       }
       .name <- rxFromSE(.var)
       .rx <- paste0(
@@ -1426,7 +1426,7 @@ rxToSE <- function(x, envir = NULL, progress = FALSE,
       # resolve -- even a literal constant (e.g. `rx_expr_3 ~ 0`) with
       # doConst=FALSE, which otherwise leaks as an undefined phantom parameter.
       .expr <- eval(parse(text = .expr))
-      assign(.var, .expr, envir = envir)
+      .rxSEassign(.var, .expr, envir)
       .rx <- paste0(
         rxFromSE(.var), "=",
         rxFromSE(.expr)
@@ -3450,27 +3450,32 @@ local({
   name
 }
 
-#' Stop symengine's constants from shadowing model variables of the same name
+#' Assign a symengine variable, unshadowing a constant of the same name
 #'
 #' [rxS()] binds symengine's constants (`e`, `E`, `I`, `Catalan`,
 #' `GoldenRatio`, `EulerGamma`; `.rxSEreserved`) into the model environment,
-#' while [rxToSE()] renames a model variable of one of those names to
+#' while [rxToSE()] stores a model variable of one of those names under
 #' `rx_SymPy_Res_<name>`.  Reading the plain name back therefore gave the
-#' constant and `D(expr, name)` errored (#1359).  Point the plain name at
-#' whatever the mangled name holds.
+#' constant and `D(expr, name)` errored (#1359).  Every write of a mangled name
+#' goes through here so the plain name always points at the same value -- doing
+#' it once after the model loads instead would leave the plain name stale as
+#' soon as the environment was extended with another [rxToSE()] call.
 #'
-#' @param env symengine environment built by [rxS()]
-#' @return `env`, invisibly (modified by reference)
+#' @param var symengine-side variable name
+#' @param value value to store
+#' @param envir symengine environment
+#' @return `value`, invisibly (`envir` is modified by reference)
 #' @author Matthew L. Fidler
 #' @noRd
-.rxSEunshadowConstants <- function(env) {
-  for (.v in names(.rxSEreserved)) {
-    .val <- get0(paste0("rx_SymPy_Res_", .v), envir = env, inherits = FALSE)
-    if (!is.null(.val)) {
-      assign(.v, .val, envir = env)
+.rxSEassign <- function(var, value, envir) {
+  assign(var, value, envir = envir)
+  if (substr(var, 1L, 13L) == "rx_SymPy_Res_") {
+    .plain <- substring(var, 14L)
+    if (any(.plain == names(.rxSEreserved))) {
+      assign(.plain, value, envir = envir)
     }
   }
-  invisible(env)
+  invisible(value)
 }
 
 #' Load a model into a symengine environment
@@ -3556,11 +3561,10 @@ rxS <- function(x, doConst = TRUE, promoteLinSens = FALSE, envir=parent.frame())
   ## S("nan")
   sapply(.pars, function(x) {
     if (any(.cnst == x)) {
-      .tmp <- paste0("rx_SymPy_Res_", x)
-      assign(.tmp, symengine::Symbol(.tmp), envir = .env)
-      # the model declares a variable of this name, so the constant binding
-      # above must not shadow it (#1359)
-      assign(x, symengine::Symbol(.tmp), envir = .env)
+      # .rxSEassign(): the model declares a variable of this name, so the
+      # constant bound above must not shadow it (#1359)
+      .rxSEassign(paste0("rx_SymPy_Res_", x), symengine::Symbol(paste0("rx_SymPy_Res_", x)),
+                  .env)
     } else {
       .tmp <- rxToSE(x, envir=.env)
       assign(.tmp, symengine::Symbol(.tmp), envir = .env)
@@ -3575,7 +3579,6 @@ rxS <- function(x, doConst = TRUE, promoteLinSens = FALSE, envir=parent.frame())
   .env$..laggedVars <- .rxCollectLaggedVars(.expr)
   # loads the model into .env by side effect; the returned text is not used
   .rxToSE(.expr, envir=.env)
-  .rxSEunshadowConstants(.env)
   class(.env) <- "rxS"
   return(.env)
 }

--- a/R/symengine.R
+++ b/R/symengine.R
@@ -3450,6 +3450,34 @@ local({
   name
 }
 
+#' Rename every reserved name in a parsed model expression to its symengine name
+#'
+#' `rxFromSE()` renders an expression with model-side names, so re-parsing that
+#' text with `symengine::S()` -- or evaluating it in the model environment --
+#' reads a variable called `e`, `E`, `I`, ... as the matching constant (#1359).
+#' Walk the expression and swap each such symbol for its `rx_SymPy_Res_*` name
+#' first; `rxFromSE()` maps them back on the way out.  Function names are left
+#' alone (the call head is never one of these).
+#'
+#' @param e a parsed model expression (`language`)
+#' @return `e` with reserved symbols renamed
+#' @author Matthew L. Fidler
+#' @noRd
+.rxSEresLang <- function(e) {
+  if (is.name(e)) {
+    .n <- as.character(e)
+    # the empty symbol (an omitted argument) is a name that as.name() cannot
+    # rebuild, so leave it be
+    if (!nzchar(.n)) return(e)
+    .m <- .rxSEres(.n)
+    return(if (identical(.m, .n)) e else as.name(.m))
+  }
+  if (is.call(e) && length(e) > 1L) {
+    for (.i in seq_along(e)[-1L]) e[[.i]] <- .rxSEresLang(e[[.i]])
+  }
+  e
+}
+
 #' The one reserved name that cannot be unshadowed
 #'
 #' `E` is the symengine spelling of the model language's `M_E` (`.rxSEcnt`), so

--- a/R/symengine.R
+++ b/R/symengine.R
@@ -3429,6 +3429,13 @@ local({
 #' plain name as the matching constant (`.rxSEreserved`); everything else keeps
 #' its name.  Mirrors `symengineRes()` (`src/expm.cpp`).
 #'
+#' Pass the result to `symengine::D()` rather than the model-side name: `D()`
+#' resolves a character to a `Symbol` (so a dotted name such as `eta.cl` is
+#' fine), while `symengine::S()` re-parses and reads a reserved name back as
+#' the constant -- "Input is not a SYMBOL" (#1359).  A character also keeps
+#' `D()`'s `stats::D` fallback working for the non-`Basic` expressions the
+#' environment stores for a constant (`f(depot) <- 0.8`).
+#'
 #' @param name character vector of model variable names
 #' @return character vector of symengine names
 #' @author Matthew L. Fidler
@@ -3437,21 +3444,6 @@ local({
   .w <- name %in% names(.rxSEreserved)
   if (any(.w)) name[.w] <- paste0("rx_SymPy_Res_", name[.w])
   name
-}
-
-#' The symengine `Symbol` to differentiate by for a model variable
-#'
-#' `symengine::S()` re-parses, so it reads a model variable called `e`, `I`,
-#' `Catalan`, ... as the matching constant and `D()` then fails with "Input is
-#' not a SYMBOL" (#1359); it also rejects a dotted rxode2 name (`eta.cl`).
-#' `Symbol()` on the `rx_SymPy_Res_*` name avoids both.
-#'
-#' @param name model variable name (length one)
-#' @return symengine `Symbol`
-#' @author Matthew L. Fidler
-#' @noRd
-.rxSEsym <- function(name) {
-  symengine::Symbol(.rxSEres(name))
 }
 
 #' Stop symengine's constants from shadowing model variables of the same name

--- a/tests/testthat/test-symengine-constants-downstream.R
+++ b/tests/testthat/test-symengine-constants-downstream.R
@@ -106,6 +106,27 @@ rxTest({
     expect_true(grepl("f(rx__sens_cen_BY_e__)=", .n, fixed = TRUE))
   })
 
+  test_that("the delay jump map keeps a parameter named like a constant", {
+    # .rxDelaySensJumpMap() re-parses the rxFromSE() text of d/dt() with
+    # symengine::S(), which reads a model-side `e` as Euler's number: the jump
+    # amplitude came out as -(M_E)*(1.5) instead of -(e)*(1.5)
+    .m <- .rxDelaySensJumpMap("cl=0.3;\nd/dt(cen)=-cl*cen+e*delay(cen,1.5*e);\n",
+                              "e")
+    expect_true(any(grepl("f(rx__sens_cen_BY_e__)=-(e)*(1.5)", .m$alagf, fixed = TRUE)))
+    expect_false(any(grepl("M_E", .m$alagf, fixed = TRUE)))
+  })
+
+  test_that("a delay duration depending on E still resolves", {
+    # `E` is deliberately left bound to Euler's number in the environment, so the
+    # duration text has to be translated before it is evaluated there -- otherwise
+    # it evaluates to a plain numeric, the "Basic" check fails and the
+    # breaking-point corrections are dropped
+    .m <- .rxDelaySensJumpMap("cl=0.3;\nd/dt(cen)=-cl*cen+0.1*delay(cen,1.5*E);\n",
+                              "E")
+    expect_true(any(grepl("alag(rx__sens_cen_BY_E__)", .m$alagf, fixed = TRUE)))
+    expect_true(any(grepl("f(rx__sens_cen_BY_E__)=-(0.1)*(1.5)", .m$alagf, fixed = TRUE)))
+  })
+
   test_that("mu-referencing keeps a covariate parameter named like a constant", {
     .f <- function() {
       ini({

--- a/tests/testthat/test-symengine-constants-downstream.R
+++ b/tests/testthat/test-symengine-constants-downstream.R
@@ -95,6 +95,17 @@ rxTest({
     expect_equal(.b, "d/dt(cen)=-cen*e+0.1*delay(cen, 1.5)")
   })
 
+  test_that("a parameter-dependent delay differentiates by a name like a constant", {
+    # d(tau)/dp is symengine::D(.tauRes, ...) in R/dde.R.  With the raw model
+    # name that call failed inside a tryCatch, so dtauByP stayed "0" and the
+    # breaking-point correction terms were silently dropped from the model.
+    .n <- rxNorm(rxode2("d/dt(cen)=-e*cen+0.1*delay(cen, 1.5*e);\n",
+                        calcSens = "e"))
+    expect_true(grepl("rxDelayD(cen,1.5*e)", .n, fixed = TRUE))
+    expect_true(grepl("alag(rx__sens_cen_BY_e__)=1.5*e", .n, fixed = TRUE))
+    expect_true(grepl("f(rx__sens_cen_BY_e__)=", .n, fixed = TRUE))
+  })
+
   test_that("mu-referencing keeps a covariate parameter named like a constant", {
     .f <- function() {
       ini({

--- a/tests/testthat/test-symengine-constants-downstream.R
+++ b/tests/testthat/test-symengine-constants-downstream.R
@@ -1,0 +1,117 @@
+rxTest({
+  # rxode2#1359, downstream of the symengine environment: the subsystems that
+  # differentiate a loaded model by one of its own names.  The environment's own
+  # behaviour is in test-symengine-constants.R.
+  # NB: rxFromSE() poisons the next `$`/`[[` read of a symengine env, so every
+  # Basic is captured BEFORE the first rxFromSE() in each test.
+  test_that("sensitivities by a parameter named like a symengine constant", {
+    .m <- rxode2({
+      cl <- exp(tcl + e)
+      d/dt(center) <- -cl * center
+    }, calcSens = TRUE)
+    .n <- rxNorm(.m)
+    expect_true(grepl("rx__sens_center_BY_e__", .n, fixed = TRUE))
+    expect_false(grepl("rx_SymPy_Res_", .n, fixed = TRUE))
+    expect_true(grepl(paste0("d/dt(rx__sens_center_BY_e__)=-exp(e+tcl)*center-",
+                             "exp(e+tcl)*rx__sens_center_BY_e__"),
+                      .n, fixed = TRUE))
+  })
+
+  test_that("a parameter named like a constant solves like any other name", {
+    .mk <- function(v) {
+      rxode2(sprintf(paste0("ka=exp(tka);\ncl=exp(tcl+%s);\n",
+                            "d/dt(depot)=-ka*depot;\n",
+                            "d/dt(center)=ka*depot-cl*center;\n"), v),
+             calcSens = TRUE)
+    }
+    .ev <- et(amt = 100) %>% et(seq(0, 24, by = 2))
+    .a <- rxSolve(.mk("e"), .ev, params = c(tka = 0.4, tcl = -0.1, e = 0.2),
+                  returnType = "data.frame", atol = 1e-11, rtol = 1e-11)
+    .b <- rxSolve(.mk("ee"), .ev, params = c(tka = 0.4, tcl = -0.1, ee = 0.2),
+                  returnType = "data.frame", atol = 1e-11, rtol = 1e-11)
+    names(.a) <- sub("_BY_e__", "_BY_ee__", names(.a), fixed = TRUE)
+    expect_equal(sort(names(.a)), sort(names(.b)))
+    expect_equal(as.matrix(.a[names(.b)]), as.matrix(.b))
+  })
+
+  test_that("jump event-sensitivities wrt a parameter named like a constant", {
+    # .rxEventSensDExpr() tested the model-side name against symengine-side free
+    # symbols, so the term was silently dropped rather than erroring
+    .mk <- function(v) {
+      sprintf(paste0("ka=exp(tka);\ncl=exp(tcl);\nf(depot)=expit(%s);\n",
+                     "d/dt(depot)=-ka*depot;\n",
+                     "d/dt(center)=ka*depot-cl*center;\n"), v)
+    }
+    .ev <- et(amt = 100) %>% et(seq(0, 24, by = 2))
+    .p <- c(tka = 0.4, tcl = -0.1)
+    .a <- rxSolve(rxode2(.mk("e"), calcSens = "e", eventSens = "jump"), .ev,
+                  params = c(.p, e = 0.2), returnType = "data.frame",
+                  atol = 1e-11, rtol = 1e-11)
+    .b <- rxSolve(rxode2(.mk("ee"), calcSens = "ee", eventSens = "jump"), .ev,
+                  params = c(.p, ee = 0.2), returnType = "data.frame",
+                  atol = 1e-11, rtol = 1e-11)
+    expect_equal(.a$rx__sens_center_BY_e__, .b$rx__sens_center_BY_ee__)
+    # and it is the real derivative, not zero
+    .mb <- rxode2(.mk("e"))
+    .h <- 1e-6
+    .fd <- (rxSolve(.mb, .ev, params = c(.p, e = 0.2 + .h),
+                    returnType = "data.frame", atol = 1e-11, rtol = 1e-11)$center -
+            rxSolve(.mb, .ev, params = c(.p, e = 0.2 - .h),
+                    returnType = "data.frame", atol = 1e-11, rtol = 1e-11)$center) / (2 * .h)
+    expect_lt(max(abs(.a$rx__sens_center_BY_e__ - .fd)), 1e-5)
+    expect_gt(max(abs(.fd)), 1)
+  })
+
+  test_that("matExp()/indLin() rate constants keep a parameter named e", {
+    # .multCollapse() re-parsed model-side text with symengine::S(), which read
+    # the parameter `e` as Euler's number: k_p_q=exp(1) instead of k_p_q=e
+    .n <- rxNorm(rxode2("d/dt(p)=-e*p;\nd/dt(q)=e*p-k*q;\n", indLin = TRUE))
+    expect_true(grepl("k_p_q=e;", .n, fixed = TRUE))
+    expect_false(grepl("exp(1)", .n, fixed = TRUE))
+  })
+
+  test_that("adjoint sensitivities accept a parameter named like a constant", {
+    .m <- rxS(rxGetModel("d/dt(depot)=-ka*depot;\nd/dt(center)=ka*depot-(e/v)*center;\n"),
+              TRUE, promoteLinSens = FALSE)
+    .v <- c("ka", "e", "v")
+    invisible(.rxJacobian(.m, c(rxStateOde(.m), .v)))
+    .adj <- .rxAdjoint(.m, .v, "center")
+    expect_true(any(grepl("d/dt(rx__sens_center_BY_e__)=rx__adjLambda_center_center__*center/v",
+                          .adj, fixed = TRUE)))
+    expect_false(any(grepl("rx_SymPy_Res_", .adj, fixed = TRUE)))
+    expect_false(any(grepl("2.718", .adj, fixed = TRUE)))
+  })
+
+  test_that("delay() terms resolve against a parameter named like a constant", {
+    .m <- .rxode2({
+      d/dt(cen) <- -e * cen + 0.1 * delay(cen, tau)
+      tau <- 1.5
+    })
+    .t <- .rxDelayTerms(.m)
+    expect_equal(.t$state, "cen")
+    expect_equal(.t$tau, "tau")
+    .s <- rxS(.m)
+    .b <- .s$..ddt
+    expect_equal(.b, "d/dt(cen)=-cen*e+0.1*delay(cen, 1.5)")
+  })
+
+  test_that("mu-referencing keeps a covariate parameter named like a constant", {
+    .f <- function() {
+      ini({
+        tcl <- 1
+        e <- 0.5
+        add.sd <- 0.7
+        eta.cl ~ 0.1
+      })
+      model({
+        cl <- exp(tcl + e * WT + eta.cl)
+        d/dt(center) <- -cl * center
+        cp <- center
+        cp ~ add(add.sd)
+      })
+    }
+    .d <- .f()$muRefCovariateDataFrame
+    expect_equal(.d$covariateParameter, "e")
+    expect_equal(.d$covariate, "WT")
+  })
+})

--- a/tests/testthat/test-symengine-constants-downstream.R
+++ b/tests/testthat/test-symengine-constants-downstream.R
@@ -24,7 +24,7 @@ rxTest({
                             "d/dt(center)=ka*depot-cl*center;\n"), v),
              calcSens = TRUE)
     }
-    .ev <- et(amt = 100) %>% et(seq(0, 24, by = 2))
+    .ev <- et(amt = 100) |> et(seq(0, 24, by = 2))
     .a <- rxSolve(.mk("e"), .ev, params = c(tka = 0.4, tcl = -0.1, e = 0.2),
                   returnType = "data.frame", atol = 1e-11, rtol = 1e-11)
     .b <- rxSolve(.mk("ee"), .ev, params = c(tka = 0.4, tcl = -0.1, ee = 0.2),
@@ -42,7 +42,7 @@ rxTest({
                      "d/dt(depot)=-ka*depot;\n",
                      "d/dt(center)=ka*depot-cl*center;\n"), v)
     }
-    .ev <- et(amt = 100) %>% et(seq(0, 24, by = 2))
+    .ev <- et(amt = 100) |> et(seq(0, 24, by = 2))
     .p <- c(tka = 0.4, tcl = -0.1)
     .a <- rxSolve(rxode2(.mk("e"), calcSens = "e", eventSens = "jump"), .ev,
                   params = c(.p, e = 0.2), returnType = "data.frame",

--- a/tests/testthat/test-symengine-constants.R
+++ b/tests/testthat/test-symengine-constants.R
@@ -57,10 +57,56 @@ rxTest({
                       .n, fixed = TRUE))
   })
 
-  test_that(".rxSEres()/.rxSEsym() mangle only the reserved names", {
+  test_that("a parameter named like a constant solves like any other name", {
+    .mk <- function(v) {
+      rxode2(sprintf(paste0("ka=exp(tka);\ncl=exp(tcl+%s);\n",
+                            "d/dt(depot)=-ka*depot;\n",
+                            "d/dt(center)=ka*depot-cl*center;\n"), v),
+             calcSens = TRUE)
+    }
+    .ev <- et(amt = 100) %>% et(seq(0, 24, by = 2))
+    .a <- rxSolve(.mk("e"), .ev, params = c(tka = 0.4, tcl = -0.1, e = 0.2),
+                  returnType = "data.frame", atol = 1e-11, rtol = 1e-11)
+    .b <- rxSolve(.mk("ee"), .ev, params = c(tka = 0.4, tcl = -0.1, ee = 0.2),
+                  returnType = "data.frame", atol = 1e-11, rtol = 1e-11)
+    names(.a) <- sub("_BY_e__", "_BY_ee__", names(.a), fixed = TRUE)
+    expect_equal(sort(names(.a)), sort(names(.b)))
+    expect_equal(as.matrix(.a[names(.b)]), as.matrix(.b))
+  })
+
+  test_that("jump event-sensitivities wrt a parameter named like a constant", {
+    # .rxEventSensDExpr() tested the model-side name against symengine-side free
+    # symbols, so the term was silently dropped rather than erroring
+    .mk <- function(v) {
+      sprintf(paste0("ka=exp(tka);\ncl=exp(tcl);\nf(depot)=expit(%s);\n",
+                     "d/dt(depot)=-ka*depot;\n",
+                     "d/dt(center)=ka*depot-cl*center;\n"), v)
+    }
+    .ev <- et(amt = 100) %>% et(seq(0, 24, by = 2))
+    .p <- c(tka = 0.4, tcl = -0.1)
+    .a <- rxSolve(rxode2(.mk("e"), calcSens = "e", eventSens = "jump"), .ev,
+                  params = c(.p, e = 0.2), returnType = "data.frame",
+                  atol = 1e-11, rtol = 1e-11)
+    .b <- rxSolve(rxode2(.mk("ee"), calcSens = "ee", eventSens = "jump"), .ev,
+                  params = c(.p, ee = 0.2), returnType = "data.frame",
+                  atol = 1e-11, rtol = 1e-11)
+    expect_equal(.a$rx__sens_center_BY_e__, .b$rx__sens_center_BY_ee__)
+    # and it is the real derivative, not zero
+    .mb <- rxode2(.mk("e"))
+    .h <- 1e-6
+    .fd <- (rxSolve(.mb, .ev, params = c(.p, e = 0.2 + .h),
+                    returnType = "data.frame", atol = 1e-11, rtol = 1e-11)$center -
+            rxSolve(.mb, .ev, params = c(.p, e = 0.2 - .h),
+                    returnType = "data.frame", atol = 1e-11, rtol = 1e-11)$center) / (2 * .h)
+    expect_lt(max(abs(.a$rx__sens_center_BY_e__ - .fd)), 1e-5)
+    expect_gt(max(abs(.fd)), 1)
+  })
+
+  test_that(".rxSEres() mangles only the reserved names", {
     expect_equal(.rxSEres(c("e", "cl", "I", "eta.cl")),
                  c("rx_SymPy_Res_e", "cl", "rx_SymPy_Res_I", "eta.cl"))
-    expect_equal(as.character(.rxSEsym("e")), "rx_SymPy_Res_e")
-    expect_equal(as.character(.rxSEsym("eta.cl")), "eta.cl")
+    expect_equal(.rxSEres(character(0)), character(0))
+    expect_equal(.rxSEres(names(.rxSEreserved)),
+                 paste0("rx_SymPy_Res_", names(.rxSEreserved)))
   })
 })

--- a/tests/testthat/test-symengine-constants.R
+++ b/tests/testthat/test-symengine-constants.R
@@ -63,6 +63,19 @@ rxTest({
     expect_equal(rxFromSE(.d), "exp(e+tcl)")
   })
 
+  test_that("differentiating by the name as a string needs .rxSEres()", {
+    # this is how every downstream call site differentiates.  The raw model name
+    # is the silent case: symengine reads "e" as the constant and D() returns 0
+    # rather than erroring, so the term is dropped with no diagnostic.
+    .D <- symengine::D
+    .s <- rxS(rxModelVars("cl=exp(tcl+e);\nd/dt(center)=-cl*center;\n"))
+    .b <- .s$cl
+    .good <- .D(.b, .rxSEres("e"))
+    .raw <- .D(.b, "e")
+    expect_equal(paste(.raw), "0")
+    expect_equal(rxFromSE(.good), "exp(e+tcl)")
+  })
+
   test_that("lag() of a variable named like a symengine constant round-trips", {
     # .rxToSELagOrLead()'s .vref() wraps the variable in symengine::S()
     expect_equal(rxNorm("b=lag(e,1);\nd/dt(center)=-b*center;\n"),

--- a/tests/testthat/test-symengine-constants.R
+++ b/tests/testthat/test-symengine-constants.R
@@ -1,0 +1,66 @@
+rxTest({
+  # rxode2#1359: symengine's own constants (e, E, I, Catalan, GoldenRatio,
+  # EulerGamma) are bound in the symengine environment, so a model variable of
+  # one of those names used to read back as the constant and D() refused it.
+  # NB: rxFromSE() poisons the next `$`/`[[` read of a symengine env, so every
+  # Basic is captured BEFORE the first rxFromSE() in each test.
+  .cnst <- c("e", "E", "I", "Catalan", "GoldenRatio", "EulerGamma")
+
+  test_that("a parameter named like a symengine constant is not shadowed", {
+    for (.v in .cnst) {
+      .s <- rxS(rxModelVars(paste0(
+        "cl=exp(tcl+", .v, ");\nd/dt(center)=-cl*center;\n")))
+      .b <- .s[[.v]]
+      .cl <- .s$cl
+      expect_true(inherits(.b, "Basic"), info = .v)
+      expect_equal(as.character(.b), paste0("rx_SymPy_Res_", .v), info = .v)
+      expect_equal(rxFromSE(.b), .v, info = .v)
+      # the model still reads the declared variable, not the constant
+      expect_equal(rxFromSE(.cl), paste0("exp(", .v, "+tcl)"), info = .v)
+    }
+  })
+
+  test_that("a state named like a symengine constant is not shadowed", {
+    .s <- rxS(rxModelVars("d/dt(e)=-cl*e;\n"))
+    .b <- .s$e
+    expect_equal(as.character(.b), "rx_SymPy_Res_e")
+    expect_equal(rxFromSE(.b), "e")
+  })
+
+  test_that("an lhs named like a symengine constant is not shadowed", {
+    .s <- rxS(rxModelVars("e=exp(tcl);\nd/dt(center)=-e*center;\n"))
+    .b <- .s$e
+    expect_equal(rxFromSE(.b), "exp(tcl)")
+  })
+
+  test_that("a symengine constant is still bound when the model does not use it", {
+    .s <- rxS(rxModelVars("cl=exp(tcl);\nd/dt(center)=-cl*center;\n"))
+    expect_equal(as.character(.s$e), "2.71828182845905")
+  })
+
+  test_that("D() by a model variable named like a symengine constant works", {
+    .s <- rxS(rxModelVars("cl=exp(tcl+e);\nd/dt(center)=-cl*center;\n"))
+    .d <- with(.s, D(cl, e))
+    expect_equal(rxFromSE(.d), "exp(e+tcl)")
+  })
+
+  test_that("sensitivities by a parameter named like a symengine constant", {
+    .m <- rxode2({
+      cl <- exp(tcl + e)
+      d/dt(center) <- -cl * center
+    }, calcSens = TRUE)
+    .n <- rxNorm(.m)
+    expect_true(grepl("rx__sens_center_BY_e__", .n, fixed = TRUE))
+    expect_false(grepl("rx_SymPy_Res_", .n, fixed = TRUE))
+    expect_true(grepl(paste0("d/dt(rx__sens_center_BY_e__)=-exp(e+tcl)*center-",
+                             "exp(e+tcl)*rx__sens_center_BY_e__"),
+                      .n, fixed = TRUE))
+  })
+
+  test_that(".rxSEres()/.rxSEsym() mangle only the reserved names", {
+    expect_equal(.rxSEres(c("e", "cl", "I", "eta.cl")),
+                 c("rx_SymPy_Res_e", "cl", "rx_SymPy_Res_I", "eta.cl"))
+    expect_equal(as.character(.rxSEsym("e")), "rx_SymPy_Res_e")
+    expect_equal(as.character(.rxSEsym("eta.cl")), "eta.cl")
+  })
+})

--- a/tests/testthat/test-symengine-constants.R
+++ b/tests/testthat/test-symengine-constants.R
@@ -118,6 +118,61 @@ rxTest({
     expect_true(any(grepl("lag(e,1)", .s$..lhs, fixed = TRUE)))
   })
 
+  test_that("the unshadowed name follows a later rxToSE() into the same env", {
+    # doing the unshadowing once after rxS() loads the model would leave the
+    # plain name stale as soon as the environment was extended
+    .s <- rxS(rxModelVars("e=1;\nd/dt(center)=-e*center;\n"))
+    expect_equal(as.character(.s$e), "1")
+    invisible(rxToSE("e=2", envir = .s))
+    expect_equal(as.character(.s$e), "2")
+    expect_equal(as.character(.s$rx_SymPy_Res_e), "2")
+  })
+
+  test_that("adjoint sensitivities accept a parameter named like a constant", {
+    .m <- rxS(rxGetModel("d/dt(depot)=-ka*depot;\nd/dt(center)=ka*depot-(e/v)*center;\n"),
+              TRUE, promoteLinSens = FALSE)
+    .v <- c("ka", "e", "v")
+    invisible(.rxJacobian(.m, c(rxStateOde(.m), .v)))
+    .adj <- .rxAdjoint(.m, .v, "center")
+    expect_true(any(grepl("d/dt(rx__sens_center_BY_e__)=rx__adjLambda_center_center__*center/v",
+                          .adj, fixed = TRUE)))
+    expect_false(any(grepl("rx_SymPy_Res_", .adj, fixed = TRUE)))
+    expect_false(any(grepl("2.718", .adj, fixed = TRUE)))
+  })
+
+  test_that("delay() terms resolve against a parameter named like a constant", {
+    .m <- .rxode2({
+      d/dt(cen) <- -e * cen + 0.1 * delay(cen, tau)
+      tau <- 1.5
+    })
+    .t <- .rxDelayTerms(.m)
+    expect_equal(.t$state, "cen")
+    expect_equal(.t$tau, "tau")
+    .s <- rxS(.m)
+    .b <- .s$..ddt
+    expect_equal(.b, "d/dt(cen)=-cen*e+0.1*delay(cen, 1.5)")
+  })
+
+  test_that("mu-referencing keeps a covariate parameter named like a constant", {
+    .f <- function() {
+      ini({
+        tcl <- 1
+        e <- 0.5
+        add.sd <- 0.7
+        eta.cl ~ 0.1
+      })
+      model({
+        cl <- exp(tcl + e * WT + eta.cl)
+        d/dt(center) <- -cl * center
+        cp <- center
+        cp ~ add(add.sd)
+      })
+    }
+    .d <- .f()$muRefCovariateDataFrame
+    expect_equal(.d$covariateParameter, "e")
+    expect_equal(.d$covariate, "WT")
+  })
+
   test_that(".rxSEres() mangles only the reserved names", {
     expect_equal(.rxSEres(c("e", "cl", "I", "eta.cl")),
                  c("rx_SymPy_Res_e", "cl", "rx_SymPy_Res_I", "eta.cl"))

--- a/tests/testthat/test-symengine-constants.R
+++ b/tests/testthat/test-symengine-constants.R
@@ -102,6 +102,22 @@ rxTest({
     expect_gt(max(abs(.fd)), 1)
   })
 
+  test_that("matExp()/indLin() rate constants keep a parameter named e", {
+    # .multCollapse() re-parsed model-side text with symengine::S(), which read
+    # the parameter `e` as Euler's number: k_p_q=exp(1) instead of k_p_q=e
+    .n <- rxNorm(rxode2("d/dt(p)=-e*p;\nd/dt(q)=e*p-k*q;\n", indLin = TRUE))
+    expect_true(grepl("k_p_q=e;", .n, fixed = TRUE))
+    expect_false(grepl("exp(1)", .n, fixed = TRUE))
+  })
+
+  test_that("lag() of a variable named like a symengine constant round-trips", {
+    # .rxToSELagOrLead()'s .vref() wraps the variable in symengine::S()
+    expect_equal(rxNorm("b=lag(e,1);\nd/dt(center)=-b*center;\n"),
+                 "b=lag(e,1);\nd/dt(center)=-b*center;\n")
+    .s <- rxS(rxModelVars("b=lag(e,1);\nd/dt(center)=-b*center;\n"))
+    expect_true(any(grepl("lag(e,1)", .s$..lhs, fixed = TRUE)))
+  })
+
   test_that(".rxSEres() mangles only the reserved names", {
     expect_equal(.rxSEres(c("e", "cl", "I", "eta.cl")),
                  c("rx_SymPy_Res_e", "cl", "rx_SymPy_Res_I", "eta.cl"))

--- a/tests/testthat/test-symengine-constants.R
+++ b/tests/testthat/test-symengine-constants.R
@@ -7,7 +7,7 @@ rxTest({
   .cnst <- c("e", "E", "I", "Catalan", "GoldenRatio", "EulerGamma")
 
   test_that("a parameter named like a symengine constant is not shadowed", {
-    for (.v in .cnst) {
+    for (.v in setdiff(.cnst, "E")) {
       .s <- rxS(rxModelVars(paste0(
         "cl=exp(tcl+", .v, ");\nd/dt(center)=-cl*center;\n")))
       .b <- .s[[.v]]
@@ -36,78 +36,31 @@ rxTest({
   test_that("a symengine constant is still bound when the model does not use it", {
     .s <- rxS(rxModelVars("cl=exp(tcl);\nd/dt(center)=-cl*center;\n"))
     expect_equal(as.character(.s$e), "2.71828182845905")
+    expect_equal(as.character(.s$E), "2.71828182845905")
+    expect_equal(as.character(.s$I), "0+1i")
+  })
+
+  test_that("E keeps meaning Euler's number even when the model declares it", {
+    # `E` is the symengine spelling of the model language's `M_E`, so unlike the
+    # other reserved names it cannot be unshadowed: a model may use `M_E` and a
+    # variable called `E` in the same expression
+    expect_equal(rxToSE("M_E"), "E")
+    expect_equal(rxToSE("E"), "rx_SymPy_Res_E")
+    .s <- rxS(rxModelVars("cl=E*2+M_E;\nd/dt(center)=-cl*center;\n"))
+    .b <- .s$cl
+    expect_equal(rxFromSE(.b), "M_E+2*E")
+    # the same expression with `e` instead: `e` does unshadow, `M_E` is untouched
+    .s2 <- rxS(rxModelVars("cl=e*2+M_E;\nd/dt(center)=-cl*center;\n"))
+    .b2 <- .s2$cl
+    .e2 <- .s2$e
+    expect_equal(as.character(.e2), "rx_SymPy_Res_e")
+    expect_equal(rxFromSE(.b2), "M_E+2*e")
   })
 
   test_that("D() by a model variable named like a symengine constant works", {
     .s <- rxS(rxModelVars("cl=exp(tcl+e);\nd/dt(center)=-cl*center;\n"))
     .d <- with(.s, D(cl, e))
     expect_equal(rxFromSE(.d), "exp(e+tcl)")
-  })
-
-  test_that("sensitivities by a parameter named like a symengine constant", {
-    .m <- rxode2({
-      cl <- exp(tcl + e)
-      d/dt(center) <- -cl * center
-    }, calcSens = TRUE)
-    .n <- rxNorm(.m)
-    expect_true(grepl("rx__sens_center_BY_e__", .n, fixed = TRUE))
-    expect_false(grepl("rx_SymPy_Res_", .n, fixed = TRUE))
-    expect_true(grepl(paste0("d/dt(rx__sens_center_BY_e__)=-exp(e+tcl)*center-",
-                             "exp(e+tcl)*rx__sens_center_BY_e__"),
-                      .n, fixed = TRUE))
-  })
-
-  test_that("a parameter named like a constant solves like any other name", {
-    .mk <- function(v) {
-      rxode2(sprintf(paste0("ka=exp(tka);\ncl=exp(tcl+%s);\n",
-                            "d/dt(depot)=-ka*depot;\n",
-                            "d/dt(center)=ka*depot-cl*center;\n"), v),
-             calcSens = TRUE)
-    }
-    .ev <- et(amt = 100) %>% et(seq(0, 24, by = 2))
-    .a <- rxSolve(.mk("e"), .ev, params = c(tka = 0.4, tcl = -0.1, e = 0.2),
-                  returnType = "data.frame", atol = 1e-11, rtol = 1e-11)
-    .b <- rxSolve(.mk("ee"), .ev, params = c(tka = 0.4, tcl = -0.1, ee = 0.2),
-                  returnType = "data.frame", atol = 1e-11, rtol = 1e-11)
-    names(.a) <- sub("_BY_e__", "_BY_ee__", names(.a), fixed = TRUE)
-    expect_equal(sort(names(.a)), sort(names(.b)))
-    expect_equal(as.matrix(.a[names(.b)]), as.matrix(.b))
-  })
-
-  test_that("jump event-sensitivities wrt a parameter named like a constant", {
-    # .rxEventSensDExpr() tested the model-side name against symengine-side free
-    # symbols, so the term was silently dropped rather than erroring
-    .mk <- function(v) {
-      sprintf(paste0("ka=exp(tka);\ncl=exp(tcl);\nf(depot)=expit(%s);\n",
-                     "d/dt(depot)=-ka*depot;\n",
-                     "d/dt(center)=ka*depot-cl*center;\n"), v)
-    }
-    .ev <- et(amt = 100) %>% et(seq(0, 24, by = 2))
-    .p <- c(tka = 0.4, tcl = -0.1)
-    .a <- rxSolve(rxode2(.mk("e"), calcSens = "e", eventSens = "jump"), .ev,
-                  params = c(.p, e = 0.2), returnType = "data.frame",
-                  atol = 1e-11, rtol = 1e-11)
-    .b <- rxSolve(rxode2(.mk("ee"), calcSens = "ee", eventSens = "jump"), .ev,
-                  params = c(.p, ee = 0.2), returnType = "data.frame",
-                  atol = 1e-11, rtol = 1e-11)
-    expect_equal(.a$rx__sens_center_BY_e__, .b$rx__sens_center_BY_ee__)
-    # and it is the real derivative, not zero
-    .mb <- rxode2(.mk("e"))
-    .h <- 1e-6
-    .fd <- (rxSolve(.mb, .ev, params = c(.p, e = 0.2 + .h),
-                    returnType = "data.frame", atol = 1e-11, rtol = 1e-11)$center -
-            rxSolve(.mb, .ev, params = c(.p, e = 0.2 - .h),
-                    returnType = "data.frame", atol = 1e-11, rtol = 1e-11)$center) / (2 * .h)
-    expect_lt(max(abs(.a$rx__sens_center_BY_e__ - .fd)), 1e-5)
-    expect_gt(max(abs(.fd)), 1)
-  })
-
-  test_that("matExp()/indLin() rate constants keep a parameter named e", {
-    # .multCollapse() re-parsed model-side text with symengine::S(), which read
-    # the parameter `e` as Euler's number: k_p_q=exp(1) instead of k_p_q=e
-    .n <- rxNorm(rxode2("d/dt(p)=-e*p;\nd/dt(q)=e*p-k*q;\n", indLin = TRUE))
-    expect_true(grepl("k_p_q=e;", .n, fixed = TRUE))
-    expect_false(grepl("exp(1)", .n, fixed = TRUE))
   })
 
   test_that("lag() of a variable named like a symengine constant round-trips", {
@@ -126,51 +79,6 @@ rxTest({
     invisible(rxToSE("e=2", envir = .s))
     expect_equal(as.character(.s$e), "2")
     expect_equal(as.character(.s$rx_SymPy_Res_e), "2")
-  })
-
-  test_that("adjoint sensitivities accept a parameter named like a constant", {
-    .m <- rxS(rxGetModel("d/dt(depot)=-ka*depot;\nd/dt(center)=ka*depot-(e/v)*center;\n"),
-              TRUE, promoteLinSens = FALSE)
-    .v <- c("ka", "e", "v")
-    invisible(.rxJacobian(.m, c(rxStateOde(.m), .v)))
-    .adj <- .rxAdjoint(.m, .v, "center")
-    expect_true(any(grepl("d/dt(rx__sens_center_BY_e__)=rx__adjLambda_center_center__*center/v",
-                          .adj, fixed = TRUE)))
-    expect_false(any(grepl("rx_SymPy_Res_", .adj, fixed = TRUE)))
-    expect_false(any(grepl("2.718", .adj, fixed = TRUE)))
-  })
-
-  test_that("delay() terms resolve against a parameter named like a constant", {
-    .m <- .rxode2({
-      d/dt(cen) <- -e * cen + 0.1 * delay(cen, tau)
-      tau <- 1.5
-    })
-    .t <- .rxDelayTerms(.m)
-    expect_equal(.t$state, "cen")
-    expect_equal(.t$tau, "tau")
-    .s <- rxS(.m)
-    .b <- .s$..ddt
-    expect_equal(.b, "d/dt(cen)=-cen*e+0.1*delay(cen, 1.5)")
-  })
-
-  test_that("mu-referencing keeps a covariate parameter named like a constant", {
-    .f <- function() {
-      ini({
-        tcl <- 1
-        e <- 0.5
-        add.sd <- 0.7
-        eta.cl ~ 0.1
-      })
-      model({
-        cl <- exp(tcl + e * WT + eta.cl)
-        d/dt(center) <- -cl * center
-        cp <- center
-        cp ~ add(add.sd)
-      })
-    }
-    .d <- .f()$muRefCovariateDataFrame
-    expect_equal(.d$covariateParameter, "e")
-    expect_equal(.d$covariate, "WT")
   })
 
   test_that(".rxSEres() mangles only the reserved names", {


### PR DESCRIPTION
Closes #1359.

`rxS()` binds symengine's own constants (`e`, `E`, `I`, `Catalan`,
`GoldenRatio`, `EulerGamma` -- `.rxSEreserved`) into the model environment,
while `rxToSE()` stores a model variable of one of those names under
`rx_SymPy_Res_<name>`.  Reading the plain name back therefore gave the
constant, and `symengine::D()` by that name returned **`0`** -- silently, not
as an error -- so the term was dropped with no diagnostic.

This takes the first of the two options the issue lists: stop the shadowing,
so `e` stays usable everywhere.  Nothing is rejected and no existing model
changes meaning.

## What was actually wrong

Solving was already correct (the parser has no such constants); every bug here
is in the symbolic layer.

- **The environment.** `rxS(u)$e` returned `2.718...` and `with(s, D(cl, e))`
  failed with "Input is not a SYMBOL".
- **`matExp()`/`indLin()`** emitted `k_p_q=exp(1)` for a rate constant that was
  the parameter `e`, while its Jacobian still said `-e`.
- **`lag(e, 1)`** lagged Euler's number.
- **A parameter-dependent delay** (`delay(cen, 1.5*e)`) lost its
  breaking-point correction terms entirely: `d(tau)/dp` failed inside a
  `tryCatch`, so `dtauByP` stayed `"0"`.
- **The delay jump map** computed its amplitude as `-(M_E)*(1.5)` instead of
  `-(e)*(1.5)` -- it re-parses `rxFromSE()` text (model-side names) with
  `symengine::S()`.
- **`rxFun2c()`** could not differentiate a user function by an argument
  named `e`.
- **`.rxEventSensDExpr()` and friends** tested the model-side name against
  symengine-side free symbols, so the term failed the membership check and was
  dropped rather than erroring.

## How

Three small helpers in `R/symengine.R`, all `@noRd`:

- `.rxSEres(name)` -- the R mirror of `symengineRes()` (`src/expm.cpp`): the
  symengine name a model variable is bound under.  Every `symengine::D()` call
  site that names a model state, parameter or covariate now goes through it.
  It returns a **character**, which `D()` resolves to a `Symbol` (dotted rxode2
  names included) while keeping `D()`'s `stats::D` fallback for the non-`Basic`
  expressions the environment stores for a constant dosing property
  (`f(depot) <- 0.8`).
- `.rxSEassign(var, value, envir)` -- used at every site that writes a mangled
  name, so the plain name always points at the same value.  Doing it once after
  the model loads would leave the plain name stale as soon as the environment
  was extended by another `rxToSE()` call.
- `.rxSEresLang(e)` -- renames the reserved symbols in a parsed model
  expression, for the places that re-parse `rxFromSE()` text with
  `symengine::S()` or evaluate it in the model environment.

### `E` is the one exception

`rxToSE()` translates the model language's `M_E` to symengine's `E`, so the
environment's `E` has to keep meaning Euler's number -- a model may use `M_E`
and a variable called `E` in the same expression.  `E` is therefore excluded
(`.rxSEnoUnshadow`).  A model variable named `E` is still correct everywhere
(it lives at `rx_SymPy_Res_E` and `rxFromSE()` maps it back); code
differentiating by it asks for `.rxSEres("E")` rather than reading the plain
name.  No other `M_` constant translates to a reserved name.

## Verification

A model with a parameter named `e` now gives **bit-identical** forward and
jump event sensitivities to the same model with the parameter renamed, and
both match finite differences.

New tests split along the seam the coverage exposed: the symengine
environment's own behaviour in `test-symengine-constants.R`, the subsystems
that consume it in `test-symengine-constants-downstream.R`.  Notably one test
pins that `symengine::D(basic, "e")` returns `0` -- the `with(env, D(cl, e))`
form passes either way, so it does not pin the downstream fixes.

Sixteen test filters run clean (`symengine-constants`, `dsl`, `ui-model`,
`piping-ini`, `mu`, `ind-lin`, `adjoint`, `dde`, `event-sensitivities`,
`opt-expr`, `lag`, `udf`, `sens`, `err`, `focei`, `rxs`) -- 0 failures.

Reviewed independently across five rounds; the findings that survived triage
are folded in as their own commits.

## Known, out of scope

A model parameter named `pi` collides with `M_PI` the same way: `.rxSEcnt`
maps `M_PI` to `pi`, and `pi` is not in `.rxSEreserved`, so it is never
mangled.  `rxode2("pi=1; cl=M_PI*2; ...", calcSens=TRUE)` differentiates `cl`
with respect to the parameter `pi` and gets `2`.  This is byte-identical
before and after this branch -- a distinct pre-existing bug in a different
name class.  Fixing it means deciding whether to reject `pi` as an lhs (the
parser already reports it as reserved) or to mangle it, so it is left alone
here.
